### PR TITLE
Bump govuk-components and solargraph

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,7 +234,7 @@ GEM
     rbs (2.4.0)
     redcarpet (3.5.1)
     redis (4.6.0)
-    regexp_parser (2.4.0)
+    regexp_parser (2.5.0)
     reline (0.3.1)
       io-console (~> 0.5)
     reverse_markdown (2.1.1)
@@ -302,7 +302,7 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    solargraph (0.44.3)
+    solargraph (0.45.0)
       backport (~> 1.2)
       benchmark
       bundler (>= 1.17.2)
@@ -352,7 +352,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.27)
+    yard (0.9.28)
       webrick (~> 1.7.0)
     zeitwerk (2.5.4)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,8 +116,9 @@ GEM
       websocket-driver (>= 0.6, < 0.8)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govuk-components (3.0.3)
+    govuk-components (3.0.6)
       activemodel (>= 6.1)
+      html-attributes-utils (~> 0.9.0)
       railties (>= 6.1)
       view_component (~> 2.49.1)
     govuk_design_system_formbuilder (3.0.2)
@@ -131,6 +132,8 @@ GEM
     haml (5.2.2)
       temple (>= 0.8.0)
       tilt
+    html-attributes-utils (0.9.0)
+      activesupport (>= 6.1.4.4)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
@@ -144,7 +147,7 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    loofah (2.17.0)
+    loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -220,7 +223,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.2)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     railties (7.0.3)
       actionpack (= 7.0.3)
@@ -354,7 +357,7 @@ GEM
       nokogiri (~> 1.8)
     yard (0.9.28)
       webrick (~> 1.7.0)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   arm64-darwin-21


### PR DESCRIPTION
`govuk-components >= 3.0.5` includes [an accessibility fix for links that are styled as buttons](https://github.com/DFE-Digital/govuk-components/pull/326).

`solargraph` was nagging me to update it locally.