### PR TITLE
Combine all checks and eligible checks

### DIFF
--- a/app/controllers/performance_controller.rb
+++ b/app/controllers/performance_controller.rb
@@ -13,8 +13,8 @@ class PerformanceController < ApplicationController
 
     @all_checks_count, @eligible_checks_count, @live_service_data =
       stats.live_service_usage
+    @time_to_complete_data = stats.time_to_complete
     @countries, @country_data = stats.country_usage
-    @duration_data = stats.duration_usage
   end
 
   def current_namespace

--- a/app/views/performance/index.html.erb
+++ b/app/views/performance/index.html.erb
@@ -32,6 +32,15 @@
 </div>
 
 <div class="app-!-border-top-1 govuk-!-padding-top-2">
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Time to complete</h2>
+  <p class="govuk-!-font-size-16">
+    How quickly did users check their eligibility <%= @since_text %>
+  </p>
+
+  <%= govuk_table(rows: @time_to_complete_data, classes: 'app-performance-table') %>
+</div>
+
+<div class="app-!-border-top-1 govuk-!-padding-top-2">
   <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Country usage</h2>
   <p class="govuk-!-font-size-16">
     Number of eligibility checks submitted by country <%= @since_text %>
@@ -45,15 +54,6 @@
   </div>
 
   <%= govuk_table(rows: @country_data, classes: 'app-performance-table') %>
-</div>
-
-<div class="app-!-border-top-1 govuk-!-padding-top-2">
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-1">Time to complete</h2>
-  <p class="govuk-!-font-size-16">
-    How quickly did users check their eligibility <%= @since_text %>
-  </p>
-
-  <%= govuk_table(rows: @duration_data, classes: 'app-performance-table') %>
 </div>
 
 <div class="govuk-grid-row">

--- a/spec/lib/performance_stats_spec.rb
+++ b/spec/lib/performance_stats_spec.rb
@@ -13,18 +13,18 @@ RSpec.describe PerformanceStats do
     end
   end
 
+  describe "#time_to_complete" do
+    it "calculates time to complete" do
+      data = subject.time_to_complete
+      expect(data.size).to eq 8
+    end
+  end
+
   describe "#country_usage" do
     it "calculates country usage" do
       count, data = subject.country_usage
       expect(count).to eq 0
       expect(data.size).to eq 1
-    end
-  end
-
-  describe "#duration_usage" do
-    it "calculates duration results" do
-      data = subject.duration_usage
-      expect(data.size).to eq 8
     end
   end
 end

--- a/spec/system/performance_spec.rb
+++ b/spec/system/performance_spec.rb
@@ -34,9 +34,7 @@ RSpec.describe "Performance", type: :system do
   end
 
   def then_i_see_the_live_stats
-    expect(page).to have_content(
-      "36\nchecks over the last 7 days"
-    )
+    expect(page).to have_content("36\nchecks over the last 7 days")
     expect(page).to have_content("30 June\t1")
     expect(page).to have_content("24 June\t7")
   end
@@ -46,9 +44,7 @@ RSpec.describe "Performance", type: :system do
   end
 
   def then_i_see_the_live_stats_since_launch
-    expect(page).to have_content(
-      "45\nchecks since launch"
-    )
+    expect(page).to have_content("45\nchecks since launch")
     expect(page).to have_content("30 June\t1")
     expect(page).to have_content("22 June\t9")
   end


### PR DESCRIPTION
This combines the two sections in the performance dashboard for all checks and successful checks in to a single table to save space and hopefully make comparisons easier to understand.

I've also moved the position of the time to complete data as I think it looks visually better on the page, especially since the country usage section can be quite long.

[Trello Card](https://trello.com/c/VMUslThU/559-iterate-the-performance-dashboard)

![Screenshot 2022-06-30 at 12 34 18](https://user-images.githubusercontent.com/510498/176667827-006383a7-f330-42a7-9400-6da6299fb3fb.png)
