### PR TITLE
Add model for regions

### DIFF
--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -13,6 +13,8 @@
 #  index_countries_on_code  (code) UNIQUE
 #
 class Country < ApplicationRecord
+  has_many :regions
+
   LOCATION_AUTOCOMPLETE_CANONICAL_LIST =
     JSON.parse(File.read("public/location-autocomplete-canonical-list.json"))
 

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: regions
+#
+#  id         :bigint           not null, primary key
+#  name       :string           default(""), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  country_id :bigint           not null
+#
+# Indexes
+#
+#  index_regions_on_country_id           (country_id)
+#  index_regions_on_country_id_and_name  (country_id,name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (country_id => countries.id)
+#
+class Region < ApplicationRecord
+  belongs_to :country
+
+  validates :name, uniqueness: { scope: :country_id }
+end

--- a/db/migrate/20220526104016_create_regions.rb
+++ b/db/migrate/20220526104016_create_regions.rb
@@ -1,0 +1,12 @@
+class CreateRegions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :regions do |t|
+      t.references :country, null: false, foreign_key: true
+      t.string :name, null: false, default: ""
+
+      t.timestamps
+    end
+
+    add_index :regions, %i[country_id name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_26_062441) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_26_104016) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,4 +41,14 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_26_062441) do
     t.index ["name"], name: "index_features_on_name", unique: true
   end
 
+  create_table "regions", force: :cascade do |t|
+    t.bigint "country_id", null: false
+    t.string "name", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
+    t.index ["country_id"], name: "index_regions_on_country_id"
+  end
+
+  add_foreign_key "regions", "countries"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,8 +6,188 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
-sct = Country.create!(code: "GB-SCT")
-sct.regions.create!
+COUNTRIES = {
+  AT: {
+  },
+  BE: {
+    regions: ["Flemish region", "French region", "German region"]
+  },
+  BG: {
+  },
+  HR: {
+  },
+  CY: {
+  },
+  CZ: {
+  },
+  DK: {
+  },
+  EE: {
+  },
+  FI: {
+  },
+  FR: {
+  },
+  DE: {
+    regions: [
+      "Baden-Wurttemberg",
+      "Bavaria",
+      "Berlin",
+      "Brandenburg",
+      "Bremen",
+      "Hamburg",
+      "Hessen",
+      "Lower Saxony",
+      "Mecklenburg-Vorpommern",
+      "Saxony-Anhalt",
+      "Schleswig-Holstein",
+      "Thuringia",
+      "North Rhine-Westphalia",
+      "Saxony",
+      "Rhineland-Palatinate",
+      "Saarland"
+    ]
+  },
+  GR: {
+  },
+  HU: {
+  },
+  IS: {
+  },
+  IT: {
+  },
+  LV: {
+  },
+  LI: {
+  },
+  LT: {
+  },
+  LU: {
+  },
+  MT: {
+  },
+  NL: {
+  },
+  NO: {
+  },
+  PL: {
+  },
+  IE: {
+  },
+  RO: {
+  },
+  SK: {
+  },
+  SI: {
+  },
+  ES: {
+  },
+  SE: {
+  },
+  CH: {
+  },
+  AU: {
+    regions: [
+      "Victoria",
+      "Queensland",
+      "Northern Territory",
+      "Western Australia",
+      "Tasmania",
+      "New South Wales",
+      "South Australia",
+      "Australian Capital Territory"
+    ]
+  },
+  CA: {
+    regions: [
+      "Ontario",
+      "Alberta",
+      "British Columbia",
+      "Manitoba",
+      "Nunavut",
+      "New Brunswick",
+      "Newfoundland and Labrador",
+      "Northwest Territories",
+      "Nova Scotia",
+      "Prince Edward Island",
+      "Quebec",
+      "Saskatchewan",
+      "Yukon"
+    ]
+  },
+  NZ: {
+  },
+  US: {
+    regions: [
+      "Alabama",
+      "Alaska",
+      "Arizona",
+      "Arkansas",
+      "California",
+      "Colorado",
+      "Connecticut",
+      "Delaware",
+      "Florida",
+      "Georgia",
+      "Hawaii",
+      "Idaho",
+      "Illinois",
+      "Indiana",
+      "Kentucky",
+      "Kansas",
+      "Louisiana",
+      "Maine",
+      "Iowa",
+      "Maryland",
+      "Massachusetts",
+      "Montana",
+      "Michigan",
+      "Minnesota",
+      "Mississippi",
+      "Missouri",
+      "Nebraska",
+      "Nevada",
+      "New Hampshire",
+      "New Jersey",
+      "New Mexico",
+      "New York",
+      "North Carolina",
+      "North Dakota",
+      "Ohio",
+      "Oklahoma",
+      "Oregon",
+      "Pennsylvania",
+      "Rhode Island",
+      "South Carolina",
+      "Tennessee",
+      "Texas",
+      "Utah",
+      "Vermont",
+      "Virginia",
+      "Washington",
+      "Washington DC",
+      "West Virginia",
+      "Wisonsin",
+      "Wyoming"
+    ]
+  },
+  GI: {
+  },
+  "GB-SCT": {
+  },
+  "GB-NIR": {
+  }
+}.freeze
 
-fr = Country.create!(code: "FR", legacy: true)
-fr.regions.create!
+COUNTRIES.each do |code, attributes|
+  legacy = attributes.fetch(:legacy, false)
+  regions = attributes.fetch(:regions, [])
+
+  country = Country.create!(code:, legacy:)
+
+  if regions.empty?
+    country.regions.create!
+  else
+    regions.each { |name| country.regions.create!(name:) }
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,5 +6,8 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
-Country.create!(code: "GB-SCT")
-Country.create!(code: "FR", legacy: true)
+sct = Country.create!(code: "GB-SCT")
+sct.regions.create!
+
+fr = Country.create!(code: "FR", legacy: true)
+fr.regions.create!

--- a/spec/factories/region.rb
+++ b/spec/factories/region.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :region do
+    association :country
+
+    sequence(:name) { |n| "Region #{n}" }
+
+    trait :national do
+      name { "" }
+    end
+  end
+end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: regions
+#
+#  id         :bigint           not null, primary key
+#  name       :string           default(""), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  country_id :bigint           not null
+#
+# Indexes
+#
+#  index_regions_on_country_id           (country_id)
+#  index_regions_on_country_id_and_name  (country_id,name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (country_id => countries.id)
+#
+require "rails_helper"
+
+RSpec.describe Region, type: :model do
+  subject(:region) { build(:region) }
+
+  describe "validations" do
+    it { is_expected.to validate_uniqueness_of(:name).scoped_to(:country_id) }
+  end
+end


### PR DESCRIPTION
This adds a new model which we'll use to represent the regions of a country. The checker hasn't been updated to use this model yet, but coming next will be a new question that asks the user which region they belong to (if there is more than one) and stores it on the `EligibilityCheck`.

See #56 for more information on the decisions around this.

[Trello Card](https://trello.com/c/7u9sFwI6/467-ask-users-for-their-state-when-selecting-certain-countries-like-canada-australia)