### PR TITLE
Add content about user research

### DIFF
--- a/app/views/eligibility_interface/finish/eligible.html.erb
+++ b/app/views/eligibility_interface/finish/eligible.html.erb
@@ -6,5 +6,7 @@
     <%= render "shared/eligible_region_content", region: @region %>
 
     <%= govuk_start_button(text: "Apply for QTS", href: @mutual_recognition_url) %>
+
+    <%= render "shared/help_us_to_improve_this_service" %>
   </div>
 </div>

--- a/app/views/eligibility_interface/finish/ineligible.html.erb
+++ b/app/views/eligibility_interface/finish/ineligible.html.erb
@@ -19,16 +19,15 @@
       </ul>
     <% end %>
 
-    <% if @eligibility_check.ineligible_reasons.include?(:country) %>
-      <p class="govuk-body">The Department for Education is currently reviewing who can apply for qualified teacher status. If you’d like to help us with our research, or if you have any questions contact the help team at:</p>
-    <% else %>
-      <p class="govuk-body">If you have any questions about QTS contact the help team at:</p>
-    <% end %>
-    <p class="govuk-body"><a class="govuk-link" href="mailto:<%= I18n.t("service.email") %>"><%= I18n.t("service.email") %></a></p>
-
     <% unless @eligibility_check.ineligible_reasons.include?(:misconduct) %>
       <p class="govuk-body">You can also <%= govuk_link_to "learn more about teaching in England", "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas" %>.</p>
     <% end %>
 
+    <% if @eligibility_check.ineligible_reasons.include?(:country) %>
+      <%= render "shared/help_us_to_improve_this_service" %>
+    <% else %>
+      <p class="govuk-body">If you have any questions about QTS contact the help team at:</p>
+      <p class="govuk-body"><a class="govuk-link" href="mailto:<%= I18n.t("service.email") %>"><%= I18n.t("service.email") %></a></p>
+    <% end %>
   </div>
 </div>

--- a/app/views/shared/_help_us_to_improve_this_service.html.erb
+++ b/app/views/shared/_help_us_to_improve_this_service.html.erb
@@ -1,0 +1,11 @@
+<aside class="govuk-!-margin-top-6">
+  <h2 class="govuk-heading-s">Help us to improve this service</h2>
+
+  <p class="govuk-body">We’re redesigning this service as part of the government's plan to boost teacher recruitment from overseas, so we’d like to talk to people who want to come to England to teach.</p>
+
+  <p class="govuk-body">Throughout July, August and September we’re inviting people to chat on video calls – it’ll take no more than 60 minutes and you’ll get up to £40 to say thank you for taking part.</p>
+
+  <p class="govuk-body">If you’d like to help, follow the link below. If you match our search criteria, we’ll be in touch.</p>
+
+  <p class="govuk-body"><%= govuk_link_to "I’d like to take part", "https://forms.office.com/pages/responsepage.aspx?id=yXfS-grGoU2187O4s0qC-fO-t7cRDD1Fs8CDk5513nBUOUE5QkFCSlg3WDlZT01ZTEZSOFlWVzJEMy4u" %></p>
+</aside>


### PR DESCRIPTION
This adds a piece of content that shows at the bottom of an eligible or ineligible result asking if the user would like to take part in our user research.

[Trello Card](https://trello.com/c/xLxZgdcP/567-ur-recruitment-added-to-checker)

## Screenshots

<img width="681" alt="Screenshot 2022-07-14 at 08 57 43" src="https://user-images.githubusercontent.com/510498/178931988-6bec1aab-2e4e-440e-8371-5708962890af.png">

![Screenshot 2022-07-13 at 14 53 09](https://user-images.githubusercontent.com/510498/178750842-100f4272-4949-45cd-81ba-7278a17b5770.png)

