### PR TITLE
Remove teaching authority fields from regions

### DIFF
--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -2,19 +2,17 @@
 #
 # Table name: regions
 #
-#  id                             :bigint           not null, primary key
-#  legacy                         :boolean          default(TRUE), not null
-#  name                           :string           default(""), not null
-#  sanction_check                 :string           default("none"), not null
-#  status_check                   :string           default("none"), not null
-#  teaching_authority_address     :text             default(""), not null
-#  teaching_authority_certificate :text             default(""), not null
-#  teaching_authority_emails      :text             default([]), not null, is an Array
-#  teaching_authority_other       :text             default(""), not null
-#  teaching_authority_websites    :text             default([]), not null, is an Array
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  country_id                     :bigint           not null
+#  id                          :bigint           not null, primary key
+#  legacy                      :boolean          default(TRUE), not null
+#  name                        :string           default(""), not null
+#  sanction_check              :string           default("none"), not null
+#  status_check                :string           default("none"), not null
+#  teaching_authority_address  :text             default(""), not null
+#  teaching_authority_emails   :text             default([]), not null, is an Array
+#  teaching_authority_websites :text             default([]), not null, is an Array
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  country_id                  :bigint           not null
 #
 # Indexes
 #

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -8,11 +8,9 @@
     - updated_at
     - status_check
     - sanction_check
-    - teaching_authority_certificate
     - teaching_authority_address
     - teaching_authority_emails
     - teaching_authority_websites
-    - teaching_authority_other
     - legacy
   :features:
     - id

--- a/db/migrate/20220711133921_remove_teaching_authority_certificate_other_from_regions.rb
+++ b/db/migrate/20220711133921_remove_teaching_authority_certificate_other_from_regions.rb
@@ -1,0 +1,16 @@
+class RemoveTeachingAuthorityCertificateOtherFromRegions < ActiveRecord::Migration[
+  7.0
+]
+  def up
+    change_table :regions, bulk: true do |t|
+      t.remove :teaching_authority_certificate, :teaching_authority_other
+    end
+  end
+
+  def down
+    change_table :regions, bulk: true do |t|
+      t.column :teaching_authority_certificate, :text, default: "", null: false
+      t.column :teaching_authority_other, :text, default: "", null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_11_131836) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_11_133921) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,10 +54,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_11_131836) do
     t.datetime "updated_at", null: false
     t.string "status_check", default: "none", null: false
     t.string "sanction_check", default: "none", null: false
-    t.text "teaching_authority_certificate", default: "", null: false
     t.text "teaching_authority_address", default: "", null: false
     t.boolean "legacy", default: true, null: false
-    t.text "teaching_authority_other", default: "", null: false
     t.text "teaching_authority_emails", default: [], null: false, array: true
     t.text "teaching_authority_websites", default: [], null: false, array: true
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -2,19 +2,17 @@
 #
 # Table name: regions
 #
-#  id                             :bigint           not null, primary key
-#  legacy                         :boolean          default(TRUE), not null
-#  name                           :string           default(""), not null
-#  sanction_check                 :string           default("none"), not null
-#  status_check                   :string           default("none"), not null
-#  teaching_authority_address     :text             default(""), not null
-#  teaching_authority_certificate :text             default(""), not null
-#  teaching_authority_emails      :text             default([]), not null, is an Array
-#  teaching_authority_other       :text             default(""), not null
-#  teaching_authority_websites    :text             default([]), not null, is an Array
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  country_id                     :bigint           not null
+#  id                          :bigint           not null, primary key
+#  legacy                      :boolean          default(TRUE), not null
+#  name                        :string           default(""), not null
+#  sanction_check              :string           default("none"), not null
+#  status_check                :string           default("none"), not null
+#  teaching_authority_address  :text             default(""), not null
+#  teaching_authority_emails   :text             default([]), not null, is an Array
+#  teaching_authority_websites :text             default([]), not null, is an Array
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  country_id                  :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -2,19 +2,17 @@
 #
 # Table name: regions
 #
-#  id                             :bigint           not null, primary key
-#  legacy                         :boolean          default(TRUE), not null
-#  name                           :string           default(""), not null
-#  sanction_check                 :string           default("none"), not null
-#  status_check                   :string           default("none"), not null
-#  teaching_authority_address     :text             default(""), not null
-#  teaching_authority_certificate :text             default(""), not null
-#  teaching_authority_emails      :text             default([]), not null, is an Array
-#  teaching_authority_other       :text             default(""), not null
-#  teaching_authority_websites    :text             default([]), not null, is an Array
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  country_id                     :bigint           not null
+#  id                          :bigint           not null, primary key
+#  legacy                      :boolean          default(TRUE), not null
+#  name                        :string           default(""), not null
+#  sanction_check              :string           default("none"), not null
+#  status_check                :string           default("none"), not null
+#  teaching_authority_address  :text             default(""), not null
+#  teaching_authority_emails   :text             default([]), not null, is an Array
+#  teaching_authority_websites :text             default([]), not null, is an Array
+#  created_at                  :datetime         not null
+#  updated_at                  :datetime         not null
+#  country_id                  :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
This removes the "other" and "certificate" teaching authority fields from regions as they're now fetched from the country.

Depends on #229 

[Trello Card](https://trello.com/c/306J3OJY/607-model-multiple-competent-authorities)