### PR TITLE
Switch worker deployment strategy

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -60,7 +60,7 @@ resource "cloudfoundry_app" "worker" {
   disk_quota   = var.apply_qts_disk_quota
   docker_image = var.apply_qts_docker_image
   command      = "bundle exec sidekiq -C ./config/sidekiq.yml"
-  strategy     = "standard"
+  strategy     = "blue-green"
   environment  = local.app_environment_variables
 
   health_check_type = "process"


### PR DESCRIPTION
This changes the strategy to `blue-green` to match our web app as there's an issue with `standard` deploys and Docker on the PaaS. We've been seeing a problem where the worker `app` gets terminated and hopefully changing this will resolve that.