### PR TITLE
Fix the country autocomplete error state

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,7 +3,20 @@ import openregisterLocationPicker from "govuk-country-and-territory-autocomplete
 
 initAll();
 
-openregisterLocationPicker({
-  selectElement: document.getElementById("location-form-country-code-field"),
-  url: "/teacher/locations.json",
-});
+const loadCountryAutoComplete = () => {
+  let locationPicker = document.getElementById(
+    "location-form-country-code-field"
+  );
+  locationPicker ??= document.getElementById(
+    "location-form-country-code-field-error"
+  );
+
+  if (locationPicker) {
+    openregisterLocationPicker({
+      selectElement: locationPicker,
+      url: "/teacher/locations.json",
+    });
+  }
+};
+
+loadCountryAutoComplete();

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -77,6 +77,17 @@ RSpec.describe "Eligibility check", type: :system do
     and_i_see_the_ineligible_misconduct_text
   end
 
+  it "handles the country picker error" do
+    when_i_visit_the_start_page
+    when_i_press_continue
+    and_i_submit
+    then_i_see_the_country_error_message
+
+    when_i_select_a_country_in_the_error_state
+    and_i_submit
+    then_i_see_the_degree_page
+  end
+
   private
 
   def and_i_submit
@@ -103,6 +114,10 @@ RSpec.describe "Eligibility check", type: :system do
     fill_in "location-form-country-code-field", with: "United Kingdom"
   end
 
+  def when_i_select_a_country_in_the_error_state
+    fill_in "location-form-country-code-field-error", with: "United Kingdom"
+  end
+
   def when_i_select_an_ineligible_country
     select "Other", from: "location-form-country-code-field"
   end
@@ -125,6 +140,12 @@ RSpec.describe "Eligibility check", type: :system do
     )
     expect(page).to have_content(
       "Where are you currently recognised as a teacher?"
+    )
+  end
+
+  def then_i_see_the_country_error_message
+    expect(page).to have_content(
+      "Tell us where you are currently recognised as a teacher"
     )
   end
 


### PR DESCRIPTION
When a Rails form has a validation error message, the form builder
outputs a different ID for the element.

This breaks the autocomplete JS because it is targeting the original ID.

While making this change, I took the opportunity to wrap the
autocomplete function with a check that the relevant HTML element is
present to avoid it erroring on other pages that don't need it.

<img width="992" alt="Screen Shot 2022-05-24 at 9 20 00 am" src="https://user-images.githubusercontent.com/3126/169985890-1dbb4e79-8bab-4e83-9d17-de2c213b01e4.png">
