### PR TITLE
Personal information form

### DIFF
--- a/app/assets/stylesheets/_task_list.scss
+++ b/app/assets/stylesheets/_task_list.scss
@@ -1,0 +1,63 @@
+.app-task-list {
+  list-style-type: none;
+  padding-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  @include govuk-media-query($from: tablet) {
+    min-width: 550px;
+  }
+}
+
+.app-task-list__section {
+  display: table;
+  @include govuk-font($size: 24, $weight: bold);
+}
+
+.app-task-list__section-number {
+  display: table-cell;
+
+  @include govuk-media-query($from: tablet) {
+    min-width: govuk-spacing(6);
+    padding-right: 0;
+  }
+}
+
+.app-task-list__items {
+  @include govuk-font($size: 19);
+  @include govuk-responsive-margin(9, "bottom");
+  list-style: none;
+  padding-left: 0;
+  @include govuk-media-query($from: tablet) {
+    padding-left: govuk-spacing(6);
+  }
+}
+
+.app-task-list__item {
+  border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: 0 !important;
+  padding-top: govuk-spacing(2);
+  padding-bottom: govuk-spacing(2);
+  @include govuk-clearfix;
+}
+
+.app-task-list__item:first-child {
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.app-task-list__task-name {
+  display: block;
+  @include govuk-media-query($from: 450px) {
+    float: left;
+  }
+}
+
+.app-task-list__tag {
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(1);
+
+  @include govuk-media-query($from: 450px) {
+    float: right;
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -7,6 +7,7 @@ $govuk-assets-path: "/";
 
 @import "_environments";
 @import "_support";
+@import "_task_list";
 
 ul.autocomplete__menu {
   li {

--- a/app/components/application_form_status_tag_component.html.erb
+++ b/app/components/application_form_status_tag_component.html.erb
@@ -1,0 +1,1 @@
+<%= govuk_tag(text:, colour:, html_attributes: { id: }, classes: %w[app-task-list__tag]) %>

--- a/app/components/application_form_status_tag_component.rb
+++ b/app/components/application_form_status_tag_component.rb
@@ -1,0 +1,21 @@
+class ApplicationFormStatusTagComponent < ViewComponent::Base
+  def initialize(key:, status:)
+    super
+    @key = key
+    @status = status
+  end
+
+  def id
+    "#{@key}-status"
+  end
+
+  def text
+    @status.to_s.humanize
+  end
+
+  COLOURS = { not_started: "grey", in_progress: "blue" }.freeze
+
+  def colour
+    COLOURS[@status]
+  end
+end

--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -1,5 +1,6 @@
 class TeacherInterface::ApplicationFormsController < TeacherInterface::BaseController
-  before_action :load_application_form, only: %i[show submit]
+  before_action :load_application_form,
+                only: %i[show update submit personal_information]
 
   def index
     @application_forms =
@@ -8,7 +9,7 @@ class TeacherInterface::ApplicationFormsController < TeacherInterface::BaseContr
 
   def create
     @application_form = ApplicationForm.new
-    if @application_form.update(application_form_params)
+    if @application_form.update(create_application_form_params)
       redirect_to teacher_interface_application_form_path(@application_form)
     else
       flash[:warning] = "Could not start application."
@@ -19,9 +20,21 @@ class TeacherInterface::ApplicationFormsController < TeacherInterface::BaseContr
   def show
   end
 
+  def update
+    if @application_form.update(update_application_form_params)
+      redirect_to [:teacher_interface, @application_form]
+    else
+      # TODO: this will need to be dynamic
+      render :personal_information, status: :unprocessable_entity
+    end
+  end
+
   def submit
     @application_form.submitted!
     redirect_to teacher_interface_application_form_path(@application_form)
+  end
+
+  def personal_information
   end
 
   private
@@ -31,10 +44,18 @@ class TeacherInterface::ApplicationFormsController < TeacherInterface::BaseContr
       ApplicationForm.where(teacher: current_teacher).find(params[:id])
   end
 
-  def application_form_params
+  def create_application_form_params
     {
       teacher: current_teacher,
       eligibility_check_id: session[:eligibility_check_id]
     }
+  end
+
+  def update_application_form_params
+    params.require(:application_form).permit(
+      :given_names,
+      :family_name,
+      :date_of_birth
+    )
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -3,6 +3,9 @@
 # Table name: application_forms
 #
 #  id                   :bigint           not null, primary key
+#  date_of_birth        :date
+#  family_name          :text             default(""), not null
+#  given_names          :text             default(""), not null
 #  reference            :string(31)       not null
 #  status               :string           default("active"), not null
 #  created_at           :datetime         not null

--- a/app/views/teacher_interface/application_forms/personal_information.html.erb
+++ b/app/views/teacher_interface/application_forms/personal_information.html.erb
@@ -1,0 +1,29 @@
+<% content_for :page_title, "Personal information" %>
+<% content_for :back_link_url, teacher_interface_application_form_path(@application_form) %>
+
+<span class="govuk-caption-l">About you</span>
+<h1 class="govuk-heading-l">Personal information</h1>
+
+<%= form_with model: [:teacher_interface, @application_form] do |f| %>
+  <%= f.govuk_text_field :given_names,
+                         label: { text: "Given names", size: "m" },
+                         hint: { text: "Enter your full name apart from your family name" } %>
+
+  <%= f.govuk_text_field :family_name,
+                         label: { text: "Family name", size: "m" },
+                         hint: { text: "Enter just your family name" } %>
+
+  <%= f.govuk_date_field :date_of_birth,
+                         date_of_birth: true,
+                         legend: { text: "Date of birth" },
+                         hint: { text: "For example, 27 3 1980" } %>
+
+  <%= govuk_details(summary_text: "Why do we ask this?") do %>
+    <p>
+      We ask for your date of birth because not all forms of identification include it.
+      It also helps with security in case we need to discuss your application with you.
+    </p>
+  <% end %>
+
+  <%= f.govuk_submit "Continue", prevent_double_click: false %>
+<% end %>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -9,5 +9,34 @@
     <strong><%= @application_form.reference %></strong>
   <% end %>
 <% else %>
-  <%= govuk_button_to "Submit", submit_teacher_interface_application_form_path %>
+  <p class="govuk-body govuk-!-margin-bottom-7">You have completed 0 of 1 section.</p>
+
+  <ol class="app-task-list">
+    <li>
+      <h2 class="app-task-list__section">
+        <span class="app-task-list__section-number">1. </span> About you
+      </h2>
+      <ul class="app-task-list__items">
+        <li class="app-task-list__item">
+          <span class="app-task-list__task-name">
+            <a href="#" aria-describedby="personal-information-status">
+              Personal information
+            </a>
+          </span>
+          <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="personal-information-status">Not started</strong>
+        </li>
+
+        <li class="app-task-list__item">
+          <span class="app-task-list__task-name">
+            <a href="#" aria-describedby="identity-documents-status">
+              Identity documents
+            </a>
+          </span>
+          <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="identity-documents-status">Not started</strong>
+        </li>
+      </ul>
+    </li>
+  </ol>
+
+  <%= govuk_button_to "Submit your application", submit_teacher_interface_application_form_path %>
 <% end %>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -32,10 +32,15 @@
           <% subsection_keys.each do |subsection_key| %>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <%= link_to subsection_key.to_s.humanize, "#", aria: { describedby: "#{subsection_key}-status" } %>
+                <%= link_to subsection_key.to_s.humanize,
+                            send("#{subsection_key}_teacher_interface_application_form_path"),
+                            aria: { describedby: "#{subsection_key}-status" } %>
               </span>
 
-              <%= render(ApplicationFormStatusTagComponent.new(key: subsection_key, status: @application_form.section_statuses.dig(section_key, subsection_key))) %>
+              <%= render(ApplicationFormStatusTagComponent.new(
+                key: subsection_key,
+                status: @application_form.section_statuses.dig(section_key, subsection_key)
+              )) %>
             </li>
           <% end %>
         </ul>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -9,34 +9,39 @@
     <strong><%= @application_form.reference %></strong>
   <% end %>
 <% else %>
-  <p class="govuk-body govuk-!-margin-bottom-7">You have completed 0 of 1 section.</p>
+  <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
+    <% if @application_form.can_submit? %>
+      Application complete
+    <% else %>
+      Application incomplete
+    <% end %>
+  </h2>
+
+  <p class="govuk-body govuk-!-margin-bottom-7">
+    You have completed <%= @application_form.completed_sections.count %> of <%= ApplicationForm::SECTIONS.count %> sections.
+  </p>
 
   <ol class="app-task-list">
-    <li>
-      <h2 class="app-task-list__section">
-        <span class="app-task-list__section-number">1. </span> About you
-      </h2>
-      <ul class="app-task-list__items">
-        <li class="app-task-list__item">
-          <span class="app-task-list__task-name">
-            <a href="#" aria-describedby="personal-information-status">
-              Personal information
-            </a>
-          </span>
-          <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="personal-information-status">Not started</strong>
-        </li>
+    <% ApplicationForm::SECTIONS.each_with_index do |(section_key, subsection_keys), index| %>
+      <li>
+        <h2 class="app-task-list__section">
+          <span class="app-task-list__section-number"><%= index + 1 %>. </span> <%= section_key.to_s.humanize %>
+        </h2>
 
-        <li class="app-task-list__item">
-          <span class="app-task-list__task-name">
-            <a href="#" aria-describedby="identity-documents-status">
-              Identity documents
-            </a>
-          </span>
-          <strong class="govuk-tag govuk-tag--grey app-task-list__tag" id="identity-documents-status">Not started</strong>
-        </li>
-      </ul>
-    </li>
+        <ul class="app-task-list__items">
+          <% subsection_keys.each do |subsection_key| %>
+            <li class="app-task-list__item">
+              <span class="app-task-list__task-name">
+                <%= link_to subsection_key.to_s.humanize, "#", aria: { describedby: "#{subsection_key}-status" } %>
+              </span>
+
+              <%= render(ApplicationFormStatusTagComponent.new(key: subsection_key, status: @application_form.section_statuses.dig(section_key, subsection_key))) %>
+            </li>
+          <% end %>
+        </ul>
+      </li>
+    <% end %>
   </ol>
 
-  <%= govuk_button_to "Submit your application", submit_teacher_interface_application_form_path %>
+  <%= govuk_button_to "Submit your application", submit_teacher_interface_application_form_path, disabled: !@application_form.can_submit? %>
 <% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -48,3 +48,6 @@
     - eligibility_check_id
     - created_at
     - updated_at
+    - given_names
+    - family_name
+    - date_of_birth

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -1,2 +1,6 @@
 ---
-shared: {}
+:shared:
+  :application_forms:
+    - given_names
+    - family_name
+    - date_of_birth

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,8 +76,12 @@ Rails.application.routes.draw do
 
     resources :application_forms,
               path: "applications",
-              only: %i[index new create show] do
-      post "submit", on: :member
+              only: %i[index new create show update] do
+      member do
+        post "submit"
+        get "personal_information"
+        get "identity_documents"
+      end
     end
   end
 

--- a/db/migrate/20220715115640_add_personal_information_to_application_forms.rb
+++ b/db/migrate/20220715115640_add_personal_information_to_application_forms.rb
@@ -1,0 +1,9 @@
+class AddPersonalInformationToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    change_table :application_forms, bulk: true do |t|
+      t.column :given_names, :text, default: "", null: false
+      t.column :family_name, :text, default: "", null: false
+      t.column :date_of_birth, :date
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_12_142508) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_15_115640) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_12_142508) do
     t.bigint "eligibility_check_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "given_names", default: "", null: false
+    t.text "family_name", default: "", null: false
+    t.date "date_of_birth"
     t.index ["eligibility_check_id"], name: "index_application_forms_on_eligibility_check_id"
     t.index ["reference"], name: "index_application_forms_on_reference", unique: true
     t.index ["status"], name: "index_application_forms_on_status"

--- a/spec/components/application_form_status_tag_component_spec.rb
+++ b/spec/components/application_form_status_tag_component_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationFormStatusTagComponent, type: :component do
+  subject(:component) { render_inline(described_class.new(key:, status:)) }
+
+  let(:key) { "key" }
+  let(:status) { :status }
+
+  describe "text" do
+    subject(:text) { component.text.strip }
+
+    it { is_expected.to eq("Status") }
+  end
+
+  describe "id" do
+    subject(:id) { component.at_css("strong")["id"] }
+
+    it { is_expected.to eq("key-status") }
+  end
+
+  describe "class" do
+    subject(:klass) { component.at_css("strong")["class"] }
+
+    context "with a 'not started' status" do
+      let(:status) { :not_started }
+
+      it { is_expected.to eq("govuk-tag govuk-tag--grey app-task-list__tag") }
+    end
+
+    context "with an 'in progress' status" do
+      let(:status) { :in_progress }
+
+      it { is_expected.to eq("govuk-tag govuk-tag--blue app-task-list__tag") }
+    end
+
+    context "with a 'completed' status" do
+      let(:status) { :completed }
+
+      it { is_expected.to eq("govuk-tag app-task-list__tag") }
+    end
+  end
+end

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -3,6 +3,9 @@
 # Table name: application_forms
 #
 #  id                   :bigint           not null, primary key
+#  date_of_birth        :date
+#  family_name          :text             default(""), not null
+#  given_names          :text             default(""), not null
 #  reference            :string(31)       not null
 #  status               :string           default("active"), not null
 #  created_at           :datetime         not null
@@ -31,6 +34,12 @@ FactoryBot.define do
 
     trait :submitted do
       status { "submitted" }
+    end
+
+    trait :with_personal_information do
+      given_names { "Given names" }
+      family_name { "Family name" }
+      date_of_birth { Date.new(2000, 1, 1) }
     end
   end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -66,4 +66,61 @@ RSpec.describe ApplicationForm, type: :model do
       it { is_expected.to eq("2000002") }
     end
   end
+
+  describe "#section_statuses" do
+    subject(:section_statuses) { application_form.section_statuses }
+
+    it do
+      is_expected.to eq(
+        {
+          about_you: {
+            personal_information: :not_started,
+            identity_documents: :not_started
+          }
+        }
+      )
+    end
+
+    describe "about you section" do
+      subject(:about_you_section_status) { section_statuses[:about_you] }
+
+      context "with some personal information" do
+        before { application_form.update!(given_names: "Given") }
+
+        it do
+          is_expected.to match(
+            a_hash_including(personal_information: :in_progress)
+          )
+        end
+      end
+
+      context "with all personal information" do
+        before do
+          application_form.update!(
+            given_names: "Given",
+            family_name: "Family",
+            date_of_birth: Date.new(2000, 1, 1)
+          )
+        end
+
+        it do
+          is_expected.to match(
+            a_hash_including(personal_information: :completed)
+          )
+        end
+      end
+    end
+  end
+
+  describe "#completed_sections" do
+    subject(:completed_sections) { application_form.completed_sections }
+
+    it { is_expected.to be_empty }
+  end
+
+  describe "#can_submit?" do
+    subject(:can_submit?) { application_form.can_submit? }
+
+    it { is_expected.to eq(false) }
+  end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -3,6 +3,9 @@
 # Table name: application_forms
 #
 #  id                   :bigint           not null, primary key
+#  date_of_birth        :date
+#  family_name          :text             default(""), not null
+#  given_names          :text             default(""), not null
 #  reference            :string(31)       not null
 #  status               :string           default("active"), not null
 #  created_at           :datetime         not null

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe "Teacher application", type: :system do
     when_i_click_start_now
     then_i_see_the_active_application_page
 
+    when_i_click_personal_information
+    then_i_see_the_personal_information_form
+
+    when_i_fill_in_personal_information
+    and_i_click_continue
+    then_i_see_completed_personal_information_section
+
     when_i_click_submit
     then_i_see_the_submitted_application_page
   end
@@ -39,7 +46,23 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_submit
-    click_button "Submit"
+    click_button "Submit your application"
+  end
+
+  def and_i_click_continue
+    click_button "Continue"
+  end
+
+  def when_i_click_personal_information
+    click_link "Personal information"
+  end
+
+  def when_i_fill_in_personal_information
+    fill_in "application-form-given-names-field", with: "Name"
+    fill_in "application-form-family-name-field", with: "Name"
+    fill_in "application_form_date_of_birth_3i", with: "1"
+    fill_in "application_form_date_of_birth_2i", with: "1"
+    fill_in "application_form_date_of_birth_1i", with: "2000"
   end
 
   def then_i_see_the_sign_up_form
@@ -61,13 +84,25 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_title("Apply for qualified teacher status (QTS)")
     expect(page).to have_content("Apply for qualified teacher status (QTS)")
 
-    expect(page).to have_content("You have completed 0 of 1 section.")
+    expect(page).to have_content("You have completed 0 of 1 sections.")
 
     expect(page).to have_content("About you")
     expect(page).to have_content("Personal information\nNOT STARTED")
     expect(page).to have_content("Identity documents\nNOT STARTED")
 
     expect(page).to have_content("Submit your application")
+  end
+
+  def then_i_see_the_personal_information_form
+    expect(page).to have_title("Personal information")
+    expect(page).to have_content("Personal information")
+    expect(page).to have_content("Given names")
+    expect(page).to have_content("Family name")
+    expect(page).to have_content("Date of birth")
+  end
+
+  def then_i_see_completed_personal_information_section
+    expect(page).to have_content("Personal information\nCOMPLETED")
   end
 
   def then_i_see_the_submitted_application_page

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -60,7 +60,14 @@ RSpec.describe "Teacher application", type: :system do
     )
     expect(page).to have_title("Apply for qualified teacher status (QTS)")
     expect(page).to have_content("Apply for qualified teacher status (QTS)")
-    expect(page).to have_content("Submit")
+
+    expect(page).to have_content("You have completed 0 of 1 section.")
+
+    expect(page).to have_content("About you")
+    expect(page).to have_content("Personal information\nNOT STARTED")
+    expect(page).to have_content("Identity documents\nNOT STARTED")
+
+    expect(page).to have_content("Submit your application")
   end
 
   def then_i_see_the_submitted_application_page


### PR DESCRIPTION
This adds the form which teachers can use to fill in their personal information, and then the status of this section is updated on the overall application form task list.

[Trello Card](https://trello.com/c/760qGtLm/619-build-personal-information-spoke)

## Screenshots

<img width="670" alt="Screenshot 2022-07-15 at 15 40 41" src="https://user-images.githubusercontent.com/510498/179246662-70cdf24e-2638-444b-81c6-3383dba725a3.png">

<img width="693" alt="Screenshot 2022-07-15 at 15 26 43" src="https://user-images.githubusercontent.com/510498/179246654-370e7d4e-6f8d-43f6-883d-00e3c6ab1d21.png">
