### PR TITLE
Add duration performance

### DIFF
--- a/app/controllers/performance_controller.rb
+++ b/app/controllers/performance_controller.rb
@@ -16,6 +16,8 @@ class PerformanceController < ApplicationController
     @eligible_checks, @submission_data = stats.submission_results
 
     @countries, @country_data = stats.country_usage
+
+    @duration_data = stats.duration_usage
   end
 
   def current_namespace

--- a/app/views/performance/index.html.erb
+++ b/app/views/performance/index.html.erb
@@ -59,6 +59,15 @@
   <%= govuk_table(rows: @country_data, classes: 'app-performance-table') %>
 </div>
 
+<div class="app-!-border-top-1 govuk-!-padding-top-2">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Time to complete</h2>
+  <p class="govuk-!-font-size-16">
+    How quickly did users check their eligibility <%= @since_text %>
+  </p>
+
+  <%= govuk_table(rows: @duration_data, classes: 'app-performance-table') %>
+</div>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">Visit this service</h2>

--- a/spec/lib/performance_stats_spec.rb
+++ b/spec/lib/performance_stats_spec.rb
@@ -37,4 +37,11 @@ RSpec.describe PerformanceStats do
       expect(data.size).to eq 1
     end
   end
+
+  describe "#duration_usage" do
+    it "calculates duration results" do
+      data = subject.duration_usage
+      expect(data.size).to eq 8
+    end
+  end
 end


### PR DESCRIPTION
This adds status on how long it takes users to check their eligibility and displays it on the performance dashboard.

[Trello Card](https://trello.com/c/yv8Q2Hea/457-analytics)