### PR TITLE
Specify REDIS_URL when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN yarn build && yarn build:css
 RUN RAILS_ENV=production \
     SECRET_KEY_BASE=required-to-run-but-not-used \
     GOVUK_NOTIFY_API_KEY=required-to-run-but-not-used \
+    REDIS_URL=required-to-run-but-not-used \
     bundle exec rails assets:precompile
 
 # Cleanup to save space in the production image


### PR DESCRIPTION
This is required as the production configuration requires this environment variable to be set as of 4fbc4ff08343913fd941290d9b9cba6965f0668a.