### PR TITLE
Enable private beta countries

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -25,3 +25,7 @@ ul.autocomplete__menu {
     text-align: right;
   }
 }
+
+.app-teaching-authority-address {
+  white-space: pre-line;
+}

--- a/app/views/eligibility_interface/pages/eligible.html.erb
+++ b/app/views/eligibility_interface/pages/eligible.html.erb
@@ -68,15 +68,15 @@
         <p class="govuk-body">You’ll need to provide a <%= @region.teaching_authority_certificate %>, which you can obtain by contacting:</p>
 
         <% if @region.teaching_authority_address.present? %>
-          <p class="govuk-body"><%= @region.teaching_authority_address %></p>
+          <p class="govuk-body app-teaching-authority-address"><%= @region.teaching_authority_address %></p>
         <% end %>
 
         <% if @region.teaching_authority_website.present? %>
-          <p class="govuk-body"><%= @region.teaching_authority_website %></p>
+          <p class="govuk-body"><a class="govuk-link" href="<%= @region.teaching_authority_website %>"><%= @region.teaching_authority_website %></a></p>
         <% end %>
 
         <% if @region.teaching_authority_email_address.present? %>
-          <p class="govuk-body"><%= @region.teaching_authority_email_address %></p>
+          <p class="govuk-body"><a class="govuk-link" href="mailto:<%= @region.teaching_authority_email_address %>"><%= @region.teaching_authority_email_address %></a></p>
         <% end %>
 
         <p class="govuk-body">This must be dated within 3 months of you applying for QTS.</p>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,191 +7,145 @@
 #   Character.create(name: "Luke", movie: movies.first)
 
 COUNTRIES = {
-  AT: {
-  },
-  BE: {
-    regions: ["Flemish region", "French region", "German region"]
-  },
-  BG: {
-  },
-  HR: {
-  },
-  CY: {
-  },
-  CZ: {
-  },
-  DK: {
-  },
-  EE: {
-  },
-  FI: {
-  },
-  FR: {
-  },
-  DE: {
-    regions: [
-      "Baden-Wurttemberg",
-      "Bavaria",
-      "Berlin",
-      "Brandenburg",
-      "Bremen",
-      "Hamburg",
-      "Hessen",
-      "Lower Saxony",
-      "Mecklenburg-Vorpommern",
-      "Saxony-Anhalt",
-      "Schleswig-Holstein",
-      "Thuringia",
-      "North Rhine-Westphalia",
-      "Saxony",
-      "Rhineland-Palatinate",
-      "Saarland"
-    ]
-  },
-  GR: {
-  },
-  HU: {
-  },
-  IS: {
-  },
-  IT: {
-  },
-  LV: {
-  },
-  LI: {
-  },
-  LT: {
-  },
-  LU: {
-  },
-  MT: {
-  },
-  NL: {
-  },
-  NO: {
-  },
-  PL: {
-  },
-  PT: {
-  },
-  IE: {
-  },
-  RO: {
-  },
-  SK: {
-  },
-  SI: {
-  },
-  ES: {
-  },
-  SE: {
-  },
-  CH: {
-  },
-  AU: {
-    regions: [
-      "Victoria",
-      "Queensland",
-      "Northern Territory",
-      "Western Australia",
-      "Tasmania",
-      "New South Wales",
-      "South Australia",
-      "Australian Capital Territory"
-    ]
-  },
-  CA: {
-    regions: [
-      "Ontario",
-      "Alberta",
-      "British Columbia",
-      "Manitoba",
-      "Nunavut",
-      "New Brunswick",
-      "Newfoundland and Labrador",
-      "Northwest Territories",
-      "Nova Scotia",
-      "Prince Edward Island",
-      "Quebec",
-      "Saskatchewan",
-      "Yukon"
-    ]
-  },
-  NZ: {
-  },
-  US: {
-    regions: [
-      "Alabama",
-      "Alaska",
-      "Arizona",
-      "Arkansas",
-      "California",
-      "Colorado",
-      "Connecticut",
-      "Delaware",
-      "Florida",
-      "Georgia",
-      "Hawaii",
-      "Idaho",
-      "Illinois",
-      "Indiana",
-      "Kentucky",
-      "Kansas",
-      "Louisiana",
-      "Maine",
-      "Iowa",
-      "Maryland",
-      "Massachusetts",
-      "Montana",
-      "Michigan",
-      "Minnesota",
-      "Mississippi",
-      "Missouri",
-      "Nebraska",
-      "Nevada",
-      "New Hampshire",
-      "New Jersey",
-      "New Mexico",
-      "New York",
-      "North Carolina",
-      "North Dakota",
-      "Ohio",
-      "Oklahoma",
-      "Oregon",
-      "Pennsylvania",
-      "Rhode Island",
-      "South Carolina",
-      "Tennessee",
-      "Texas",
-      "Utah",
-      "Vermont",
-      "Virginia",
-      "Washington",
-      "Washington DC",
-      "West Virginia",
-      "Wisonsin",
-      "Wyoming"
-    ]
-  },
-  GI: {
-  },
-  "GB-SCT": {
-  },
-  "GB-NIR": {
-  }
+  AT: [],
+  BE: ["Flemish region", "French region", "German region"],
+  BG: [],
+  HR: [],
+  CY: [],
+  CZ: [],
+  DK: [],
+  EE: [],
+  FI: [],
+  FR: [],
+  DE: [
+    "Baden-Wurttemberg",
+    "Bavaria",
+    "Berlin",
+    "Brandenburg",
+    "Bremen",
+    "Hamburg",
+    "Hessen",
+    "Lower Saxony",
+    "Mecklenburg-Vorpommern",
+    "Saxony-Anhalt",
+    "Schleswig-Holstein",
+    "Thuringia",
+    "North Rhine-Westphalia",
+    "Saxony",
+    "Rhineland-Palatinate",
+    "Saarland"
+  ],
+  GR: [],
+  HU: [],
+  IS: [],
+  IT: [],
+  LV: [],
+  LI: [],
+  LT: [],
+  LU: [],
+  MT: [],
+  NL: [],
+  NO: [],
+  PL: [],
+  PT: [],
+  IE: [],
+  RO: [],
+  SK: [],
+  SI: [],
+  ES: [],
+  SE: [],
+  CH: [],
+  AU: [
+    "Victoria",
+    "Queensland",
+    "Northern Territory",
+    "Western Australia",
+    "Tasmania",
+    "New South Wales",
+    "South Australia",
+    "Australian Capital Territory"
+  ],
+  CA: [
+    "Ontario",
+    "Alberta",
+    "British Columbia",
+    "Manitoba",
+    "Nunavut",
+    "New Brunswick",
+    "Newfoundland and Labrador",
+    "Northwest Territories",
+    "Nova Scotia",
+    "Prince Edward Island",
+    "Quebec",
+    "Saskatchewan",
+    "Yukon"
+  ],
+  NZ: [],
+  US: [
+    "Alabama",
+    "Alaska",
+    "Arizona",
+    "Arkansas",
+    "California",
+    "Colorado",
+    "Connecticut",
+    "Delaware",
+    "Florida",
+    "Georgia",
+    "Hawaii",
+    "Idaho",
+    "Illinois",
+    "Indiana",
+    "Kentucky",
+    "Kansas",
+    "Louisiana",
+    "Maine",
+    "Iowa",
+    "Maryland",
+    "Massachusetts",
+    "Montana",
+    "Michigan",
+    "Minnesota",
+    "Mississippi",
+    "Missouri",
+    "Nebraska",
+    "Nevada",
+    "New Hampshire",
+    "New Jersey",
+    "New Mexico",
+    "New York",
+    "North Carolina",
+    "North Dakota",
+    "Ohio",
+    "Oklahoma",
+    "Oregon",
+    "Pennsylvania",
+    "Rhode Island",
+    "South Carolina",
+    "Tennessee",
+    "Texas",
+    "Utah",
+    "Vermont",
+    "Virginia",
+    "Washington",
+    "Washington DC",
+    "West Virginia",
+    "Wisonsin",
+    "Wyoming"
+  ],
+  GI: [],
+  "GB-SCT": [],
+  "GB-NIR": []
 }.freeze
 
-COUNTRIES.each do |code, attributes|
-  legacy = attributes.fetch(:legacy, false)
-  regions = attributes.fetch(:regions, [])
-
+COUNTRIES.each do |code, regions|
   country = Country.find_or_create_by!(code:)
 
   if regions.empty?
-    country.regions.find_or_create_by!(name: "").update!(legacy:)
+    country.regions.find_or_create_by!(name: "").update!(legacy: false)
   else
     regions.each do |name|
-      country.regions.find_or_create_by!(name:).update!(legacy:)
+      country.regions.find_or_create_by!(name:).update!(legacy: false)
     end
   end
 end

--- a/lib/tasks/countries.rake
+++ b/lib/tasks/countries.rake
@@ -1,0 +1,25 @@
+namespace :countries do
+  desc "Set up countries for the private beta (assumes the database has been seeded)"
+  task private_beta: :environment do
+    regions = [
+      { country_code: :IE }, # Republic of Ireland
+      { country_code: :PL }, # Poland
+      { country_code: :US, name: "Hawaii" }, # USA (Hawaii)
+      { country_code: :ES }, # Spain
+      { country_code: :CA, name: "British Columbia" }, # Canada (British Columbia)
+      { country_code: :CY } # Cyprus
+    ]
+
+    Region.where(legacy: false).update_all(legacy: true)
+
+    regions.each do |region_attributes|
+      country_code = region_attributes.fetch(:country_code)
+      name = region_attributes.fetch(:name, "")
+
+      region =
+        Region.joins(:country).find_by!(country: { code: country_code }, name:)
+
+      region.update!(legacy: false)
+    end
+  end
+end

--- a/lib/tasks/countries.rake
+++ b/lib/tasks/countries.rake
@@ -2,12 +2,53 @@ namespace :countries do
   desc "Set up countries for the private beta (assumes the database has been seeded)"
   task private_beta: :environment do
     regions = [
-      { country_code: :IE }, # Republic of Ireland
-      { country_code: :PL }, # Poland
-      { country_code: :US, name: "Hawaii" }, # USA (Hawaii)
-      { country_code: :ES }, # Spain
-      { country_code: :CA, name: "British Columbia" }, # Canada (British Columbia)
-      { country_code: :CY } # Cyprus
+      # Republic of Ireland
+      {
+        country_code: :IE,
+        sanction_check: :written,
+        status_check: :online,
+        teaching_authority_certificate: "Letter of Professional Standing",
+        teaching_authority_email_address: "info@teachingcouncil.ie",
+        teaching_authority_address:
+          "The Teaching Council\nBlock A\nMaynooth Business Campus\nMaynooth, Co. Kildare\nW23 Y7X0\nIreland"
+      },
+      # Poland
+      {
+        country_code: :PL,
+        sanction_check: :written,
+        status_check: :written,
+        teaching_authority_certificate: "Letter of Confirmation",
+        teaching_authority_email_address: "sekretariat.dko@mein.gov.pl",
+        teaching_authority_address:
+          "Ministry of Education and Science\nul. Aleja Jana Chrystiana Szucha 25\n00-918 Warsaw\nPoland"
+      },
+      # USA (Hawaii)
+      {
+        country_code: :US,
+        name: "Hawaii",
+        sanction_check: :online,
+        status_check: :online
+      },
+      # Spain
+      {
+        country_code: :ES,
+        sanction_check: :none,
+        status_check: :written,
+        teaching_authority_certificate: "Solicitud",
+        teaching_authority_address:
+          "Subdirectora General de Títulos y Ordenación\nSeguimiento y Gestión de las Enseñanzas Universitarias\n" \
+            "SECRETARÍA GENERAL DE UNIVERSIDADES\nMINISTERIO DE UNIVERSIDADES\n" \
+            "Paseo de la Castellana 162, planta 17\n28071 MADRID"
+      },
+      # Canada (British Columbia)
+      {
+        country_code: :CA,
+        name: "British Columbia",
+        sanction_check: :online,
+        status_check: :online
+      },
+      # Cyprus
+      { country_code: :CY, sanction_check: :none, status_check: :none }
     ]
 
     Region.where(legacy: false).update_all(legacy: true)
@@ -19,7 +60,9 @@ namespace :countries do
       region =
         Region.joins(:country).find_by!(country: { code: country_code }, name:)
 
-      region.update!(legacy: false)
+      region.update!(
+        region_attributes.except(:country_code, :name).merge(legacy: false)
+      )
     end
   end
 end


### PR DESCRIPTION
This simplifies the seed and adds a Rake task which enables the private beta countries. The steps to get the production database in the right state for the private beta are:

```sh
$ bundle exec rails db:seed
$ bundle exec rake countries:private_beta
```

I've decided _not_ to write tests for this Rake task as it will be short lived, but I'm happy to add some if people see a benefit to doing so. Once we've got a support interface to manage countries I imagine we will remove the task.