### PR TITLE
Only complete eligibility check if persisted

### DIFF
--- a/app/controllers/eligibility_interface/pages_controller.rb
+++ b/app/controllers/eligibility_interface/pages_controller.rb
@@ -26,7 +26,7 @@ module EligibilityInterface
     private
 
     def complete_eligibility_check
-      @eligibility_check.complete!
+      @eligibility_check.complete! if @eligibility_check.persisted?
     end
 
     def load_eligibility_check


### PR DESCRIPTION
This prevents a Sentry error from being recorded if someone where to navigate directly to the eligible page, for example.

[Sentry Issue](https://sentry.io/organizations/dfe-teacher-services/issues/3345259577/)