### PR TITLE
Fix typos in the form generator

### DIFF
--- a/lib/generators/form/templates/form.erb
+++ b/lib/generators/form/templates/form.erb
@@ -7,10 +7,13 @@ attr_reader <%= attributes.map { |attribute| ":#{attribute.name}" }.join(', ') %
   <% end -%>
 
   validates :eligibility_check, presence: true
+  <% attributes.map do |attribute| -%>
+  validates :<%= attribute.name %>, <%= attribute.type == :boolean ? "inclusion: { in: [true, false] }" : "presence: true" %>
+  <% end -%>
 
   <% attributes.map do |attribute| -%>
 def <%= attribute.name %>=(value)
-    @<%= attribute.name %> = <%= attribute.type == :boolean ? "ActiveMode::Type.new.cast(value)" : "value" %>
+    @<%= attribute.name %> = <%= attribute.type == :boolean ? "ActiveModel::Type::Boolean.new.cast(value)" : "value" %>
   end
   <% end -%>
 
@@ -23,7 +26,17 @@ eligibility_check.<%= attribute.name %> = <%= attribute.name %>
 eligibility_check.save
   end
 
+  def eligible?
+    <%= attributes.map { |attribute| "eligibility_check.#{attribute.name}" }.join(' && ') %>
+  end
+
   def success_url
-    ApplicationController.routes.url_helpers.teacher_interface_<%= plural_name %>_path
+    return Rails.application.routes.url_helpers.teacher_interface_ineligible_path unless eligible?
+
+    Rails
+      .application
+      .routes
+      .url_helpers
+      .teacher_interface_<%= plural_name %>_path
   end
 end

--- a/lib/generators/form/templates/form_controller.erb
+++ b/lib/generators/form/templates/form_controller.erb
@@ -17,7 +17,7 @@ module TeacherInterface
     private
 
     def <%= model_resource_name %>_form_params
-      params.require(:<%= model_resource_name %>_form).permit
+      params.require(:<%= model_resource_name %>_form).permit(<%= attributes.map { |attribute| ":#{attribute.name}" }.join(', ') %>)
     end
   end
 end

--- a/lib/generators/form/templates/form_spec.erb
+++ b/lib/generators/form/templates/form_spec.erb
@@ -4,4 +4,33 @@ RSpec.describe <%= class_name %>Form, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:eligibility_check) }
   end
+
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    let(:eligibility_check) { EligibilityCheck.new }
+    let(:form) { described_class.new(eligibility_check:, <%= attributes.map {|attribute| "#{attribute.name}:" }.join(', ') %>) }
+    <% attributes.each do |attribute| %>let(:<%= attribute.name %>) { "true" }<% end %>
+
+    it { is_expected.to be_truthy }
+    <% attributes.each do |attribute| %>
+    context "when <%= attribute.name %> is blank" do
+      let(:<%= attribute.name %>) { "" }
+
+      it { is_expected.to be_falsy }
+    end
+    <% end %>
+  end
+
+  describe "#save" do
+    subject(:save!) { form.save }
+
+    let(:eligibility_check) { EligibilityCheck.new }
+    let(:form) { described_class.new(eligibility_check:, <%= attributes.map {|attribute| "#{attribute.name}: true" }.join(', ') %>) }
+
+    it "saves the eligibility check" do
+      save!
+      <% attributes.each do |attribute| %>expect(eligibility_check.<%= attribute.name %>).to be_truthy<% end %>
+    end
+  end
 end


### PR DESCRIPTION
There are some typos in the form generator that create invalid code.

This fixes those up and introduces a validation for the supplied
attribute.
