### PR TITLE
Allow users to answer all questions before seeing results

### DIFF
--- a/app/forms/degree_form.rb
+++ b/app/forms/degree_form.rb
@@ -18,17 +18,7 @@ class DegreeForm
     eligibility_check.save!
   end
 
-  def eligible?
-    eligibility_check.degree
-  end
-
   def success_url
-    unless eligible?
-      return(
-        Rails.application.routes.url_helpers.teacher_interface_ineligible_path
-      )
-    end
-
     Rails.application.routes.url_helpers.teacher_interface_qualifications_path
   end
 end

--- a/app/forms/misconduct_form.rb
+++ b/app/forms/misconduct_form.rb
@@ -19,17 +19,11 @@ class MisconductForm
     eligibility_check.save!
   end
 
-  def eligible?
-    eligibility_check.free_of_sanctions
-  end
-
   def success_url
-    unless eligible?
-      return(
-        Rails.application.routes.url_helpers.teacher_interface_ineligible_path
-      )
+    if eligibility_check.eligible?
+      Rails.application.routes.url_helpers.teacher_interface_eligible_path
+    else
+      Rails.application.routes.url_helpers.teacher_interface_ineligible_path
     end
-
-    Rails.application.routes.url_helpers.teacher_interface_eligible_path
   end
 end

--- a/app/forms/qualification_form.rb
+++ b/app/forms/qualification_form.rb
@@ -18,21 +18,7 @@ class QualificationForm
     eligibility_check.save!
   end
 
-  def eligible?
-    eligibility_check.qualification
-  end
-
   def success_url
-    if eligible?
-      return(
-        Rails
-          .application
-          .routes
-          .url_helpers
-          .teacher_interface_teach_children_path
-      )
-    end
-
-    Rails.application.routes.url_helpers.teacher_interface_ineligible_path
+    Rails.application.routes.url_helpers.teacher_interface_teach_children_path
   end
 end

--- a/app/forms/recognised_form.rb
+++ b/app/forms/recognised_form.rb
@@ -18,17 +18,7 @@ class RecognisedForm
     eligibility_check.save!
   end
 
-  def eligible?
-    eligibility_check.recognised
-  end
-
   def success_url
-    unless eligible?
-      return(
-        Rails.application.routes.url_helpers.teacher_interface_ineligible_path
-      )
-    end
-
     Rails.application.routes.url_helpers.teacher_interface_misconduct_path
   end
 end

--- a/app/forms/teach_children_form.rb
+++ b/app/forms/teach_children_form.rb
@@ -18,17 +18,7 @@ class TeachChildrenForm
     eligibility_check.save!
   end
 
-  def eligible?
-    eligibility_check.teach_children
-  end
-
   def success_url
-    unless eligible?
-      return(
-        Rails.application.routes.url_helpers.teacher_interface_ineligible_path
-      )
-    end
-
     Rails.application.routes.url_helpers.teacher_interface_recognised_path
   end
 end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -15,12 +15,12 @@
 class EligibilityCheck < ApplicationRecord
   def ineligible_reasons
     [
-      !free_of_sanctions ? :misconduct : nil,
-      !recognised ? :recognised : nil,
-      !teach_children ? :teach_children : nil,
-      !qualification ? :qualification : nil,
+      !(eligible_country_code? || legacy_country_code?) ? :country : nil,
       !degree ? :degree : nil,
-      !(eligible_country_code? || legacy_country_code?) ? :country : nil
+      !qualification ? :qualification : nil,
+      !teach_children ? :teach_children : nil,
+      !recognised ? :recognised : nil,
+      !free_of_sanctions ? :misconduct : nil
     ].compact
   end
 

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -13,17 +13,19 @@
 #  updated_at        :datetime         not null
 #
 class EligibilityCheck < ApplicationRecord
-  def ineligible_reason
-    return :misconduct unless free_of_sanctions.nil? || free_of_sanctions
-    return :recognised unless recognised.nil? || recognised
-    return :teach_children unless teach_children.nil? || teach_children
-    return :qualification unless qualification.nil? || qualification
-    return :degree unless degree.nil? || degree
-    if !country_code.nil? && !eligible_country_code? && !legacy_country_code?
-      return :country
-    end
+  def ineligible_reasons
+    [
+      !free_of_sanctions ? :misconduct : nil,
+      !recognised ? :recognised : nil,
+      !teach_children ? :teach_children : nil,
+      !qualification ? :qualification : nil,
+      !degree ? :degree : nil,
+      !(eligible_country_code? || legacy_country_code?) ? :country : nil
+    ].compact
+  end
 
-    nil
+  def eligible?
+    ineligible_reasons.empty?
   end
 
   def eligible_country_code?

--- a/app/views/teacher_interface/pages/ineligible.html.erb
+++ b/app/views/teacher_interface/pages/ineligible.html.erb
@@ -5,9 +5,15 @@
     <h1 class="govuk-heading-xl">
       You’re not eligible to apply for qualified teacher status (QTS) in England
     </h1>
-    <% @eligibility_check.ineligible_reasons.each do |reason| %>
-      <p class="govuk-body"><%= I18n.t("activemodel.attributes.eligibility_check.ineligible_reason.#{reason}") %></p>
+
+    <% if @eligibility_check.ineligible_reasons.include?(:country) %>
+      <p class="govuk-body"><%= I18n.t("activemodel.attributes.eligibility_check.ineligible_reason.country") %></p>
+    <% else %>
+      <% @eligibility_check.ineligible_reasons.each do |reason| %>
+        <p class="govuk-body"><%= I18n.t("activemodel.attributes.eligibility_check.ineligible_reason.#{reason}") %></p>
+      <% end %>
     <% end %>
+
     <p class="govuk-body">You can find out <a href="https://getintoteaching.education.gov.uk/ways-to-train">how to train to become a teacher in England</a></p>
   </div>
 </div>

--- a/app/views/teacher_interface/pages/ineligible.html.erb
+++ b/app/views/teacher_interface/pages/ineligible.html.erb
@@ -5,7 +5,9 @@
     <h1 class="govuk-heading-xl">
       You’re not eligible to apply for qualified teacher status (QTS) in England
     </h1>
-    <p class="govuk-body"><%= I18n.t("activemodel.attributes.eligibility_check.ineligible_reason.#{@eligibility_check.ineligible_reason}") %></p>
+    <% @eligibility_check.ineligible_reasons.each do |reason| %>
+      <p class="govuk-body"><%= I18n.t("activemodel.attributes.eligibility_check.ineligible_reason.#{reason}") %></p>
+    <% end %>
     <p class="govuk-body">You can find out <a href="https://getintoteaching.education.gov.uk/ways-to-train">how to train to become a teacher in England</a></p>
   </div>
 </div>

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -17,79 +17,100 @@ require "rails_helper"
 RSpec.describe EligibilityCheck, type: :model do
   let(:eligibility_check) { EligibilityCheck.new }
 
-  describe "#ineligible_reason" do
-    subject(:ineligible_reason) { eligibility_check.ineligible_reason }
+  describe "#ineligible_reasons" do
+    subject(:ineligible_reasons) { eligibility_check.ineligible_reasons }
 
     context "when free_of_sanctions is true" do
       before { eligibility_check.free_of_sanctions = true }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to_not include(:misconduct) }
     end
 
     context "when free_of_sanctions is false" do
       before { eligibility_check.free_of_sanctions = false }
 
-      it { is_expected.to eq(:misconduct) }
+      it { is_expected.to include(:misconduct) }
     end
 
     context "when recognised is true" do
       before { eligibility_check.recognised = true }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to_not include(:recognised) }
     end
 
     context "when recognised is false" do
       before { eligibility_check.recognised = false }
 
-      it { is_expected.to eq(:recognised) }
+      it { is_expected.to include(:recognised) }
     end
 
     context "when teach_children is true" do
       before { eligibility_check.teach_children = true }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to_not include(:teach_children) }
     end
 
     context "when teach_children is false" do
       before { eligibility_check.teach_children = false }
 
-      it { is_expected.to eq(:teach_children) }
+      it { is_expected.to include(:teach_children) }
     end
 
     context "when qualification is true" do
       before { eligibility_check.qualification = true }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to_not include(:qualification) }
     end
 
     context "when qualification is false" do
       before { eligibility_check.qualification = false }
 
-      it { is_expected.to eq(:qualification) }
+      it { is_expected.to include(:qualification) }
     end
 
     context "when degree is true" do
       before { eligibility_check.degree = true }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to_not include(:degree) }
     end
 
     context "when degree is false" do
       before { eligibility_check.degree = false }
 
-      it { is_expected.to eq(:degree) }
+      it { is_expected.to include(:degree) }
     end
 
     context "when country_code is eligible" do
       before { eligibility_check.country_code = "GB" }
 
-      it { is_expected.to be_nil }
+      it { is_expected.to_not include(:country) }
     end
 
     context "when country_code is ineligible" do
       before { eligibility_check.country_code = "INELIGIBLE" }
 
-      it { is_expected.to eq(:country) }
+      it { is_expected.to include(:country) }
+    end
+  end
+
+  describe "#eligible?" do
+    subject(:eligible?) { eligibility_check.eligible? }
+
+    context "when not eligible" do
+      it { is_expected.to be false }
+    end
+
+    context "when eligible" do
+      before do
+        eligibility_check.free_of_sanctions = true
+        eligibility_check.recognised = true
+        eligibility_check.teach_children = true
+        eligibility_check.qualification = true
+        eligibility_check.degree = true
+        eligibility_check.country_code = "GB"
+      end
+
+      it { is_expected.to be true }
     end
   end
 

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -50,39 +50,27 @@ RSpec.describe "Eligibility check", type: :system do
     and_i_submit
     when_i_choose_no
     and_i_submit
+    then_i_see_the_qualification_page
+
+    when_i_choose_no
+    and_i_submit
+    then_i_see_the_teach_children_page
+
+    when_i_choose_no
+    and_i_submit
+    then_i_see_the_recognised_page
+
+    when_i_choose_no
+    and_i_submit
+    then_i_see_the_clean_record_page
+
+    when_i_choose_no
+    and_i_submit
     then_i_see_the_ineligible_page
     and_i_see_the_ineligible_degree_text
-
-    when_i_press_back
-    when_i_choose_yes
-    and_i_submit
-    when_i_choose_no
-    and_i_submit
-    then_i_see_the_ineligible_page
     and_i_see_the_ineligible_qualification_text
-
-    when_i_press_back
-    when_i_choose_yes
-    and_i_submit
-    when_i_choose_no
-    and_i_submit
-    then_i_see_the_ineligible_page
     and_i_see_the_ineligible_teach_children_text
-
-    when_i_press_back
-    when_i_choose_yes
-    and_i_submit
-    when_i_choose_no
-    and_i_submit
-    then_i_see_the_ineligible_page
     and_i_see_the_ineligible_recognised_text
-
-    when_i_press_back
-    when_i_choose_yes
-    and_i_submit
-    when_i_choose_no
-    and_i_submit
-    then_i_see_the_ineligible_page
     and_i_see_the_ineligible_misconduct_text
   end
 


### PR DESCRIPTION
At the moment users are kicked out of the flow the moment they answer a question which makes them not eligible. This changes that so instead they get to answer all the questions and at the end can see all the reasons which makes them ineligible. We think this is a better experience for users and allows us to get data on where users tend to become ineligible.

![Screenshot 2022-05-25 at 16 32 25](https://user-images.githubusercontent.com/510498/170306096-68abf61d-bef2-429c-92df-4b0cf23ee4e0.png)

I've left the content as it is, which at the moment reads a little weird, but we can change this when we've got designs for this page.

[Trello Card](https://trello.com/c/pJaChy2d/456-new-ineligible-page)