### PR TITLE
Add check your answers for personal information

### DIFF
--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -1,15 +1,18 @@
 class TeacherInterface::ApplicationFormsController < TeacherInterface::BaseController
-  before_action :load_application_form,
-                only: %i[show update submit personal_information]
+  before_action :load_application_form, only: %i[show submit]
 
   def index
     @application_forms =
       ApplicationForm.where(teacher: current_teacher).order(created_at: :desc)
   end
 
+  def new
+    @application_form = ApplicationForm.new
+  end
+
   def create
     @application_form = ApplicationForm.new
-    if @application_form.update(create_application_form_params)
+    if @application_form.update(application_form_params)
       redirect_to teacher_interface_application_form_path(@application_form)
     else
       flash[:warning] = "Could not start application."
@@ -20,42 +23,17 @@ class TeacherInterface::ApplicationFormsController < TeacherInterface::BaseContr
   def show
   end
 
-  def update
-    if @application_form.update(update_application_form_params)
-      redirect_to [:teacher_interface, @application_form]
-    else
-      # TODO: this will need to be dynamic
-      render :personal_information, status: :unprocessable_entity
-    end
-  end
-
   def submit
     @application_form.submitted!
     redirect_to teacher_interface_application_form_path(@application_form)
   end
 
-  def personal_information
-  end
-
   private
 
-  def load_application_form
-    @application_form =
-      ApplicationForm.where(teacher: current_teacher).find(params[:id])
-  end
-
-  def create_application_form_params
+  def application_form_params
     {
       teacher: current_teacher,
       eligibility_check_id: session[:eligibility_check_id]
     }
-  end
-
-  def update_application_form_params
-    params.require(:application_form).permit(
-      :given_names,
-      :family_name,
-      :date_of_birth
-    )
   end
 end

--- a/app/controllers/teacher_interface/base_controller.rb
+++ b/app/controllers/teacher_interface/base_controller.rb
@@ -4,4 +4,11 @@ class TeacherInterface::BaseController < ApplicationController
   layout "two_thirds"
 
   before_action :authenticate_teacher!
+
+  def load_application_form
+    @application_form =
+      ApplicationForm.where(teacher: current_teacher).find(
+        params[:application_form_id] || params[:id]
+      )
+  end
 end

--- a/app/controllers/teacher_interface/personal_information_controller.rb
+++ b/app/controllers/teacher_interface/personal_information_controller.rb
@@ -1,0 +1,35 @@
+class TeacherInterface::PersonalInformationController < TeacherInterface::BaseController
+  before_action :load_application_form
+
+  def show
+    unless @application_form.personal_information_status == :completed
+      redirect_to [
+                    :edit,
+                    :teacher_interface,
+                    @application_form,
+                    :personal_information
+                  ]
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @application_form.update(personal_information_params)
+      redirect_to [:teacher_interface, @application_form, :personal_information]
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def personal_information_params
+    params.require(:application_form).permit(
+      :given_names,
+      :family_name,
+      :date_of_birth
+    )
+  end
+end

--- a/app/controllers/teacher_interface/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/work_histories_controller.rb
@@ -51,13 +51,6 @@ class TeacherInterface::WorkHistoriesController < TeacherInterface::BaseControll
 
   private
 
-  def load_application_form
-    @application_form =
-      ApplicationForm.where(teacher: current_teacher).find(
-        params[:application_form_id]
-      )
-  end
-
   def load_work_history
     @work_history = @application_form.work_histories.find(params[:id])
   end

--- a/app/views/teacher_interface/personal_information/edit.erb
+++ b/app/views/teacher_interface/personal_information/edit.erb
@@ -4,7 +4,7 @@
 <span class="govuk-caption-l">About you</span>
 <h1 class="govuk-heading-l">Personal information</h1>
 
-<%= form_with model: [:teacher_interface, @application_form] do |f| %>
+<%= form_with model: @application_form, url: [:teacher_interface, @application_form, :personal_information] do |f| %>
   <%= f.govuk_text_field :given_names,
                          label: { text: "Given names", size: "m" },
                          hint: { text: "Enter your full name apart from your family name" } %>

--- a/app/views/teacher_interface/personal_information/show.erb
+++ b/app/views/teacher_interface/personal_information/show.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title, "Check your answers" %>
+<% content_for :back_link_url, edit_teacher_interface_application_form_personal_information_path(@application_form) %>
+
+<h1 class="govuk-heading-l">Check your answers</h1>
+
+<%= govuk_summary_list do |summary_list|
+  summary_list.row do |row|
+    row.key { "Given names" }
+    row.value { @application_form.given_names }
+    row.action(text: "Change", href: [:edit, :teacher_interface, @application_form, :personal_information], visually_hidden_text: "school name")
+  end
+
+  summary_list.row do |row|
+    row.key { "Family name" }
+    row.value { @application_form.family_name }
+    row.action(text: "Change", href: [:edit, :teacher_interface, @application_form, :personal_information], visually_hidden_text: "city of institution")
+  end
+
+  summary_list.row do |row|
+    row.key { "Date of birth" }
+    row.value { @application_form.date_of_birth&.strftime("%e %B %Y") }
+    row.action(text: "Change", href: [:edit, :teacher_interface, @application_form, :personal_information], visually_hidden_text: "country of institution")
+  end
+end %>
+
+<%= govuk_button_link_to "Continue", teacher_interface_application_form_path(@application_form) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,12 +76,14 @@ Rails.application.routes.draw do
 
     resources :application_forms,
               path: "applications",
-              only: %i[index new create show update] do
+              only: %i[index new create show] do
+      resource :personal_information,
+               controller: :personal_information,
+               only: %i[show edit update]
       resources :work_histories, except: %i[show]
 
       member do
         post "submit"
-        get "personal_information"
         get "identity_documents"
       end
     end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_personal_information
     and_i_click_continue
+    then_i_see_the_personal_information_summary
+
+    when_i_click_continue
     then_i_see_completed_personal_information_section
 
     when_i_click_work_history
@@ -58,6 +61,10 @@ RSpec.describe "Teacher application", type: :system do
 
   def when_i_click_submit
     click_button "Submit your application"
+  end
+
+  def when_i_click_continue
+    click_link "Continue"
   end
 
   def and_i_click_continue
@@ -138,6 +145,13 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_title("Your work history in education")
     expect(page).to have_content("Your work history in education")
     expect(page).to have_content("Your current or most recent role")
+  end
+
+  def then_i_see_the_personal_information_summary
+    expect(page).to have_content("Check your answers")
+    expect(page).to have_content("Given names\tName")
+    expect(page).to have_content("Family name\tName")
+    expect(page).to have_content("Date of birth\t1 January 2000")
   end
 
   def then_i_see_completed_personal_information_section


### PR DESCRIPTION
This moves the logic related to personal information controller in to its own controller so we can better display a "Check your answers" page rather than polluting the application forms controller with lots of methods.

[Trello Card](https://trello.com/c/760qGtLm/619-build-personal-information-spoke)

## Screenshots

<img width="727" alt="Screenshot 2022-07-20 at 14 17 18" src="https://user-images.githubusercontent.com/510498/179991740-aec8178e-8967-459b-8c78-5a1b045263b7.png">
