### PR TITLE
Add a completed state for an eligibility check

### DIFF
--- a/db/migrate/20220527101213_add_result_to_eligibility_check.rb
+++ b/db/migrate/20220527101213_add_result_to_eligibility_check.rb
@@ -1,0 +1,5 @@
+class AddResultToEligibilityCheck < ActiveRecord::Migration[7.0]
+  def change
+    add_column :eligibility_checks, :completed_at, :datetime
+  end
+end


### PR DESCRIPTION
In a previous change, I somehow missed adding the migration to add the
`completed_at` field.
