### PR TITLE
Set esbuild target to IE11

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "sass": "^1.51.0"
   },
   "scripts": {
-    "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds",
+    "build": "esbuild app/javascript/*.* --bundle --sourcemap --target=ie11 --outdir=app/assets/builds",
     "build:css": "sass ./app/assets/stylesheets/application.sass.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules --quiet-deps"
   },
   "devDependencies": {


### PR DESCRIPTION
We know that some of our users will be using IE11 so we should target the JavaScript build to that level.

See https://esbuild.github.io/api/#target for the documentation on this argument.