### PR TITLE
Create common system helpers

### DIFF
--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -1,0 +1,22 @@
+module SystemHelpers
+  def given_the_service_is_open
+    FeatureFlag.activate(:service_open)
+  end
+
+  def given_the_service_is_closed
+    FeatureFlag.deactivate(:service_open)
+  end
+
+  def given_the_service_is_startable
+    FeatureFlag.activate(:service_start)
+  end
+
+  def when_i_am_authorized_as_a_support_user
+    page.driver.basic_authorize(
+      ENV.fetch("SUPPORT_USERNAME", "test"),
+      ENV.fetch("SUPPORT_PASSWORD", "test")
+    )
+  end
+end
+
+RSpec.configure { |config| config.include SystemHelpers, type: :system }

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -188,24 +188,12 @@ RSpec.describe "Eligibility check", type: :system do
     create(:region, country: it, name: "Other Region")
   end
 
-  def given_the_service_is_closed
-    FeatureFlag.deactivate(:service_open)
-  end
-
-  def given_the_service_is_open
-    FeatureFlag.activate(:service_open)
-  end
-
   def given_the_service_cannot_be_started
     FeatureFlag.deactivate(:service_start)
   end
 
   def given_the_service_can_be_started
     FeatureFlag.activate(:service_start)
-  end
-
-  def when_i_am_authorized_as_a_support_user
-    page.driver.basic_authorize("test", "test")
   end
 
   def when_i_choose_no

--- a/spec/system/performance_spec.rb
+++ b/spec/system/performance_spec.rb
@@ -17,10 +17,6 @@ RSpec.describe "Performance", type: :system do
 
   private
 
-  def given_the_service_is_open
-    FeatureFlag.activate(:service_open)
-  end
-
   def given_there_are_a_few_eligibility_checks
     (0..8).each.with_index do |n, i|
       (i + 1).times do

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -56,13 +56,6 @@ RSpec.describe "Countries support", type: :system do
     create(:region, :national, country: create(:country, code: "CY"))
   end
 
-  def when_i_am_authorized_as_a_support_user
-    page.driver.basic_authorize(
-      ENV.fetch("SUPPORT_USERNAME", "test"),
-      ENV.fetch("SUPPORT_PASSWORD", "test")
-    )
-  end
-
   def when_i_visit_the_countries_page
     visit support_interface_countries_path
   end

--- a/spec/system/support_interface/features_spec.rb
+++ b/spec/system/support_interface/features_spec.rb
@@ -35,13 +35,6 @@ RSpec.describe "Features support", type: :system do
     click_on "Activate Service open"
   end
 
-  def when_i_am_authorized_as_a_support_user
-    page.driver.basic_authorize(
-      ENV.fetch("SUPPORT_USERNAME", "test"),
-      ENV.fetch("SUPPORT_PASSWORD", "test")
-    )
-  end
-
   def when_i_deactivate_the_service_open_flag
     click_on "Deactivate Service open"
   end

--- a/spec/system/support_interface/sidekiq_spec.rb
+++ b/spec/system/support_interface/sidekiq_spec.rb
@@ -9,13 +9,6 @@ RSpec.describe "Sidekiq support", type: :system do
 
   private
 
-  def when_i_am_authorized_as_a_support_user
-    page.driver.basic_authorize(
-      ENV.fetch("SUPPORT_USERNAME", "test"),
-      ENV.fetch("SUPPORT_PASSWORD", "test")
-    )
-  end
-
   def when_i_visit_the_sidekiq_page
     visit "/support/sidekiq"
   end

--- a/spec/system/support_interface/staff_spec.rb
+++ b/spec/system/support_interface/staff_spec.rb
@@ -28,19 +28,8 @@ RSpec.describe "Staff support", type: :system do
 
   private
 
-  def given_the_service_is_startable
-    FeatureFlag.activate(:service_start)
-  end
-
   def given_the_service_is_staff_http_basic_auth
     FeatureFlag.activate(:staff_http_basic_auth)
-  end
-
-  def when_i_am_authorized_as_a_support_user
-    page.driver.basic_authorize(
-      ENV.fetch("SUPPORT_USERNAME", "test"),
-      ENV.fetch("SUPPORT_PASSWORD", "test")
-    )
   end
 
   def when_i_visit_the_staff_page

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -30,14 +30,6 @@ RSpec.describe "Teacher authentication", type: :system do
 
   private
 
-  def given_the_service_is_open
-    FeatureFlag.activate(:service_open)
-  end
-
-  def given_the_service_is_startable
-    FeatureFlag.activate(:service_start)
-  end
-
   def given_i_clear_my_session
     page.driver.clear_cookies
   end


### PR DESCRIPTION
This moves helper methods which are used in multiple system specs in to a single module and configures RSpec to include them in system specs. We should only use this module for helper methods which are strictly used in multiple system specs. I've done this to reduce the amount of duplication in the system specs.