### PR TITLE
Fix countries support interface not saving

### DIFF
--- a/app/views/support_interface/countries/confirm_edit.html.erb
+++ b/app/views/support_interface/countries/confirm_edit.html.erb
@@ -8,6 +8,10 @@
   <h3 class="govuk-heading-s">Teaching authority</h3>
 
   <%= render "shared/teaching_authority_contactable", contactable: @country %>
+
+  <p class="govuk-body"><%= @country.teaching_authority_certificate %></p>
+
+  <%= raw GovukMarkdown.render(@country.teaching_authority_other) %>
 <% end %>
 
 <% if @diff_actions.present? %>
@@ -45,5 +49,7 @@
   <%= f.hidden_field :teaching_authority_address, value: @country.teaching_authority_address %>
   <%= f.hidden_field :teaching_authority_emails_string, value: @country.teaching_authority_emails_string %>
   <%= f.hidden_field :teaching_authority_websites_string, value: @country.teaching_authority_websites_string %>
+  <%= f.hidden_field :teaching_authority_certificate, value: @country.teaching_authority_certificate %>
+  <%= f.hidden_field :teaching_authority_other, value: @country.teaching_authority_other %>
   <%= f.govuk_submit "Confirm save", prevent_double_click: false %>
 <% end %>

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -95,6 +95,8 @@ RSpec.describe "Countries support", type: :system do
     expect(page).to have_content("Address")
     expect(page).to have_content("Email address")
     expect(page).to have_content("Website")
+    expect(page).to have_content("Certificate")
+    expect(page).to have_content("Other")
   end
 
   def then_i_see_region_changes_confirmation


### PR DESCRIPTION
This fixes a bug where the other and certificate field don't save correctly when a user presses the save button.