### PR TITLE
Add yarn to setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -17,6 +17,9 @@ FileUtils.chdir APP_ROOT do
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
 
+  puts "\n== Installing yarn dependencies =="
+  system! "yarn"
+
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")
   #   FileUtils.cp "config/database.yml.sample", "config/database.yml"


### PR DESCRIPTION
Running yarn is necessary to install JS dependencies.