### PR TITLE
Custom country content

### DIFF
--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -2,11 +2,12 @@
 #
 # Table name: countries
 #
-#  id         :bigint           not null, primary key
-#  code       :string           not null
-#  legacy     :boolean          default(FALSE), not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id               :bigint           not null, primary key
+#  code             :string           not null
+#  eligible_content :text             default(""), not null
+#  legacy           :boolean          default(FALSE), not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 # Indexes
 #

--- a/app/views/teacher_interface/pages/eligible.html.erb
+++ b/app/views/teacher_interface/pages/eligible.html.erb
@@ -5,9 +5,13 @@
     <h1 class="govuk-heading-xl">You might be eligible to apply for QTS</h1>
     <p class="govuk-body">Based on the information you've given, you can apply for QTS.</p>
 
+    <% if @eligibility_check.country.eligible_content.present? %>
+      <%= GovukMarkdown.render(@eligibility_check.country.eligible_content) %>
+    <% end %>
+
     <h2 class="govuk-heading-m">You can prepare to apply now</h2>
     <p class="govuk-body">
-      If you decide to apply, you'll need to provide a range of evidence. We'll ask you 
+      If you decide to apply, you'll need to provide a range of evidence. We'll ask you
       to upload some scans, photos, or original files, so it's useful to get these now.
     </p>
 

--- a/db/migrate/20220526073159_add_eligible_content_to_country.rb
+++ b/db/migrate/20220526073159_add_eligible_content_to_country.rb
@@ -1,0 +1,5 @@
+class AddEligibleContentToCountry < ActiveRecord::Migration[7.0]
+  def change
+    add_column :countries, :eligible_content, :text, null: false, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_26_062441) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_26_073159) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_26_062441) do
     t.boolean "legacy", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "eligible_content", default: "", null: false
     t.index ["code"], name: "index_countries_on_code", unique: true
   end
 

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -2,11 +2,12 @@
 #
 # Table name: countries
 #
-#  id         :bigint           not null, primary key
-#  code       :string           not null
-#  legacy     :boolean          default(FALSE), not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id               :bigint           not null, primary key
+#  code             :string           not null
+#  eligible_content :text             default(""), not null
+#  legacy           :boolean          default(FALSE), not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
 #
 # Indexes
 #

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def given_countries_exist
-    create(:country, code: "GB")
+    create(:country, code: "GB", eligible_content: "Custom eligible content.")
     create(:country, :legacy, code: "FR")
   end
 
@@ -211,6 +211,7 @@ RSpec.describe "Eligibility check", type: :system do
   def then_i_see_the_eligible_page
     expect(page).to have_current_path("/teacher/eligible")
     expect(page).to have_content("You might be eligible to apply for QTS")
+    expect(page).to have_content("Custom eligible content.")
   end
 
   def then_i_see_the_ineligible_page


### PR DESCRIPTION
This allows us to customise content per country and render that on the final eligible page.

**This is a proof of concept and shouldn't be merged until we're sure what custom fields we might need, and how they affect the design.**

Depends on #52 

[Trello Card](https://trello.com/c/qOIyeI66/462-update-eligibility-page-with-custom-content-based-on-the-selected-country)