### PR TITLE
Improve teaching authority contact content

### DIFF
--- a/app/models/concerns/teaching_authority_contactable.rb
+++ b/app/models/concerns/teaching_authority_contactable.rb
@@ -18,4 +18,9 @@ module TeachingAuthorityContactable
     self.teaching_authority_websites =
       string.split("\n").map(&:chomp).compact_blank
   end
+
+  def teaching_authority_present?
+    teaching_authority_address.present? || teaching_authority_emails.present? ||
+      teaching_authority_websites.present?
+  end
 end

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -80,6 +80,10 @@
 
         <%= render "shared/teaching_authority_contactable", contactable: region.country %>
 
+        <% if region.country.teaching_authority_present? && region.teaching_authority_present? %>
+          <p class="govuk-body">or</p>
+        <% end %>
+
         <%= render "shared/teaching_authority_contactable", contactable: region %>
 
         <% if region.country.teaching_authority_other.present? %>

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -95,4 +95,32 @@ RSpec.describe Country, type: :model do
       it { is_expected.to eq(%w[example1.com example2.com]) }
     end
   end
+
+  describe "#teaching_authority_present?" do
+    subject(:teaching_authority_present?) do
+      country.teaching_authority_present?
+    end
+
+    it { is_expected.to eq(false) }
+
+    context "with an address" do
+      before { country.update(teaching_authority_address: "Address") }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "with an email address" do
+      before { country.update(teaching_authority_emails: ["test@example.com"]) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a website" do
+      before do
+        country.update(teaching_authority_websites: ["https://www.example.com"])
+      end
+
+      it { is_expected.to eq(true) }
+    end
+  end
 end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -111,4 +111,30 @@ RSpec.describe Region, type: :model do
       it { is_expected.to eq(%w[example1.com example2.com]) }
     end
   end
+
+  describe "#teaching_authority_present?" do
+    subject(:teaching_authority_present?) { region.teaching_authority_present? }
+
+    it { is_expected.to eq(false) }
+
+    context "with an address" do
+      before { region.update(teaching_authority_address: "Address") }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "with an email address" do
+      before { region.update(teaching_authority_emails: ["test@example.com"]) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "with a website" do
+      before do
+        region.update(teaching_authority_websites: ["https://www.example.com"])
+      end
+
+      it { is_expected.to eq(true) }
+    end
+  end
 end


### PR DESCRIPTION
If there are contact details for both the countries and the regions, we add the phrase "or" between the two contact details to separate them.

This content is a first attempt, but we might want to change it in the future.

<img width="528" alt="Screenshot 2022-07-12 at 09 45 19" src="https://user-images.githubusercontent.com/510498/178449355-ac1bfcd1-93a9-4df5-b3d6-b319ebec71a3.png">

[Trello Card](https://trello.com/c/306J3OJY/607-model-multiple-competent-authorities)
