### PR TITLE
Group countries in to eligible, legacy or not eligible

### DIFF
--- a/app/controllers/teacher_interface/countries_controller.rb
+++ b/app/controllers/teacher_interface/countries_controller.rb
@@ -27,7 +27,7 @@ module TeacherInterface
       JSON.parse(File.read("public/location-autocomplete-canonical-list.json"))
 
     def location_form_params
-      params.require(:country_form).permit(:country_code)
+      params.require(:country_form).permit(:location)
     end
 
     def locations

--- a/app/controllers/teacher_interface/countries_controller.rb
+++ b/app/controllers/teacher_interface/countries_controller.rb
@@ -12,7 +12,7 @@ module TeacherInterface
       @country_form =
         CountryForm.new(location_form_params.merge(eligibility_check:))
       if @country_form.save
-        redirect_to @country_form.success_url
+        redirect_to @country_form.success_url, allow_other_host: true
       else
         render :new
       end

--- a/app/forms/country_form.rb
+++ b/app/forms/country_form.rb
@@ -13,17 +13,13 @@ class CountryForm
     eligibility_check.save!
   end
 
-  def eligible?
-    eligibility_check.country_code != "INELIGIBLE"
-  end
-
   def success_url
-    unless eligible?
-      return(
-        Rails.application.routes.url_helpers.teacher_interface_ineligible_path
-      )
+    if eligibility_check.eligible_country_code?
+      Rails.application.routes.url_helpers.teacher_interface_degree_path
+    elsif eligibility_check.legacy_country_code?
+      "https://teacherservices.education.gov.uk/MutualRecognition/"
+    else
+      Rails.application.routes.url_helpers.teacher_interface_ineligible_path
     end
-
-    Rails.application.routes.url_helpers.teacher_interface_degree_path
   end
 end

--- a/app/forms/country_form.rb
+++ b/app/forms/country_form.rb
@@ -1,15 +1,15 @@
 class CountryForm
   include ActiveModel::Model
 
-  attr_accessor :country_code, :eligibility_check
+  attr_accessor :location, :eligibility_check
 
-  validates :country_code, presence: true
+  validates :location, presence: true
   validates :eligibility_check, presence: true
 
   def save
     return false unless valid?
 
-    eligibility_check.country_code = country_code
+    eligibility_check.country_code = location.split(":")[1]
     eligibility_check.save!
   end
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,16 +4,14 @@ import openregisterLocationPicker from "govuk-country-and-territory-autocomplete
 initAll();
 
 const loadCountryAutoComplete = () => {
-  let countryPicker = document.getElementById(
-    "country-form-country-code-field"
-  );
-  countryPicker ??= document.getElementById(
-    "country-form-country-code-field-error"
+  let locationPicker = document.getElementById("country-form-location-field");
+  locationPicker ??= document.getElementById(
+    "country-form-location-field-error"
   );
 
-  if (countryPicker) {
+  if (locationPicker) {
     openregisterLocationPicker({
-      selectElement: countryPicker,
+      selectElement: locationPicker,
       url: "/teacher/locations.json",
     });
   }

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -19,8 +19,22 @@ class EligibilityCheck < ApplicationRecord
     return :teach_children unless teach_children.nil? || teach_children
     return :qualification unless qualification.nil? || qualification
     return :degree unless degree.nil? || degree
-    return :country if !country_code.nil? && country_code == "INELIGIBLE"
+    if !country_code.nil? && !eligible_country_code? && !legacy_country_code?
+      return :country
+    end
 
     nil
   end
+
+  def eligible_country_code?
+    ELIGIBLE_COUNTRY_CODES.include?(country_code)
+  end
+
+  def legacy_country_code?
+    LEGACY_COUNTRY_CODES.include?(country_code)
+  end
+
+  ELIGIBLE_COUNTRY_CODES = ["GB"].freeze
+
+  LEGACY_COUNTRY_CODES = ["FR"].freeze
 end

--- a/app/views/teacher_interface/countries/new.html.erb
+++ b/app/views/teacher_interface/countries/new.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @country_form, url: teacher_interface_countries_url, method: :post do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_select :country_code, options_for_select(locations),
+      <%= f.govuk_select :location, options_for_select(locations),
             hint: { text: "This means you have all the qualifications needed to teach in a state school. You'll need to provide evidence of this if you apply for QTS." },
             label: { size: 'xl', text: "Where are you currently recognised as a teacher?" },
             options: { include_blank: true }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,7 +26,7 @@ en:
               inclusion: Tell us if you have a degree
         country_form:
           attributes:
-            country_code:
+            location:
               blank: Tell us where you are currently recognised as a teacher
         misconduct_form:
           attributes:

--- a/spec/forms/country_form_spec.rb
+++ b/spec/forms/country_form_spec.rb
@@ -3,14 +3,16 @@ require "rails_helper"
 RSpec.describe CountryForm, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:eligibility_check) }
-    it { is_expected.to validate_presence_of(:country_code) }
+    it { is_expected.to validate_presence_of(:location) }
   end
 
   describe "#valid?" do
     subject(:valid) { form.valid? }
 
     let(:eligibility_check) { EligibilityCheck.new }
-    let(:form) { described_class.new(eligibility_check:, country_code: "GB") }
+    let(:form) do
+      described_class.new(eligibility_check:, location: "country:GB")
+    end
 
     it { is_expected.to be_truthy }
   end
@@ -19,7 +21,9 @@ RSpec.describe CountryForm, type: :model do
     subject(:save!) { form.save }
 
     let(:eligibility_check) { EligibilityCheck.new }
-    let(:form) { described_class.new(eligibility_check:, country_code: "GB") }
+    let(:form) do
+      described_class.new(eligibility_check:, location: "country:GB")
+    end
 
     it "saves the eligibility check" do
       save!

--- a/spec/forms/country_form_spec.rb
+++ b/spec/forms/country_form_spec.rb
@@ -30,4 +30,35 @@ RSpec.describe CountryForm, type: :model do
       expect(eligibility_check.country_code).to eq("GB")
     end
   end
+
+  describe "#success_url" do
+    subject(:success_url) { form.success_url }
+
+    let(:eligibility_check) { EligibilityCheck.new }
+    let(:form) { described_class.new(eligibility_check:) }
+
+    before { eligibility_check.country_code = country_code }
+
+    context "with an eligible country" do
+      let(:country_code) { "GB" }
+
+      it { is_expected.to eq("/teacher/degree") }
+    end
+
+    context "with a legacy country" do
+      let(:country_code) { "FR" }
+
+      it do
+        is_expected.to eq(
+          "https://teacherservices.education.gov.uk/MutualRecognition/"
+        )
+      end
+    end
+
+    context "with a non-eligible country" do
+      let(:country_code) { "ES" }
+
+      it { is_expected.to eq("/teacher/ineligible") }
+    end
+  end
 end

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -15,10 +15,10 @@
 require "rails_helper"
 
 RSpec.describe EligibilityCheck, type: :model do
+  let(:eligibility_check) { EligibilityCheck.new }
+
   describe "#ineligible_reason" do
     subject(:ineligible_reason) { eligibility_check.ineligible_reason }
-
-    let(:eligibility_check) { EligibilityCheck.new }
 
     context "when free_of_sanctions is true" do
       before { eligibility_check.free_of_sanctions = true }
@@ -90,6 +90,40 @@ RSpec.describe EligibilityCheck, type: :model do
       before { eligibility_check.country_code = "INELIGIBLE" }
 
       it { is_expected.to eq(:country) }
+    end
+  end
+
+  describe "#eligible_country_code?" do
+    subject(:eligible_country_code?) do
+      eligibility_check.eligible_country_code?
+    end
+
+    context "when country_code is eligible" do
+      before { eligibility_check.country_code = "GB" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when country_code is not eligible" do
+      before { eligibility_check.country_code = "ES" }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#legacy_country_code?" do
+    subject(:legacy_country_code?) { eligibility_check.legacy_country_code? }
+
+    context "when country_code is legacy" do
+      before { eligibility_check.country_code = "FR" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when country_code is not legacy" do
+      before { eligibility_check.country_code = "ES" }
+
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -139,15 +139,15 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def when_i_select_a_country
-    fill_in "country-form-country-code-field", with: "United Kingdom"
+    fill_in "country-form-location-field", with: "United Kingdom"
   end
 
   def when_i_select_a_country_in_the_error_state
-    fill_in "country-form-country-code-field-error", with: "United Kingdom"
+    fill_in "country-form-location-field-error", with: "United Kingdom"
   end
 
   def when_i_select_an_ineligible_country
-    select "Other", from: "country-form-country-code-field"
+    select "Other", from: "country-form-location-field"
   end
 
   def when_i_visit_the_start_page

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -38,7 +38,14 @@ RSpec.describe "Eligibility check", type: :system do
 
   it "ineligible paths" do
     when_i_visit_the_start_page
+
     when_i_press_continue
+    when_i_select_an_ineligible_country
+    and_i_submit
+    then_i_see_the_ineligible_page
+    and_i_see_the_ineligible_country_text
+
+    when_i_press_back
     when_i_select_a_country
     and_i_submit
     when_i_choose_no
@@ -88,6 +95,14 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_select_a_country_in_the_error_state
     and_i_submit
     then_i_see_the_degree_page
+  end
+
+  it "sends legacy users to the old service" do
+    when_i_visit_the_start_page
+    when_i_press_continue
+    when_i_select_a_legacy_country
+    and_i_submit
+    then_i_see_the_legacy_service
   end
 
   it "service is closed" do
@@ -147,7 +162,11 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def when_i_select_an_ineligible_country
-    select "Other", from: "country-form-location-field"
+    fill_in "country-form-location-field", with: "Spain"
+  end
+
+  def when_i_select_a_legacy_country
+    fill_in "country-form-location-field", with: "France"
   end
 
   def when_i_visit_the_start_page
@@ -203,6 +222,10 @@ RSpec.describe "Eligibility check", type: :system do
     expect(page).to have_content(
       "You’re not eligible to apply for qualified teacher status (QTS) in England"
     )
+  end
+
+  def then_i_see_the_legacy_service
+    expect(page).to have_current_path("/MutualRecognition/")
   end
 
   def and_i_see_the_ineligible_country_text


### PR DESCRIPTION
This sends users to a different place depending on the country they pick. Eligible countries are sent through the checker, legacy countries are sent to the old service and the rest are marked as not eligible.

For now, I've hard coded the countries in the `EligibilityCheck` model, but in the future, as we have more customised functionality per country, we would want to build a database or have a static YAML file containing this information. I decided that would make sense to implement in a separate PR.

[Trello Card](https://trello.com/c/uAzoRaR7/461-split-countries-into-private-beta-ones-straight-to-dqt-ones-and-ineligible-ones)