### PR TITLE
Add eligibility start page

### DIFF
--- a/app/views/teacher_interface/pages/start.html.erb
+++ b/app/views/teacher_interface/pages/start.html.erb
@@ -1,44 +1,12 @@
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">
-        <%= t('service.name') %>
-      </h1>
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      Check your eligibility to apply for qualified teacher status (QTS) in England
+    </h1>
 
-      <p class="govuk-body">
-        Teacher training in England leads to qualified teacher status (QTS). QTS is a legal requirement to teach in many English schools. 
-      </p>
-  
-      <p class="govuk-body">
-        If you trained to teach outside the UK, you can use the service to apply for qualified teacher status (QTS). 
-      </p>
-  
-      <p class="govuk-body">To make an application, you will need to upload a PDF or jpeg of your:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>personal identification document, including proof of any name change</li>
-        <li>degree qualification certificate</li>
-        <li>teacher training qualification certificate</li>
-        <li>teacher training qualification transcript</li>
-        <li>letter of professional standing, if you do not have a registration number</li>
-      </ul>
+    <p class="govuk-body">Teacher training in England leads to qualified teacher status (QTS). QTS is a legal requirement to teach in many English schools.</p>
+    <p class="govuk-body">We'll ask some questions to check your eligibility to apply for QTS in England. This should take about 5 minutes.</p>
 
-      <p class="govuk-body">You cannot use this service if you have ever been banned from teaching or working with children, or if you have ever started but not completed teacher training in England.</p>
-
-      <%= govuk_start_button(text: 'Start now', href: '#', classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
-    </div>
-
-    <div class="govuk-grid-column-one-third">
-      <aside class="app-related-items" role="complementary">
-        <h2 class="govuk-heading-m" id="subsection-title">Links</h2>
-        <nav role="navigation" aria-labelledby="links">
-          <ul class="govuk-list govuk-!-font-size-16">
-            <li class="app-related-items__link">
-              <a class="govuk-link" href="https://getintoteaching.education.gov.uk/train-to-teach-in-england-as-an-international-student">
-                Learn more about routes to teaching in England if you do not yet have a teaching qualification
-              </a>
-            </li>
-          </ul>
-        </nav>
-      </aside>
-    </div>
+    <%= govuk_start_button(text: 'Continue', href: '#', classes: 'govuk-!-margin-top-2 govuk-!-margin-bottom-9') %>
   </div>
 </div>


### PR DESCRIPTION
The page at `/teacher/start` needs to be the start of the eligibility
check flow.

This change ensures the HTML matches the prototype.

<img width="1008" alt="Screen Shot 2022-05-12 at 12 30 40 pm" src="https://user-images.githubusercontent.com/3126/168065434-e851f525-0c88-49ee-be95-1da87ec15180.png">
