### PR TITLE
Add a worker CloudFoundary app

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-web: bin/rails db:migrate && bin/rails server -p ${PORT:-5000} -e $RAILS_ENV
-worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,0 @@
----
-applications:
-  - name: sandbox-apply-for-qts-in-england
-    memory: 256M
-    buildpacks:
-      - ruby_buildpack
-    services:
-      - sandbox-apply-for-qts-in-england-postgres

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -1,5 +1,9 @@
 locals {
-  app_environment_variables = merge(try(local.application_environment_variables, {}), {
+  azure_environment_variables = try(yamldecode(
+    data.azurerm_key_vault_secret.secrets["APPLY-QTS-APP-VARIABLES"].value
+  ), {})
+
+  app_environment_variables = merge(local.azure_environment_variables, {
     SENTRY_ENVIRONMENT = var.environment_name,
     REDIS_URL          = cloudfoundry_service_key.redis_key.credentials.uri
   })

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,6 +1,5 @@
 locals {
-  azure_credentials                 = try(jsondecode(var.azure_sp_credentials_json), null)
-  application_environment_variables = yamldecode(data.azurerm_key_vault_secret.secrets["APPLY-QTS-APP-VARIABLES"].value)
+  azure_credentials = try(jsondecode(var.azure_sp_credentials_json), null)
 }
 
 provider "azurerm" {


### PR DESCRIPTION
This will be used to run Sidekiq and process background jobs. I've decided to use the same memory, disk quota and instances as the web app, but if we decide this isn't appropriate in the future we can always change it. I've also set the deployment strategy to standard as we don't need two Sidekiq processes running in parallel during deployment, and it keeps things simple.