### PR TITLE
Ignore concurrent migration exceptions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,5 +75,5 @@ RUN apk add --no-cache libpq
 COPY --from=builder /app /app
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 
-CMD bundle exec rails db:migrate && \
+CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && \
     bundle exec rails server -b 0.0.0.0

--- a/lib/tasks/ignore_concurrent_migration_exceptions.rake
+++ b/lib/tasks/ignore_concurrent_migration_exceptions.rake
@@ -1,0 +1,10 @@
+namespace :db do
+  namespace :migrate do
+    desc "db:migrate but ignores ActiveRecord::ConcurrentMigrationError errors"
+    task ignore_concurrent_migration_exceptions: :environment do
+      Rake::Task["db:migrate"].invoke
+    rescue ActiveRecord::ConcurrentMigrationError
+      # Do nothing
+    end
+  end
+end


### PR DESCRIPTION
Blue/green deployment to the PaaS can result in a Sentry error:

https://sentry.io/organizations/dfe-teacher-services/issues/3357485654/?referrer=slack

Swallowing the error is acceptable and is how Find and Apply for Teacher Training work around this issue.