### PR TITLE
Fix path after completed requirements

### DIFF
--- a/app/forms/eligibility_interface/completed_requirements_form.rb
+++ b/app/forms/eligibility_interface/completed_requirements_form.rb
@@ -19,10 +19,6 @@ class EligibilityInterface::CompletedRequirementsForm
   end
 
   def success_url
-    Rails
-      .application
-      .routes
-      .url_helpers
-      .eligibility_interface_qualifications_path
+    Rails.application.routes.url_helpers.eligibility_interface_degree_path
   end
 end


### PR DESCRIPTION
This should be degree, otherwise we miss a question.

This isn't causing a problem in production because the question order enforcer is working to redirect users to the degree question.