### PR TITLE
Add beta phase banner text

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -4,14 +4,14 @@ module HostingEnvironment
   end
 
   def self.phase
-    return nil if production?
+    return "Beta" if production?
     return "Development" if development?
 
     name.capitalize
   end
 
   def self.phase_text
-    return nil if production?
+    return I18n.t("service.phase_banner_text") if production?
 
     "This is a '#{phase}' version of the service."
   end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -48,20 +48,18 @@
       <% end %>
     <% end %>
 
-    <% if HostingEnvironment.phase %>
-      <div class="govuk-width-container">
-        <div class="govuk-phase-banner">
-          <p class="govuk-phase-banner__content">
-            <strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag--<%= HostingEnvironment.name %>">
-              <%= HostingEnvironment.phase %>
-            </strong>
-            <span class="govuk-phase-banner__text">
-              <%= HostingEnvironment.phase_text %>
-            </span>
-          </p>
-        </div>
+    <div class="govuk-width-container">
+      <div class="govuk-phase-banner">
+        <p class="govuk-phase-banner__content">
+          <strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag--<%= HostingEnvironment.name %>">
+            <%= HostingEnvironment.phase %>
+          </strong>
+          <span class="govuk-phase-banner__text">
+            <%= HostingEnvironment.phase_text.html_safe %>
+          </span>
+        </p>
       </div>
-    <% end %>
+    </div>
 
     <div class="govuk-width-container">
       <%= govuk_back_link(href: yield(:back_link_url)) unless yield(:back_link_url).blank? %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,7 @@ en:
     name: Apply for qualified teacher status (QTS) in England
     email: qts.enquiries@education.gov.uk
     url: https://apply-for-qts-in-england.education.gov.uk
+    phase_banner_text: This is a new service – <a href="mailto:qts.enquiries@education.gov.uk">your feedback will help us to improve it</a>.
 
   activemodel:
     attributes:


### PR DESCRIPTION
This is required ahead of launching, the feedback link sends an email to the QTS enquiries email address.

<img width="1011" alt="Screenshot 2022-06-17 at 17 27 52" src="https://user-images.githubusercontent.com/510498/174339147-44c08d7d-1da6-4200-b965-341b408405ed.png">
