### PR TITLE
Redirect to mutual recognition unless service can be started

### DIFF
--- a/app/controllers/teacher_interface/pages_controller.rb
+++ b/app/controllers/teacher_interface/pages_controller.rb
@@ -4,7 +4,7 @@ module TeacherInterface
     before_action :complete_eligibility_check, only: %i[eligible ineligible]
 
     MUTUAL_RECOGNITION_URL =
-      "https://teacherservices.education.gov.uk/MutualRecognition/"
+      "https://teacherservices.education.gov.uk/MutualRecognition/".freeze
 
     def root
       redirect_to teacher_interface_start_url

--- a/app/controllers/teacher_interface/pages_controller.rb
+++ b/app/controllers/teacher_interface/pages_controller.rb
@@ -3,7 +3,11 @@ module TeacherInterface
     before_action :load_eligibility_check
     before_action :complete_eligibility_check, only: %i[eligible ineligible]
 
+    MUTUAL_RECOGNITION_URL =
+      "https://teacherservices.education.gov.uk/MutualRecognition/"
+
     def eligible
+      @mutual_recognition_url = MUTUAL_RECOGNITION_URL
       session[:eligibility_check_complete] = true
     end
 

--- a/app/controllers/teacher_interface/pages_controller.rb
+++ b/app/controllers/teacher_interface/pages_controller.rb
@@ -7,7 +7,11 @@ module TeacherInterface
       "https://teacherservices.education.gov.uk/MutualRecognition/".freeze
 
     def root
-      redirect_to teacher_interface_start_url
+      if FeatureFlag.active?(:service_start)
+        redirect_to teacher_interface_start_url
+      else
+        redirect_to MUTUAL_RECOGNITION_URL, allow_other_host: true
+      end
     end
 
     def eligible

--- a/app/controllers/teacher_interface/pages_controller.rb
+++ b/app/controllers/teacher_interface/pages_controller.rb
@@ -1,10 +1,14 @@
 module TeacherInterface
   class PagesController < BaseController
-    before_action :load_eligibility_check
+    before_action :load_eligibility_check, except: %i[root]
     before_action :complete_eligibility_check, only: %i[eligible ineligible]
 
     MUTUAL_RECOGNITION_URL =
       "https://teacherservices.education.gov.uk/MutualRecognition/"
+
+    def root
+      redirect_to teacher_interface_start_url
+    end
 
     def eligible
       @mutual_recognition_url = MUTUAL_RECOGNITION_URL

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -3,13 +3,19 @@ class FeatureFlag
 
   attr_accessor :description, :name, :owner
 
-  PERMANENT_SETTINGS = [].freeze
+  PERMANENT_SETTINGS = [
+    [
+      :service_open,
+      "Allow users to access the service without HTTP basic auth",
+      "Felix Clack"
+    ]
+  ].freeze
 
   TEMPORARY_FEATURE_FLAGS = [
     [
-      :service_open,
-      "Allow users to access the service and check their eligibility",
-      "Felix Clack"
+      :service_start,
+      "Allow users to use the service, rather than being sent to the legacy mutual recognition site",
+      "Thomas Leese"
     ]
   ].freeze
 

--- a/app/views/teacher_interface/pages/eligible.html.erb
+++ b/app/views/teacher_interface/pages/eligible.html.erb
@@ -16,6 +16,6 @@
 
     <p class="govuk-body">You’ll make your application on the Teaching Regulation Agency website.</p>
 
-    <%= govuk_start_button(text: "Apply for QTS", href: "https://teacherservices.education.gov.uk/MutualRecognition/") %>
+    <%= govuk_start_button(text: "Apply for QTS", href: @mutual_recognition_url) %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   end
 
   namespace :teacher_interface, path: "/teacher" do
+    root to: "pages#root"
     get "degree", to: "degrees#new"
     post "degree", to: "degrees#create"
     get "countries", to: "countries#new"
@@ -34,8 +35,6 @@ Rails.application.routes.draw do
     get "misconduct", to: "misconduct#new"
     post "misconduct", to: "misconduct#create"
     get "locations", to: "countries#index"
-
-    root to: redirect("/teacher/start")
   end
 
   get "accessibility", to: "static#accessibility"

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Eligibility check", type: :system do
   before do
     given_countries_exist
     given_the_service_is_open
+    given_the_service_can_be_started
   end
 
   it "happy path" do
@@ -125,6 +126,13 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the_start_page
   end
 
+  it "service cannot be started" do
+    given_the_service_cannot_be_started
+    when_i_visit_the_start_page
+    then_i_do_not_see_the_start_page
+    then_i_see_the_legacy_service
+  end
+
   private
 
   def and_i_submit
@@ -146,6 +154,14 @@ RSpec.describe "Eligibility check", type: :system do
 
   def given_the_service_is_open
     FeatureFlag.activate(:service_open)
+  end
+
+  def given_the_service_cannot_be_started
+    FeatureFlag.deactivate(:service_start)
+  end
+
+  def given_the_service_can_be_started
+    FeatureFlag.activate(:service_start)
   end
 
   def when_i_am_authorized_as_a_support_user


### PR DESCRIPTION
This adds a new feature flag to determine if the service can be started, which means users will be taken to the start page, otherwise redirected to the legacy mutual recognition service.

This means `/teacher` becomes the entry point for the service, and users are either redirected to `/teacher/start` or the legacy mutual recognition service. I've decided _not_ to redirect users if the feature isn't on and they navigate directly to `/teacher/start` to make the service easy for us to access, but this decision could be up for discussion.

[Trello Card](https://trello.com/c/B6tT13Yz/495-set-up-redirect-to-mutualrecognition-behind-feature-flag)