### PR TITLE
Disable completed requirements question

### DIFF
--- a/app/forms/eligibility_interface/country_form.rb
+++ b/app/forms/eligibility_interface/country_form.rb
@@ -20,7 +20,7 @@ class EligibilityInterface::CountryForm
           .application
           .routes
           .url_helpers
-          .eligibility_interface_completed_requirements_path,
+          .eligibility_interface_qualifications_path,
       ineligible:
         Rails
           .application

--- a/app/forms/eligibility_interface/region_form.rb
+++ b/app/forms/eligibility_interface/region_form.rb
@@ -25,7 +25,7 @@ class EligibilityInterface::RegionForm
           .application
           .routes
           .url_helpers
-          .eligibility_interface_completed_requirements_path,
+          .eligibility_interface_qualifications_path,
       legacy:
         Rails.application.routes.url_helpers.eligibility_interface_eligible_path
     }.fetch(eligibility_check.region_eligibility_status)

--- a/app/views/eligibility_interface/qualifications/new.html.erb
+++ b/app/views/eligibility_interface/qualifications/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @qualification_form.errors.any?}Do you have a teacher training qualification?" %>
-<% content_for :back_link_url, back_link_url(eligibility_interface_completed_requirements_path) %>
+<% content_for :back_link_url, back_link_url(eligibility_interface_countries_path) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/spec/forms/eligibility_interface/country_form_spec.rb
+++ b/spec/forms/eligibility_interface/country_form_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe EligibilityInterface::CountryForm, type: :model do
     context "with an eligible country" do
       let(:country) { create(:country, :with_national_region) }
 
-      it { is_expected.to eq("/eligibility/completed-requirements") }
+      it { is_expected.to eq("/eligibility/qualifications") }
     end
 
     context "with a legacy country" do

--- a/spec/forms/eligibility_interface/region_form_spec.rb
+++ b/spec/forms/eligibility_interface/region_form_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe EligibilityInterface::RegionForm, type: :model do
     context "with an eligible country" do
       let(:region) { create(:region) }
 
-      it { is_expected.to eq("/eligibility/completed-requirements") }
+      it { is_expected.to eq("/eligibility/qualifications") }
     end
 
     context "with a legacy country" do

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -281,37 +281,18 @@ RSpec.describe EligibilityCheck, type: :model do
     context "when a region is present" do
       let(:attributes) { { region: create(:region) } }
 
-      it { is_expected.to eq(:completed_requirements) }
-    end
-
-    context "when completed requirements is present" do
-      let(:attributes) do
-        { completed_requirements: true, region: create(:region) }
-      end
-
       it { is_expected.to eq(:qualification) }
     end
 
     context "when qualification is present" do
-      let(:attributes) do
-        {
-          qualification: true,
-          completed_requirements: true,
-          region: create(:region)
-        }
-      end
+      let(:attributes) { { qualification: true, region: create(:region) } }
 
       it { is_expected.to eq(:degree) }
     end
 
     context "when degree is present" do
       let(:attributes) do
-        {
-          qualification: true,
-          degree: true,
-          completed_requirements: true,
-          region: create(:region)
-        }
+        { qualification: true, degree: true, region: create(:region) }
       end
 
       it { is_expected.to eq(:teach_children) }
@@ -323,7 +304,6 @@ RSpec.describe EligibilityCheck, type: :model do
           teach_children: true,
           qualification: true,
           degree: true,
-          completed_requirements: true,
           region: create(:region)
         }
       end
@@ -338,7 +318,6 @@ RSpec.describe EligibilityCheck, type: :model do
           teach_children: true,
           qualification: true,
           degree: true,
-          completed_requirements: true,
           region: create(:region)
         }
       end

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -17,11 +17,7 @@ RSpec.describe "Eligibility check", type: :system do
 
     when_i_select_a_country
     and_i_submit
-    then_i_see_the_completed_requirements_page
-
-    when_i_choose_yes
-    and_i_submit
-    then_i_see_the_qualification_page
+    then_i_see_the_qualifications_page
 
     when_i_choose_yes
     and_i_submit
@@ -57,9 +53,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_press_back
     when_i_select_a_country
     and_i_submit
-    when_i_choose_no
-    and_i_submit
-    then_i_see_the_qualification_page
+    then_i_see_the_qualifications_page
 
     when_i_choose_no
     and_i_submit
@@ -76,7 +70,6 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_choose_yes
     and_i_submit
     then_i_see_the_ineligible_page
-    and_i_see_the_ineligible_completed_requirements_text
     and_i_see_the_ineligible_degree_text
     and_i_see_the_ineligible_qualification_text
     and_i_see_the_ineligible_teach_children_text
@@ -101,17 +94,10 @@ RSpec.describe "Eligibility check", type: :system do
 
     when_i_select_a_country
     and_i_submit
-    then_i_see_the_completed_requirements_page
-
-    when_i_try_to_go_to_the_qualifications_page
-    then_i_see_the_completed_requirements_page
-
-    when_i_choose_yes
-    and_i_submit
-    then_i_see_the_qualification_page
+    then_i_see_the_qualifications_page
 
     when_i_try_to_go_to_the_degree_page
-    then_i_see_the_qualification_page
+    then_i_see_the_qualifications_page
 
     when_i_choose_yes
     and_i_submit
@@ -140,7 +126,7 @@ RSpec.describe "Eligibility check", type: :system do
 
     when_i_select_a_country_in_the_error_state
     and_i_submit
-    then_i_see_the_completed_requirements_page
+    then_i_see_the_qualifications_page
   end
 
   it "sends legacy users to the old service" do
@@ -163,7 +149,7 @@ RSpec.describe "Eligibility check", type: :system do
 
     when_i_choose_region
     and_i_submit
-    then_i_see_the_completed_requirements_page
+    then_i_see_the_qualifications_page
   end
 
   it "service is closed" do
@@ -424,7 +410,7 @@ RSpec.describe "Eligibility check", type: :system do
     expect(page).to have_content("Do you have a university degree?")
   end
 
-  def then_i_see_the_qualification_page
+  def then_i_see_the_qualifications_page
     expect(page).to have_current_path("/eligibility/qualifications")
     expect(page).to have_title("Do you have a teacher training qualification?")
     expect(page).to have_content(


### PR DESCRIPTION
This temporarily removes the question as we're not sure it works in a way that want just for the time being. It's nearly there, but it doesn't work perfectly and we need to take it down to give it more thought.

We can reinstate once we've got the logic properly sorted.