### PR TITLE
Extend the form generator to add attributes

### DIFF
--- a/lib/generators/form/USAGE
+++ b/lib/generators/form/USAGE
@@ -4,10 +4,11 @@ Description:
     """
 
 Example:
-    bin/rails generate form Thing
+    bin/rails generate form Thing attribute:type
 
     This will create:
         app/forms/thing_form.rb
         app/controllers/teacher_interface/things_controller.rb
         app/views/teacher_interface/things/new.html.erb
         spec/forms/thing_form_spec.rb
+        db/migration/add_thing_to_eligibility_check.rb

--- a/lib/generators/form/form_generator.rb
+++ b/lib/generators/form/form_generator.rb
@@ -1,6 +1,11 @@
 class FormGenerator < Rails::Generators::NamedBase
   source_root File.expand_path("templates", __dir__)
 
+  argument :attributes,
+           type: :array,
+           default: [],
+           banner: "field:type field:type"
+
   def copy_form_files
     template "form.erb", "app/forms/#{file_name}_form.rb"
     template "form_spec.erb", "spec/forms/#{file_name}_form_spec.rb"
@@ -14,5 +19,11 @@ class FormGenerator < Rails::Generators::NamedBase
                        "namespace :teacher_interface, path: '/teacher' do\n" do
       "    get '#{plural_name}', to: '#{plural_name}#new'\n    post '#{plural_name}', to: '#{plural_name}#create'\n"
     end
+    generate :migration,
+             "Add#{class_name}ToEligibilityCheck #{
+               attributes
+                 .map { |attribute| [attribute.name, attribute.type].join(":") }
+                 .join(" ")
+             }"
   end
 end

--- a/lib/generators/form/templates/form.erb
+++ b/lib/generators/form/templates/form.erb
@@ -2,12 +2,24 @@ class <%= class_name %>Form
   include ActiveModel::Model
 
   attr_accessor :eligibility_check
+  <% if attributes.any? -%>
+attr_reader <%= attributes.map { |attribute| ":#{attribute.name}" }.join(', ') %>
+  <% end -%>
 
   validates :eligibility_check, presence: true
+
+  <% attributes.map do |attribute| -%>
+def <%= attribute.name %>=(value)
+    @<%= attribute.name %> = <%= attribute.type == :boolean ? "ActiveMode::Type.new.cast(value)" : "value" %>
+  end
+  <% end -%>
 
   def save
     return false unless valid?
 
-    eligibility_check.save
+    <% attributes.map do |attribute| -%>
+eligibility_check.<%= attribute.name %> = <%= attribute.name %>
+    <% end -%>
+eligibility_check.save
   end
 end

--- a/lib/generators/form/templates/new_form.html.erb
+++ b/lib/generators/form/templates/new_form.html.erb
@@ -5,8 +5,18 @@
   <div class="govuk-grid-column-two-thirds">
     <%%= form_with model: @<%= model_resource_name %>_form, url: teacher_interface_<%= plural_name %>_url, method: :post do |f| %>
       <%%= f.govuk_error_summary %>
-
-      <%%= f.govuk_submit prevent_double_click: false %>
+      <% attributes.map do |attribute|
+        next unless attribute.type == :boolean -%>
+<%%= f.govuk_collection_radio_buttons(
+          :<%= attribute.name %>,
+          [OpenStruct.new(label: 'Yes', value: true), OpenStruct.new(label: 'No', value: false)],
+          :value,
+          :label,
+          legend: { size: 'l', text: 'Change this question?' },
+          hint: { text: 'Change this hint' }
+        ) %>
+      <% end -%>
+<%%= f.govuk_submit prevent_double_click: false %>
     <%% end %>
   </div>
 </div>


### PR DESCRIPTION
We want the form generator to write more of the boilerplate for us.

In this change, I have co-opted the convention for defining attributes
on a model, eg. attribute:type, as a way of defining attributes for the
form object and a related one on the EligiblityCheck.

Currently, this only supports boolean types. These are the easiest to
output the HTML components for.

Running `rails generate form FormName attribute:type` results in
creating the relevant form object, adding the attribute to both it and
the `EligibilityCheck`.

Also, the component for the question HTML gets added.

This will reduce the amount of custom code we need to write to add a new
question to the flow.
