### PR TITLE
Use country name instead of region name

### DIFF
--- a/app/lib/country_name.rb
+++ b/app/lib/country_name.rb
@@ -17,7 +17,7 @@ class CountryName
 
     def from_eligibility_check(eligibility_check, with_definite_article: false)
       if eligibility_check.region.present?
-        from_region(eligibility_check.region, with_definite_article:)
+        from_country(eligibility_check.region.country, with_definite_article:)
       else
         from_code(eligibility_check.country_code, with_definite_article:)
       end

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -32,7 +32,7 @@
         <li>A transcript (or diploma supplement) for that qualification, issued by the awarding body. If your teacher training was part of your university degree, use your degree transcript. </li>
       </ul>
       <p class="govuk-body">A transcript is a document from the institution where you studied. It lists all the modules or subjects you studied in each year, and the marks or grades you were awarded.
-        Note that you must have completed all of your teacher training qualification in <%= CountryName.from_region(region, with_definite_article: true) %>.
+        Note that you must have completed all of your teacher training qualification in <%= CountryName.from_country(region.country, with_definite_article: true) %>.
       </p>
     <% end %>
 

--- a/spec/lib/country_name_spec.rb
+++ b/spec/lib/country_name_spec.rb
@@ -90,10 +90,12 @@ RSpec.describe CountryName do
 
     context "with a named region" do
       before do
-        eligibility_check.update!(region: create(:region, name: "California"))
+        eligibility_check.update!(
+          region: create(:region, country: create(:country, code: "US"))
+        )
       end
 
-      it { is_expected.to eq("California") }
+      it { is_expected.to eq("United States") }
     end
   end
 end


### PR DESCRIPTION
This changes how the country names are determined to use the region name in more places than before. We think this is clearer for users since although the teaching authority is different per state, the overall requirements are specific to the country.