### PR TITLE
Add govuk-country-and-territory-autocomplete

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -3,3 +3,9 @@ $govuk-new-link-styles: true;
 $govuk-assets-path: "/";
 
 @import "govuk-frontend/govuk/all";
+
+ul.autocomplete__menu {
+  li {
+    font-family: $govuk-font-family;
+  }
+}

--- a/app/controllers/teacher_interface/locations_controller.rb
+++ b/app/controllers/teacher_interface/locations_controller.rb
@@ -1,5 +1,14 @@
 module TeacherInterface
   class LocationsController < BaseController
+    def index
+      render json:
+               JSON.parse(
+                 File.read(
+                   "node_modules/govuk-country-and-territory-autocomplete/dist/location-autocomplete-graph.json"
+                 )
+               )
+    end
+
     def new
       @location_form = LocationForm.new
     end
@@ -21,5 +30,14 @@ module TeacherInterface
     def location_form_params
       params.require(:location_form).permit(:country_code)
     end
+
+    def locations
+      JSON.parse(
+        File.read(
+          "node_modules/govuk-country-and-territory-autocomplete/dist/location-autocomplete-canonical-list.json"
+        )
+      )
+    end
+    helper_method :locations
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,9 @@
 import { initAll } from "govuk-frontend";
+import openregisterLocationPicker from "govuk-country-and-territory-autocomplete";
 
 initAll();
+
+openregisterLocationPicker({
+  selectElement: document.getElementById("location-form-country-code-field"),
+  url: "/teacher/locations.json",
+});

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -18,6 +18,7 @@
     <%= favicon_link_tag asset_path('images/govuk-apple-touch-icon-180x180.png'), rel: 'apple-touch-icon', type: 'image/png', size: '180x180' %>
 
     <%= stylesheet_link_tag "application" %>
+    <link rel="stylesheet" href="/location-autocomplete.min.css" />
     <%= javascript_include_tag "application", defer: true %>
   </head>
 

--- a/app/views/teacher_interface/locations/new.html.erb
+++ b/app/views/teacher_interface/locations/new.html.erb
@@ -5,8 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @location_form, url: teacher_interface_countries_url, method: :post do |f| %>
       <%= f.govuk_error_summary %>
-      <% countries = [OpenStruct.new(label: 'United Kingdom', value: 'GB'), OpenStruct.new(label: 'Canada', value: 'CA'), OpenStruct.new(label: 'Other', value: 'INELIGIBLE')] %>
-      <%= f.govuk_collection_select :country_code, countries, :value, :label, 
+      <%= f.govuk_select :country_code, options_for_select(locations),
             hint: { text: "This means you have all the qualifications needed to teach in a state school. You'll need to provide evidence of this if you apply for QTS." },
             label: { size: 'xl', text: "Where are you currently recognised as a teacher?" },
             options: { include_blank: true }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,9 @@ Rails.application.routes.draw do
     get "ineligible", to: "pages#ineligible"
     get "misconduct", to: "misconduct#new"
     post "misconduct", to: "misconduct#create"
+
+    resources :locations, only: [:index]
+
     root to: redirect("/teacher/start")
   end
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,8 @@
 ---
 applications:
-- name: sandbox-apply-for-qts-in-england
-  memory: 256M
-  buildpacks:
-  - ruby_buildpack
-  services:
-  - sandbox-apply-for-qts-in-england-postgres
+  - name: sandbox-apply-for-qts-in-england
+    memory: 256M
+    buildpacks:
+      - ruby_buildpack
+    services:
+      - sandbox-apply-for-qts-in-england-postgres

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": "true",
   "dependencies": {
     "esbuild": "^0.14.39",
+    "govuk-country-and-territory-autocomplete": "^1.0.2",
     "govuk-frontend": "^4.0.1",
     "sass": "^1.51.0"
   },

--- a/public/location-autocomplete.min.css
+++ b/public/location-autocomplete.min.css
@@ -1,0 +1,137 @@
+.autocomplete__wrapper {
+  position: relative;
+}
+.autocomplete__hint,
+.autocomplete__input {
+  -webkit-appearance: none;
+  border: 2px solid #0b0c0c;
+  border-radius: 0;
+  box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  margin-bottom: 0;
+  width: 100%;
+}
+.autocomplete__input {
+  background-color: transparent;
+  position: relative;
+}
+.autocomplete__hint {
+  color: #b1b4b6;
+  position: absolute;
+}
+.autocomplete__input--default {
+  padding: 5px;
+}
+.autocomplete__input--focused {
+  outline: 3px solid #fd0;
+  outline-offset: 0;
+  box-shadow: inset 0 0 0 2px;
+}
+.autocomplete__input--show-all-values {
+  padding: 5px 34px 5px 5px;
+  cursor: pointer;
+}
+.autocomplete__dropdown-arrow-down {
+  z-index: -1;
+  display: inline-block;
+  position: absolute;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  top: 10px;
+}
+.autocomplete__menu {
+  background-color: #fff;
+  border: 2px solid #0b0c0c;
+  border-top: 0;
+  color: #0b0c0c;
+  margin: 0;
+  max-height: 342px;
+  overflow-x: hidden;
+  padding: 0;
+  width: 100%;
+  width: calc(100% - 4px);
+}
+.autocomplete__menu--visible {
+  display: block;
+}
+.autocomplete__menu--hidden {
+  display: none;
+}
+.autocomplete__menu--overlay {
+  box-shadow: rgba(0, 0, 0, 0.256863) 0 2px 6px;
+  left: 0;
+  position: absolute;
+  top: 100%;
+  z-index: 100;
+}
+.autocomplete__menu--inline {
+  position: relative;
+}
+.autocomplete__option {
+  border-bottom: solid #b1b4b6;
+  border-width: 1px 0;
+  cursor: pointer;
+  display: block;
+  position: relative;
+}
+.autocomplete__option > * {
+  pointer-events: none;
+}
+.autocomplete__option:first-of-type {
+  border-top-width: 0;
+}
+.autocomplete__option:last-of-type {
+  border-bottom-width: 0;
+}
+.autocomplete__option--odd {
+  background-color: #fafafa;
+}
+.autocomplete__option--focused,
+.autocomplete__option:hover {
+  background-color: #1d70b8;
+  border-color: #1d70b8;
+  color: #fff;
+  outline: 0;
+}
+@media (-ms-high-contrast: active), (forced-colors: active) {
+  .autocomplete__menu {
+    border-color: FieldText;
+  }
+  .autocomplete__option {
+    background-color: Field;
+    color: FieldText;
+  }
+  .autocomplete__option--focused,
+  .autocomplete__option:hover {
+    forced-color-adjust: none;
+    background-color: SelectedItem;
+    border-color: SelectedItem;
+    color: SelectedItemText;
+    outline-color: SelectedItemText;
+  }
+}
+.autocomplete__option--no-results {
+  background-color: #fafafa;
+  color: #646b6f;
+  cursor: not-allowed;
+}
+.autocomplete__hint,
+.autocomplete__input,
+.autocomplete__option {
+  font-size: 16px;
+  line-height: 1.25;
+}
+.autocomplete__hint,
+.autocomplete__option {
+  padding: 5px;
+}
+@media (min-width: 641px) {
+  .autocomplete__hint,
+  .autocomplete__input,
+  .autocomplete__option {
+    font-size: 19px;
+    line-height: 1.31579;
+  }
+}

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -37,12 +37,6 @@ RSpec.describe "Eligibility check", type: :system do
   it "ineligible paths" do
     when_i_visit_the_start_page
     when_i_press_continue
-    when_i_select_an_ineligible_country
-    and_i_submit
-    then_i_see_the_ineligible_page
-    and_i_see_the_ineligible_country_text
-
-    when_i_press_back
     when_i_select_a_country
     and_i_submit
     when_i_choose_no
@@ -106,7 +100,7 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def when_i_select_a_country
-    select "United Kingdom", from: "location-form-country-code-field"
+    fill_in "location-form-country-code-field", with: "United Kingdom"
   end
 
   def when_i_select_an_ineligible_country

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     prettier ">=2.3.0"
 
+accessible-autocomplete@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz#e295256c8d268b97c5ab456a1cb084b553ed3eb0"
+  integrity sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==
+  dependencies:
+    preact "^8.3.1"
+
 anymatch@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
@@ -43,6 +50,18 @@ braces@~3.0.2:
     readdirp "~3.6.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+core-js@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.2.1.tgz#cd41f38534da6cc59f7db050fe67307de9868b09"
+  integrity sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw==
+
+corejs-typeahead@^1.1.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/corejs-typeahead/-/corejs-typeahead-1.3.1.tgz#26b9b158cba7f123556c74068bffce9356505bd3"
+  integrity sha512-fyNlBNWJNL6EQUnJyAunEzBzRcwR2cEHtZXBi2pndHPOJ/wpOf3wbS+/Oh+kYYS5sKowQcs0LFwMSl6Y2Xeqkw==
+  dependencies:
+    jquery ">=1.11"
 
 esbuild-android-64@0.14.39:
   version "0.14.39"
@@ -189,6 +208,15 @@ glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
+govuk-country-and-territory-autocomplete@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/govuk-country-and-territory-autocomplete/-/govuk-country-and-territory-autocomplete-1.0.2.tgz#24c0af23af7211de9e35bd4346aa7d626a613209"
+  integrity sha512-jQ0EQ51hRx8aVEEA6ARiFWiJ64HBU4jWX2CG+xqmfxP79LVkL20oiUo/uA6xpuELFkfWZA5Lpu/ADTK/9N/LyQ==
+  dependencies:
+    accessible-autocomplete "^2.0.4"
+    core-js "3.2.1"
+    openregister-picker-engine "^1.2.1"
+
 govuk-frontend@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.0.1.tgz#bceff58ecb399272cba32bd2b357fe16198e3249"
@@ -223,15 +251,33 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+jquery@>=1.11:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+openregister-picker-engine@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/openregister-picker-engine/-/openregister-picker-engine-1.2.1.tgz#e7ab34dc34b9c4cb13915bf3fbfae65b0e281e34"
+  integrity sha512-8sbJY+iX6rW28seEri8tVTpAS2VBLNckbFDbVqNXy/kRn48Uii2IvaH6uJXKFJxXOOKB6RVcmnigIm1qA07v/Q==
+  dependencies:
+    corejs-typeahead "^1.1.1"
+    whatwg-fetch "^2.0.3"
+
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+preact@^8.3.1:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.3.tgz#78c2a5562fcecb1fed1d0055fa4ac1e27bde17c1"
+  integrity sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==
 
 prettier@>=2.3.0, prettier@^2.6.2:
   version "2.6.2"
@@ -265,3 +311,8 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+whatwg-fetch@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
+  integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==


### PR DESCRIPTION
There is an existing library that implements the country autocomplete
field that is suitable for our purposes.

[govuk-country-and-territory-autocomplete](https://github.com/alphagov/govuk-country-and-territory-autocomplete)

The country list is provided by this library. An assumption here is that
the list it provides is suitable for what we need at the moment.

With this addition, it is no longer possible to reach the ineligible
country page. We're assuming that we will address that in a future
change when we have defined what makes a country ineligible for the
purposes of this check.

I had to add a style for the list of options that renders when using
autocomplete. The default styles appear to rely on the default font
styles, which for some reason aren't being set.

<img width="993" alt="Screen Shot 2022-05-20 at 11 47 17 am" src="https://user-images.githubusercontent.com/3126/169512500-2693ded0-2e69-4edf-bbb7-3348061a6746.png">
