### PR TITLE
Move teaching authority fields to countries

### DIFF
--- a/app/controllers/support_interface/countries_controller.rb
+++ b/app/controllers/support_interface/countries_controller.rb
@@ -63,7 +63,9 @@ class SupportInterface::CountriesController < SupportInterface::BaseController
     params.require(:country).permit(
       :teaching_authority_address,
       :teaching_authority_emails_string,
-      :teaching_authority_websites_string
+      :teaching_authority_websites_string,
+      :teaching_authority_certificate,
+      :teaching_authority_other
     )
   end
 end

--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -37,10 +37,8 @@ module SupportInterface
         :sanction_check,
         :status_check,
         :teaching_authority_address,
-        :teaching_authority_certificate,
         :teaching_authority_emails_string,
-        :teaching_authority_websites_string,
-        :teaching_authority_other
+        :teaching_authority_websites_string
       )
     end
   end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -2,13 +2,15 @@
 #
 # Table name: countries
 #
-#  id                          :bigint           not null, primary key
-#  code                        :string           not null
-#  teaching_authority_address  :text             default(""), not null
-#  teaching_authority_emails   :text             default([]), not null, is an Array
-#  teaching_authority_websites :text             default([]), not null, is an Array
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
+#  id                             :bigint           not null, primary key
+#  code                           :string           not null
+#  teaching_authority_address     :text             default(""), not null
+#  teaching_authority_certificate :text             default(""), not null
+#  teaching_authority_emails      :text             default([]), not null, is an Array
+#  teaching_authority_other       :text             default(""), not null
+#  teaching_authority_websites    :text             default([]), not null, is an Array
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
 #
 # Indexes
 #

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -44,7 +44,4 @@ class Region < ApplicationRecord
   validates :name, uniqueness: { scope: :country_id }
   validates :sanction_check, inclusion: { in: sanction_checks.values }
   validates :status_check, inclusion: { in: status_checks.values }
-  validates :teaching_authority_certificate,
-            presence: true,
-            if: -> { sanction_check_written? || status_check_written? }
 end

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -75,16 +75,15 @@
 
       <% if region.status_check_written? || region.sanction_check_written? %>
         <p class="govuk-body">
-          You’ll need to provide <%= region.teaching_authority_certificate.indefinite_article %> <span lang="<%= region.country.code %>"><%= region.teaching_authority_certificate %></span>,
-          which you can obtain by contacting:
+          You’ll need to provide <%= region.country.teaching_authority_certificate.indefinite_article || "a" %> <span lang="<%= region.country.code %>"><%= region.country.teaching_authority_certificate.presence || "certificate" %></span>, which you can obtain by contacting:
         </p>
 
         <%= render "shared/teaching_authority_contactable", contactable: region.country %>
 
         <%= render "shared/teaching_authority_contactable", contactable: region %>
 
-        <% if region.teaching_authority_other.present? %>
-          <%= raw GovukMarkdown.render(region.teaching_authority_other) %>
+        <% if region.country.teaching_authority_other.present? %>
+          <%= raw GovukMarkdown.render(region.country.teaching_authority_other) %>
         <% end %>
 
         <p class="govuk-body">This must be dated within 3 months of you applying for QTS.</p>

--- a/app/views/support_interface/countries/confirm_edit.html.erb
+++ b/app/views/support_interface/countries/confirm_edit.html.erb
@@ -6,6 +6,7 @@
 
 <% if @country.changed? %>
   <h3 class="govuk-heading-s">Teaching authority</h3>
+
   <%= render "shared/teaching_authority_contactable", contactable: @country %>
 <% end %>
 

--- a/app/views/support_interface/countries/edit.html.erb
+++ b/app/views/support_interface/countries/edit.html.erb
@@ -5,11 +5,15 @@
 <%= form_with model: @country, url: confirm_edit_support_interface_country_path(@country), method: "POST" do |f| %>
   <%= render "shared/teaching_authority_contactable_fields", f: %>
 
+  <%= f.govuk_text_field :teaching_authority_certificate, label: { text: "Teaching authority certificate" } %>
+
+  <%= f.govuk_text_area :teaching_authority_other, label: { text: "Teaching authority other" } %>
+
   <%= f.govuk_text_area :all_regions,
                         value: @all_regions,
                         label: { text: "Regions" },
                         hint: { text: "Include a region on each line." },
-                        rows: 30 %>
+                        rows: 20 %>
 
   <%= f.govuk_submit "Save", prevent_double_click: false %>
 <% end %>

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -17,11 +17,7 @@
     OpenStruct.new(id: 'none', name: 'None')
   ], :id, :name, label: { text: "Status check" } %>
 
-  <%= f.govuk_text_field :teaching_authority_certificate, label: { text: "Teaching authority certificate" } %>
-
   <%= render "shared/teaching_authority_contactable_fields", f: %>
-
-  <%= f.govuk_text_area :teaching_authority_other, label: { text: "Teaching authority other" } %>
 
   <%= f.govuk_submit "Save", prevent_double_click: false do %>
     <%= f.govuk_submit "Save and preview", prevent_double_click: false, name: "preview", value: "preview" %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -37,6 +37,8 @@
     - code
     - created_at
     - updated_at
+    - teaching_authority_certificate
+    - teaching_authority_other
     - teaching_authority_address
     - teaching_authority_emails
     - teaching_authority_websites

--- a/db/migrate/20220711131836_add_teaching_authority_certificate_other_to_countries.rb
+++ b/db/migrate/20220711131836_add_teaching_authority_certificate_other_to_countries.rb
@@ -1,0 +1,25 @@
+class AddTeachingAuthorityCertificateOtherToCountries < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    change_table :countries, bulk: true do |t|
+      t.column :teaching_authority_certificate, :text, default: "", null: false
+      t.column :teaching_authority_other, :text, default: "", null: false
+    end
+
+    regions_to_update =
+      Region
+        .includes(:country)
+        .where.not(teaching_authority_certificate: "")
+        .or(Region.where.not(teaching_authority_other: ""))
+
+    regions_to_update.find_each do |region|
+      region.country.update!(
+        {
+          teaching_authority_certificate: region.teaching_authority_certificate,
+          teaching_authority_other: region.teaching_authority_other
+        }.compact_blank
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_11_124042) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_11_131836) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_11_124042) do
     t.text "teaching_authority_address", default: "", null: false
     t.text "teaching_authority_emails", default: [], null: false, array: true
     t.text "teaching_authority_websites", default: [], null: false, array: true
+    t.text "teaching_authority_certificate", default: "", null: false
+    t.text "teaching_authority_other", default: "", null: false
     t.index ["code"], name: "index_countries_on_code", unique: true
   end
 

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -2,13 +2,15 @@
 #
 # Table name: countries
 #
-#  id                          :bigint           not null, primary key
-#  code                        :string           not null
-#  teaching_authority_address  :text             default(""), not null
-#  teaching_authority_emails   :text             default([]), not null, is an Array
-#  teaching_authority_websites :text             default([]), not null, is an Array
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
+#  id                             :bigint           not null, primary key
+#  code                           :string           not null
+#  teaching_authority_address     :text             default(""), not null
+#  teaching_authority_certificate :text             default(""), not null
+#  teaching_authority_emails      :text             default([]), not null, is an Array
+#  teaching_authority_other       :text             default(""), not null
+#  teaching_authority_websites    :text             default([]), not null, is an Array
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -2,13 +2,15 @@
 #
 # Table name: countries
 #
-#  id                          :bigint           not null, primary key
-#  code                        :string           not null
-#  teaching_authority_address  :text             default(""), not null
-#  teaching_authority_emails   :text             default([]), not null, is an Array
-#  teaching_authority_websites :text             default([]), not null, is an Array
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
+#  id                             :bigint           not null, primary key
+#  code                           :string           not null
+#  teaching_authority_address     :text             default(""), not null
+#  teaching_authority_certificate :text             default(""), not null
+#  teaching_authority_emails      :text             default([]), not null, is an Array
+#  teaching_authority_other       :text             default(""), not null
+#  teaching_authority_websites    :text             default([]), not null, is an Array
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -44,18 +44,6 @@ RSpec.describe Region, type: :model do
         .with_prefix(:status_check)
         .backed_by_column_of_type(:string)
     end
-    it do
-      is_expected.to_not validate_presence_of(:teaching_authority_certificate)
-    end
-
-    context "with written checks" do
-      before do
-        allow(region).to receive(:status_check_written?).and_return(true)
-      end
-      it do
-        is_expected.to validate_presence_of(:teaching_authority_certificate)
-      end
-    end
   end
 
   describe "#teaching_authority_emails_string" do

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_address
     when_i_fill_teaching_authority_emails
     when_i_fill_teaching_authority_websites
+    when_i_fill_teaching_authority_certificate
+    when_i_fill_teaching_authority_other
     when_i_fill_regions
     and_i_save
     then_i_see_country_contact_preview
@@ -27,11 +29,9 @@ RSpec.describe "Countries support", type: :system do
 
     when_i_select_sanction_check
     when_i_select_status_check
-    when_i_fill_teaching_authority_certificate
     when_i_fill_teaching_authority_address
     when_i_fill_teaching_authority_emails
     when_i_fill_teaching_authority_websites
-    when_i_fill_teaching_authority_other
     and_i_save_and_preview
     then_i_see_the_preview
     and_i_see_a_success_banner
@@ -129,10 +129,6 @@ RSpec.describe "Countries support", type: :system do
     select "Online", from: "region-status-check-field"
   end
 
-  def when_i_fill_teaching_authority_certificate
-    fill_in "region-teaching-authority-certificate-field", with: "Certificate"
-  end
-
   def when_i_fill_teaching_authority_address
     fill_in "region-teaching-authority-address-field", with: "Address"
   rescue Capybara::ElementNotFound
@@ -153,8 +149,12 @@ RSpec.describe "Countries support", type: :system do
     fill_in "country-teaching-authority-websites-string-field", with: "Website"
   end
 
+  def when_i_fill_teaching_authority_certificate
+    fill_in "country-teaching-authority-certificate-field", with: "Certificate"
+  end
+
   def when_i_fill_teaching_authority_other
-    fill_in "region-teaching-authority-other-field", with: "Other"
+    fill_in "country-teaching-authority-other-field", with: "Other"
   end
 
   def and_i_save

--- a/spec/views/eligibility_interface/shared/eligible_region_content_spec.rb
+++ b/spec/views/eligibility_interface/shared/eligible_region_content_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe "Eligible region content", type: :view do
     let(:region) do
       create(
         :region,
+        country:
+          create(:country, teaching_authority_certificate: "certificate"),
         status_check: :written,
         sanction_check: :written,
-        teaching_authority_certificate: "certificate",
         teaching_authority_address: "address"
       )
     end
@@ -39,9 +40,10 @@ RSpec.describe "Eligible region content", type: :view do
     let(:region) do
       create(
         :region,
+        country:
+          create(:country, teaching_authority_certificate: "certificate"),
         status_check: :online,
         sanction_check: :written,
-        teaching_authority_certificate: "certificate",
         teaching_authority_address: "address"
       )
     end
@@ -57,9 +59,10 @@ RSpec.describe "Eligible region content", type: :view do
     let(:region) do
       create(
         :region,
+        country:
+          create(:country, teaching_authority_certificate: "certificate"),
         status_check: :written,
         sanction_check: :none,
-        teaching_authority_certificate: "certificate",
         teaching_authority_address: "address"
       )
     end


### PR DESCRIPTION
This adds the "certificate" and "other" teaching authority fields to countries as they won't change on a per-region basis. Once this has been deployed they'll be a follow up PR to remove the fields from regions.

Depends on #228.

[Trello Card](https://trello.com/c/306J3OJY/607-model-multiple-competent-authorities)