### PR TITLE
Use DfE Analytics testing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics
-  revision: b5a03c732a154dc100c7c5d13c23e931b4aab502
+  revision: 52fc43d39d061014cdc97bf3042defc297fc8c4d
   specs:
-    dfe-analytics (1.0.0)
+    dfe-analytics (1.2.1)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 
@@ -145,9 +145,9 @@ GEM
       websocket-driver (>= 0.6, < 0.8)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    google-apis-bigquery_v2 (0.34.0)
-      google-apis-core (>= 0.5, < 2.a)
-    google-apis-core (0.5.0)
+    google-apis-bigquery_v2 (0.35.0)
+      google-apis-core (>= 0.6, < 2.a)
+    google-apis-core (0.7.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -168,7 +168,7 @@ GEM
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
     google-cloud-errors (1.2.0)
-    googleauth (1.1.3)
+    googleauth (1.2.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -386,9 +386,9 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    signet (0.16.1)
+    signet (0.17.0)
       addressable (~> 2.8)
-      faraday (>= 0.17.5, < 3.0)
+      faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
     solargraph (0.45.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ end
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 require "capybara/cuprite"
+require "dfe/analytics/testing"
 require "view_component/test_helpers"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/support/dfe_analytics.rb
+++ b/spec/support/dfe_analytics.rb
@@ -1,5 +1,0 @@
-RSpec.configure do |config|
-  config.around(:example, type: :system) do |example|
-    ClimateControl.modify(BIGQUERY_DISABLE: "true") { example.run }
-  end
-end


### PR DESCRIPTION
This changes the way we disable DfE Analytics in our tests by using the built-in DfE Analytics fake testing mode.

Note that this depends on https://github.com/DFE-Digital/dfe-analytics/pull/26.