### PR TITLE
Fix logic to check whether analytics should be disabled

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -1,6 +1,6 @@
 DfE::Analytics.configure do |config|
   config.enable_analytics =
-    proc { ENV.fetch("BIGQUERY_DISABLE", "false") != "false" }
+    proc { ENV.fetch("BIGQUERY_DISABLE", "false") != "true" }
   config.queue = :analytics
   config.environment = ENV.fetch("SENTRY_ENVIRONMENT", "development")
 end


### PR DESCRIPTION
Previously we were saying that analytics should be enabled only if `BIGQUERY_DISABLE` was set to something other than `false`, whereas we want it to be the other way around.