### PR TITLE
Add "full checks" to performance dashboard

### DIFF
--- a/app/controllers/performance_controller.rb
+++ b/app/controllers/performance_controller.rb
@@ -11,7 +11,10 @@ class PerformanceController < ApplicationController
 
     stats = PerformanceStats.new(from:)
 
-    @all_checks_count, @eligible_checks_count, @live_service_data =
+    @all_checks_count,
+    @answered_all_questions_checks_count,
+    @eligible_checks_count,
+    @live_service_data =
       stats.live_service_usage
     @time_to_complete_data = stats.time_to_complete
     @usage_by_country_count, @usage_by_country_data = stats.usage_by_country

--- a/app/views/performance/index.html.erb
+++ b/app/views/performance/index.html.erb
@@ -23,6 +23,10 @@
       <p>checks <%= @since_text %></p>
     </div>
     <div style="display: inline-block" class="govuk-!-margin-left-8">
+      <p class="govuk-!-font-size-48 govuk-!-margin-bottom-0 govuk-!-text-align-left govuk-!-font-weight-bold app-!-colour--link"><%= number_with_delimiter(@answered_all_questions_checks_count) %></p>
+      <p>full checks <%= @since_text %></p>
+    </div>
+    <div style="display: inline-block" class="govuk-!-margin-left-8">
       <p class="govuk-!-font-size-48 govuk-!-margin-bottom-0 govuk-!-text-align-left govuk-!-font-weight-bold app-!-colour--link"><%= number_with_delimiter(@eligible_checks_count) %></p>
       <p>eligible checks <%= @since_text %></p>
     </div>

--- a/spec/lib/performance_stats_spec.rb
+++ b/spec/lib/performance_stats_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe PerformanceStats do
 
   describe "#live_service_usage" do
     it "calculates live service usage" do
-      count, data = subject.live_service_usage
-      expect(count).to eq 0
+      all_count, full_count, eligible_count, data = subject.live_service_usage
+      expect(all_count).to eq 0
+      expect(full_count).to eq 0
+      expect(eligible_count).to eq 0
       expect(data.size).to eq 8
     end
   end


### PR DESCRIPTION
This shows us checks where the users have answered all the questions, meaning that they've gone through the entire flow. This is already shown in the countries usage table, but we'd like to see it on the live usage table too.