### PR TITLE
Use Devise for staff HTTP Basic auth

### DIFF
--- a/app/controllers/support_interface/base_controller.rb
+++ b/app/controllers/support_interface/base_controller.rb
@@ -1,7 +1,6 @@
 module SupportInterface
   class BaseController < ApplicationController
-    http_basic_authenticate_with name: ENV.fetch("SUPPORT_USERNAME", "test"),
-                                 password: ENV.fetch("SUPPORT_PASSWORD", "test")
+    before_action :authenticate_staff!
 
     def current_namespace
       "support"

--- a/app/lib/staff_http_basic_auth_strategy.rb
+++ b/app/lib/staff_http_basic_auth_strategy.rb
@@ -1,0 +1,48 @@
+class StaffHttpBasicAuthStrategy < Warden::Strategies::Base
+  def valid?
+    FeatureFlag.active?(:staff_http_basic_auth) || !Staff.exists?
+  end
+
+  def store?
+    false
+  end
+
+  def authenticate!
+    auth = Rack::Auth::Basic::Request.new(env)
+
+    return success!(true) if credentials_valid?(auth)
+
+    custom!(
+      [
+        401,
+        {
+          "Content-Type" => "text/plain",
+          "Content-Length" => "0",
+          "WWW-Authenticate" => "Basic realm=\"Application\""
+        },
+        []
+      ]
+    )
+  end
+
+  private
+
+  SUPPORT_USERNAME =
+    Digest::SHA256.hexdigest(ENV.fetch("SUPPORT_USERNAME", "test"))
+  SUPPORT_PASSWORD =
+    Digest::SHA256.hexdigest(ENV.fetch("SUPPORT_PASSWORD", "test"))
+
+  def credentials_valid?(auth)
+    return false unless auth.provided? && auth.basic? && auth.credentials
+
+    valid_comparison?(SUPPORT_USERNAME, auth.credentials.first) &&
+      valid_comparison?(SUPPORT_PASSWORD, auth.credentials.last)
+  end
+
+  def valid_comparison?(correct_value, given_value)
+    ActiveSupport::SecurityUtils.secure_compare(
+      Digest::SHA256.hexdigest(given_value),
+      correct_value
+    )
+  end
+end

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -8,8 +8,15 @@ class FeatureFlag
   PERMANENT_SETTINGS = [
     [
       :service_open,
-      "Allow users to access the service without HTTP basic auth. Should be \
-      inactive on production, and active on all other environments.",
+      "Allow users to access the service without HTTP basic auth. Should be " \
+        "inactive on production, and active on all other environments.",
+      "Thomas Leese"
+    ],
+    [
+      :staff_http_basic_auth,
+      "Allow signing in as a staff user using HTTP Basic authentication. " \
+        "This is useful before staff users have been created, but should " \
+        "otherwise be inactive.",
       "Thomas Leese"
     ]
   ].freeze
@@ -17,8 +24,8 @@ class FeatureFlag
   TEMPORARY_FEATURE_FLAGS = [
     [
       :service_start,
-      "Allow users to use the service, rather than being sent to the legacy \
-      mutual recognition site",
+      "Allow users to use the service, rather than being sent to the " \
+        "legacy mutual recognition site",
       "Thomas Leese"
     ]
   ].freeze

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -321,10 +321,10 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    manager.strategies.add(:staff_http_basic_auth, StaffHttpBasicAuthStrategy)
+    manager.default_strategies(scope: :staff).unshift :staff_http_basic_auth
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/spec/factories/features.rb
+++ b/spec/factories/features.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: features
+#
+#  id         :bigint           not null, primary key
+#  active     :boolean          default(FALSE), not null
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_features_on_name  (name) UNIQUE
+#
+FactoryBot.define do
+  factory :feature do
+    name { "feature" }
+    active { false }
+
+    trait :active do
+      active { true }
+    end
+  end
+end

--- a/spec/lib/staff_http_basic_auth_strategy_spec.rb
+++ b/spec/lib/staff_http_basic_auth_strategy_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+RSpec.describe StaffHttpBasicAuthStrategy do
+  subject(:staff_http_basic_auth_strategy) { described_class.new(env) }
+
+  let(:env) { {} }
+
+  describe "#valid?" do
+    subject(:valid?) { staff_http_basic_auth_strategy.valid? }
+
+    context "with staff users" do
+      before { create(:staff) }
+
+      it { is_expected.to eq(false) }
+    end
+
+    context "when feature is active" do
+      before { create(:feature, :active, name: "staff_http_basic_auth") }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "when there are no staff users" do
+      it { is_expected.to eq(true) }
+    end
+  end
+
+  describe "#store?" do
+    subject(:store?) { staff_http_basic_auth_strategy.store? }
+
+    it { is_expected.to eq(false) }
+  end
+
+  describe "#authenticate!" do
+    before { staff_http_basic_auth_strategy.authenticate! }
+
+    it "should halt the strategy" do
+      expect(staff_http_basic_auth_strategy.halted?).to eq(true)
+    end
+
+    it "should not be successful" do
+      expect(staff_http_basic_auth_strategy.successful?).to eq(false)
+      expect(staff_http_basic_auth_strategy.custom_response).to eq(
+        [
+          401,
+          {
+            "Content-Length" => "0",
+            "Content-Type" => "text/plain",
+            "WWW-Authenticate" => "Basic realm=\"Application\""
+          },
+          []
+        ]
+      )
+    end
+
+    context "with valid credentials" do
+      let(:env) do
+        { "HTTP_AUTHORIZATION" => "Basic #{Base64.encode64("test:test")}" }
+      end
+
+      it "should be successful" do
+        expect(staff_http_basic_auth_strategy.successful?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/models/feature_flag_spec.rb
+++ b/spec/models/feature_flag_spec.rb
@@ -1,8 +1,7 @@
-# frozen_string_literal: true
 require "rails_helper"
 
 RSpec.describe FeatureFlag do
-  let(:feature) { Feature.create_or_find_by(name: feature_name) }
+  let(:feature) { create(:feature, name: feature_name) }
   let(:feature_name) { :service_open }
 
   describe ".activate" do

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -1,21 +1,9 @@
 require "rails_helper"
 
-RSpec.describe "Support", type: :system do
-  before { given_countries_exist }
+RSpec.describe "Countries support", type: :system do
+  it "allows modifying countries" do
+    given_countries_exist
 
-  it "features" do
-    when_i_am_authorized_as_a_support_user
-    when_i_visit_the_feature_flags_page
-    then_i_see_the_feature_flags
-
-    when_i_activate_the_service_open_flag
-    then_the_service_open_flag_is_on
-
-    when_i_deactivate_the_service_open_flag
-    then_the_service_open_flag_is_off
-  end
-
-  it "countries" do
     when_i_am_authorized_as_a_support_user
     when_i_visit_the_countries_page
     then_i_see_the_countries
@@ -50,39 +38,11 @@ RSpec.describe "Support", type: :system do
     create(:region, :national, country: create(:country, code: "CY"))
   end
 
-  def then_i_see_the_feature_flags
-    expect(page).to have_current_path("/support/features")
-    expect(page).to have_title("Features")
-    expect(page).to have_content("Features")
-  end
-
-  def then_the_service_open_flag_is_off
-    expect(page).to have_content("Feature “Service open” deactivated")
-    expect(page).to have_content("Service open\n- Inactive")
-  end
-
-  def then_the_service_open_flag_is_on
-    expect(page).to have_content("Feature “Service open” activated")
-    expect(page).to have_content("Service open\n- Active")
-  end
-
-  def when_i_activate_the_service_open_flag
-    click_on "Activate Service open"
-  end
-
   def when_i_am_authorized_as_a_support_user
     page.driver.basic_authorize(
       ENV.fetch("SUPPORT_USERNAME", "test"),
       ENV.fetch("SUPPORT_PASSWORD", "test")
     )
-  end
-
-  def when_i_deactivate_the_service_open_flag
-    click_on "Deactivate Service open"
-  end
-
-  def when_i_visit_the_feature_flags_page
-    visit support_interface_features_path
   end
 
   def when_i_visit_the_countries_page

--- a/spec/system/support_interface/features_spec.rb
+++ b/spec/system/support_interface/features_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "Features support", type: :system do
+  it "allows activating/deactivating features" do
+    when_i_am_authorized_as_a_support_user
+    when_i_visit_the_feature_flags_page
+    then_i_see_the_feature_flags
+
+    when_i_activate_the_service_open_flag
+    then_the_service_open_flag_is_on
+
+    when_i_deactivate_the_service_open_flag
+    then_the_service_open_flag_is_off
+  end
+
+  private
+
+  def then_i_see_the_feature_flags
+    expect(page).to have_current_path("/support/features")
+    expect(page).to have_title("Features")
+    expect(page).to have_content("Features")
+  end
+
+  def then_the_service_open_flag_is_off
+    expect(page).to have_content("Feature “Service open” deactivated")
+    expect(page).to have_content("Service open\n- Inactive")
+  end
+
+  def then_the_service_open_flag_is_on
+    expect(page).to have_content("Feature “Service open” activated")
+    expect(page).to have_content("Service open\n- Active")
+  end
+
+  def when_i_activate_the_service_open_flag
+    click_on "Activate Service open"
+  end
+
+  def when_i_am_authorized_as_a_support_user
+    page.driver.basic_authorize(
+      ENV.fetch("SUPPORT_USERNAME", "test"),
+      ENV.fetch("SUPPORT_PASSWORD", "test")
+    )
+  end
+
+  def when_i_deactivate_the_service_open_flag
+    click_on "Deactivate Service open"
+  end
+
+  def when_i_visit_the_feature_flags_page
+    visit support_interface_features_path
+  end
+end

--- a/spec/system/support_interface/sidekiq_spec.rb
+++ b/spec/system/support_interface/sidekiq_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Sidekiq support", type: :system do
+  it "allows viewing Sidekiq dashboard" do
+    when_i_am_authorized_as_a_support_user
+    when_i_visit_the_sidekiq_page
+    then_i_see_the_sidekiq_dashboard
+  end
+
+  private
+
+  def when_i_am_authorized_as_a_support_user
+    page.driver.basic_authorize(
+      ENV.fetch("SUPPORT_USERNAME", "test"),
+      ENV.fetch("SUPPORT_PASSWORD", "test")
+    )
+  end
+
+  def when_i_visit_the_sidekiq_page
+    visit "/support/sidekiq"
+  end
+
+  def then_i_see_the_sidekiq_dashboard
+    expect(page).to have_current_path("/support/sidekiq")
+    expect(page).to have_content("Dashboard")
+    expect(page).to have_content("History")
+  end
+end


### PR DESCRIPTION
This changes how we authenticate access to the support interface, by using a Devise/Warden strategy which uses HTTP Basic auth if there are no staff members, or normal Devise authentication if there are staff members.

This means that regardless of how the user got to the support/assessor interface (either via database authentication or via this new strategy), the controllers will handle them in the same way reducing potential duplication.

I've also added a feature so we can enable support for HTTP basic auth at any point, but by default it's only enabled if there are no staff users.

[Trello Card](https://trello.com/c/gzMG6AzK/522-applicant-sign-in-and-sign-back-in)