### PR TITLE
Add solargraph-rails

### DIFF
--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,0 +1,23 @@
+---
+include:
+- "**/*.rb"
+exclude:
+- spec/**/*
+- test/**/*
+- vendor/**/*
+- ".bundle/**/*"
+require: []
+domains: []
+reporters:
+- rubocop
+- require_not_found
+formatter:
+  rubocop:
+    cops: safe
+    except: []
+    only: []
+    extra_args: []
+require_paths: []
+plugins:
+  - solargraph-rails
+max_files: 5000

--- a/Gemfile
+++ b/Gemfile
@@ -24,9 +24,11 @@ group :development do
   gem "rladr"
   gem "web-console"
 
+  gem "annotate", require: false
   gem "prettier_print", require: false
   gem "rubocop-govuk", require: false
   gem "solargraph", require: false
+  gem "solargraph-rails", require: false
   gem "syntax_tree", require: false
   gem "syntax_tree-haml", require: false
   gem "syntax_tree-rbs", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,9 @@ GEM
       tzinfo (~> 2.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     backport (1.2.0)
     benchmark (0.2.0)
@@ -278,6 +281,9 @@ GEM
       thor (~> 1.0)
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
+    solargraph-rails (0.3.1)
+      activesupport
+      solargraph (>= 0.41.1)
     strscan (3.0.2)
     syntax_tree (2.6.0)
       prettier_print
@@ -319,6 +325,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  annotate
   bootsnap
   capybara (~> 3.37)
   cssbundling-rails
@@ -338,6 +345,7 @@ DEPENDENCIES
   rubocop-govuk
   shoulda-matchers (~> 5.1)
   solargraph
+  solargraph-rails
   syntax_tree
   syntax_tree-haml
   syntax_tree-rbs

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: eligibility_checks
+#
+#  id                :bigint           not null, primary key
+#  free_of_sanctions :boolean
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  recognised        :boolean
+#  teach_children    :boolean
+#
 class EligibilityCheck < ApplicationRecord
   def ineligible_reason
     return :misconduct unless free_of_sanctions.nil? || free_of_sanctions

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: eligibility_checks
+#
+#  id                :bigint           not null, primary key
+#  free_of_sanctions :boolean
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  recognised        :boolean
+#  teach_children    :boolean
+#
 require "rails_helper"
 
 RSpec.describe EligibilityCheck, type: :model do


### PR DESCRIPTION
Makes solargraph more aware of ActiveRecord and methods that can't be found using static analysis.

[annotate](https://github.com/ctran/annotate_models/) is also required and it set up to automatically add schema definition comments to the top of models when we migrate.