### PR TITLE
Build identity and name change documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules
 public/assets
 tmp/*
 tmp/pids/*
+storage/*

--- a/app/components/check_your_answers_summary_component.rb
+++ b/app/components/check_your_answers_summary_component.rb
@@ -35,7 +35,7 @@ class CheckYourAnswersSummaryComponent < ViewComponent::Base
         value
           .uploads
           .order(:created_at)
-          .map { |upload| upload.attachment&.name }
+          .map { |upload| upload.attachment&.filename }
           .compact
           .join(", ")
       )

--- a/app/controllers/teacher_interface/base_controller.rb
+++ b/app/controllers/teacher_interface/base_controller.rb
@@ -9,10 +9,21 @@ class TeacherInterface::BaseController < ApplicationController
     @application_form = application_form
   end
 
+  def load_document
+    @document = document
+  end
+
   def application_form
     @application_form ||=
       ApplicationForm.where(teacher: current_teacher).find(
         params[:application_form_id] || params[:id]
+      )
+  end
+
+  def document
+    @document ||=
+      Document.where(documentable: application_form).find(
+        params[:document_id] || params[:id]
       )
   end
 

--- a/app/controllers/teacher_interface/documents_controller.rb
+++ b/app/controllers/teacher_interface/documents_controller.rb
@@ -1,0 +1,41 @@
+module TeacherInterface
+  class DocumentsController < BaseController
+    before_action :load_application_form
+    before_action :load_document
+
+    def edit
+      if document.uploads.empty?
+        redirect_to new_teacher_interface_application_form_document_upload_path(
+                      @application_form,
+                      @document
+                    )
+      end
+    end
+
+    def update
+      if ActiveModel::Type::Boolean.new.cast(document_params[:add_another])
+        redirect_to new_teacher_interface_application_form_document_upload_path(
+                      @application_form,
+                      @document
+                    )
+      else
+        redirect_to continue_url
+      end
+    end
+
+    private
+
+    def document_params
+      params.require(:document).permit(:add_another)
+    end
+
+    def continue_url
+      case document.document_type
+      when "name_change"
+        [:teacher_interface, application_form, :personal_information]
+      else
+        [:teacher_interface, application_form]
+      end
+    end
+  end
+end

--- a/app/controllers/teacher_interface/personal_information_controller.rb
+++ b/app/controllers/teacher_interface/personal_information_controller.rb
@@ -60,9 +60,10 @@ module TeacherInterface
         )
       if @alternative_name_form.save
         redirect_to_if_save_and_continue [
+                                           :edit,
                                            :teacher_interface,
                                            application_form,
-                                           :personal_information
+                                           application_form.name_change_document
                                          ]
       else
         render :alternative_name, status: :unprocessable_entity

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -1,0 +1,41 @@
+module TeacherInterface
+  class UploadsController < BaseController
+    before_action :load_application_form
+    before_action :load_document
+    before_action :load_upload, only: %i[delete destroy]
+
+    def new
+      @upload = Upload.new(document:)
+    end
+
+    def create
+      attachment = params.dig(:upload, :attachment)
+      @upload = document.uploads.build(attachment:, translation: false)
+      if @upload.save
+        redirect_to_if_save_and_continue [
+                                           :edit,
+                                           :teacher_interface,
+                                           @application_form,
+                                           @document
+                                         ]
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def delete
+    end
+
+    def destroy
+      @upload.attachment.purge
+      @upload.destroy!
+      redirect_to [:edit, :teacher_interface, @application_form, @document]
+    end
+
+    private
+
+    def load_upload
+      @upload = document.uploads.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -27,8 +27,11 @@ module TeacherInterface
     end
 
     def destroy
-      @upload.attachment.purge
-      @upload.destroy!
+      if ActiveModel::Type::Boolean.new.cast(params.dig(:upload, :confirm))
+        @upload.attachment.purge
+        @upload.destroy!
+      end
+
       redirect_to [:edit, :teacher_interface, @application_form, @document]
     end
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -53,6 +53,8 @@ class ApplicationForm < ApplicationRecord
           class_name: "Document",
           as: :documentable
 
+  before_create :build_documents
+
   validates :reference, presence: true, uniqueness: true, length: 3..31
 
   enum status: { active: "active", submitted: "submitted" }
@@ -112,6 +114,12 @@ class ApplicationForm < ApplicationRecord
   end
 
   private
+
+  def build_documents
+    build_identification_document(document_type: :identification)
+    build_name_change_document(document_type: :name_change)
+    build_written_statement_document(document_type: :written_statement)
+  end
 
   def needs_work_history?
     region.status_check_none? || region.sanction_check_none?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -73,7 +73,7 @@ class ApplicationForm < ApplicationRecord
     @tasks ||=
       begin
         hash = {}
-        hash.merge!(about_you: %i[personal_information])
+        hash.merge!(about_you: %i[personal_information identity_documents])
         hash.merge!(qualifications: %i[age_range])
         hash.merge!(work_history: %i[work_history]) if needs_work_history?
         hash
@@ -104,6 +104,15 @@ class ApplicationForm < ApplicationRecord
   def path_for_task_item(key)
     url_helpers = Rails.application.routes.url_helpers
 
+    if key == :identity_documents
+      return(
+        url_helpers.edit_teacher_interface_application_form_document_path(
+          self,
+          identification_document
+        )
+      )
+    end
+
     key = :work_histories if key == :work_history
 
     begin
@@ -129,6 +138,8 @@ class ApplicationForm < ApplicationRecord
     case key
     when :personal_information
       personal_information_status
+    when :identity_documents
+      identification_document.uploaded? ? :completed : :not_started
     when :age_range
       status_for_values(age_range_min, age_range_max)
     when :work_history

--- a/app/views/teacher_interface/application_forms/edit.html.erb
+++ b/app/views/teacher_interface/application_forms/edit.html.erb
@@ -5,6 +5,7 @@
 
 <h2 class="govuk-heading-m">About you</h2>
 <%= render "teacher_interface/personal_information/summary", application_form: @application_form %>
+<%= render "teacher_interface/identity_documents/summary", application_form: @application_form %>
 
 <h2 class="govuk-heading-m">Who you can teach</h2>
 <%= render "teacher_interface/age_range/summary", application_form: @application_form %>

--- a/app/views/teacher_interface/documents/edit.html.erb
+++ b/app/views/teacher_interface/documents/edit.html.erb
@@ -1,0 +1,31 @@
+<% content_for :page_title, "Check your uploaded files" %>
+<% content_for :back_link_url, teacher_interface_application_form_path(@application_form) %>
+
+<h1 class="govuk-heading-l">Check your uploaded files</h1>
+
+<h2 class="govuk-heading-m">Files added</h2>
+
+<%= govuk_summary_list do |summary_list|
+  @document.uploads.each_with_index do |upload, index|
+    summary_list.row do |row|
+      row.key(text: "File #{index + 1}")
+      row.value(text: upload.attachment.filename)
+      row.action(
+        text: "Delete",
+        href: delete_teacher_interface_application_form_document_upload_path(@application_form, @document, upload),
+        visually_hidden_text: upload.attachment.filename
+      )
+    end
+  end
+end %>
+
+<%= form_with model: [:teacher_interface, @application_form, @document] do |f| %>
+  <%= f.govuk_radio_buttons_fieldset :add_another,
+                                     legend: { text: "Do you need to upload another page?" },
+                                     hint: { text: "If your document has several pages, you can upload them here. Otherwise, select ‘No’ and then ‘Continue’." } do %>
+    <%= f.govuk_radio_button :add_another, "true", label: { text: "Yes" } %>
+    <%= f.govuk_radio_button :add_another, "false", label: { text: "No" } %>
+  <% end %>
+
+  <%= f.govuk_submit "Continue", prevent_double_click: false %>
+<% end %>

--- a/app/views/teacher_interface/identity_documents/_summary.html.erb
+++ b/app/views/teacher_interface/identity_documents/_summary.html.erb
@@ -1,0 +1,6 @@
+<%= render(CheckYourAnswersSummaryComponent.new(model: application_form, title: "Identity documents", fields: {
+  identification_document: {
+    key: "Identity documents",
+    href: [:edit, :teacher_interface, application_form, application_form.identification_document]
+  },
+})) %>

--- a/app/views/teacher_interface/personal_information/_summary.html.erb
+++ b/app/views/teacher_interface/personal_information/_summary.html.erb
@@ -12,13 +12,13 @@
     key: "Legal name different to identity document?",
     href: [:alternative_name, :teacher_interface, application_form, :personal_information]
   },
-  alternative_given_names: application_form.has_alternative_name != false ? {
+  alternative_given_names: application_form.has_alternative_name? ? {
     href: [:alternative_name, :teacher_interface, application_form, :personal_information]
   } : nil,
-  alternative_family_name: application_form.has_alternative_name != false ? {
+  alternative_family_name: application_form.has_alternative_name? ? {
     href: [:alternative_name, :teacher_interface, application_form, :personal_information]
   } : nil,
-  name_change_document: application_form.has_alternative_name != false ? {
-    href: [:alternative_name, :teacher_interface, application_form, :personal_information]
+  name_change_document: application_form.has_alternative_name? ? {
+    href: [:edit, :teacher_interface, application_form, application_form.name_change_document]
   } : nil,
 })) %>

--- a/app/views/teacher_interface/uploads/delete.html.erb
+++ b/app/views/teacher_interface/uploads/delete.html.erb
@@ -1,10 +1,13 @@
 <% content_for :page_title, "Delete file" %>
 <% content_for :back_link_url, edit_teacher_interface_application_form_document_path(@application_form, @document) %>
 
-<h1 class="govuk-heading-l">Delete <%= @upload.attachment.filename %>?</h1>
-
 <%= form_with model: [:teacher_interface, @application_form, @document, @upload], method: :delete do |f| %>
-  <%= f.govuk_submit "Yes", prevent_double_click: false, warning: true do %>
-    <%= govuk_button_link_to "No, return to document", edit_teacher_interface_application_form_document_path(@application_form, @document) %>
-  <% end %>
+  <%= f.govuk_collection_radio_buttons :confirm,
+                                       [OpenStruct.new(id: "true", name: "Yes"), OpenStruct.new(id: "false", name: "No")],
+                                       :id,
+                                       :name,
+                                       inline: true,
+                                       legend: { text: "Are you sure you want to delete #{@upload.attachment.filename}?", size: "l", tag: "h1" } %>
+
+  <%= f.govuk_submit "Continue", prevent_double_click: false %>
 <% end %>

--- a/app/views/teacher_interface/uploads/delete.html.erb
+++ b/app/views/teacher_interface/uploads/delete.html.erb
@@ -1,0 +1,10 @@
+<% content_for :page_title, "Delete file" %>
+<% content_for :back_link_url, edit_teacher_interface_application_form_document_path(@application_form, @document) %>
+
+<h1 class="govuk-heading-l">Delete <%= @upload.attachment.filename %>?</h1>
+
+<%= form_with model: [:teacher_interface, @application_form, @document, @upload], method: :delete do |f| %>
+  <%= f.govuk_submit "Yes", prevent_double_click: false, warning: true do %>
+    <%= govuk_button_link_to "No, return to document", edit_teacher_interface_application_form_document_path(@application_form, @document) %>
+  <% end %>
+<% end %>

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -1,0 +1,25 @@
+<% content_for :page_title, "Upload a document" %>
+<% content_for :back_link_url, teacher_interface_application_form_path(@application_form) %>
+
+<% if @document.identification? || @document.name_change? %>
+  <h1 class="govuk-heading-l">Upload a valid identification document</h1>
+
+  <p class="govuk-body">The document must show your date of birth and your nationality. If your ID document has several pages, you can add them on the next screen. </p>
+
+  <p class="govuk-body">Acceptable documents include:</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>passport</li>
+    <li>driving licence</li>
+    <li>identity card</li>
+    <li>birth certificate.</li>
+  </ul>
+<% end %>
+
+<%= form_with model: [:teacher_interface, @application_form, @document, @upload] do |f| %>
+  <%= f.govuk_file_field :attachment,
+                         label: { text: "Select a file to upload" },
+                         hint: { text: "You can upload your files in PDF, JPG or DOC format. Each file must be no larger than 20MB." } %>
+
+  <%= render "shared/save_submit_buttons", f: %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
         work_history: Your work history
       items:
         personal_information: Enter personal information
+        identity_documents: Upload identity documents
         age_range: Enter age range
         work_history: Add work history
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,12 @@ Rails.application.routes.draw do
 
       resource :age_range, controller: :age_range, only: %i[show edit update]
       resources :work_histories, except: %i[show]
+
+      resources :documents, only: %i[edit update] do
+        resources :uploads, only: %i[new create destroy] do
+          get "delete", on: :member
+        end
+      end
     end
   end
 

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe CheckYourAnswersSummaryComponent, type: :component do
     end
 
     it "renders the value" do
-      expect(row.at_css(".govuk-summary-list__value").text).to eq("attachment")
+      expect(row.at_css(".govuk-summary-list__value").text).to eq("upload.txt")
     end
 
     it "renders the change link" do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe ApplicationForm, type: :model do
     end
   end
 
+  it "attaches empty documents" do
+    expect(application_form.identification_document).to_not be_nil
+    expect(application_form.name_change_document).to_not be_nil
+    expect(application_form.written_statement_document).to_not be_nil
+  end
+
   describe "#reference" do
     let!(:application_form1) { create(:application_form, reference: nil) }
     let!(:application_form2) { create(:application_form, reference: nil) }
@@ -153,9 +159,10 @@ RSpec.describe ApplicationForm, type: :model do
               application_form.update!(
                 has_alternative_name: true,
                 alternative_given_names: "Alt Given",
-                alternative_family_name: "Alt Family",
-                name_change_document: create(:document, :with_upload)
+                alternative_family_name: "Alt Family"
               )
+
+              create(:upload, document: application_form.name_change_document)
             end
 
             it { is_expected.to eq(:completed) }

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -86,7 +86,10 @@ RSpec.describe ApplicationForm, type: :model do
 
       it do
         is_expected.to eq(
-          { about_you: %i[personal_information], qualifications: %i[age_range] }
+          {
+            about_you: %i[personal_information identity_documents],
+            qualifications: %i[age_range]
+          }
         )
       end
     end
@@ -97,7 +100,7 @@ RSpec.describe ApplicationForm, type: :model do
       it do
         is_expected.to eq(
           {
-            about_you: %i[personal_information],
+            about_you: %i[personal_information identity_documents],
             qualifications: %i[age_range],
             work_history: %i[work_history]
           }
@@ -113,7 +116,8 @@ RSpec.describe ApplicationForm, type: :model do
       is_expected.to eq(
         {
           about_you: {
-            personal_information: :not_started
+            personal_information: :not_started,
+            identity_documents: :not_started
           },
           qualifications: {
             age_range: :not_started
@@ -167,6 +171,24 @@ RSpec.describe ApplicationForm, type: :model do
 
             it { is_expected.to eq(:completed) }
           end
+        end
+      end
+
+      describe "identity documents item" do
+        subject(:identity_documents_status) do
+          about_you_status[:identity_documents]
+        end
+
+        context "without uploads" do
+          it { is_expected.to eq(:not_started) }
+        end
+
+        context "with uploads" do
+          before do
+            create(:upload, document: application_form.identification_document)
+          end
+
+          it { is_expected.to eq(:completed) }
         end
       end
     end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -11,6 +11,10 @@ module SystemHelpers
     FeatureFlag.activate(:service_start)
   end
 
+  def given_the_service_allows_teacher_applications
+    FeatureFlag.activate(:teacher_applications)
+  end
+
   def given_an_eligible_eligibility_check
     create(:country, :with_national_region, code: "GB-SCT")
     visit "/eligibility/start"

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -39,6 +39,18 @@ module SystemHelpers
     )
   end
 
+  def when_i_choose_yes
+    choose "Yes", visible: false
+  end
+
+  alias_method :and_i_choose_yes, :when_i_choose_yes
+
+  def when_i_choose_no
+    choose "No", visible: false
+  end
+
+  alias_method :and_i_choose_no, :when_i_choose_no
+
   def when_i_fill_teacher_email_address
     fill_in "teacher-email-field", with: "test@example.com"
   end

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -196,14 +196,6 @@ RSpec.describe "Eligibility check", type: :system do
     FeatureFlag.activate(:service_start)
   end
 
-  def when_i_choose_no
-    choose "No", visible: false
-  end
-
-  def when_i_choose_yes
-    choose "Yes", visible: false
-  end
-
   def when_i_choose_region
     choose "Region", visible: false
   end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -59,10 +59,6 @@ RSpec.describe "Teacher application", type: :system do
 
   private
 
-  def given_the_service_allows_teacher_applications
-    FeatureFlag.activate(:teacher_applications)
-  end
-
   def when_i_click_apply_for_qts
     click_link "Apply for QTS"
   end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -161,10 +161,6 @@ RSpec.describe "Teacher application", type: :system do
     choose "Yes", visible: false
   end
 
-  def when_i_choose_no
-    choose "No", visible: false
-  end
-
   def then_i_see_the_new_application_page
     expect(page).to have_current_path("/teacher/applications/new")
     expect(page).to have_title("Start your application")

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_alternative_name_form
     and_i_click_continue
+    then_i_see_the_upload_name_change_form
+
+    when_i_fill_in_the_upload_name_change_form
+    and_i_click_continue
+    then_i_see_the_check_your_name_change_uploads
+
+    when_i_choose_no
+    and_i_click_continue
     then_i_see_the_personal_information_summary
 
     when_i_click_continue
@@ -104,6 +112,11 @@ RSpec.describe "Teacher application", type: :system do
             with: "Name"
   end
 
+  def when_i_fill_in_the_upload_name_change_form
+    attach_file "upload-attachment-field",
+                Rails.root.join(file_fixture("upload.txt"))
+  end
+
   def when_i_click_age_range
     click_link "Enter age range"
   end
@@ -176,6 +189,17 @@ RSpec.describe "Teacher application", type: :system do
       "Yes – I'll upload another document to prove this"
     )
     expect(page).to have_content("No")
+  end
+
+  def then_i_see_the_upload_name_change_form
+    expect(page).to have_title("Upload a document")
+    expect(page).to have_content("Upload a valid identification document")
+  end
+
+  def then_i_see_the_check_your_name_change_uploads
+    expect(page).to have_title("Check your uploaded files")
+    expect(page).to have_content("Check your uploaded files")
+    expect(page).to have_content("File 1\tupload.txt\tDelete")
   end
 
   def then_i_see_the_age_range_form

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe "Teacher application", type: :system do
     when_i_click_continue
     then_i_see_completed_personal_information_section
 
+    when_i_click_identity_documents
+    then_i_see_the_upload_identification_form
+
+    when_i_fill_in_the_upload_identification_form
+    and_i_click_continue
+    then_i_see_the_check_your_identification_uploads
+
+    when_i_choose_no
+    and_i_click_continue
+    then_i_see_completed_identity_documents_section
+
     when_i_click_age_range
     then_i_see_the_age_range_form
 
@@ -117,6 +128,15 @@ RSpec.describe "Teacher application", type: :system do
                 Rails.root.join(file_fixture("upload.txt"))
   end
 
+  def when_i_click_identity_documents
+    click_link "Upload identity documents"
+  end
+
+  def when_i_fill_in_the_upload_identification_form
+    attach_file "upload-attachment-field",
+                Rails.root.join(file_fixture("upload.txt"))
+  end
+
   def when_i_click_age_range
     click_link "Enter age range"
   end
@@ -162,6 +182,7 @@ RSpec.describe "Teacher application", type: :system do
 
     expect(page).to have_content("About you")
     expect(page).to have_content("Enter personal information\nNOT STARTED")
+    expect(page).to have_content("Upload identity documents\nNOT STARTED")
 
     expect(page).to have_content("Your qualifications")
     expect(page).to have_content("Enter age range\nNOT STARTED")
@@ -202,6 +223,17 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("File 1\tupload.txt\tDelete")
   end
 
+  def then_i_see_the_upload_identification_form
+    expect(page).to have_title("Upload a document")
+    expect(page).to have_content("Upload a valid identification document")
+  end
+
+  def then_i_see_the_check_your_identification_uploads
+    expect(page).to have_title("Check your uploaded files")
+    expect(page).to have_content("Check your uploaded files")
+    expect(page).to have_content("File 1\tupload.txt\tDelete")
+  end
+
   def then_i_see_the_age_range_form
     expect(page).to have_title("Age range")
     expect(page).to have_content("Who you can teach")
@@ -231,6 +263,10 @@ RSpec.describe "Teacher application", type: :system do
 
   def then_i_see_completed_personal_information_section
     expect(page).to have_content("Enter personal information\nCOMPLETED")
+  end
+
+  def then_i_see_completed_identity_documents_section
+    expect(page).to have_content("Upload identity documents\nCOMPLETED")
   end
 
   def then_i_see_the_age_range_summary

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Teacher application", type: :system do
     then_i_see_the_personal_information_summary
 
     when_i_click_continue
-    # then_i_see_completed_personal_information_section
+    then_i_see_completed_personal_information_section
 
     when_i_click_age_range
     then_i_see_the_age_range_form
@@ -53,8 +53,8 @@ RSpec.describe "Teacher application", type: :system do
     when_i_click_check_your_answers
     then_i_see_the_check_your_answers_page
 
-    # when_i_click_submit
-    # then_i_see_the_submitted_application_page
+    when_i_click_submit
+    then_i_see_the_submitted_application_page
   end
 
   private

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -27,8 +27,14 @@ RSpec.describe "Teacher documents", type: :system do
     and_i_click_continue
     then_i_see_the_check_your_uploaded_files_page_with_two_files
 
-    when_i_delete_the_first_document
-    and_i_click_yes
+    when_i_click_delete_on_the_first_document
+    and_i_choose_no
+    and_i_click_continue
+    then_i_see_the_check_your_uploaded_files_page_with_two_files
+
+    when_i_click_delete_on_the_first_document
+    and_i_choose_yes
+    and_i_click_continue
     then_i_see_the_check_your_uploaded_files_page
   end
 
@@ -53,16 +59,8 @@ RSpec.describe "Teacher documents", type: :system do
                 Rails.root.join(file_fixture("upload.txt"))
   end
 
-  def when_i_choose_yes
-    choose "Yes", visible: false
-  end
-
-  def when_i_delete_the_first_document
+  def when_i_click_delete_on_the_first_document
     first(:link, "Delete").click
-  end
-
-  def and_i_click_yes
-    click_button "Yes"
   end
 
   def then_i_see_document_form

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe "Teacher documents", type: :system do
+  before do
+    given_the_service_is_open
+    given_the_service_is_startable
+    given_the_service_allows_teacher_applications
+    given_an_active_application
+  end
+
+  it "uploading and deleting files" do
+    when_i_click_identity_documents
+    then_i_see_document_form
+
+    when_i_upload_a_document
+    and_i_click_continue
+    then_i_see_the_check_your_uploaded_files_page
+
+    when_i_choose_yes
+    and_i_click_continue
+    then_i_see_document_form
+
+    and_i_click_continue
+    then_i_see_document_form
+
+    when_i_upload_a_document_with_error
+    and_i_click_continue
+    then_i_see_the_check_your_uploaded_files_page_with_two_files
+
+    when_i_delete_the_first_document
+    and_i_click_yes
+    then_i_see_the_check_your_uploaded_files_page
+  end
+
+  def given_an_active_application
+    given_an_eligible_eligibility_check
+    click_link "Apply for QTS"
+    and_i_sign_up
+    click_button "Start now"
+  end
+
+  def when_i_click_identity_documents
+    click_link "Upload identity documents"
+  end
+
+  def when_i_upload_a_document
+    attach_file "upload-attachment-field",
+                Rails.root.join(file_fixture("upload.txt"))
+  end
+
+  def when_i_upload_a_document_with_error
+    attach_file "upload-attachment-field-error",
+                Rails.root.join(file_fixture("upload.txt"))
+  end
+
+  def when_i_choose_yes
+    choose "Yes", visible: false
+  end
+
+  def when_i_delete_the_first_document
+    first(:link, "Delete").click
+  end
+
+  def and_i_click_yes
+    click_button "Yes"
+  end
+
+  def then_i_see_document_form
+    expect(page).to have_title("Upload a document")
+    expect(page).to have_content("Upload a valid identification document")
+  end
+
+  def then_i_see_the_check_your_uploaded_files_page
+    expect(page).to have_title("Check your uploaded files")
+    expect(page).to have_content("Check your uploaded files")
+    expect(page).to have_content("File 1\tupload.txt\tDelete")
+  end
+
+  def then_i_see_the_check_your_uploaded_files_page_with_two_files
+    then_i_see_the_check_your_uploaded_files_page
+    expect(page).to have_content("File 2\tupload.txt\tDelete")
+  end
+end


### PR DESCRIPTION
This implements a generic file upload mechanism, and applies it to the alternative name and identity documents. See individual commits for more details, builds upon #262 and #272.

[Trello Card](https://trello.com/c/fOSrRFIv/641-build-identity-documents-spoke)

## Screenshots
![Screenshot 2022-07-27 at 12 29 34](https://user-images.githubusercontent.com/510498/181236324-75ccb100-fc68-44aa-903e-e10128990fea.png)
![Screenshot 2022-07-27 at 12 29 40](https://user-images.githubusercontent.com/510498/181236329-d8ed273e-bff4-4ab4-9cad-7c7b429753f7.png)
![Screenshot 2022-07-27 at 12 29 48](https://user-images.githubusercontent.com/510498/181236334-85c87220-94ca-48c3-89d0-a12cdad1922d.png)

