### PR TITLE
Enforce eligibility question order 

### DIFF
--- a/app/controllers/concerns/enforce_eligibility_question_order.rb
+++ b/app/controllers/concerns/enforce_eligibility_question_order.rb
@@ -1,0 +1,31 @@
+module EnforceEligibilityQuestionOrder
+  extend ActiveSupport::Concern
+
+  included { before_action :redirect_by_status }
+
+  def redirect_by_status
+    return if current_page_is_allowed?
+
+    expected_path = paths[eligibility_check.status]
+    redirect_to(expected_path) if expected_path && expected_path != request.path
+  end
+
+  private
+
+  def current_page_is_allowed?
+    order = paths.keys.index(eligibility_check&.status)
+    current_position = paths.values.index(request.path)
+    current_position && order && current_position <= order
+  end
+
+  def paths
+    {
+      country: eligibility_interface_countries_path,
+      region: eligibility_interface_region_path,
+      degree: eligibility_interface_degree_path,
+      qualification: eligibility_interface_qualifications_path,
+      teach_children: eligibility_interface_teach_children_path,
+      misconduct: eligibility_interface_misconduct_path
+    }
+  end
+end

--- a/app/controllers/eligibility_interface/countries_controller.rb
+++ b/app/controllers/eligibility_interface/countries_controller.rb
@@ -1,5 +1,7 @@
 module EligibilityInterface
   class CountriesController < BaseController
+    include EnforceEligibilityQuestionOrder
+
     def index
       render json: LOCATION_AUTOCOMPLETE_GRAPH
     end

--- a/app/controllers/eligibility_interface/degrees_controller.rb
+++ b/app/controllers/eligibility_interface/degrees_controller.rb
@@ -1,5 +1,7 @@
 module EligibilityInterface
   class DegreesController < BaseController
+    include EnforceEligibilityQuestionOrder
+
     def new
       @degree_form = DegreeForm.new
     end

--- a/app/controllers/eligibility_interface/misconduct_controller.rb
+++ b/app/controllers/eligibility_interface/misconduct_controller.rb
@@ -1,5 +1,7 @@
 module EligibilityInterface
   class MisconductController < BaseController
+    include EnforceEligibilityQuestionOrder
+
     def new
       @misconduct_form = MisconductForm.new
     end

--- a/app/controllers/eligibility_interface/pages_controller.rb
+++ b/app/controllers/eligibility_interface/pages_controller.rb
@@ -1,7 +1,9 @@
 module EligibilityInterface
   class PagesController < BaseController
-    before_action :load_eligibility_check, except: %i[root]
+    before_action :ensure_eligibility_check_status,
+                  only: %i[eligible ineligible]
     before_action :complete_eligibility_check, only: %i[eligible ineligible]
+    before_action :load_eligibility_check, only: %i[eligible ineligible]
 
     MUTUAL_RECOGNITION_URL =
       "https://teacherservices.education.gov.uk/MutualRecognition/".freeze
@@ -25,8 +27,14 @@ module EligibilityInterface
 
     private
 
+    def ensure_eligibility_check_status
+      if eligibility_check.status != :eligibility
+        redirect_to eligibility_interface_start_path
+      end
+    end
+
     def complete_eligibility_check
-      @eligibility_check.complete! if @eligibility_check.persisted?
+      eligibility_check.complete! if eligibility_check.persisted?
     end
 
     def load_eligibility_check

--- a/app/controllers/eligibility_interface/qualifications_controller.rb
+++ b/app/controllers/eligibility_interface/qualifications_controller.rb
@@ -1,5 +1,7 @@
 module EligibilityInterface
   class QualificationsController < BaseController
+    include EnforceEligibilityQuestionOrder
+
     def new
       @qualification_form = QualificationForm.new
     end

--- a/app/controllers/eligibility_interface/recognised_controller.rb
+++ b/app/controllers/eligibility_interface/recognised_controller.rb
@@ -1,5 +1,7 @@
 module EligibilityInterface
   class RecognisedController < BaseController
+    include EnforceEligibilityQuestionOrder
+
     def new
       @recognised_form = RecognisedForm.new
     end

--- a/app/controllers/eligibility_interface/region_controller.rb
+++ b/app/controllers/eligibility_interface/region_controller.rb
@@ -1,5 +1,7 @@
 module EligibilityInterface
   class RegionController < BaseController
+    include EnforceEligibilityQuestionOrder
+
     before_action :load_regions
 
     def new

--- a/app/controllers/eligibility_interface/teach_children_controller.rb
+++ b/app/controllers/eligibility_interface/teach_children_controller.rb
@@ -1,5 +1,7 @@
 module EligibilityInterface
   class TeachChildrenController < BaseController
+    include EnforceEligibilityQuestionOrder
+
     def new
       @teach_children_form = TeachChildrenForm.new
     end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -82,4 +82,21 @@ class EligibilityCheck < ApplicationRecord
   def complete!
     touch(:completed_at)
   end
+
+  def status
+    # Ineligible and legacy countries aren't required to answer all the questions
+    if (country_code.present? && country_eligibility_status == :ineligible) ||
+         country_eligibility_status == :legacy
+      return :eligibility
+    end
+
+    return :eligibility unless free_of_sanctions.nil?
+    return :misconduct unless teach_children.nil?
+    return :teach_children unless qualification.nil?
+    return :qualification unless degree.nil?
+    return :degree if region.present?
+    return :region if country_code.present?
+
+    :country
+  end
 end

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -228,4 +228,82 @@ RSpec.describe EligibilityCheck, type: :model do
       end
     end
   end
+
+  describe "#status" do
+    subject { eligibility_check.status }
+
+    let(:eligibility_check) { described_class.new(attributes) }
+    let(:country) { create(:country) }
+
+    context "when no attributes are present" do
+      let(:attributes) { nil }
+
+      it { is_expected.to eq(:country) }
+    end
+
+    context "when a country_code is present" do
+      let(:attributes) { { country_code: country.code } }
+
+      it { is_expected.to eq(:region) }
+    end
+
+    context "when a region is present" do
+      let(:attributes) { { region: create(:region) } }
+
+      it { is_expected.to eq(:degree) }
+    end
+
+    context "when a degree is present" do
+      let(:attributes) { { degree: true, region: create(:region) } }
+
+      it { is_expected.to eq(:qualification) }
+    end
+
+    context "when qualification is present" do
+      let(:attributes) do
+        { qualification: true, degree: true, region: create(:region) }
+      end
+
+      it { is_expected.to eq(:teach_children) }
+    end
+
+    context "when teach children is present" do
+      let(:attributes) do
+        {
+          teach_children: true,
+          qualification: true,
+          degree: true,
+          region: create(:region)
+        }
+      end
+
+      it { is_expected.to eq(:misconduct) }
+    end
+
+    context "when free of sanctions is present" do
+      let(:attributes) do
+        {
+          free_of_sanctions: true,
+          teach_children: true,
+          qualification: true,
+          degree: true,
+          region: create(:region)
+        }
+      end
+
+      it { is_expected.to eq(:eligibility) }
+    end
+
+    context "with a legacy region" do
+      let(:attributes) { { region: create(:region, :legacy) } }
+
+      it { is_expected.to eq(:eligibility) }
+    end
+
+    context "with an ineligible country" do
+      let(:attributes) { { country_code: "XX" } }
+
+      it { is_expected.to eq(:eligibility) }
+    end
+  end
 end

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -78,6 +78,48 @@ RSpec.describe "Eligibility check", type: :system do
     and_i_see_the_ineligible_misconduct_text
   end
 
+  it "trying to skip steps" do
+    when_i_visit_the_start_page
+    then_i_see_the_start_page
+
+    when_i_try_to_go_to_the_eligible_page
+    then_i_see_the_start_page
+
+    when_i_try_to_go_to_the_ineligible_page
+    then_i_see_the_start_page
+
+    when_i_press_start_now
+    then_i_see_the_countries_page
+
+    when_i_try_to_go_to_the_region_page
+    then_i_see_the_countries_page
+
+    when_i_select_a_country
+    and_i_submit
+    then_i_see_the_degree_page
+
+    when_i_try_to_go_to_the_qualifications_page
+    then_i_see_the_degree_page
+
+    when_i_choose_yes
+    and_i_submit
+    then_i_see_the_qualification_page
+
+    when_i_try_to_go_to_the_teach_children_page
+    then_i_see_the_qualification_page
+
+    when_i_choose_yes
+    and_i_submit
+    then_i_see_the_teach_children_page
+
+    when_i_try_to_go_to_the_misconduct_page
+    then_i_see_the_teach_children_page
+
+    when_i_choose_yes
+    and_i_submit
+    then_i_see_the_misconduct_page
+  end
+
   it "handles the country picker error" do
     when_i_visit_the_start_page
     when_i_press_start_now
@@ -216,6 +258,30 @@ RSpec.describe "Eligibility check", type: :system do
 
   def when_i_visit_the_start_page
     visit "/eligibility"
+  end
+
+  def when_i_try_to_go_to_the_eligible_page
+    visit "/eligibility/eligible"
+  end
+
+  def when_i_try_to_go_to_the_ineligible_page
+    visit "/eligibility/ineligible"
+  end
+
+  def when_i_try_to_go_to_the_region_page
+    visit "/eligibility/region"
+  end
+
+  def when_i_try_to_go_to_the_qualifications_page
+    visit "/eligibility/qualifications"
+  end
+
+  def when_i_try_to_go_to_the_teach_children_page
+    visit "/eligibility/teach-children"
+  end
+
+  def when_i_try_to_go_to_the_misconduct_page
+    visit "/eligibility/misconduct"
   end
 
   def then_i_do_not_see_the_start_page


### PR DESCRIPTION
Currently, we don't enforce the order of the steps in the eligibility check and if someone happens to know a valid URL, they can enter it and effectively skip steps in the question flow.

This has been implemented with a basic state machine for eligibility checks to track at which point in the journey the user is in.

This determines the furthest step that has been completed in the flow based on the presence of the attributes.

The system needs to allow people to go to a previously completed step as well.

This is based off https://github.com/DFE-Digital/find-a-lost-trn/pull/119.