### PR TITLE
Be explicit about country name usage

### DIFF
--- a/app/controllers/eligibility_interface/base_controller.rb
+++ b/app/controllers/eligibility_interface/base_controller.rb
@@ -1,6 +1,6 @@
 module EligibilityInterface
   class BaseController < ApplicationController
-    before_action :load_country_name
+    before_action :load_region
     after_action :save_eligibility_check_id
 
     def eligibility_check
@@ -14,12 +14,8 @@ module EligibilityInterface
         end
     end
 
-    def load_country_name
-      @country_name =
-        CountryName.from_eligibility_check(
-          eligibility_check,
-          with_definite_article: true
-        )
+    def load_region
+      @region = eligibility_check.region
     end
 
     def save_eligibility_check_id

--- a/app/views/eligibility_interface/completed_requirements/new.html.erb
+++ b/app/views/eligibility_interface/completed_requirements/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{'Error: ' if @completed_requirements_form.errors.any?}Have you completed all requirements to work as a qualified teacher in #{@country_name}?" %>
+<% content_for :page_title, "#{'Error: ' if @completed_requirements_form.errors.any?}Have you completed all requirements to work as a qualified teacher in #{CountryName.from_region(@region, with_definite_article: true)}?" %>
 <% content_for :back_link_url, back_link_url(eligibility_interface_countries_url) %>
 
 <div class="govuk-grid-row">
@@ -10,7 +10,7 @@
             [OpenStruct.new(label: 'Yes', value: true), OpenStruct.new(label: 'No', value: false)],
             :value,
             :label,
-            legend: { size: 'l', tag: 'h1', text: "Have you completed all requirements to work as a qualified teacher in #{@country_name}?" },
+            legend: { size: 'l', tag: 'h1', text: "Have you completed all requirements to work as a qualified teacher in #{CountryName.from_region(@region, with_definite_article: true)}?" },
             hint: { text: "For example, you need to have completed any mandatory professional experience or induction periods." }
           ) %>
       <%= f.govuk_submit prevent_double_click: false %>

--- a/app/views/eligibility_interface/finish/ineligible.html.erb
+++ b/app/views/eligibility_interface/finish/ineligible.html.erb
@@ -8,13 +8,13 @@
     </h1>
 
     <% if @eligibility_check.ineligible_reasons.include?(:country) %>
-      <p class="govuk-body">Teachers applying from <%= @country_name %> are not currently eligible to use this service. However, you can <%= govuk_link_to "apply for QTS using alternative routes", "https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#qts-exemption-for-teachers-from-outside-the-uk" %>.</p>
+      <p class="govuk-body">Teachers applying from <%= CountryName.from_eligibility_check(@eligibility_check, with_definite_article: true) %> are not currently eligible to use this service. However, you can <%= govuk_link_to "apply for QTS using alternative routes", "https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#qts-exemption-for-teachers-from-outside-the-uk" %>.</p>
     <% else %>
       <p class="govuk-body">This is because:</p>
 
       <ul class="govuk-list govuk-list--bullet">
         <% @eligibility_check.ineligible_reasons.each do |reason| %>
-          <li><%= I18n.t("activemodel.attributes.eligibility_check.ineligible_reason.#{reason}", country_name: @country_name) %></li>
+          <li><%= I18n.t("activemodel.attributes.eligibility_check.ineligible_reason.#{reason}", country_name: CountryName.from_eligibility_check(@eligibility_check, with_definite_article: true)) %></li>
         <% end %>
       </ul>
     <% end %>


### PR DESCRIPTION
There are some places where we want to show the country name (even if there's a named region), and some places where we want to show the region name. I've fixed where this is incorrect (in the completed requirements question) and moved where we call `CountryName` to be explicit about what we want to see in each place.

Follow up of #205.