### PR TITLE
Update the form generator to confirm to lint rules

### DIFF
--- a/lib/generators/form/form_generator.rb
+++ b/lib/generators/form/form_generator.rb
@@ -11,8 +11,8 @@ class FormGenerator < Rails::Generators::NamedBase
 
     insert_into_file "config/routes.rb",
                      after:
-                       "namespace :teacher_interface, path: '/teacher' do\n" do
-      "    get '#{plural_name}', to: '#{plural_name}#new'\n    post '#{plural_name}', to: '#{plural_name}#create'\n"
+                       "namespace :teacher_interface, path: \"/teacher\" do\n" do
+      "    get \"#{plural_name}\", to: \"#{plural_name}#new\"\n    post \"#{plural_name}\", to: \"#{plural_name}#create\"\n"
     end
   end
 end

--- a/lib/generators/form/templates/form.erb
+++ b/lib/generators/form/templates/form.erb
@@ -10,4 +10,8 @@ class <%= class_name %>Form
 
     eligibility_check.save
   end
+
+  def success_url
+    ApplicationController.routes.url_helpers.teacher_interface_<%= plural_name %>_path
+  end
 end

--- a/lib/generators/form/templates/form_controller.erb
+++ b/lib/generators/form/templates/form_controller.erb
@@ -8,7 +8,7 @@ module TeacherInterface
       eligibility_check = EligibilityCheck.find(session[:eligibility_check_id])
       @<%= model_resource_name %>_form = <%= class_name %>Form.new(<%= model_resource_name %>_form_params.merge(eligibility_check:))
       if @<%= model_resource_name %>_form.save
-
+        redirect_to @<%= model_resource_name %>_form.success_url
       else
         render :new
       end
@@ -17,7 +17,7 @@ module TeacherInterface
     private
 
     def <%= model_resource_name %>_form_params
-      params.require(:<%= model_resource_name %>_form).permit()
+      params.require(:<%= model_resource_name %>_form).permit
     end
   end
 end

--- a/lib/generators/form/templates/form_spec.erb
+++ b/lib/generators/form/templates/form_spec.erb
@@ -1,7 +1,7 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe <%= class_name %>Form, type: :model do
-  describe 'validations' do
+  describe "validations" do
     it { is_expected.to validate_presence_of(:eligibility_check) }
   end
 end


### PR DESCRIPTION
The code generated by the form generator violates the new lint rules.

Rather than having to update the generated code with the linter
immediately, we can change the templates to conform to the lint rules.
