### PR TITLE
Fix eligible page typo

### DIFF
--- a/app/views/eligibility_interface/pages/eligible.html.erb
+++ b/app/views/eligibility_interface/pages/eligible.html.erb
@@ -30,7 +30,7 @@
         <li>a transcript or diploma supplement of the qualification that led you to being a recognised teacher. This should be issued by the awarding body and show all the modules you studied and the marks you got for each. If your teacher training was completed as part of your degree, you should supply your degree transcript.</li>
       </ul>
 
-      <p class="govuk-body">Note that you must have done some of all of your teacher training qualification in <%= @region.country.name_with_prefix %>.</p>
+      <p class="govuk-body">Note that you must have completed all of your teacher training qualification in <%= @region.country.name_with_prefix %>.</p>
 
       <h3 class="govuk-heading-s">3. Proof that you’re recognised as a teacher</h3>
 


### PR DESCRIPTION
Fix typo in eligible.html so that the correct content is displayed
for reminding applicant that they must have completed all qualifications