### PR TITLE
Send legacy countries to eligible page

### DIFF
--- a/app/forms/country_form.rb
+++ b/app/forms/country_form.rb
@@ -19,7 +19,8 @@ class CountryForm
         Rails.application.routes.url_helpers.teacher_interface_degree_path,
       ineligible:
         Rails.application.routes.url_helpers.teacher_interface_ineligible_path,
-      legacy: "https://teacherservices.education.gov.uk/MutualRecognition/"
+      legacy:
+        Rails.application.routes.url_helpers.teacher_interface_eligible_path
     }.fetch(eligibility_check.country_eligibility_status)
   end
 end

--- a/app/views/teacher_interface/pages/eligible.html.erb
+++ b/app/views/teacher_interface/pages/eligible.html.erb
@@ -7,11 +7,13 @@
 
     <h2 class="govuk-heading-m">You can prepare to apply now</h2>
     <p class="govuk-body">
-      If you decide to apply, you'll need to provide a range of evidence. We'll ask you 
+      If you decide to apply, you'll need to provide a range of evidence. We'll ask you
       to upload some scans, photos, or original files, so it's useful to get these now.
     </p>
 
     <h2 class="govuk-heading-m">You might need to provide translations</h2>
     <p class="govuk-body">If your documents are not in English, you’ll need to provide a certified translation of each one.</p>
+
+    <%= govuk_start_button(text: "Start now", href: "https://teacherservices.education.gov.uk/MutualRecognition/") %>
   </div>
 </div>

--- a/spec/forms/country_form_spec.rb
+++ b/spec/forms/country_form_spec.rb
@@ -48,11 +48,7 @@ RSpec.describe CountryForm, type: :model do
     context "with a legacy country" do
       let(:country) { create(:country, :legacy) }
 
-      it do
-        is_expected.to eq(
-          "https://teacherservices.education.gov.uk/MutualRecognition/"
-        )
-      end
+      it { is_expected.to eq("/teacher/eligible") }
     end
 
     context "with a non-eligible country" do

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -93,6 +93,9 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_press_continue
     when_i_select_a_legacy_country
     and_i_submit
+    then_i_see_the_eligible_page
+
+    when_i_press_start
     then_i_see_the_legacy_service
   end
 
@@ -147,6 +150,10 @@ RSpec.describe "Eligibility check", type: :system do
 
   def when_i_press_continue
     click_link "Continue"
+  end
+
+  def when_i_press_start
+    click_link "Start now"
   end
 
   def when_i_select_a_country


### PR DESCRIPTION
Then they will be able to press a start now button which takes them to the old service. This hasn't been signed off by design/content yet, so I imagine we might have some textual content changes that are required in the future.

I've decided to leave the system test as it is, but if it's problematic we can change it to look for the link rather than clicking the start button.

![Screenshot 2022-05-26 at 14 49 43](https://user-images.githubusercontent.com/510498/170501905-916903e4-909e-43c9-8914-fb6cea4dc5ed.png)