### PR TITLE
Combine common logic from controllers

### DIFF
--- a/app/controllers/teacher_interface/base_controller.rb
+++ b/app/controllers/teacher_interface/base_controller.rb
@@ -1,4 +1,18 @@
 module TeacherInterface
   class BaseController < ApplicationController
+    after_action :save_eligibility_check_id
+
+    def eligibility_check
+      @eligibility_check ||=
+        if session[:eligibility_check_id]
+          EligibilityCheck.find(session[:eligibility_check_id])
+        else
+          EligibilityCheck.new
+        end
+    end
+
+    def save_eligibility_check_id
+      session[:eligibility_check_id] = eligibility_check.id
+    end
   end
 end

--- a/app/controllers/teacher_interface/countries_controller.rb
+++ b/app/controllers/teacher_interface/countries_controller.rb
@@ -9,11 +9,9 @@ module TeacherInterface
     end
 
     def create
-      eligibility_check = EligibilityCheck.new
       @country_form =
         CountryForm.new(location_form_params.merge(eligibility_check:))
       if @country_form.save
-        session[:eligibility_check_id] = eligibility_check.id
         redirect_to @country_form.success_url
       else
         render :new

--- a/app/controllers/teacher_interface/degrees_controller.rb
+++ b/app/controllers/teacher_interface/degrees_controller.rb
@@ -5,11 +5,9 @@ module TeacherInterface
     end
 
     def create
-      eligibility_check = EligibilityCheck.new
       @degree_form =
         DegreeForm.new(degree_form_params.merge(eligibility_check:))
       if @degree_form.save
-        session[:eligibility_check_id] = eligibility_check.id
         redirect_to @degree_form.success_url
       else
         render :new

--- a/app/controllers/teacher_interface/misconduct_controller.rb
+++ b/app/controllers/teacher_interface/misconduct_controller.rb
@@ -5,7 +5,6 @@ module TeacherInterface
     end
 
     def create
-      eligibility_check = EligibilityCheck.find(session[:eligibility_check_id])
       @misconduct_form =
         MisconductForm.new(misconduct_params.merge(eligibility_check:))
       if @misconduct_form.save

--- a/app/controllers/teacher_interface/misconduct_controller.rb
+++ b/app/controllers/teacher_interface/misconduct_controller.rb
@@ -8,13 +8,7 @@ module TeacherInterface
       @misconduct_form =
         MisconductForm.new(misconduct_params.merge(eligibility_check:))
       if @misconduct_form.save
-        redirect_to(
-          if @misconduct_form.free_of_sanctions
-            teacher_interface_eligible_url
-          else
-            teacher_interface_ineligible_url
-          end
-        )
+        redirect_to @misconduct_form.success_url
       else
         render :new
       end

--- a/app/controllers/teacher_interface/pages_controller.rb
+++ b/app/controllers/teacher_interface/pages_controller.rb
@@ -1,12 +1,18 @@
 module TeacherInterface
   class PagesController < BaseController
+    before_action :load_eligibility_check
+
     def eligible
-      @eligibility_check = EligibilityCheck.find(session[:eligibility_check_id])
       session[:eligibility_check_complete] = true
     end
 
     def ineligible
-      @eligibility_check = EligibilityCheck.find(session[:eligibility_check_id])
+    end
+
+    private
+
+    def load_eligibility_check
+      @eligibility_check = eligibility_check
     end
   end
 end

--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -5,7 +5,6 @@ module TeacherInterface
     end
 
     def create
-      eligibility_check = EligibilityCheck.find(session[:eligibility_check_id])
       @qualification_form =
         QualificationForm.new(
           qualification_form_params.merge(eligibility_check:)

--- a/app/controllers/teacher_interface/recognised_controller.rb
+++ b/app/controllers/teacher_interface/recognised_controller.rb
@@ -8,13 +8,7 @@ module TeacherInterface
       @recognised_form =
         RecognisedForm.new(recognised_form_params.merge(eligibility_check:))
       if @recognised_form.save
-        redirect_to(
-          if @recognised_form.recognised
-            teacher_interface_misconduct_url
-          else
-            teacher_interface_ineligible_url
-          end
-        )
+        redirect_to @recognised_form.success_url
       else
         render :new
       end

--- a/app/controllers/teacher_interface/recognised_controller.rb
+++ b/app/controllers/teacher_interface/recognised_controller.rb
@@ -5,11 +5,9 @@ module TeacherInterface
     end
 
     def create
-      eligibility_check = EligibilityCheck.new
       @recognised_form =
         RecognisedForm.new(recognised_form_params.merge(eligibility_check:))
       if @recognised_form.save
-        session[:eligibility_check_id] = eligibility_check.id
         redirect_to(
           if @recognised_form.recognised
             teacher_interface_misconduct_url

--- a/app/controllers/teacher_interface/teach_children_controller.rb
+++ b/app/controllers/teacher_interface/teach_children_controller.rb
@@ -10,13 +10,7 @@ module TeacherInterface
           teach_children_form_params.merge(eligibility_check:)
         )
       if @teach_children_form.save
-        redirect_to(
-          if @teach_children_form.teach_children
-            teacher_interface_recognised_url
-          else
-            teacher_interface_ineligible_url
-          end
-        )
+        redirect_to @teach_children_form.success_url
       else
         render :new
       end

--- a/app/controllers/teacher_interface/teach_children_controller.rb
+++ b/app/controllers/teacher_interface/teach_children_controller.rb
@@ -5,7 +5,6 @@ module TeacherInterface
     end
 
     def create
-      eligibility_check = EligibilityCheck.find(session[:eligibility_check_id])
       @teach_children_form =
         TeachChildrenForm.new(
           teach_children_form_params.merge(eligibility_check:)

--- a/app/forms/misconduct_form.rb
+++ b/app/forms/misconduct_form.rb
@@ -18,4 +18,18 @@ class MisconductForm
     eligibility_check.free_of_sanctions = free_of_sanctions
     eligibility_check.save!
   end
+
+  def eligible?
+    eligibility_check.free_of_sanctions
+  end
+
+  def success_url
+    unless eligible?
+      return(
+        Rails.application.routes.url_helpers.teacher_interface_ineligible_path
+      )
+    end
+
+    Rails.application.routes.url_helpers.teacher_interface_eligible_path
+  end
 end

--- a/app/forms/qualification_form.rb
+++ b/app/forms/qualification_form.rb
@@ -18,8 +18,12 @@ class QualificationForm
     eligibility_check.save!
   end
 
+  def eligible?
+    eligibility_check.qualification
+  end
+
   def success_url
-    if qualification
+    if eligible?
       return(
         Rails
           .application

--- a/app/forms/recognised_form.rb
+++ b/app/forms/recognised_form.rb
@@ -17,4 +17,18 @@ class RecognisedForm
     eligibility_check.recognised = recognised
     eligibility_check.save!
   end
+
+  def eligible?
+    eligibility_check.recognised
+  end
+
+  def success_url
+    unless eligible?
+      return(
+        Rails.application.routes.url_helpers.teacher_interface_ineligible_path
+      )
+    end
+
+    Rails.application.routes.url_helpers.teacher_interface_misconduct_path
+  end
 end

--- a/app/forms/teach_children_form.rb
+++ b/app/forms/teach_children_form.rb
@@ -17,4 +17,18 @@ class TeachChildrenForm
     eligibility_check.teach_children = teach_children
     eligibility_check.save!
   end
+
+  def eligible?
+    eligibility_check.teach_children
+  end
+
+  def success_url
+    unless eligible?
+      return(
+        Rails.application.routes.url_helpers.teacher_interface_ineligible_path
+      )
+    end
+
+    Rails.application.routes.url_helpers.teacher_interface_recognised_path
+  end
 end

--- a/lib/generators/form/templates/form_controller.erb
+++ b/lib/generators/form/templates/form_controller.erb
@@ -5,7 +5,6 @@ module TeacherInterface
     end
 
     def create
-      eligibility_check = EligibilityCheck.find(session[:eligibility_check_id])
       @<%= model_resource_name %>_form = <%= class_name %>Form.new(<%= model_resource_name %>_form_params.merge(eligibility_check:))
       if @<%= model_resource_name %>_form.save
         redirect_to @<%= model_resource_name %>_form.success_url


### PR DESCRIPTION
Depends on #43 

This moves common logic related to the eligibility check model in to the base controller so it's loaded and saved in the same way. Also adds a `success_url` to all the forms so they have a consistent interface and the controllers are all interacting with the form in the same way, allowing us to make the controllers more generic in the future.
