### PR TITLE
Add performance dashboard

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -10,3 +10,18 @@ ul.autocomplete__menu {
     font-family: $govuk-font-family;
   }
 }
+
+.app-\!-border-top-1 {
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.app-\!-colour--link {
+  color: $govuk-link-colour;
+}
+
+.app-performance-table {
+  .govuk-table__header:nth-child(n + 2),
+  .govuk-table__cell:nth-child(n + 2) {
+    text-align: right;
+  }
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,21 +1,32 @@
 class PagesController < ApplicationController
   def performance
+    since = 1.week.ago.beginning_of_day
+    until_days = 6
+    @since_text = "over the last 7 days"
+
+    if params.key? :since_launch
+      launch_date = Date.new(2022, 6, 1).beginning_of_day
+      since = launch_date
+      until_days = ((Time.zone.now.beginning_of_day - since) / (3600 * 24)).to_i
+      @since_text = "since launch"
+    end
+
     eligibility_checks =
-      EligibilityCheck.where(
-        created_at: 1.week.ago.beginning_of_day..Time.zone.now
-      ).group("date_trunc('day', created_at)")
+      EligibilityCheck.where(created_at: since..Time.zone.now).group(
+        "date_trunc('day', created_at)"
+      )
 
     eligibility_checks_total = eligibility_checks.count
 
     eligibility_checks_eligible = eligibility_checks.eligible.count
 
-    last_7_days = (0..6).map { |n| n.days.ago.beginning_of_day.utc }
+    last_n_days = (0..until_days).map { |n| n.days.ago.beginning_of_day.utc }
 
-    @checks_over_last_7_days = eligibility_checks_total.values.sum
+    @checks_over_last_n_days = eligibility_checks_total.values.sum
 
     @live_service_data = [%w[Date Requests]]
     @live_service_data +=
-      last_7_days.map do |day|
+      last_n_days.map do |day|
         [day.strftime("%d %B"), eligibility_checks_total[day] || 0]
       end
 
@@ -23,7 +34,7 @@ class PagesController < ApplicationController
 
     @submission_data = [["Date", "Successful checks"]]
     @submission_data +=
-      last_7_days.map do |day|
+      last_n_days.map do |day|
         [day.strftime("%d %B"), eligibility_checks_eligible[day] || 0]
       end
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,2 +1,30 @@
 class PagesController < ApplicationController
+  def performance
+    eligibility_checks =
+      EligibilityCheck.where(
+        created_at: 1.week.ago.beginning_of_day..Time.zone.now
+      ).group("date_trunc('day', created_at)")
+
+    eligibility_checks_total = eligibility_checks.count
+
+    eligibility_checks_eligible = eligibility_checks.eligible.count
+
+    last_7_days = (0..6).map { |n| n.days.ago.beginning_of_day.utc }
+
+    @checks_over_last_7_days = eligibility_checks_total.values.sum
+
+    @live_service_data = [%w[Date Requests]]
+    @live_service_data +=
+      last_7_days.map do |day|
+        [day.strftime("%d %B"), eligibility_checks_total[day] || 0]
+      end
+
+    @eligible_checks = eligibility_checks_eligible.values.sum
+
+    @submission_data = [["Date", "Successful checks"]]
+    @submission_data +=
+      last_7_days.map do |day|
+        [day.strftime("%d %B"), eligibility_checks_eligible[day] || 0]
+      end
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -37,5 +37,20 @@ class PagesController < ApplicationController
       last_n_days.map do |day|
         [day.strftime("%d %B"), eligibility_checks_eligible[day] || 0]
       end
+
+    eligibility_checks_by_country =
+      EligibilityCheck
+        .where(created_at: since..Time.zone.now)
+        .group("region")
+        .where.not(region: nil)
+        .count
+
+    @country_data = [%w[Country Requests]]
+    @country_data +=
+      eligibility_checks_by_country.map do |region, count|
+        [region.full_name, count]
+      end
+
+    @countries = eligibility_checks_by_country.count
   end
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -18,8 +18,14 @@ class Country < ApplicationRecord
   LOCATION_AUTOCOMPLETE_CANONICAL_LIST =
     JSON.parse(File.read("public/location-autocomplete-canonical-list.json"))
 
-  COUNTRY_CODES =
-    LOCATION_AUTOCOMPLETE_CANONICAL_LIST.map { |row| row.last.split(":").last }
+  COUNTRIES =
+    LOCATION_AUTOCOMPLETE_CANONICAL_LIST
+      .map { |row| [row.last.split(":").last, row.first] }
+      .to_h
 
-  validates :code, inclusion: { in: COUNTRY_CODES }
+  validates :code, inclusion: { in: COUNTRIES.keys }
+
+  def name
+    COUNTRIES.fetch(code)
+  end
 end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -20,6 +20,17 @@
 class EligibilityCheck < ApplicationRecord
   belongs_to :region, optional: true
 
+  scope :eligible,
+        -> {
+          where.not(region: nil).where(
+            degree: true,
+            qualification: true,
+            teach_children: true,
+            recognised: true,
+            free_of_sanctions: true
+          )
+        }
+
   def country_code=(value)
     super(value)
 

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -22,4 +22,10 @@ class Region < ApplicationRecord
   has_many :eligibility_checks
 
   validates :name, uniqueness: { scope: :country_id }
+
+  def full_name
+    string = country.name
+    string += " — #{name}" if name.present?
+    string
+  end
 end

--- a/app/views/pages/performance.html.erb
+++ b/app/views/pages/performance.html.erb
@@ -1,0 +1,68 @@
+<% content_for :page_title, 'Performance dashboard' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">
+        <%= t('service.name') %>
+      </span>
+      Performance dashboard
+    </h1>
+  </div>
+</div>
+
+<div class="app-!-border-top-1 govuk-!-padding-top-2">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Live service usage</h2>
+  <p class="govuk-!-font-size-16">
+    Number of eligibility checks submitted daily over the last 7 days
+  </p>
+
+  <div class="govuk-!-text-align-right">
+    <div style="display: inline-block">
+      <p class="govuk-!-font-size-48 govuk-!-margin-bottom-0 govuk-!-text-align-left govuk-!-font-weight-bold app-!-colour--link"><%= number_with_delimiter(@checks_over_last_7_days) %></p>
+      <p>eligibility checks over the last 7 days</p>
+    </div>
+  </div>
+
+  <%= govuk_table(rows: @live_service_data, classes: 'app-performance-table') %>
+</div>
+
+<div class="app-!-border-top-1 govuk-!-padding-top-2">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Submission results</h2>
+  <p class="govuk-!-font-size-16">
+    Number of successful checks over the last 7 days
+  </p>
+
+  <div class="govuk-!-text-align-right">
+    <div style="display: inline-block">
+      <p class="govuk-!-font-size-48 govuk-!-margin-bottom-0 govuk-!-text-align-left govuk-!-font-weight-bold app-!-colour--link"><%= number_with_delimiter(@eligible_checks) %></p>
+      <p>successful checks found over the last 7 days</p>
+    </div>
+  </div>
+
+  <%= govuk_table(rows: @submission_data, classes: 'app-performance-table') %>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">Visit this service</h2>
+    <p class="govuk-heading-m">
+      <%= govuk_link_to t('service.name'), teacher_interface_start_path %>
+    </p>
+
+    <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">Ministerial department:</h2>
+    <p class="govuk-heading-m">
+      Department for Education
+    </p>
+
+    <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">User:</h2>
+    <p class="govuk-heading-m">
+      Individuals
+    </p>
+
+    <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">Service costs paid by:</h2>
+    <p class="govuk-heading-m">
+      Department budget
+    </p>
+  </div>
+</div>

--- a/app/views/pages/performance.html.erb
+++ b/app/views/pages/performance.html.erb
@@ -14,13 +14,13 @@
 <div class="app-!-border-top-1 govuk-!-padding-top-2">
   <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Live service usage</h2>
   <p class="govuk-!-font-size-16">
-    Number of eligibility checks submitted daily over the last 7 days
+    Number of eligibility checks submitted daily <%= @since_text %>
   </p>
 
   <div class="govuk-!-text-align-right">
     <div style="display: inline-block">
-      <p class="govuk-!-font-size-48 govuk-!-margin-bottom-0 govuk-!-text-align-left govuk-!-font-weight-bold app-!-colour--link"><%= number_with_delimiter(@checks_over_last_7_days) %></p>
-      <p>eligibility checks over the last 7 days</p>
+      <p class="govuk-!-font-size-48 govuk-!-margin-bottom-0 govuk-!-text-align-left govuk-!-font-weight-bold app-!-colour--link"><%= number_with_delimiter(@checks_over_last_n_days) %></p>
+      <p>eligibility checks submitted <%= @since_text %></p>
     </div>
   </div>
 
@@ -30,13 +30,13 @@
 <div class="app-!-border-top-1 govuk-!-padding-top-2">
   <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Submission results</h2>
   <p class="govuk-!-font-size-16">
-    Number of successful checks over the last 7 days
+    Number of successful checks submitted <%= @since_text %>
   </p>
 
   <div class="govuk-!-text-align-right">
     <div style="display: inline-block">
       <p class="govuk-!-font-size-48 govuk-!-margin-bottom-0 govuk-!-text-align-left govuk-!-font-weight-bold app-!-colour--link"><%= number_with_delimiter(@eligible_checks) %></p>
-      <p>successful checks found over the last 7 days</p>
+      <p>successful checks submitted <%= @since_text %></p>
     </div>
   </div>
 

--- a/app/views/pages/performance.html.erb
+++ b/app/views/pages/performance.html.erb
@@ -43,6 +43,22 @@
   <%= govuk_table(rows: @submission_data, classes: 'app-performance-table') %>
 </div>
 
+<div class="app-!-border-top-1 govuk-!-padding-top-2">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Country usage</h2>
+  <p class="govuk-!-font-size-16">
+    Number of eligibility checks submitted by country <%= @since_text %>
+  </p>
+
+  <div class="govuk-!-text-align-right">
+    <div style="display: inline-block">
+      <p class="govuk-!-font-size-48 govuk-!-margin-bottom-0 govuk-!-text-align-left govuk-!-font-weight-bold app-!-colour--link"><%= number_with_delimiter(@countries) %></p>
+      <p>countries</p>
+    </div>
+  </div>
+
+  <%= govuk_table(rows: @country_data, classes: 'app-performance-table') %>
+</div>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">Visit this service</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,7 @@ Rails.application.routes.draw do
   end
 
   get "cookies", to: "static#cookies"
+  get "performance", to: "pages#performance"
 
   root to: redirect("/teacher/start")
 end

--- a/spec/factories/country.rb
+++ b/spec/factories/country.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :country do
-    sequence :code, Country::COUNTRY_CODES.cycle
+    sequence :code, Country::COUNTRIES.keys.cycle
 
     legacy { false }
 

--- a/spec/factories/eligibility_check.rb
+++ b/spec/factories/eligibility_check.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  factory :eligibility_check do
+    country_code { nil }
+    degree { nil }
+    free_of_sanctions { nil }
+    qualification { nil }
+    recognised { nil }
+    teach_children { nil }
+
+    trait :eligible do
+      association :region
+      degree { true }
+      free_of_sanctions { true }
+      qualification { true }
+      recognised { true }
+      teach_children { true }
+
+      after(:create) do |eligiblity_check, _evaluator|
+        eligiblity_check.country_code = eligiblity_check.region.country.code
+      end
+    end
+  end
+end

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -19,4 +19,12 @@ RSpec.describe Country, type: :model do
     it { is_expected.to validate_inclusion_of(:code).in_array(%w[GB-SCT FR]) }
     it { is_expected.to_not validate_inclusion_of(:code).in_array(%w[ABC]) }
   end
+
+  describe "#name" do
+    subject(:name) { country.name }
+
+    let(:country) { create(:country, code: "GB-SCT") }
+
+    it { is_expected.to eq("Scotland") }
+  end
 end

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -167,4 +167,14 @@ RSpec.describe EligibilityCheck, type: :model do
 
     it { is_expected.to eq([region_1, region_2]) }
   end
+
+  describe "#eligible" do
+    subject(:eligible) { described_class.eligible }
+
+    let(:eligibility_check_1) { create(:eligibility_check) }
+    let(:eligibility_check_2) { create(:eligibility_check, :eligible) }
+
+    it { is_expected.to_not include(eligibility_check_1) }
+    it { is_expected.to include(eligibility_check_2) }
+  end
 end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -25,4 +25,22 @@ RSpec.describe Region, type: :model do
   describe "validations" do
     it { is_expected.to validate_uniqueness_of(:name).scoped_to(:country_id) }
   end
+
+  describe "#full_name" do
+    subject(:full_name) { region.full_name }
+
+    let(:country) { create(:country, code: "GB-SCT") }
+
+    context "with a region" do
+      let(:region) { create(:region, country:, name: "Edinburgh") }
+
+      it { is_expected.to eq("Scotland — Edinburgh") }
+    end
+
+    context "with a nameless region" do
+      let(:region) { create(:region, :national, country:) }
+
+      it { is_expected.to eq("Scotland") }
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,7 +66,6 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.before(:each, type: :system) { driven_by(:cuprite) }
-  config.include ActiveSupport::Testing::TimeHelpers
   config.include ViewComponent::TestHelpers, type: :component
 end
 

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,1 @@
+RSpec.configure { |config| config.include ActiveSupport::Testing::TimeHelpers }

--- a/spec/system/performance_spec.rb
+++ b/spec/system/performance_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Performance", type: :system do
+  before { travel_to Date.new(2022, 4, 21) }
+
+  after { travel_back }
+
+  it "using the performance dashboard" do
+    given_the_service_is_open
+    given_there_are_a_few_eligibility_checks
+    when_i_visit_the_performance_page
+    then_i_see_the_live_stats
+  end
+
+  private
+
+  def given_the_service_is_open
+    FeatureFlag.activate(:service_open)
+  end
+
+  def given_there_are_a_few_eligibility_checks
+    (0..6).each.with_index do |n, i|
+      (i + 1).times do
+        create(:eligibility_check, :eligible, created_at: n.days.ago)
+      end
+    end
+  end
+
+  def when_i_visit_the_performance_page
+    visit performance_path
+  end
+
+  def then_i_see_the_live_stats
+    expect(page).to have_content("28\neligibility checks over the last 7 days")
+    expect(page).to have_content("21 April\t1")
+    expect(page).to have_content("15 April\t7")
+  end
+end

--- a/spec/system/performance_spec.rb
+++ b/spec/system/performance_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Performance", type: :system do
-  before { travel_to Date.new(2022, 4, 21) }
+  before { travel_to Date.new(2022, 6, 10) }
 
   after { travel_back }
 
@@ -10,6 +10,9 @@ RSpec.describe "Performance", type: :system do
     given_there_are_a_few_eligibility_checks
     when_i_visit_the_performance_page
     then_i_see_the_live_stats
+
+    when_i_visit_the_performance_page_since_launch
+    then_i_see_the_live_stats_since_launch
   end
 
   private
@@ -19,7 +22,7 @@ RSpec.describe "Performance", type: :system do
   end
 
   def given_there_are_a_few_eligibility_checks
-    (0..6).each.with_index do |n, i|
+    (0..8).each.with_index do |n, i|
       (i + 1).times do
         create(:eligibility_check, :eligible, created_at: n.days.ago)
       end
@@ -31,8 +34,22 @@ RSpec.describe "Performance", type: :system do
   end
 
   def then_i_see_the_live_stats
-    expect(page).to have_content("28\neligibility checks over the last 7 days")
-    expect(page).to have_content("21 April\t1")
-    expect(page).to have_content("15 April\t7")
+    expect(page).to have_content(
+      "36\neligibility checks submitted over the last 7 days"
+    )
+    expect(page).to have_content("10 June\t1")
+    expect(page).to have_content("4 June\t7")
+  end
+
+  def when_i_visit_the_performance_page_since_launch
+    visit performance_path(since_launch: true)
+  end
+
+  def then_i_see_the_live_stats_since_launch
+    expect(page).to have_content(
+      "45\neligibility checks submitted since launch"
+    )
+    expect(page).to have_content("10 June\t1")
+    expect(page).to have_content("2 June\t9")
   end
 end


### PR DESCRIPTION
This is heavily based on https://github.com/DFE-Digital/find-a-lost-trn/pull/165 and allows users to see the number of eligibility checks which have been performed over time.

<img width="820" alt="Screenshot 2022-05-27 at 12 15 56" src="https://user-images.githubusercontent.com/510498/170690192-42e46941-d300-4d89-ba75-84b0cb7f237c.png">

[Trello Card](https://trello.com/c/xpRT00DD/458-performance-page)