### PR TITLE
Create infrastructure for `test` and `pre-prod` environments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,12 +4,14 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "Deploy environment ( dev or production )"
+        description: "Deploy environment ( dev or test or preprod or production )"
         required: true
         default: dev
         type: environment
         options:
           - dev
+          - test
+          - preprod
           - production
   push:
     branches:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,23 @@ dev:
 	$(eval AZURE_SUBSCRIPTION=s165-teachingqualificationsservice-development)
 	$(eval RESOURCE_NAME_PREFIX=s165d01)
 	$(eval ENV_SHORT=dv)
+	$(eval ENV_TAG=dev)
+
+.PHONY: test
+test:
+	$(eval DEPLOY_ENV=test)
+	$(eval AZURE_SUBSCRIPTION=s165-teachingqualificationsservice-test)
+	$(eval RESOURCE_NAME_PREFIX=s165t01)
+	$(eval ENV_SHORT=st)
+	$(eval ENV_TAG=test)
+
+.PHONY: preprod
+preprod:
+	$(eval DEPLOY_ENV=preprod)
+	$(eval AZURE_SUBSCRIPTION=s165-teachingqualificationsservice-test)
+	$(eval RESOURCE_NAME_PREFIX=s165t01)
+	$(eval ENV_SHORT=pp)
+	$(eval ENV_TAG=pre-prod)
 
 .PHONY: production
 production:
@@ -36,7 +53,7 @@ ci:	## Run in automation environment
 	$(eval SP_AUTH=true)
 
 tags: ##Tags that will be added to resource group on it's creation in ARM template
-	$(eval RG_TAGS=$(shell echo '{"Portfolio": "Early years and Schools Group", "Parent Business":"Teaching Regulation Agency", "Product" : "Apply for QTS in England", "Service Line": "Becoming a teacher", "Service": "Apply for QTS in England", "Service Offering": "Apply for QTS in England"}' | jq . ))
+	$(eval RG_TAGS=$(shell echo '{"Portfolio": "Early years and Schools Group", "Parent Business":"Teaching Regulation Agency", "Product" : "Apply for QTS in England", "Service Line": "Teaching Workforce", "Service": "Teacher Services", "Service Offering": "Apply for QTS in England", "Environment" : "$(ENV_TAG)"}' | jq . ))
 
 .PHONY: install-fetch-config
 install-fetch-config: ## Install the fetch-config script, for viewing/editing secrets in Azure Key Vault
@@ -87,7 +104,7 @@ remove-postgres-tf-state: terraform-init ## make dev remove-postgres-tf-state PA
 
 terraform-init:
 	$(if $(or $(DISABLE_PASSCODE),$(PASSCODE)), , $(error Missing environment variable "PASSCODE", retrieve from https://login.london.cloud.service.gov.uk/passcode))
-	[[ "${SP_AUTH}" != "true" ]] && az account set -s $(AZURE_SUBSCRIPTION) || true
+	[[ "${SP_AUTH}" != "true" ]] && az account show && az account set -s $(AZURE_SUBSCRIPTION) || true
 	terraform -chdir=terraform init -backend-config workspace_variables/${DEPLOY_ENV}.backend.tfvars -upgrade -reconfigure
 
 terraform-plan: terraform-init

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ test:
 	$(eval DEPLOY_ENV=test)
 	$(eval AZURE_SUBSCRIPTION=s165-teachingqualificationsservice-test)
 	$(eval RESOURCE_NAME_PREFIX=s165t01)
-	$(eval ENV_SHORT=st)
+	$(eval ENV_SHORT=ts)
 	$(eval ENV_TAG=test)
 
 .PHONY: preprod

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 1.0"
 
   backend "azurerm" {
-    container_name = "apply-qts-tfstate"
+    container_name = "afqts-tfstate"
   }
 
   required_providers {

--- a/terraform/workspace_variables/preprod.backend.tfvars
+++ b/terraform/workspace_variables/preprod.backend.tfvars
@@ -1,0 +1,3 @@
+storage_account_name = "s165t01afqtstfstatepp"
+key                  = "preprod.tfstate"
+resource_group_name  = "s165t01-afqts-pp-rg"

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -1,0 +1,6 @@
+{
+  "environment_name": "preprod",
+  "key_vault_name": "s165t01-afqts-pp-kv",
+  "resource_group_name": "s165t01-afqts-pp-rg",
+  "paas_space": "tra-test"
+}

--- a/terraform/workspace_variables/test.backend.tfvars
+++ b/terraform/workspace_variables/test.backend.tfvars
@@ -1,0 +1,3 @@
+storage_account_name = "s165t01afqtstfstatest"
+key                  = "test.tfstate"
+resource_group_name  = "s165t01-afqts-st-rg"

--- a/terraform/workspace_variables/test.backend.tfvars
+++ b/terraform/workspace_variables/test.backend.tfvars
@@ -1,3 +1,3 @@
-storage_account_name = "s165t01afqtstfstatest"
+storage_account_name = "s165t01afqtstfstatets"
 key                  = "test.tfstate"
-resource_group_name  = "s165t01-afqts-st-rg"
+resource_group_name  = "s165t01-afqts-ts-rg"

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -1,6 +1,6 @@
 {
   "environment_name": "test",
-  "key_vault_name": "s165t01-afqts-st-kv",
-  "resource_group_name": "s165t01-afqts-st-rg",
+  "key_vault_name": "s165t01-afqts-ts-kv",
+  "resource_group_name": "s165t01-afqts-ts-rg",
   "paas_space": "tra-test"
 }

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -1,0 +1,6 @@
+{
+  "environment_name": "test",
+  "key_vault_name": "s165t01-afqts-st-kv",
+  "resource_group_name": "s165t01-afqts-st-rg",
+  "paas_space": "tra-test"
+}


### PR DESCRIPTION
Updated Makefile and terraform vars to support deployment to `test` and `pre-prod` environments.
Updated workflow file to include `test` and `pre-prod` environments.

[x] Attach to trello