### PR TITLE
Fix autocomplete locations

### DIFF
--- a/app/controllers/autocomplete_locations_controller.rb
+++ b/app/controllers/autocomplete_locations_controller.rb
@@ -1,0 +1,8 @@
+class AutocompleteLocationsController < ApplicationController
+  LOCATION_AUTOCOMPLETE_GRAPH =
+    JSON.parse(File.read("public/location-autocomplete-graph.json"))
+
+  def index
+    render json: LOCATION_AUTOCOMPLETE_GRAPH
+  end
+end

--- a/app/controllers/eligibility_interface/countries_controller.rb
+++ b/app/controllers/eligibility_interface/countries_controller.rb
@@ -2,10 +2,6 @@ module EligibilityInterface
   class CountriesController < BaseController
     include EnforceEligibilityQuestionOrder
 
-    def index
-      render json: LOCATION_AUTOCOMPLETE_GRAPH
-    end
-
     def new
       @country_form = CountryForm.new
     end
@@ -21,9 +17,6 @@ module EligibilityInterface
     end
 
     private
-
-    LOCATION_AUTOCOMPLETE_GRAPH =
-      JSON.parse(File.read("public/location-autocomplete-graph.json"))
 
     def location_form_params
       params.require(:eligibility_interface_country_form).permit(:location)

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -14,7 +14,7 @@ const loadCountryAutoComplete = () => {
   if (locationPicker) {
     openregisterLocationPicker({
       selectElement: locationPicker,
-      url: "/eligibility/locations.json",
+      url: "/autocomplete_locations.json",
     });
   }
 };

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,6 @@ Rails.application.routes.draw do
     get "ineligible", to: "pages#ineligible"
     get "misconduct", to: "misconduct#new"
     post "misconduct", to: "misconduct#create"
-    get "locations", to: "countries#index"
   end
 
   namespace :support_interface, path: "/support" do
@@ -63,6 +62,8 @@ Rails.application.routes.draw do
 
     mount Sidekiq::Web, at: "sidekiq"
   end
+
+  resources :autocomplete_locations, only: %i[index]
 
   get "accessibility", to: "static#accessibility"
   get "cookies", to: "static#cookies"


### PR DESCRIPTION
This was accidentally broken in a4e5e92d801584d8f092c0cd1f767ade1c7eeb0f as the controller method for getting the locations ended up redirecting the user rather than serving the results. I've pulled it out into a separate controller since it might be useful in other parts of the app anyway.