### PR TITLE
Add basic healthcheck endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "rails", "~> 7.0.3"
 gem "bootsnap", require: false
 gem "cssbundling-rails"
 gem "jsbundling-rails"
+gem "okcomputer"
 gem "pg"
 gem "propshaft"
 gem "puma", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
+    okcomputer (1.18.4)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -350,6 +351,7 @@ DEPENDENCIES
   govuk_design_system_formbuilder
   govuk_markdown
   jsbundling-rails
+  okcomputer
   pg
   prettier_print
   propshaft

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,6 @@
+OkComputer.mount_at = "healthcheck"
+
+OkComputer::Registry.register "postgresql", OkComputer::ActiveRecordCheck.new
+OkComputer::Registry.register "version", OkComputer::AppVersionCheck.new
+
+OkComputer.make_optional %w[version]

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "Healthcheck", type: :request do
+  it "responds successfully" do
+    get "/healthcheck"
+
+    expect(response).to have_http_status(:ok)
+  end
+end


### PR DESCRIPTION
This is necessary to get the service live, and is a dependency of #45.

I've set this up using the [okcomputer](https://github.com/sportngin/okcomputer) Gem.

[Trello Card](https://trello.com/c/1whoUAO4/451-health-endpoint-use-okcomputer-gem-this-time-around)