### PR TITLE
Switch to Redis 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ psql -d default
 > CREATE ROLE postgres LOGIN SUPERUSER;
 ```
 
-You'll also need to install Redis 7.x. The way to do this is different on
+You'll also need to install Redis 6.x. The way to do this is different on
 each operating system, but on macOS you can try the following:
 
 ```bash
-brew install redis@7
+brew install redis@6
 brew services start redis
 ```
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -51,7 +51,7 @@ variable "postgres_database_service_plan" {
 
 variable "redis_service_plan" {
   type    = string
-  default = "tiny-7_x"
+  default = "tiny-6_x"
 }
 
 locals {


### PR DESCRIPTION
The PaaS only supports Redis 6.0 as the latest version, so we can't use 7.0 yet.

```
│Error: Invalid index
│
│  on app.tf line 57, in resource "cloudfoundry_service_instance" "redis":
│  57:   service_plan = data.cloudfoundry_service.redis.service_plans[var.redis_service_plan]
│├────────────────
││data.cloudfoundry_service.redis.service_plans is map of string with 27 elements
││var.redis_service_plan is "tiny-7_x"
│
│The given key does not identify an element in this collection value.
```