### PR TITLE
Add page for 429 errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
@@ -8,6 +7,10 @@ class ErrorsController < ApplicationController
 
   def unprocessable_entity
     render "unprocessable_entity", status: :unprocessable_entity
+  end
+
+  def too_many_requests
+    render "too_many_requests", status: :too_many_requests
   end
 
   def internal_server_error

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -1,0 +1,19 @@
+<%= content_for :page_title, "Sorry, there’s a problem with the service" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Sorry, there’s a problem with the service</h1>
+
+    <p class="govuk-body">Try again later.</p>
+
+    <p class="govuk-body">
+      You’re seeing this message as you’ve tried to access this page repeatedly,
+      please wait a few moments before trying again.
+    </p>
+
+    <p class="govuk-body">
+      If you have any questions, please email us at
+      <a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.
+    </p>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   scope via: :all do
     get "/404", to: "errors#not_found"
     get "/422", to: "errors#unprocessable_entity"
+    get "/429", to: "errors#too_many_requests"
     get "/500", to: "errors#internal_server_error"
   end
 


### PR DESCRIPTION
This adds an error page which users are seen if they receive a 429 error, meaning they've triggered our rate limiting checks.

This was missed in f225a5ac24b72aa564bc80303c5f99ac29cf4ab4.