### PR TITLE
Change development environment name

### DIFF
--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -1,5 +1,5 @@
 {
-  "environment_name": "dev",
+  "environment_name": "development",
   "key_vault_name": "s165d01-kv",
   "resource_group_name": "s165d01-rg",
   "paas_space": "tra-dev"


### PR DESCRIPTION
Use the full name so this appears in Sentry and on our frontend with a more human-readable name. I don't mind if the domain name or PaaS space is left as `dev` but for the environment name we should stick to the full name for consistency with `production`.

Related to #116 