### PR TITLE
Create new eligiblity checks if necessary

### DIFF
--- a/app/controllers/eligibility_interface/start_controller.rb
+++ b/app/controllers/eligibility_interface/start_controller.rb
@@ -11,6 +11,7 @@ class EligibilityInterface::StartController < EligibilityInterface::BaseControll
   end
 
   def create
+    @eligibility_check = EligibilityCheck.new if eligibility_check.completed_at?
     eligibility_check.save!
     redirect_to eligibility_interface_countries_path
   end

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_choose_no
     and_i_submit
     then_i_see_the_eligible_page
+
+    when_i_visit_the_start_page
+    then_i_see_the_start_page
+    when_i_press_start_now
+    then_i_have_two_eligibility_checks
   end
 
   it "ineligible paths" do
@@ -438,5 +443,9 @@ RSpec.describe "Eligibility check", type: :system do
     expect(page).to have_content(
       "Are you qualified to teach children who are aged somewhere between 5 and 16 years?"
     )
+  end
+
+  def then_i_have_two_eligibility_checks
+    expect(EligibilityCheck.count).to eq(2)
   end
 end


### PR DESCRIPTION
This ensures that a user who wants to answer the questions again, by going back to the start, is recorded in a new eligibility check. The main reason for this is to ensure our analytics are correct, it doesn't really affect the functionality of the tool.