### PR TITLE
Add email contact link to bottom of ineligible page

### DIFF
--- a/app/views/eligibility_interface/pages/ineligible.html.erb
+++ b/app/views/eligibility_interface/pages/ineligible.html.erb
@@ -7,7 +7,7 @@
     </h1>
 
     <% if @eligibility_check.ineligible_reasons.include?(:country) %>
-      <p class="govuk-body">This is because teachers with qualifications from this country are not eligible under current legislation. The Department for Education is currently reviewing these rules.</p>
+      <p class="govuk-body">This is because teachers with qualifications from this country are not eligible under current legislation.</p>
     <% else %>
       <p class="govuk-body">This is because:</p>
 
@@ -23,8 +23,11 @@
     <% end %>
 
     <% if @eligibility_check.ineligible_reasons.include?(:country) %>
-      <p class="govuk-body">The Department for Education is currently reviewing who can apply for qualified teacher status. If you’d like to help us with our research, contact:</p>
-      <p class="govuk-body"><a class="govuk-link" href="mailto:<%= I18n.t("service.email") %>"><%= I18n.t("service.email") %></a></p>
+      <p class="govuk-body">The Department for Education is currently reviewing who can apply for qualified teacher status. If you’d like to help us with our research, or if you have any questions contact the help team at:</p>
+    <% else %>
+      <p class="govuk-body">If you have any questions about QTS contact the help team at:</p>
     <% end %>
+    
+    <p class="govuk-body"><a class="govuk-link" href="mailto:<%= I18n.t("service.email") %>"><%= I18n.t("service.email") %></a></p>
   </div>
 </div>


### PR DESCRIPTION
This means users will always have a way of getting in touch, rather than only seeing it if their country is not eligible yet.