### PR TITLE
Fix format of fake REDIS_URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN yarn build && yarn build:css
 RUN RAILS_ENV=production \
     SECRET_KEY_BASE=required-to-run-but-not-used \
     GOVUK_NOTIFY_API_KEY=required-to-run-but-not-used \
-    REDIS_URL=required-to-run-but-not-used \
+    REDIS_URL=redis://required-to-run-but-not-used \
     bundle exec rails assets:precompile
 
 # Cleanup to save space in the production image


### PR DESCRIPTION
Without the scheme we get an error when trying to precompile the assets. This was missed in 0e96a0033914843e93f0854facb7ad76236cc14d. 🤦🏻‍♂️ 