### PR TITLE
Revert "Change development environment name"

### DIFF
--- a/app/assets/stylesheets/_environments.scss
+++ b/app/assets/stylesheets/_environments.scss
@@ -1,9 +1,9 @@
 $app-colour-development: govuk-colour("dark-grey", $legacy: "grey-1");
 
-.app-header--development .govuk-header__container {
+.app-header--dev .govuk-header__container {
   border-bottom-color: $app-colour-development;
 }
 
-.app-environment-tag--development {
+.app-environment-tag--dev {
   background-color: $app-colour-development;
 }

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,10 +1,11 @@
 module HostingEnvironment
   def self.name
-    ENV.fetch("HOSTING_ENVIRONMENT", "development")
+    ENV.fetch("HOSTING_ENVIRONMENT", "dev")
   end
 
   def self.phase
     return nil if production?
+    return "Development" if development?
 
     name.capitalize
   end
@@ -12,10 +13,14 @@ module HostingEnvironment
   def self.phase_text
     return nil if production?
 
-    "This is a #{name} version of the service."
+    "This is a '#{phase}' version of the service."
   end
 
   def self.production?
     name == "production"
+  end
+
+  def self.development?
+    name == "dev"
   end
 end

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe HostingEnvironment do
     end
 
     context "when the environment variable isn't set" do
-      it { is_expected.to eq("development") }
+      it { is_expected.to eq("dev") }
     end
   end
 end

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -1,5 +1,5 @@
 {
-  "environment_name": "development",
+  "environment_name": "dev",
   "key_vault_name": "s165d01-kv",
   "resource_group_name": "s165d01-rg",
   "paas_space": "tra-dev"


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-qualified-teacher-status#117

This changed more than I expected, the domain name and the app name, and various other things. I've decided to go down a different approach so we at least see "Development" on the frontend, but internally we stick with `dev`.