### PR TITLE
Disable toggling :service_open on/off in prod

### DIFF
--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -3,10 +3,13 @@ class FeatureFlag
 
   attr_accessor :description, :name, :owner
 
+  DISABLED_IN_PRODUCTION = %i[service_open].freeze
+
   PERMANENT_SETTINGS = [
     [
       :service_open,
-      "Allow users to access the service without HTTP basic auth",
+      "Allow users to access the service without HTTP basic auth. Should be \
+      inactive on production, and active on all other environments.",
       "Felix Clack"
     ]
   ].freeze
@@ -14,7 +17,8 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [
       :service_start,
-      "Allow users to use the service, rather than being sent to the legacy mutual recognition site",
+      "Allow users to use the service, rather than being sent to the legacy \
+      mutual recognition site",
       "Thomas Leese"
     ]
   ].freeze
@@ -50,6 +54,13 @@ class FeatureFlag
     feature.active = active
 
     feature.save!
+  end
+
+  def self.disabled_in_production?(feature_name)
+    raise unless feature_name.in?(FEATURES)
+    return false unless HostingEnvironment.production?
+
+    feature_name.to_sym.in?(DISABLED_IN_PRODUCTION)
   end
 
   def self.feature_statuses

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -10,7 +10,7 @@ class FeatureFlag
       :service_open,
       "Allow users to access the service without HTTP basic auth. Should be \
       inactive on production, and active on all other environments.",
-      "Felix Clack"
+      "Thomas Leese"
     ]
   ].freeze
 

--- a/app/views/support_interface/feature_flags/index.html.erb
+++ b/app/views/support_interface/feature_flags/index.html.erb
@@ -10,11 +10,11 @@
     </span>
   </h2>
   <% rows = [
-      { 
+      {
         key: { text: 'Description'},
         value: { text: feature_flag.description },
       },
-      { 
+      {
         key: { text: 'Status'},
         value: {
           text: govuk_tag(
@@ -23,20 +23,28 @@
           )
         },
       },
-      { 
+      {
         key: { text: 'Owner'},
         value: { text: feature_flag.owner },
       },
   ] %>
   <%= govuk_summary_list(rows: rows) %>
-  <% if FeatureFlag.active?(feature_name) %>
-    <% feature_url = support_interface_deactivate_feature_path(feature_name) %>
-    <% label = 'Deactivate ' %>
-  <% else %>
-    <% feature_url = support_interface_activate_feature_path(feature_name) %>
-    <% label = 'Activate ' %>
-  <% end %>
-  <%= form_with(url: feature_url) do |f| %>
-    <%= f.govuk_submit label + feature_name.humanize, prevent_double_click: false %>
+    <% if FeatureFlag.disabled_in_production?(feature_name) %>
+      <%= govuk_button_link_to "Not allowed in production", "#", disabled: true, secondary: true %>
+      <p>
+        This feature cannot be toggled from the feature dashboard in
+        Production. It can still be toggled from a Rails console.
+      </p>
+    <% else %>
+      <% if FeatureFlag.active?(feature_name) %>
+        <% feature_url = support_interface_deactivate_feature_path(feature_name) %>
+        <% label = 'Deactivate ' %>
+      <% else %>
+        <% feature_url = support_interface_activate_feature_path(feature_name) %>
+        <% label = 'Activate ' %>
+      <% end %>
+      <%= form_with(url: feature_url) do |f| %>
+        <%= f.govuk_submit label + feature_name.humanize, prevent_double_click: false %>
+    <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
Now that the service is live, the button to switch `:service_open` back off is dangerous. It can lock users out of the service, and cause an incident.

This PR adds some conditional logic to display an alternative, disabled button with an explanation for features that we still want to toggle in other envs, but not in prod.

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/1650875/174807584-a72275ce-5884-4e06-a367-4111caf2df51.png) | ![image](https://user-images.githubusercontent.com/1650875/174807472-1788054a-45f4-4346-9221-c365e24468a6.png) | 

### Guidance to review

Should I add some tests?