### PR TITLE
Track complete checks

### DIFF
--- a/app/controllers/teacher_interface/pages_controller.rb
+++ b/app/controllers/teacher_interface/pages_controller.rb
@@ -1,6 +1,7 @@
 module TeacherInterface
   class PagesController < BaseController
     before_action :load_eligibility_check
+    before_action :complete_eligibility_check, only: %i[eligible ineligible]
 
     def eligible
       session[:eligibility_check_complete] = true
@@ -10,6 +11,10 @@ module TeacherInterface
     end
 
     private
+
+    def complete_eligibility_check
+      @eligibility_check.complete!
+    end
 
     def load_eligibility_check
       @eligibility_check = eligibility_check

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_26_154413) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_27_101213) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_26_154413) do
     t.boolean "degree"
     t.string "country_code"
     t.bigint "region_id"
+    t.datetime "completed_at"
   end
 
   create_table "features", force: :cascade do |t|

--- a/spec/factories/eligibility_check.rb
+++ b/spec/factories/eligibility_check.rb
@@ -19,5 +19,13 @@ FactoryBot.define do
         eligiblity_check.country_code = eligiblity_check.region.country.code
       end
     end
+
+    trait :complete do
+      completed_at { Time.current }
+    end
+
+    trait :ineligible do
+      degree { false }
+    end
   end
 end

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -3,6 +3,7 @@
 # Table name: eligibility_checks
 #
 #  id                :bigint           not null, primary key
+#  completed_at      :datetime
 #  country_code      :string
 #  degree            :boolean
 #  free_of_sanctions :boolean
@@ -176,5 +177,37 @@ RSpec.describe EligibilityCheck, type: :model do
 
     it { is_expected.to_not include(eligibility_check_1) }
     it { is_expected.to include(eligibility_check_2) }
+  end
+
+  describe ".complete" do
+    subject(:complete) { described_class.complete }
+
+    let!(:incomplete_check) { create(:eligibility_check) }
+    let!(:complete_check) { create(:eligibility_check, :complete) }
+
+    it { is_expected.to eq([complete_check]) }
+  end
+
+  describe ".ineligible" do
+    subject(:ineligible) { described_class.ineligible }
+
+    let!(:ineligible_check) { create(:eligibility_check, :ineligible) }
+    let!(:eligible_check) { create(:eligibility_check, :eligible) }
+
+    it { is_expected.to eq([ineligible_check]) }
+  end
+
+  describe "#complete!" do
+    subject(:complete!) { eligibility_check.complete! }
+
+    let(:eligibility_check) { create(:eligibility_check, :eligible) }
+
+    it "sets the completed_at attribute" do
+      freeze_time do
+        expect { complete! }.to change(eligibility_check, :completed_at).from(
+          nil
+        ).to(Time.current)
+      end
+    end
   end
 end


### PR DESCRIPTION
We want a way of being able to tell whether someone completed an
eligibility check.

I considered storing this as multiple fields, to represent the different
states a check could be in, eg. eligible_at and ineligible_at.

This seemed like overkill and introduces slightly more complexity than
the simpler approach of storing the timestamp of when the person reached
either the eligible or ineligible page.

We can calculate the eligibility status from the existing fields, so
having multiple timestamp fields seemed redundant.

I also removed the session value representing when the flow was
completed. This was something we brought across from Find but isn't as
relevant to the check flow.

If, in the future, we do need to know if the final screen was displayed,
we can use the presence of the `completed_at` field to determine this.
