### PR TITLE
Disable DfE Analytics by default in development

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,4 +1,4 @@
-BIGQUERY_DISABLE=true
+BIGQUERY_DISABLE=false
 BIGQUERY_API_JSON_KEY={ replaceMe: 'I should be a copy of a BigQuery JSON key' }
 BIGQUERY_DATASET=events_local
 BIGQUERY_PROJECT_ID=apply-for-qts-in-england

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ bin/dev
 
 Edit `.env.local` and add a BigQuery key if you want to use BigQuery locally.
 
-Remove `BIGQUERY_DISABLE=true` or set it to `false`.
+Set `BIGQUERY_DISABLE` to `false` as it defaults to `true` in the development environment.
 
 [Read more about setting up BigQuery](docs/set-up-analytics.md).
 

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -1,6 +1,10 @@
 DfE::Analytics.configure do |config|
-  config.enable_analytics =
-    proc { ENV.fetch("BIGQUERY_DISABLE", "false") != "true" }
   config.queue = :analytics
   config.environment = HostingEnvironment.name
+
+  config.enable_analytics =
+    proc do
+      disabled_by_default = Rails.env.development?
+      ENV.fetch("BIGQUERY_DISABLE", disabled_by_default.to_s) != "true"
+    end
 end


### PR DESCRIPTION
Most likely in a development environment we don't want DfE Analytics to be enabled, so this should be default. Instead, users need to explicitly turn it on if they'd like to use it.

This makes sense as it means out of the box the application runs with reasonable defaults, rather than needing the user to create a `.env.local` file and disable BigQuery.