### PR TITLE
Make staff users invitable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "rails", "~> 7.0.3"
 gem "bootsnap", require: false
 gem "cssbundling-rails"
 gem "devise"
+gem "devise_invitable"
 gem "jsbundling-rails"
 gem "okcomputer"
 gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise_invitable (2.0.6)
+      actionmailer (>= 5.0)
+      devise (>= 4.6)
     diff-lcs (1.5.0)
     digest (3.1.0)
     dotenv (2.7.6)
@@ -453,6 +456,7 @@ DEPENDENCIES
   cuprite (~> 0.13)
   debug
   devise
+  devise_invitable
   dfe-analytics!
   dotenv-rails
   factory_bot_rails

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -39,4 +39,8 @@ class Staff < ApplicationRecord
          :timeoutable,
          :validatable,
          :lockable
+
+  def send_devise_notification(notification, *args)
+    devise_mailer.send(notification, self, *args).deliver_later
+  end
 end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -11,6 +11,13 @@
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  failed_attempts        :integer          default(0), not null
+#  invitation_accepted_at :datetime
+#  invitation_created_at  :datetime
+#  invitation_limit       :integer
+#  invitation_sent_at     :datetime
+#  invitation_token       :string
+#  invitations_count      :integer          default(0)
+#  invited_by_type        :string
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string
 #  locked_at              :datetime
@@ -22,11 +29,15 @@
 #  unlock_token           :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  invited_by_id          :bigint
 #
 # Indexes
 #
 #  index_staff_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_staff_on_email                 (email) UNIQUE
+#  index_staff_on_invitation_token      (invitation_token) UNIQUE
+#  index_staff_on_invited_by            (invited_by_type,invited_by_id)
+#  index_staff_on_invited_by_id         (invited_by_id)
 #  index_staff_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_staff_on_unlock_token          (unlock_token) UNIQUE
 #
@@ -38,7 +49,8 @@ class Staff < ApplicationRecord
          :trackable,
          :timeoutable,
          :validatable,
-         :lockable
+         :lockable,
+         :invitable
 
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -26,4 +26,8 @@ class Teacher < ApplicationRecord
               allow_blank: true,
               if: :will_save_change_to_email?
             }
+
+  def send_devise_notification(notification, *args)
+    devise_mailer.send(notification, self, *args).deliver_later
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,4 +66,5 @@ Rails.application.configure do
   config.active_job.queue_adapter = :sidekiq
 
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  config.action_mailer.delivery_method = :file
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -129,6 +129,55 @@ Devise.setup do |config|
   # Send a notification email when the user's password is changed.
   # config.send_password_change_notification = false
 
+  # ==> Configuration for :invitable
+  # The period the generated invitation token is valid.
+  # After this period, the invited resource won't be able to accept the invitation.
+  # When invite_for is 0 (the default), the invitation won't expire.
+  config.invite_for = 1.week
+
+  # Number of invitations users can send.
+  # - If invitation_limit is nil, there is no limit for invitations, users can
+  # send unlimited invitations, invitation_limit column is not used.
+  # - If invitation_limit is 0, users can't send invitations by default.
+  # - If invitation_limit n > 0, users can send n invitations.
+  # You can change invitation_limit column for some users so they can send more
+  # or less invitations, even with global invitation_limit = 0
+  # Default: nil
+  # config.invitation_limit = 5
+
+  # The key to be used to check existing users when sending an invitation
+  # and the regexp used to test it when validate_on_invite is not set.
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/ }
+  # config.invite_key = { email: /\A[^@]+@[^@]+\z/, username: nil }
+
+  # Ensure that invited record is valid.
+  # The invitation won't be sent if this check fails.
+  # Default: false
+  # config.validate_on_invite = true
+
+  # Resend invitation if user with invited status is invited again
+  # Default: true
+  # config.resend_invitation = false
+
+  # The class name of the inviting model. If this is nil,
+  # the #invited_by association is declared to be polymorphic.
+  # Default: nil
+  # config.invited_by_class_name = 'User'
+
+  # The foreign key to the inviting model (if invited_by_class_name is set)
+  # Default: :invited_by_id
+  # config.invited_by_foreign_key = :invited_by_id
+
+  # The column name used for counter_cache column. If this is nil,
+  # the #invited_by association is declared without counter_cache.
+  # Default: nil
+  # config.invited_by_counter_cache = :invitations_count
+
+  # Auto-login after the user accepts the invite. If this is false,
+  # the user will need to manually log in after accepting the invite.
+  # Default: true
+  # config.allow_insecure_sign_in_after_accept = false
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -1,0 +1,31 @@
+en:
+  devise:
+    failure:
+      invited: "You have a pending invitation, accept it to finish creating your account."
+    invitations:
+      send_instructions: "An invitation email has been sent to %{email}."
+      invitation_token_invalid: "The invitation token provided is not valid!"
+      updated: "Your password was set successfully. You are now signed in."
+      updated_not_active: "Your password was set successfully."
+      no_invitations_remaining: "No invitations remaining"
+      invitation_removed: "Your invitation was removed."
+      new:
+        header: "Send invitation"
+        submit_button: "Send an invitation"
+      edit:
+        header: "Set your password"
+        submit_button: "Set my password"
+    mailer:
+      invitation_instructions:
+        subject: "Invitation instructions"
+        hello: "Hello %{email}"
+        someone_invited_you: "Someone has invited you to %{url}, you can accept it through the link below."
+        accept: "Accept invitation"
+        accept_until: "This invitation will be due in %{due_date}."
+        ignore: "If you don't want to accept the invitation, please ignore this email. Your account won't be created until you access the link above and set your password."
+  time:
+    formats:
+      devise:
+        mailer:
+          invitation_instructions:
+            accept_until_format: "%B %d, %Y %I:%M %p"

--- a/db/migrate/20220623144235_devise_invitable_add_to_staff.rb
+++ b/db/migrate/20220623144235_devise_invitable_add_to_staff.rb
@@ -1,0 +1,27 @@
+class DeviseInvitableAddToStaff < ActiveRecord::Migration[7.0]
+  def up
+    change_table :staff, bulk: true do |t|
+      t.string :invitation_token
+      t.datetime :invitation_created_at
+      t.datetime :invitation_sent_at
+      t.datetime :invitation_accepted_at
+      t.integer :invitation_limit
+      t.references :invited_by, polymorphic: true
+      t.integer :invitations_count, default: 0
+      t.index :invitation_token, unique: true # for invitable
+      t.index :invited_by_id
+    end
+  end
+
+  def down
+    change_table :staff, bulk: true do |t|
+      t.remove_references :invited_by, polymorphic: true
+      t.remove :invitations_count,
+               :invitation_limit,
+               :invitation_sent_at,
+               :invitation_accepted_at,
+               :invitation_token,
+               :invitation_created_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_23_075656) do
+ActiveRecord::Schema[7.0].define(version: 2022_06_23_144235) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -77,8 +77,19 @@ ActiveRecord::Schema[7.0].define(version: 2022_06_23_075656) do
     t.datetime "locked_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.string "invited_by_type"
+    t.bigint "invited_by_id"
+    t.integer "invitations_count", default: 0
     t.index ["confirmation_token"], name: "index_staff_on_confirmation_token", unique: true
     t.index ["email"], name: "index_staff_on_email", unique: true
+    t.index ["invitation_token"], name: "index_staff_on_invitation_token", unique: true
+    t.index ["invited_by_id"], name: "index_staff_on_invited_by_id"
+    t.index ["invited_by_type", "invited_by_id"], name: "index_staff_on_invited_by"
     t.index ["reset_password_token"], name: "index_staff_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_staff_on_unlock_token", unique: true
   end

--- a/spec/factories/staff.rb
+++ b/spec/factories/staff.rb
@@ -11,6 +11,13 @@
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  failed_attempts        :integer          default(0), not null
+#  invitation_accepted_at :datetime
+#  invitation_created_at  :datetime
+#  invitation_limit       :integer
+#  invitation_sent_at     :datetime
+#  invitation_token       :string
+#  invitations_count      :integer          default(0)
+#  invited_by_type        :string
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string
 #  locked_at              :datetime
@@ -22,11 +29,15 @@
 #  unlock_token           :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  invited_by_id          :bigint
 #
 # Indexes
 #
 #  index_staff_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_staff_on_email                 (email) UNIQUE
+#  index_staff_on_invitation_token      (invitation_token) UNIQUE
+#  index_staff_on_invited_by            (invited_by_type,invited_by_id)
+#  index_staff_on_invited_by_id         (invited_by_id)
 #  index_staff_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_staff_on_unlock_token          (unlock_token) UNIQUE
 #

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -11,6 +11,13 @@
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  failed_attempts        :integer          default(0), not null
+#  invitation_accepted_at :datetime
+#  invitation_created_at  :datetime
+#  invitation_limit       :integer
+#  invitation_sent_at     :datetime
+#  invitation_token       :string
+#  invitations_count      :integer          default(0)
+#  invited_by_type        :string
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string
 #  locked_at              :datetime
@@ -22,11 +29,15 @@
 #  unlock_token           :string
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  invited_by_id          :bigint
 #
 # Indexes
 #
 #  index_staff_on_confirmation_token    (confirmation_token) UNIQUE
 #  index_staff_on_email                 (email) UNIQUE
+#  index_staff_on_invitation_token      (invitation_token) UNIQUE
+#  index_staff_on_invited_by            (invited_by_type,invited_by_id)
+#  index_staff_on_invited_by_id         (invited_by_id)
 #  index_staff_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_staff_on_unlock_token          (unlock_token) UNIQUE
 #


### PR DESCRIPTION
This allows us to "invite" new staff users by filling in a form and then sending an email. From there the user will then register their account by setting a password. This uses the popular [`devise_invitable`](https://github.com/scambra/devise_invitable) Gem.

This is how the support staff interface will work for adding new staff users, rather than setting a password when creating the user, the staff member will set the password themselves, meaning there's no need to share passwords.

[Trello Card](https://trello.com/c/gzMG6AzK/522-applicant-sign-in-and-sign-back-in)