### PR TITLE
Add solargraph

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,21 +11,22 @@ gem "jsbundling-rails"
 gem "pg"
 gem "propshaft"
 gem "puma", "~> 5.0"
-gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ] # Windows
+gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby] # Windows
 
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 
 group :development, :test do
-  gem "debug", platforms: %i[ mri mingw x64_mingw ]
+  gem "debug", platforms: %i[mri mingw x64_mingw]
 end
 
 group :development do
-  gem 'rladr'
+  gem "rladr"
   gem "web-console"
 
   gem "prettier_print", require: false
   gem "rubocop-govuk", require: false
+  gem "solargraph", require: false
   gem "syntax_tree", require: false
   gem "syntax_tree-haml", require: false
   gem "syntax_tree-rbs", require: false
@@ -33,7 +34,7 @@ end
 
 group :test do
   gem "capybara", "~> 3.37"
-  gem 'cuprite', '~> 0.13'
+  gem "cuprite", "~> 0.13"
   gem "rspec"
   gem "rspec-rails"
   gem "shoulda-matchers", "~> 5.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,8 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    backport (1.2.0)
+    benchmark (0.2.0)
     bindex (0.8.1)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
@@ -96,6 +98,7 @@ GEM
     deep_merge (1.2.2)
     diff-lcs (1.5.0)
     digest (3.1.0)
+    e2mmap (0.1.0)
     erubi (1.10.0)
     ferrum (0.11)
       addressable (~> 2.5)
@@ -121,8 +124,13 @@ GEM
     io-console (0.5.11)
     irb (1.4.1)
       reline (>= 0.3.0)
+    jaro_winkler (1.5.4)
     jsbundling-rails (1.0.2)
       railties (>= 6.0.0)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     loofah (2.17.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -202,6 +210,8 @@ GEM
     regexp_parser (2.4.0)
     reline (0.3.1)
       io-console (~> 0.5)
+    reverse_markdown (2.1.1)
+      nokogiri
     rexml (3.2.5)
     rladr (1.2.0)
     rspec (3.11.0)
@@ -253,6 +263,21 @@ GEM
     ruby-progressbar (1.11.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
+    solargraph (0.44.3)
+      backport (~> 1.2)
+      benchmark
+      bundler (>= 1.17.2)
+      diff-lcs (~> 1.4)
+      e2mmap
+      jaro_winkler (~> 1.5)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      parser (~> 3.0)
+      reverse_markdown (>= 1.0.5, < 3)
+      rubocop (>= 0.52)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
     strscan (3.0.2)
     syntax_tree (2.6.0)
       prettier_print
@@ -279,11 +304,14 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.27)
+      webrick (~> 1.7.0)
     zeitwerk (2.5.4)
 
 PLATFORMS
@@ -309,6 +337,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   shoulda-matchers (~> 5.1)
+  solargraph
   syntax_tree
   syntax_tree-haml
   syntax_tree-rbs

--- a/README.md
+++ b/README.md
@@ -52,6 +52,25 @@ Run the application on `http://localhost:3000`:
 bin/dev
 ```
 
+### Intellisense
+
+[solargraph](https://github.com/castwide/solargraph) is bundled as part of the
+development dependencies. You need to [set it up for your
+editor](https://github.com/castwide/solargraph#using-solargraph), and then run
+this command to index your local bundle (re-run if/when we install new
+dependencies and you want completion):
+
+```sh
+bin/bundle exec yard gems
+```
+
+You'll also need to configure your editor's `solargraph` plugin to
+`useBundler`:
+
+```diff
++  "solargraph.useBundler": true,
+```
+
 ### Linting
 
 To run the linters:


### PR DESCRIPTION
[solargraph](https://github.com/castwide/solargraph) is a Ruby language server protocol; it provides intellisense capabilities to [compatible editors](https://github.com/castwide/solargraph#using-solargraph).

`solargraph` can be used without adding a `development` dependency to a project, and it provides basic Ruby language completion for core language features. To set it up to work with our bespoke modules, gems, and Rails, you need to bundle it and run a command. I've documented this in the README.

The gem is `require: false`d and is not bundled in the production build.

### How it works

| Before | After |
| - | - |
| Vim doesn't know what classes are under the ActiveModel::Type namespace | Full class list and inline documentation |
| ![image](https://user-images.githubusercontent.com/1650875/168996614-1569cee6-48aa-455e-ac94-4dd0cc7d5ac4.png) | ![image](https://user-images.githubusercontent.com/1650875/168997430-69c06b0f-fbfb-4466-86f2-07ed94ab6f4d.png) |
| String based autocompletion of instance methods |  Dynamic introspection |
| ![image](https://user-images.githubusercontent.com/1650875/168996796-495d6fb4-b0fb-4240-896b-eae0aad66943.png) | ![image](https://user-images.githubusercontent.com/1650875/168997511-44188867-e089-495c-a61a-a7b76d05de73.png) |
