### PR TITLE
Remove single teaching authority columns

### DIFF
--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -2,21 +2,19 @@
 #
 # Table name: regions
 #
-#  id                               :bigint           not null, primary key
-#  legacy                           :boolean          default(TRUE), not null
-#  name                             :string           default(""), not null
-#  sanction_check                   :string           default("none"), not null
-#  status_check                     :string           default("none"), not null
-#  teaching_authority_address       :text             default(""), not null
-#  teaching_authority_certificate   :text             default(""), not null
-#  teaching_authority_email_address :text             default(""), not null
-#  teaching_authority_emails        :text             default([]), not null, is an Array
-#  teaching_authority_other         :text             default(""), not null
-#  teaching_authority_website       :text             default(""), not null
-#  teaching_authority_websites      :text             default([]), not null, is an Array
-#  created_at                       :datetime         not null
-#  updated_at                       :datetime         not null
-#  country_id                       :bigint           not null
+#  id                             :bigint           not null, primary key
+#  legacy                         :boolean          default(TRUE), not null
+#  name                           :string           default(""), not null
+#  sanction_check                 :string           default("none"), not null
+#  status_check                   :string           default("none"), not null
+#  teaching_authority_address     :text             default(""), not null
+#  teaching_authority_certificate :text             default(""), not null
+#  teaching_authority_emails      :text             default([]), not null, is an Array
+#  teaching_authority_other       :text             default(""), not null
+#  teaching_authority_websites    :text             default([]), not null, is an Array
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  country_id                     :bigint           not null
 #
 # Indexes
 #

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -12,8 +12,6 @@
     - teaching_authority_address
     - teaching_authority_emails
     - teaching_authority_websites
-    - teaching_authority_website
-    - teaching_authority_email_address
     - teaching_authority_other
     - legacy
   :features:

--- a/db/migrate/20220706105701_remove_teaching_authority_singles.rb
+++ b/db/migrate/20220706105701_remove_teaching_authority_singles.rb
@@ -1,0 +1,17 @@
+class RemoveTeachingAuthoritySingles < ActiveRecord::Migration[7.0]
+  def up
+    change_table :regions, bulk: true do |t|
+      t.remove :teaching_authority_website, :teaching_authority_email_address
+    end
+  end
+
+  def down
+    change_table :regions, bulk: true do |t|
+      t.column :teaching_authority_website, :text, default: "", null: false
+      t.column :teaching_authority_email_address,
+               :text,
+               default: "",
+               null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_05_141202) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_06_105701) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,8 +51,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_05_141202) do
     t.string "sanction_check", default: "none", null: false
     t.text "teaching_authority_certificate", default: "", null: false
     t.text "teaching_authority_address", default: "", null: false
-    t.text "teaching_authority_website", default: "", null: false
-    t.text "teaching_authority_email_address", default: "", null: false
     t.boolean "legacy", default: true, null: false
     t.text "teaching_authority_other", default: "", null: false
     t.text "teaching_authority_emails", default: [], null: false, array: true

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -2,21 +2,19 @@
 #
 # Table name: regions
 #
-#  id                               :bigint           not null, primary key
-#  legacy                           :boolean          default(TRUE), not null
-#  name                             :string           default(""), not null
-#  sanction_check                   :string           default("none"), not null
-#  status_check                     :string           default("none"), not null
-#  teaching_authority_address       :text             default(""), not null
-#  teaching_authority_certificate   :text             default(""), not null
-#  teaching_authority_email_address :text             default(""), not null
-#  teaching_authority_emails        :text             default([]), not null, is an Array
-#  teaching_authority_other         :text             default(""), not null
-#  teaching_authority_website       :text             default(""), not null
-#  teaching_authority_websites      :text             default([]), not null, is an Array
-#  created_at                       :datetime         not null
-#  updated_at                       :datetime         not null
-#  country_id                       :bigint           not null
+#  id                             :bigint           not null, primary key
+#  legacy                         :boolean          default(TRUE), not null
+#  name                           :string           default(""), not null
+#  sanction_check                 :string           default("none"), not null
+#  status_check                   :string           default("none"), not null
+#  teaching_authority_address     :text             default(""), not null
+#  teaching_authority_certificate :text             default(""), not null
+#  teaching_authority_emails      :text             default([]), not null, is an Array
+#  teaching_authority_other       :text             default(""), not null
+#  teaching_authority_websites    :text             default([]), not null, is an Array
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  country_id                     :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -2,21 +2,19 @@
 #
 # Table name: regions
 #
-#  id                               :bigint           not null, primary key
-#  legacy                           :boolean          default(TRUE), not null
-#  name                             :string           default(""), not null
-#  sanction_check                   :string           default("none"), not null
-#  status_check                     :string           default("none"), not null
-#  teaching_authority_address       :text             default(""), not null
-#  teaching_authority_certificate   :text             default(""), not null
-#  teaching_authority_email_address :text             default(""), not null
-#  teaching_authority_emails        :text             default([]), not null, is an Array
-#  teaching_authority_other         :text             default(""), not null
-#  teaching_authority_website       :text             default(""), not null
-#  teaching_authority_websites      :text             default([]), not null, is an Array
-#  created_at                       :datetime         not null
-#  updated_at                       :datetime         not null
-#  country_id                       :bigint           not null
+#  id                             :bigint           not null, primary key
+#  legacy                         :boolean          default(TRUE), not null
+#  name                           :string           default(""), not null
+#  sanction_check                 :string           default("none"), not null
+#  status_check                   :string           default("none"), not null
+#  teaching_authority_address     :text             default(""), not null
+#  teaching_authority_certificate :text             default(""), not null
+#  teaching_authority_emails      :text             default([]), not null, is an Array
+#  teaching_authority_other       :text             default(""), not null
+#  teaching_authority_websites    :text             default([]), not null, is an Array
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  country_id                     :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
We're not longer using them since https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/207 has been deployed.