### PR TITLE
Preview region as active

### DIFF
--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -22,6 +22,9 @@ module SupportInterface
 
     def preview
       @region = Region.find(params[:id])
+
+      # Non-legacy previews are more useful to the team.
+      @region.legacy = false
     end
 
     private


### PR DESCRIPTION
It's less useful to see a legacy region, and actually the main reason behind the preview was to allow content designers to add content before making them live.