### PR TITLE
Disable Azure Storage

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :microsoft
+  config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -5,9 +5,8 @@ test:
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
-
-microsoft:
-  service: AzureStorage
-  storage_account_name: <%= ENV.fetch("AZURE_STORAGE_ACCOUNT_NAME") %>
-  storage_access_key: <%= ENV.fetch("AZURE_STORAGE_ACCESS_KEY") %>
-  container: <%= ENV.fetch("AZURE_STORAGE_CONTAINER") %>
+#microsoft:
+#  service: AzureStorage
+#  storage_account_name: <%#= ENV.fetch("AZURE_STORAGE_ACCOUNT_NAME") %>
+#  storage_access_key: <%#= ENV.fetch("AZURE_STORAGE_ACCESS_KEY") %>
+#  container: <%#= ENV.fetch("AZURE_STORAGE_CONTAINER") %>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,6 +8,6 @@ local:
 
 microsoft:
   service: AzureStorage
-  storage_account_name: <%= ENV["AZURE_STORAGE_ACCOUNT_NAME"] %>
-  storage_access_key: <%= ENV["AZURE_STORAGE_ACCESS_KEY"] %>
-  container: <%= ENV["AZURE_STORAGE_CONTAINER"] %>
+  storage_account_name: <%= ENV.fetch("AZURE_STORAGE_ACCOUNT_NAME") %>
+  storage_access_key: <%= ENV.fetch("AZURE_STORAGE_ACCESS_KEY") %>
+  container: <%= ENV.fetch("AZURE_STORAGE_CONTAINER") %>


### PR DESCRIPTION
We can't enable it yet as the env vars aren't in place and it's causing the app to fail to deploy.

We can at least start building our application form against ActiveStorage, but it won't work in any of the environments until the Azure env vars are set up.

[Trello Card](https://trello.com/c/ebfhG5aS/651-prepare-for-file-uploads)