### PR TITLE
Calculate duration for users who've answered all questions

### DIFF
--- a/app/lib/performance_stats.rb
+++ b/app/lib/performance_stats.rb
@@ -77,7 +77,8 @@ class PerformanceStats
   def calculate_duration_usage
     percentiles_by_day =
       @eligibility_checks
-        .where.not(completed_at: nil)
+        .complete
+        .answered_all_questions
         .group("1")
         .pluck(
           Arel.sql("date_trunc('day', created_at) AS day"),

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -40,6 +40,15 @@ class EligibilityCheck < ApplicationRecord
             .or(where(region: nil))
             .or(where(teach_children: false))
         }
+  scope :answered_all_questions,
+        -> {
+          where.not(
+            degree: nil,
+            free_of_sanctions: nil,
+            qualification: nil,
+            teach_children: nil
+          )
+        }
 
   def country_code=(value)
     super(value)

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -173,6 +173,15 @@ RSpec.describe EligibilityCheck, type: :model do
     it { is_expected.to eq([region_1, region_2]) }
   end
 
+  describe "#complete" do
+    subject(:complete) { described_class.complete }
+
+    let!(:incomplete_check) { create(:eligibility_check) }
+    let!(:complete_check) { create(:eligibility_check, :complete) }
+
+    it { is_expected.to eq([complete_check]) }
+  end
+
   describe "#eligible" do
     subject(:eligible) { described_class.eligible }
 
@@ -183,15 +192,6 @@ RSpec.describe EligibilityCheck, type: :model do
     it { is_expected.to include(eligibility_check_2) }
   end
 
-  describe "#complete" do
-    subject(:complete) { described_class.complete }
-
-    let!(:incomplete_check) { create(:eligibility_check) }
-    let!(:complete_check) { create(:eligibility_check, :complete) }
-
-    it { is_expected.to eq([complete_check]) }
-  end
-
   describe "#ineligible" do
     subject(:ineligible) { described_class.ineligible }
 
@@ -199,6 +199,24 @@ RSpec.describe EligibilityCheck, type: :model do
     let!(:eligible_check) { create(:eligibility_check, :eligible) }
 
     it { is_expected.to eq([ineligible_check]) }
+  end
+
+  describe "#answered_all_questions" do
+    subject(:eligible) { described_class.answered_all_questions }
+
+    let(:eligibility_check_1) { create(:eligibility_check) }
+    let(:eligibility_check_2) do
+      create(
+        :eligibility_check,
+        degree: true,
+        free_of_sanctions: false,
+        qualification: true,
+        teach_children: false
+      )
+    end
+
+    it { is_expected.to_not include(eligibility_check_1) }
+    it { is_expected.to include(eligibility_check_2) }
   end
 
   describe "#complete!" do


### PR DESCRIPTION
At the moment we calculate the duration stats for all completed eligibility checks, but this includes ones not in the private beta which means users are immediately taken to the eligible or ineligible page after choosing their country. This skews the data and suggests that it takes no time at all to complete the journey, when in reality we only care about users who are filling in all the questions.

[Trello Card](https://trello.com/c/VMUslThU/559-iterate-the-performance-dashboard)