### PR TITLE
Fix bug when signing in without an account

### DIFF
--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -6,16 +6,16 @@ class Teachers::SessionsController < Devise::SessionsController
   layout "two_thirds"
 
   def create
-    if create_params[:create_or_sign_in] == "create"
+    if resource_params[:create_or_sign_in] == "create"
       redirect_to :new_teacher_registration
       return
     end
 
-    self.resource = resource_class.find_by(email: create_params[:email])
+    self.resource = resource_class.find_by(email: resource_params[:email])
 
     if resource
       if resource.active_for_authentication?
-        resource.send_magic_link(create_params[:remember_me])
+        resource.send_magic_link(resource_params[:remember_me])
       else
         resource.resend_confirmation_instructions
       end
@@ -23,7 +23,7 @@ class Teachers::SessionsController < Devise::SessionsController
       redirect_to :teacher_check_email
     else
       set_flash_message(:alert, :not_found_in_database, now: true)
-      self.resource = resource_class.new(create_params)
+      self.resource = resource_class.new(email: resource_params[:email])
       render :new
     end
   end
@@ -39,11 +39,5 @@ class Teachers::SessionsController < Devise::SessionsController
     else
       super
     end
-  end
-
-  private
-
-  def create_params
-    resource_params.permit(:email, :remember_me, :create_or_sign_in)
   end
 end

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe "Teacher authentication", type: :system do
   end
 
   it "sign in when unconfirmed" do
+    when_i_visit_the_sign_in_page
+    then_i_see_the_sign_in_form
+
+    when_i_choose_yes_sign_in
+    and_i_fill_teacher_email_address
+    and_i_click_continue
+    then_i_see_the_sign_in_form
+  end
+
+  it "sign in invalid email" do
     when_i_visit_the_sign_up_page
     then_i_see_the_sign_up_form
 
@@ -69,9 +79,6 @@ RSpec.describe "Teacher authentication", type: :system do
     and_i_click_continue
     then_i_see_the_check_your_email_page
     and_i_receive_a_teacher_confirmation_email
-
-    when_i_visit_the_teacher_confirmation_email
-    then_i_see_successful_confirmation_message
   end
 
   private


### PR DESCRIPTION
This fixes a bug where if you attempt to sign in with an account that doesn't exist, users see an error page instead of being asked to sign up.

[Sentry Issue](https://sentry.io/organizations/dfe-teacher-services/issues/3452550323/?project=6426061&referrer=slack)