### PR TITLE
Keep non-secret environment variables in source

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -5,7 +5,11 @@ locals {
 
   app_environment_variables = merge(local.azure_environment_variables, {
     HOSTING_ENVIRONMENT = var.environment_name,
-    REDIS_URL           = cloudfoundry_service_key.redis_key.credentials.uri
+    REDIS_URL           = cloudfoundry_service_key.redis_key.credentials.uri,
+
+    BIGQUERY_PROJECT_ID = local.bigquery_project_id,
+    BIGQUERY_DATASET    = local.bigquery_dataset,
+    BIGQUERY_TABLE_NAME = local.bigquery_table_name
   })
 }
 

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -9,7 +9,9 @@ locals {
 
     BIGQUERY_PROJECT_ID = local.bigquery_project_id,
     BIGQUERY_DATASET    = local.bigquery_dataset,
-    BIGQUERY_TABLE_NAME = local.bigquery_table_name
+    BIGQUERY_TABLE_NAME = local.bigquery_table_name,
+
+    RAILS_SERVE_STATIC_FILES = "true"
   })
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -72,4 +72,8 @@ locals {
   apply_qts_app_name     = "apply-for-qts-in-england-${var.environment_name}${var.app_suffix}"
   postgres_database_name = "apply-for-qts-in-england-${var.environment_name}${var.app_suffix}-pg-svc"
   redis_database_name    = "apply-for-qts-in-england-${var.environment_name}${var.app_suffix}-redis-svc"
+
+  bigquery_project_id = "apply-for-qts-in-england"
+  bigquery_dataset    = "events_${var.environment_name}"
+  bigquery_table_name = "events"
 }


### PR DESCRIPTION
This sets environment variables which are currently in the secrets key vault but aren't secret and moves them in to the Terraform source code. Once this is deployed, I'll remove the secrets.

[Trello Card](https://trello.com/c/Xa3ARLCN/574-refactor-non-secret-environment-variables-to-terraform-setup)