### PR TITLE
Improve design of "Check your answers" pages

### DIFF
--- a/app/assets/stylesheets/_summary_list_card.scss
+++ b/app/assets/stylesheets/_summary_list_card.scss
@@ -1,0 +1,136 @@
+.govuk-summary-list__card {
+  margin-bottom: 20px;
+  border: 1px solid #b1b4b6;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-summary-list__card {
+    margin-bottom: 30px;
+  }
+}
+
+.govuk-summary-list__card-title-wrapper {
+  padding: 15px;
+  background-color: #f3f2f1;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-summary-list__card-title-wrapper {
+    display: -ms-flexbox;
+    display: -webkit-box;
+    display: flex;
+    -ms-flex-pack: justify;
+    -webkit-box-pack: justify;
+    justify-content: space-between;
+    padding: 15px 20px;
+  }
+}
+
+.govuk-summary-list__card-title {
+  font-family: "GDS Transport", arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
+  margin: 0;
+}
+
+@media print {
+  .govuk-summary-list__card-title {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-summary-list__card-title {
+    font-size: 19px;
+    font-size: 1.1875rem;
+    line-height: 1.3157894737;
+  }
+}
+
+@media print {
+  .govuk-summary-list__card-title {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-summary-list__card-actions-list {
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-summary-list__card-actions-list {
+    display: -ms-flexbox;
+    display: -webkit-box;
+    display: flex;
+    margin: 0;
+  }
+}
+
+.govuk-summary-list__card-actions-list-item {
+  font-family: "GDS Transport", arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 400;
+  font-size: 16px;
+  font-size: 1rem;
+  line-height: 1.25;
+  display: inline;
+  margin-right: 10px;
+  padding-right: 10px;
+}
+
+@media print {
+  .govuk-summary-list__card-actions-list-item {
+    font-family: sans-serif;
+  }
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-summary-list__card-actions-list-item {
+    font-size: 19px;
+    font-size: 1.1875rem;
+    line-height: 1.3157894737;
+  }
+}
+
+@media print {
+  .govuk-summary-list__card-actions-list-item {
+    font-size: 14pt;
+    line-height: 1.15;
+  }
+}
+
+.govuk-summary-list__card-actions-list-item:last-child {
+  margin-right: 0;
+  padding-right: 0;
+}
+
+.govuk-summary-list__card-actions-list-item:not(:last-child) {
+  border-right: 1px solid #b1b4b6;
+}
+
+.govuk-summary-list__card-content {
+  padding: 15px 15px 0;
+}
+
+@media (min-width: 40.0625em) {
+  .govuk-summary-list__card-content {
+    padding: 15px 20px;
+  }
+}
+
+.govuk-summary-list__card-content .govuk-summary-list {
+  margin-bottom: 0;
+}
+
+.govuk-summary-list__card-content .govuk-summary-list__row:last-of-type {
+  margin-bottom: 0;
+  border-bottom: none;
+}

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -6,6 +6,7 @@ $govuk-assets-path: "/";
 @import "location-autocomplete.min";
 
 @import "_environments";
+@import "_summary_list_card";
 @import "_support";
 @import "_task_list";
 

--- a/app/components/check_your_answers_summary_component.html.erb
+++ b/app/components/check_your_answers_summary_component.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-summary-list__card">
+  <div class="govuk-summary-list__card-title-wrapper">
+    <h2 class="govuk-summary-list__card-title"><%= title %></h2>
+  </div>
+
+  <div class="govuk-summary-list__card-content">
+    <dl class="govuk-summary-list">
+      <% rows.each do |row| %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key"><%= row.fetch(:key) %></dt>
+          <dd class="govuk-summary-list__value"><%= row.fetch(:value) %></dd>
+          <dd class="govuk-summary-list__actions">
+            <%= govuk_link_to(row.fetch(:href)) do %>
+              Change <span class="govuk-visually-hidden"><%= row.fetch(:key).downcase %></span>
+            <% end %>
+          </dd>
+        </div>
+      <% end %>
+    </dl>
+  </div>
+</div>

--- a/app/components/check_your_answers_summary_component.rb
+++ b/app/components/check_your_answers_summary_component.rb
@@ -1,0 +1,37 @@
+class CheckYourAnswersSummaryComponent < ViewComponent::Base
+  def initialize(model:, title:, fields:)
+    super
+    @model = model
+    @title = title
+    @fields = fields
+  end
+
+  attr_reader :title
+
+  def rows
+    fields.map { |key, opts| opts ? row_for_field(key, opts) : nil }.compact
+  end
+
+  private
+
+  def row_for_field(key, opts)
+    {
+      key: opts.fetch(:key, key.to_s.humanize),
+      value: format_value(model.send(key), opts),
+      href: opts.fetch(:href)
+    }
+  end
+
+  def format_value(value, opts)
+    return "" if value.nil?
+
+    if value.is_a?(Date)
+      format = opts[:format] == :without_day ? "%B %Y" : "%e %B %Y"
+      return value.strftime(format).strip
+    end
+
+    value.to_s
+  end
+
+  attr_reader :model, :fields
+end

--- a/app/controllers/teacher_interface/age_range_controller.rb
+++ b/app/controllers/teacher_interface/age_range_controller.rb
@@ -3,27 +3,29 @@ module TeacherInterface
     before_action :load_application_form
 
     def show
-      if @application_form.age_range_status == :not_started
-        redirect_to [:edit, :teacher_interface, @application_form, :age_range]
+      if application_form.age_range_status == :not_started
+        redirect_to [:edit, :teacher_interface, application_form, :age_range]
       end
     end
 
     def edit
       @age_range_form =
         AgeRangeForm.new(
-          application_form: @application_form,
-          age_range_min: @application_form.age_range_min,
-          age_range_max: @application_form.age_range_max
+          application_form:,
+          age_range_min: application_form.age_range_min,
+          age_range_max: application_form.age_range_max
         )
     end
 
     def update
       @age_range_form =
-        AgeRangeForm.new(
-          age_range_params.merge(application_form: @application_form)
-        )
+        AgeRangeForm.new(age_range_params.merge(application_form:))
       if @age_range_form.save
-        redirect_to [:teacher_interface, @application_form, :age_range]
+        redirect_to_if_save_and_continue [
+                                           :teacher_interface,
+                                           application_form,
+                                           :age_range
+                                         ]
       else
         render :edit, status: :unprocessable_entity
       end

--- a/app/controllers/teacher_interface/base_controller.rb
+++ b/app/controllers/teacher_interface/base_controller.rb
@@ -6,9 +6,21 @@ class TeacherInterface::BaseController < ApplicationController
   before_action :authenticate_teacher!
 
   def load_application_form
-    @application_form =
+    @application_form = application_form
+  end
+
+  def application_form
+    @application_form ||=
       ApplicationForm.where(teacher: current_teacher).find(
         params[:application_form_id] || params[:id]
       )
+  end
+
+  def redirect_to_if_save_and_continue(*args)
+    if params[:next] == "save_and_continue"
+      redirect_to(*args)
+    else
+      redirect_to [:teacher_interface, application_form]
+    end
   end
 end

--- a/app/controllers/teacher_interface/personal_information_controller.rb
+++ b/app/controllers/teacher_interface/personal_information_controller.rb
@@ -2,11 +2,11 @@ class TeacherInterface::PersonalInformationController < TeacherInterface::BaseCo
   before_action :load_application_form
 
   def show
-    if @application_form.personal_information_status == :not_started
+    if application_form.personal_information_status == :not_started
       redirect_to [
                     :edit,
                     :teacher_interface,
-                    @application_form,
+                    application_form,
                     :personal_information
                   ]
     end
@@ -16,8 +16,12 @@ class TeacherInterface::PersonalInformationController < TeacherInterface::BaseCo
   end
 
   def update
-    if @application_form.update(personal_information_params)
-      redirect_to [:teacher_interface, @application_form, :personal_information]
+    if application_form.update(personal_information_params)
+      redirect_to_if_save_and_continue [
+                                         :teacher_interface,
+                                         application_form,
+                                         :personal_information
+                                       ]
     else
       render :edit, status: :unprocessable_entity
     end

--- a/app/views/shared/_save_submit_buttons.html.erb
+++ b/app/views/shared/_save_submit_buttons.html.erb
@@ -1,0 +1,3 @@
+<%= f.govuk_submit "Continue", name: "next", value: "save_and_continue", prevent_double_click: false do %>
+  <%= f.govuk_submit "Save and come back later", name: "next", value: "save_and_return", secondary: true, prevent_double_click: false %>
+<% end %>

--- a/app/views/teacher_interface/age_range/_summary.html.erb
+++ b/app/views/teacher_interface/age_range/_summary.html.erb
@@ -1,13 +1,10 @@
-<%= govuk_summary_list do |summary_list|
-  summary_list.row do |row|
-    row.key { "Minimum age" }
-    row.value { application_form.age_range_min.to_s }
-    row.action(text: "Change", href: [:edit, :teacher_interface, application_form, :age_range], visually_hidden_text: "from")
-  end
-
-  summary_list.row do |row|
-    row.key { "Maximum age" }
-    row.value { application_form.age_range_max.to_s }
-    row.action(text: "Change", href: [:edit, :teacher_interface, application_form, :age_range], visually_hidden_text: "to")
-  end
-end %>
+<%= render(CheckYourAnswersSummaryComponent.new(model: application_form, title: "Age range", fields: {
+  age_range_min: {
+    key: "Minimum age",
+    href: [:edit, :teacher_interface, application_form, :age_range]
+  },
+  age_range_max: {
+    key: "Maximum age",
+    href: [:edit, :teacher_interface, application_form, :age_range]
+  },
+})) %>

--- a/app/views/teacher_interface/age_range/edit.erb
+++ b/app/views/teacher_interface/age_range/edit.erb
@@ -22,5 +22,5 @@
     </p>
   <% end %>
 
-  <%= f.govuk_submit "Continue", prevent_double_click: false %>
+  <%= render "shared/save_submit_buttons", f: %>
 <% end %>

--- a/app/views/teacher_interface/personal_information/_summary.html.erb
+++ b/app/views/teacher_interface/personal_information/_summary.html.erb
@@ -1,19 +1,11 @@
-<%= govuk_summary_list do |summary_list|
-  summary_list.row do |row|
-    row.key { "Given names" }
-    row.value { application_form.given_names }
-    row.action(text: "Change", href: [:edit, :teacher_interface, application_form, :personal_information], visually_hidden_text: "school name")
-  end
-
-  summary_list.row do |row|
-    row.key { "Family name" }
-    row.value { application_form.family_name }
-    row.action(text: "Change", href: [:edit, :teacher_interface, application_form, :personal_information], visually_hidden_text: "city of institution")
-  end
-
-  summary_list.row do |row|
-    row.key { "Date of birth" }
-    row.value { application_form.date_of_birth&.strftime("%e %B %Y") }
-    row.action(text: "Change", href: [:edit, :teacher_interface, application_form, :personal_information], visually_hidden_text: "country of institution")
-  end
-end %>
+<%= render(CheckYourAnswersSummaryComponent.new(model: application_form, title: "Personal information", fields: {
+  given_names: {
+    href: [:edit, :teacher_interface, application_form, :personal_information]
+  },
+  family_name: {
+    href: [:edit, :teacher_interface, application_form, :personal_information]
+  },
+  date_of_birth: {
+    href: [:edit, :teacher_interface, application_form, :personal_information]
+  },
+})) %>

--- a/app/views/teacher_interface/personal_information/edit.erb
+++ b/app/views/teacher_interface/personal_information/edit.erb
@@ -25,5 +25,5 @@
     </p>
   <% end %>
 
-  <%= f.govuk_submit "Continue", prevent_double_click: false %>
+  <%= render "shared/save_submit_buttons", f: %>
 <% end %>

--- a/app/views/teacher_interface/work_histories/_summary.html.erb
+++ b/app/views/teacher_interface/work_histories/_summary.html.erb
@@ -1,53 +1,37 @@
 <% work_histories.each do |work_history| %>
-  <% if work_history.current_or_most_recent_role? %>
-    <p class="govuk-body">Your current or most recent role</p>
-  <% else %>
-    <p class="govuk-body">Previous workplace</p>
-  <% end %>
-
-  <%= govuk_summary_list do |summary_list|
-    summary_list.row do |row|
-      row.key { "School name" }
-      row.value { work_history.school_name }
-      row.action(text: "Change", href: [:edit, :teacher_interface, application_form, work_history], visually_hidden_text: "school name")
-    end
-
-    summary_list.row do |row|
-      row.key { "City of institution" }
-      row.value { work_history.city }
-      row.action(text: "Change", href: [:edit, :teacher_interface, application_form, work_history], visually_hidden_text: "city of institution")
-    end
-
-    summary_list.row do |row|
-      row.key { "Country of institution" }
-      row.value { work_history.country }
-      row.action(text: "Change", href: [:edit, :teacher_interface, application_form, work_history], visually_hidden_text: "country of institution")
-    end
-
-    summary_list.row do |row|
-      row.key { "Your job role" }
-      row.value { work_history.job }
-      row.action(text: "Change", href: [:edit, :teacher_interface, application_form, work_history], visually_hidden_text: "your job role")
-    end
-
-    summary_list.row do |row|
-      row.key { "Contact email address" }
-      row.value { work_history.email }
-      row.action(text: "Change", href: [:edit, :teacher_interface, application_form, work_history], visually_hidden_text: "contact email address")
-    end
-
-    summary_list.row do |row|
-      row.key { "Role start date" }
-      row.value { work_history.start_date&.strftime("%B %Y") }
-      row.action(text: "Change", href: [:edit, :teacher_interface, application_form, work_history], visually_hidden_text: "role start date")
-    end
-
-    unless work_history.still_employed
-      summary_list.row do |row|
-        row.key { "Role end date" }
-        row.value { work_history.end_date&.strftime("%B %Y") }
-        row.action(text: "Change", href: [:edit, :teacher_interface, application_form, work_history], visually_hidden_text: "role end date")
-      end
-    end
-  end %>
+  <%= render(CheckYourAnswersSummaryComponent.new(
+    model: work_history,
+    title: work_history.current_or_most_recent_role? ? "Your current or most recent role" : "Previous role",
+    fields: {
+      school_name: {
+        href: [:edit, :teacher_interface, application_form, work_history]
+      },
+      city: {
+        key: "City of institution",
+        href: [:edit, :teacher_interface, application_form, work_history]
+      },
+      country: {
+        key: "Country of institution",
+        href: [:edit, :teacher_interface, application_form, work_history]
+      },
+      job: {
+        key: "Your job role",
+        href: [:edit, :teacher_interface, application_form, work_history]
+      },
+      email: {
+        key: "Contact email address",
+        href: [:edit, :teacher_interface, application_form, work_history]
+      },
+      start_date: {
+        key: "Role start date",
+        format: :without_day,
+        href: [:edit, :teacher_interface, application_form, work_history]
+      },
+      end_date: work_history.still_employed ? {
+        key: "Role end date",
+        format: :without_day,
+        href: [:edit, :teacher_interface, application_form, work_history]
+      } : nil,
+    }
+  )) %>
 <% end %>

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -1,0 +1,175 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CheckYourAnswersSummaryComponent, type: :component do
+  subject(:component) do
+    render_inline(described_class.new(model:, title:, fields:))
+  end
+
+  let(:model) do
+    double(
+      string: "String value",
+      number: 10,
+      date: Date.new(2020, 1, 1),
+      date_without_day: Date.new(2020, 1, 1),
+      custom_key: "Custom key value",
+      nil_value: nil
+    )
+  end
+
+  let(:title) { "Title" }
+
+  let(:fields) do
+    {
+      string: {
+        href: "/string"
+      },
+      number: {
+        href: "/number"
+      },
+      date: {
+        href: "/date"
+      },
+      date_without_day: {
+        format: :without_day,
+        href: "/date_without_day"
+      },
+      custom_key: {
+        key: "A custom key",
+        href: "/custom_key"
+      },
+      nil_value: {
+        href: "/nil_value"
+      }
+    }
+  end
+
+  it "renders the title" do
+    expect(component.css(".govuk-summary-list__card-title").text).to eq("Title")
+  end
+
+  describe "string row" do
+    subject(:row) { component.css(".govuk-summary-list__row")[0] }
+
+    it "renders the key" do
+      expect(row.at_css(".govuk-summary-list__key").text).to eq("String")
+    end
+
+    it "renders the value" do
+      expect(row.at_css(".govuk-summary-list__value").text).to eq(
+        "String value"
+      )
+    end
+
+    it "renders the change link" do
+      a = row.at_css(".govuk-summary-list__actions .govuk-link")
+
+      expect(a.text.strip).to eq("Change string")
+      expect(a.attribute("href").value).to eq("/string")
+    end
+  end
+
+  describe "number row" do
+    subject(:row) { component.css(".govuk-summary-list__row")[1] }
+
+    it "renders the key" do
+      expect(row.at_css(".govuk-summary-list__key").text).to eq("Number")
+    end
+
+    it "renders the value" do
+      expect(row.at_css(".govuk-summary-list__value").text).to eq("10")
+    end
+
+    it "renders the change link" do
+      a = row.at_css(".govuk-summary-list__actions .govuk-link")
+
+      expect(a.text.strip).to eq("Change number")
+      expect(a.attribute("href").value).to eq("/number")
+    end
+  end
+
+  describe "date row" do
+    subject(:row) { component.css(".govuk-summary-list__row")[2] }
+
+    it "renders the key" do
+      expect(row.at_css(".govuk-summary-list__key").text).to eq("Date")
+    end
+
+    it "renders the value" do
+      expect(row.at_css(".govuk-summary-list__value").text).to eq(
+        "1 January 2020"
+      )
+    end
+
+    it "renders the change link" do
+      a = row.at_css(".govuk-summary-list__actions .govuk-link")
+
+      expect(a.text.strip).to eq("Change date")
+      expect(a.attribute("href").value).to eq("/date")
+    end
+  end
+
+  describe "date without day row" do
+    subject(:row) { component.css(".govuk-summary-list__row")[3] }
+
+    it "renders the key" do
+      expect(row.at_css(".govuk-summary-list__key").text).to eq(
+        "Date without day"
+      )
+    end
+
+    it "renders the value" do
+      expect(row.at_css(".govuk-summary-list__value").text).to eq(
+        "January 2020"
+      )
+    end
+
+    it "renders the change link" do
+      a = row.at_css(".govuk-summary-list__actions .govuk-link")
+
+      expect(a.text.strip).to eq("Change date without day")
+      expect(a.attribute("href").value).to eq("/date_without_day")
+    end
+  end
+
+  describe "custom key row" do
+    subject(:row) { component.css(".govuk-summary-list__row")[4] }
+
+    it "renders the key" do
+      expect(row.at_css(".govuk-summary-list__key").text).to eq("A custom key")
+    end
+
+    it "renders the value" do
+      expect(row.at_css(".govuk-summary-list__value").text).to eq(
+        "Custom key value"
+      )
+    end
+
+    it "renders the change link" do
+      a = row.at_css(".govuk-summary-list__actions .govuk-link")
+
+      expect(a.text.strip).to eq("Change a custom key")
+      expect(a.attribute("href").value).to eq("/custom_key")
+    end
+  end
+
+  describe "nil value row" do
+    subject(:row) { component.css(".govuk-summary-list__row")[5] }
+
+    it "renders the key" do
+      expect(row.at_css(".govuk-summary-list__key").text).to eq("Nil value")
+    end
+
+    it "renders the value" do
+      expect(row.at_css(".govuk-summary-list__value").text).to eq("")
+    end
+
+    it "renders the change link" do
+      a = row.at_css(".govuk-summary-list__actions .govuk-link")
+
+      expect(a.text.strip).to eq("Change nil value")
+      expect(a.attribute("href").value).to eq("/nil_value")
+    end
+  end
+end


### PR DESCRIPTION
This makes two changes to the design of the "Check your answers" pages to match the prototype:

- Add a "Save and come back later" button to each question
- Use the summary list card style for the summary list

## Screenshots

![Screenshot 2022-07-26 at 10 46 03](https://user-images.githubusercontent.com/510498/180977195-a9a447ab-4c64-4582-a005-d8f59e3d415a.png)

![Screenshot 2022-07-26 at 10 46 10](https://user-images.githubusercontent.com/510498/180977197-016ac724-949b-40ed-95c9-a71885304bf1.png)

