### PR TITLE
Configure Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem "jsbundling-rails"
 gem "pg"
 gem "propshaft"
 gem "puma", "~> 5.0"
+gem "sentry-rails"
+gem "sentry-ruby"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby] # Windows
 
 gem "govuk-components"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -270,6 +270,14 @@ GEM
     rubocop-rspec (2.10.0)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    sentry-rails (5.3.1)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 5.3.1)
+    sentry-ruby (5.3.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      sentry-ruby-core (= 5.3.1)
+    sentry-ruby-core (5.3.1)
+      concurrent-ruby
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
     solargraph (0.44.3)
@@ -351,6 +359,8 @@ DEPENDENCIES
   rspec
   rspec-rails
   rubocop-govuk
+  sentry-rails
+  sentry-ruby
   shoulda-matchers (~> 5.1)
   solargraph
   solargraph-rails

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "active_support/parameter_filter"
+
+Sentry.init do |config|
+  config.breadcrumbs_logger = %i[active_support_logger http_logger]
+
+  filter =
+    ActiveSupport::ParameterFilter.new(
+      Rails.application.config.filter_parameters
+    )
+  config.before_send = lambda { |event, _hint| filter.filter(event.to_hash) }
+
+  config.inspect_exception_causes_for_exclusion = true
+  config.excluded_exceptions += [
+    # The following exceptions are user-errors that aren't actionable, and can
+    # be safely ignored.
+    "ActionController::BadRequest",
+    "ActionController::UnknownFormat",
+    "ActionController::UnknownHttpMethod",
+    "ActionDispatch::Http::Parameters::ParseError",
+    "Mime::Type::InvalidMimeType"
+  ]
+end


### PR DESCRIPTION
This initialises Sentry for Rails with a few extra options.

As recommended by the Sentry docs, this configures the breadcrumbs to be picked up from the Active Support and HTTP loggers, this enhances the breadcrumbs we'll see in Sentry issues.

Certain URL parameters (ones containing sensitive information such as auth tokens) are filtered out.

Some exceptions have been included, specifically ones where there has been a client error when making the request and we wouldn't be able to action.

We don't need to specify the DSN or the environment as these are picked up automatically from environment variables, `SENTRY_DSN` and `SENTRY_ENVIRONMENT`. If the environment is not set, it defaults to
`development` (https://github.com/getsentry/sentry-ruby/blob/eb8c59861cc3dc29a17282d432309edd86db8286/sentry-ruby/lib/sentry/configuration.rb#L467-L469).

[Trello Card](https://trello.com/c/3t0fYW7G/440-sentry-error-tracking)