### PR TITLE
Add Country model

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
         run: yarn build && yarn build:css
 
       - name: Setup DB
-        run: bin/rails db:prepare
+        run: bin/rails db:test:prepare
 
       - name: Run tests
         run: bin/bundle exec rspec --format documentation

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ end
 group :test do
   gem "capybara", "~> 3.37"
   gem "cuprite", "~> 0.13"
+  gem "factory_bot_rails"
   gem "rspec"
   gem "rspec-rails"
   gem "shoulda-matchers", "~> 5.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,11 @@ GEM
     digest (3.1.0)
     e2mmap (0.1.0)
     erubi (1.10.0)
+    factory_bot (6.2.1)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     ferrum (0.11)
       addressable (~> 2.5)
       cliver (~> 0.3)
@@ -347,6 +352,7 @@ DEPENDENCIES
   cssbundling-rails
   cuprite (~> 0.13)
   debug
+  factory_bot_rails
   govuk-components
   govuk_design_system_formbuilder
   govuk_markdown

--- a/app/controllers/teacher_interface/countries_controller.rb
+++ b/app/controllers/teacher_interface/countries_controller.rb
@@ -23,15 +23,12 @@ module TeacherInterface
     LOCATION_AUTOCOMPLETE_GRAPH =
       JSON.parse(File.read("public/location-autocomplete-graph.json"))
 
-    LOCATION_AUTOCOMPLETE_CANONICAL_LIST =
-      JSON.parse(File.read("public/location-autocomplete-canonical-list.json"))
-
     def location_form_params
       params.require(:country_form).permit(:location)
     end
 
     def locations
-      LOCATION_AUTOCOMPLETE_CANONICAL_LIST
+      Country::LOCATION_AUTOCOMPLETE_CANONICAL_LIST
     end
 
     helper_method :locations

--- a/app/forms/country_form.rb
+++ b/app/forms/country_form.rb
@@ -14,12 +14,12 @@ class CountryForm
   end
 
   def success_url
-    if eligibility_check.country&.legacy
-      "https://teacherservices.education.gov.uk/MutualRecognition/"
-    elsif eligibility_check.country
-      Rails.application.routes.url_helpers.teacher_interface_degree_path
-    else
-      Rails.application.routes.url_helpers.teacher_interface_ineligible_path
-    end
+    {
+      eligible:
+        Rails.application.routes.url_helpers.teacher_interface_degree_path,
+      ineligible:
+        Rails.application.routes.url_helpers.teacher_interface_ineligible_path,
+      legacy: "https://teacherservices.education.gov.uk/MutualRecognition/"
+    }.fetch(eligibility_check.country_eligibility_status)
   end
 end

--- a/app/forms/country_form.rb
+++ b/app/forms/country_form.rb
@@ -14,10 +14,10 @@ class CountryForm
   end
 
   def success_url
-    if eligibility_check.eligible_country_code?
-      Rails.application.routes.url_helpers.teacher_interface_degree_path
-    elsif eligibility_check.legacy_country_code?
+    if eligibility_check.country&.legacy
       "https://teacherservices.education.gov.uk/MutualRecognition/"
+    elsif eligibility_check.country
+      Rails.application.routes.url_helpers.teacher_interface_degree_path
     else
       Rails.application.routes.url_helpers.teacher_interface_ineligible_path
     end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: countries
+#
+#  id         :bigint           not null, primary key
+#  code       :string           not null
+#  legacy     :boolean          default(FALSE), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_countries_on_code  (code) UNIQUE
+#
+class Country < ApplicationRecord
+  LOCATION_AUTOCOMPLETE_CANONICAL_LIST =
+    JSON.parse(File.read("public/location-autocomplete-canonical-list.json"))
+
+  COUNTRY_CODES =
+    LOCATION_AUTOCOMPLETE_CANONICAL_LIST.map { |row| row.last.split(":").last }
+
+  validates :code, inclusion: { in: COUNTRY_CODES }
+end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -15,7 +15,7 @@
 class EligibilityCheck < ApplicationRecord
   def ineligible_reasons
     [
-      !(eligible_country_code? || legacy_country_code?) ? :country : nil,
+      !country ? :country : nil,
       !degree ? :degree : nil,
       !qualification ? :qualification : nil,
       !teach_children ? :teach_children : nil,
@@ -28,15 +28,7 @@ class EligibilityCheck < ApplicationRecord
     ineligible_reasons.empty?
   end
 
-  def eligible_country_code?
-    ELIGIBLE_COUNTRY_CODES.include?(country_code)
+  def country
+    @country ||= Country.find_by(code: country_code)
   end
-
-  def legacy_country_code?
-    LEGACY_COUNTRY_CODES.include?(country_code)
-  end
-
-  ELIGIBLE_COUNTRY_CODES = ["GB"].freeze
-
-  LEGACY_COUNTRY_CODES = ["FR"].freeze
 end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -31,4 +31,10 @@ class EligibilityCheck < ApplicationRecord
   def country
     @country ||= Country.find_by(code: country_code)
   end
+
+  def country_eligibility_status
+    return :legacy if country&.legacy
+    return :eligible if country
+    :ineligible
+  end
 end

--- a/db/migrate/20220526062441_create_countries.rb
+++ b/db/migrate/20220526062441_create_countries.rb
@@ -1,0 +1,12 @@
+class CreateCountries < ActiveRecord::Migration[7.0]
+  def change
+    create_table :countries do |t|
+      t.string :code, null: false
+      t.boolean :legacy, null: false, default: false
+
+      t.timestamps
+    end
+
+    add_index :countries, :code, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_24_083728) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_26_062441) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "countries", force: :cascade do |t|
+    t.string "code", null: false
+    t.boolean "legacy", default: false, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["code"], name: "index_countries_on_code", unique: true
+  end
 
   create_table "eligibility_checks", force: :cascade do |t|
     t.boolean "free_of_sanctions"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,6 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+Country.create!(code: "GB")
+Country.create!(code: "FR", legacy: true)

--- a/spec/factories/country.rb
+++ b/spec/factories/country.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :country do
+    sequence :code, Country::COUNTRY_CODES.cycle
+
+    legacy { false }
+
+    trait :legacy do
+      legacy { true }
+    end
+  end
+end

--- a/spec/forms/country_form_spec.rb
+++ b/spec/forms/country_form_spec.rb
@@ -37,16 +37,16 @@ RSpec.describe CountryForm, type: :model do
     let(:eligibility_check) { EligibilityCheck.new }
     let(:form) { described_class.new(eligibility_check:) }
 
-    before { eligibility_check.country_code = country_code }
+    before { eligibility_check.country_code = country&.code }
 
     context "with an eligible country" do
-      let(:country_code) { "GB" }
+      let(:country) { create(:country) }
 
       it { is_expected.to eq("/teacher/degree") }
     end
 
     context "with a legacy country" do
-      let(:country_code) { "FR" }
+      let(:country) { create(:country, :legacy) }
 
       it do
         is_expected.to eq(
@@ -56,7 +56,7 @@ RSpec.describe CountryForm, type: :model do
     end
 
     context "with a non-eligible country" do
-      let(:country_code) { "ES" }
+      let(:country) { nil }
 
       it { is_expected.to eq("/teacher/ineligible") }
     end

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: countries
+#
+#  id         :bigint           not null, primary key
+#  code       :string           not null
+#  legacy     :boolean          default(FALSE), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_countries_on_code  (code) UNIQUE
+#
+require "rails_helper"
+
+RSpec.describe Country, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_inclusion_of(:code).in_array(%w[GB FR]) }
+    it { is_expected.to_not validate_inclusion_of(:code).in_array(%w[ABC]) }
+  end
+end

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -80,14 +80,16 @@ RSpec.describe EligibilityCheck, type: :model do
       it { is_expected.to include(:degree) }
     end
 
-    context "when country_code is eligible" do
-      before { eligibility_check.country_code = "GB" }
+    context "when country exists" do
+      let(:country) { create(:country) }
+
+      before { eligibility_check.country_code = country.code }
 
       it { is_expected.to_not include(:country) }
     end
 
-    context "when country_code is ineligible" do
-      before { eligibility_check.country_code = "INELIGIBLE" }
+    context "when country doesn't exist" do
+      before { eligibility_check.country_code = "ABC" }
 
       it { is_expected.to include(:country) }
     end
@@ -101,50 +103,36 @@ RSpec.describe EligibilityCheck, type: :model do
     end
 
     context "when eligible" do
+      let(:country) { create(:country) }
+
       before do
         eligibility_check.free_of_sanctions = true
         eligibility_check.recognised = true
         eligibility_check.teach_children = true
         eligibility_check.qualification = true
         eligibility_check.degree = true
-        eligibility_check.country_code = "GB"
+        eligibility_check.country_code = country.code
       end
 
       it { is_expected.to be true }
     end
   end
 
-  describe "#eligible_country_code?" do
-    subject(:eligible_country_code?) do
-      eligibility_check.eligible_country_code?
+  describe "#country" do
+    subject(:country) { eligibility_check.country }
+
+    context "when country_code exists" do
+      let(:country) { create(:country) }
+
+      before { eligibility_check.country_code = country.code }
+
+      it { is_expected.to eq(country) }
     end
 
-    context "when country_code is eligible" do
-      before { eligibility_check.country_code = "GB" }
+    context "when country_code doesn't exist" do
+      before { eligibility_check.country_code = "ABC" }
 
-      it { is_expected.to be true }
-    end
-
-    context "when country_code is not eligible" do
-      before { eligibility_check.country_code = "ES" }
-
-      it { is_expected.to be false }
-    end
-  end
-
-  describe "#legacy_country_code?" do
-    subject(:legacy_country_code?) { eligibility_check.legacy_country_code? }
-
-    context "when country_code is legacy" do
-      before { eligibility_check.country_code = "FR" }
-
-      it { is_expected.to be true }
-    end
-
-    context "when country_code is not legacy" do
-      before { eligibility_check.country_code = "ES" }
-
-      it { is_expected.to be false }
+      it { is_expected.to be_nil }
     end
   end
 end

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -135,4 +135,28 @@ RSpec.describe EligibilityCheck, type: :model do
       it { is_expected.to be_nil }
     end
   end
+
+  describe "#country_eligibility_status" do
+    subject(:country_eligibility_status) do
+      eligibility_check.country_eligibility_status
+    end
+
+    context "when the country exists" do
+      before { eligibility_check.country_code = create(:country).code }
+
+      it { is_expected.to eq(:eligible) }
+    end
+
+    context "when the country exists and is legacy" do
+      before { eligibility_check.country_code = create(:country, :legacy).code }
+
+      it { is_expected.to eq(:legacy) }
+    end
+
+    context "when the country doesn't exist" do
+      before { eligibility_check.country_code = "ABC" }
+
+      it { is_expected.to be(:ineligible) }
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -76,3 +76,5 @@ Shoulda::Matchers.configure do |config|
     with.library :rails
   end
 end
+
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,1 @@
+RSpec.configure { |config| config.include FactoryBot::Syntax::Methods }

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -2,7 +2,10 @@
 require "rails_helper"
 
 RSpec.describe "Eligibility check", type: :system do
-  before { given_the_service_is_open }
+  before do
+    given_countries_exist
+    given_the_service_is_open
+  end
 
   it "happy path" do
     when_i_visit_the_start_page
@@ -111,6 +114,11 @@ RSpec.describe "Eligibility check", type: :system do
 
   def and_i_submit
     click_button "Continue", visible: false
+  end
+
+  def given_countries_exist
+    create(:country, code: "GB")
+    create(:country, :legacy, code: "FR")
   end
 
   def given_the_service_is_closed


### PR DESCRIPTION
This introduces a new model to store information on the countries we support in the checker. At the moment this is used only to decide whether a user is eligible, and whether they should go through this service or end up at the legacy service.

In the future I imagine this model will include customised content to show the user on the final page, and we could build some support pages to allow admin staff to manage the list of countries.

Depends on #49 