### PR TITLE
Remove old eligibility checks when removing a region

### DIFF
--- a/app/controllers/support_interface/countries_controller.rb
+++ b/app/controllers/support_interface/countries_controller.rb
@@ -22,7 +22,9 @@ class SupportInterface::CountriesController < SupportInterface::BaseController
       when :create
         @country.regions.create!(name: action[:name])
       when :delete
-        @country.regions.find_by!(name: action[:name]).destroy!
+        region = @country.regions.find_by!(name: action[:name])
+        region.eligibility_checks.delete_all
+        region.destroy!
       end
     end
 

--- a/app/views/support_interface/countries/confirm_edit.html.erb
+++ b/app/views/support_interface/countries/confirm_edit.html.erb
@@ -8,7 +8,7 @@
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive">Warning</span>
-    This action is irreversible.
+    This action is irreversible and could affect historic eligibility checks.
   </strong>
 </div>
 


### PR DESCRIPTION
There's not much else we can do with these eligibility checks if we're removing a region for the system. We think it's okay to delete them because:

They'll most likely be non-private beta countries, so we don't care so much about those analytics in the performance dashboard, and we've got the data in BigQuery to see the historical data.

[Sentry ssue](https://sentry.io/organizations/dfe-teacher-services/issues/3400064433/)