### PR TITLE
Build written statement question

### DIFF
--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -11,7 +11,16 @@ module TeacherInterface
     def create
       attachment = params.dig(:upload, :attachment)
       @upload = document.uploads.build(attachment:, translation: false)
+
       if @upload.save
+        translated_attachment = params.dig(:upload, :translated_attachment)
+        if translated_attachment
+          document.uploads.create!(
+            attachment: translated_attachment,
+            translation: true
+          )
+        end
+
         redirect_to_if_save_and_continue [
                                            :edit,
                                            :teacher_interface,

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -76,6 +76,9 @@ class ApplicationForm < ApplicationRecord
         hash.merge!(about_you: %i[personal_information identity_documents])
         hash.merge!(qualifications: %i[age_range])
         hash.merge!(work_history: %i[work_history]) if needs_work_history?
+        if needs_written_statement?
+          hash.merge!(proof_of_recognition: %i[written_statement])
+        end
         hash
       end
   end
@@ -113,6 +116,15 @@ class ApplicationForm < ApplicationRecord
       )
     end
 
+    if key == :written_statement
+      return(
+        url_helpers.edit_teacher_interface_application_form_document_path(
+          self,
+          written_statement_document
+        )
+      )
+    end
+
     key = :work_histories if key == :work_history
 
     begin
@@ -134,6 +146,10 @@ class ApplicationForm < ApplicationRecord
     region.status_check_none? || region.sanction_check_none?
   end
 
+  def needs_written_statement?
+    region.status_check_written? || region.sanction_check_written?
+  end
+
   def task_item_status(key)
     case key
     when :personal_information
@@ -148,6 +164,8 @@ class ApplicationForm < ApplicationRecord
         return :completed
       end
       :in_progress
+    when :written_statement
+      written_statement_document.uploaded? ? :completed : :not_started
     else
       :not_started
     end

--- a/app/views/teacher_interface/application_forms/edit.html.erb
+++ b/app/views/teacher_interface/application_forms/edit.html.erb
@@ -13,6 +13,9 @@
 <h2 class="govuk-heading-m">Your work history</h2>
 <%= render "teacher_interface/work_histories/summary", application_form: @application_form, work_histories: @application_form.work_histories %>
 
+<h2 class="govuk-heading-m">Proof that you’re recognised as a teacher</h2>
+<%= render "teacher_interface/written_statement/summary", application_form: @application_form %>
+
 <% if @application_form.can_submit? %>
   <h2 class="govuk-heading-m">Submitting your application</h2>
   <p class="govuk-body">By selecting the ‘Submit application button’ you confirm that, to the best of your knowledge, the details you’ve provided are correct.</p>

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -21,5 +21,17 @@
                          label: { text: "Select a file to upload" },
                          hint: { text: "You can upload your files in PDF, JPG or DOC format. Each file must be no larger than 20MB." } %>
 
+  <% if @document.translatable? %>
+    <%= f.govuk_radio_buttons_fieldset :written_in_english, legend: { size: "m", text: "Is your document written in English?" } do %>
+      <%= f.govuk_radio_button :written_in_english, "true", label: { text: "Yes" }, link_errors: true, checked: false %>
+
+      <%= f.govuk_radio_button :written_in_english, "false", label: { text: "No, I'll upload a translation as well" }, checked: false do %>
+        <%= f.govuk_file_field :translated_attachment,
+                               label: { text: "Select a file to upload" },
+                               hint: { text: "You can upload your files in PDF, JPG or DOC format. Each file must be no larger than 20MB." } %>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <%= render "shared/save_submit_buttons", f: %>
 <% end %>

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -14,6 +14,39 @@
     <li>identity card</li>
     <li>birth certificate.</li>
   </ul>
+<% elsif @document.written_statement? %>
+  <span class="govuk-caption-l">Proof that you're recognised as a teacher</span>
+  <h1 class="govuk-heading-l">Upload your written statement</h1>
+
+  <p class="govuk-body">
+    You need to provide a written statement from <span lang="<%= @application_form.region.country.code %>"><%= @application_form.region.country.teaching_authority_name.presence || @application_form.region.teaching_authority_name.presence %></span>.
+  </p>
+
+  <p class="govuk-body">
+    This is called <%= @application_form.region.country.teaching_authority_certificate.indefinite_article || "a" %> <span lang="<%= @application_form.region.country.code %>"><%= @application_form.region.country.teaching_authority_certificate.presence || "certificate" %></span>.
+  </p>
+
+  <div class="govuk-inset-text">If this document is not written in English, you'll also need to upload a translation.</div>
+
+  <p class="govuk-body">It must confirm:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>that you've completed a teaching qualification/teacher training</li>
+    <li>that you've successfully completed any period of professional experience comparable to an induction period (if required)</li>
+    <li>the age ranges and subjects you're qualified to teach</li>
+  </ul>
+  <p class="govuk-body">This written confirmation must be dated within 3 months of you applying for QTS.</p>
+
+  <%= govuk_details(summary_text: "I do not have this yet") do %>
+    <p class="govuk-body">If you do not have this yet, you can obtain it by contacting:</p>
+
+    <%= render "shared/teaching_authority_contactable", contactable: @application_form.region.country %>
+
+    <% if @application_form.region.country.teaching_authority_present? && @application_form.region.teaching_authority_present? %>
+      <p class="govuk-body">or</p>
+    <% end %>
+
+    <%= render "shared/teaching_authority_contactable", contactable: @application_form.region %>
+  <% end %>
 <% end %>
 
 <%= form_with model: [:teacher_interface, @application_form, @document, @upload] do |f| %>

--- a/app/views/teacher_interface/written_statement/_summary.html.erb
+++ b/app/views/teacher_interface/written_statement/_summary.html.erb
@@ -1,0 +1,6 @@
+<%= render(CheckYourAnswersSummaryComponent.new(model: application_form, title: "Written statement", fields: {
+  identification_document: {
+    key: "Written statement",
+    href: [:edit, :teacher_interface, application_form, application_form.written_statement_document]
+  },
+})) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,11 +16,13 @@ en:
         about_you: About you
         qualifications: Your qualifications
         work_history: Your work history
+        proof_of_recognition: Proof that you’re recognised as a teacher
       items:
         personal_information: Enter personal information
         identity_documents: Upload identity documents
         age_range: Enter age range
         work_history: Add work history
+        written_statement: Upload your written statement
 
   activemodel:
     attributes:

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -44,6 +44,11 @@ FactoryBot.define do
       status_check { :online }
     end
 
+    trait :written_checks do
+      sanction_check { :written }
+      status_check { :written }
+    end
+
     trait :none_checks do
       sanction_check { :none }
       status_check { :none }

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -16,7 +16,9 @@ module SystemHelpers
   end
 
   def given_an_eligible_eligibility_check
-    create(:country, :with_national_region, code: "GB-SCT")
+    country = create(:country, :with_national_region, code: "GB-SCT")
+    country.regions.first.update!(status_check: :written)
+
     visit "/eligibility/start"
     click_button "Start now"
     fill_in "eligibility-interface-country-form-location-field",

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_title("Apply for qualified teacher status (QTS)")
     expect(page).to have_content("Apply for qualified teacher status (QTS)")
 
-    expect(page).to have_content("You have completed 0 of 3 sections.")
+    expect(page).to have_content("You have completed 0 of 4 sections.")
 
     expect(page).to have_content("About you")
     expect(page).to have_content("Enter personal information\nNOT STARTED")
@@ -185,6 +185,9 @@ RSpec.describe "Teacher application", type: :system do
 
     expect(page).to have_content("Your work history")
     expect(page).to have_content("Add work history\nNOT STARTED")
+
+    expect(page).to have_content("Proof that you’re recognised as a teacher")
+    expect(page).to have_content("Upload your written statement\nNOT STARTED")
 
     expect(page).to have_content("Check your answers")
   end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe "Teacher application", type: :system do
     and_i_click_continue
     then_i_see_completed_work_history_section
 
+    when_i_click_written_statement
+    then_i_see_the_upload_written_statement_form
+
+    when_i_fill_in_the_upload_written_statement_form
+    and_i_click_continue
+    then_i_see_the_check_your_written_statement_uploads
+
+    when_i_choose_no
+    and_i_click_continue
+    then_i_see_completed_written_statement_section
+
     when_i_click_check_your_answers
     then_i_see_the_check_your_answers_page
 
@@ -161,6 +172,15 @@ RSpec.describe "Teacher application", type: :system do
     choose "Yes", visible: false
   end
 
+  def when_i_click_written_statement
+    click_link "Upload your written statement"
+  end
+
+  def when_i_fill_in_the_upload_written_statement_form
+    attach_file "upload-attachment-field",
+                Rails.root.join(file_fixture("upload.txt"))
+  end
+
   def then_i_see_the_new_application_page
     expect(page).to have_current_path("/teacher/applications/new")
     expect(page).to have_title("Start your application")
@@ -247,6 +267,17 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("Your current or most recent role")
   end
 
+  def then_i_see_the_upload_written_statement_form
+    expect(page).to have_title("Upload a document")
+    expect(page).to have_content("Upload your written statement")
+  end
+
+  def then_i_see_the_check_your_written_statement_uploads
+    expect(page).to have_title("Check your uploaded files")
+    expect(page).to have_content("Check your uploaded files")
+    expect(page).to have_content("File 1\tupload.txt\tDelete")
+  end
+
   def then_i_see_the_personal_information_summary
     expect(page).to have_content("Check your answers")
     expect(page).to have_content("Given names\tName")
@@ -292,6 +323,10 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("Add work history\nCOMPLETED")
   end
 
+  def then_i_see_completed_written_statement_section
+    expect(page).to have_content("Upload your written statement\nCOMPLETED")
+  end
+
   def then_i_see_the_check_your_answers_page
     expect(page).to have_title("Check your answers")
     expect(page).to have_content(
@@ -300,6 +335,7 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("About you")
     expect(page).to have_content("Who you can teach")
     expect(page).to have_content("Your work history")
+    expect(page).to have_content("Proof that you’re recognised as a teacher")
   end
 
   def then_i_see_the_submitted_application_page

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Teacher documents", type: :system do
   end
 
   it "uploading and deleting files" do
-    when_i_click_identity_documents
+    when_i_click_written_statement
     then_i_see_document_form
 
     when_i_upload_a_document
@@ -25,12 +25,12 @@ RSpec.describe "Teacher documents", type: :system do
 
     when_i_upload_a_document_with_error
     and_i_click_continue
-    then_i_see_the_check_your_uploaded_files_page_with_two_files
+    then_i_see_the_check_your_uploaded_files_page_with_three_files
 
     when_i_click_delete_on_the_first_document
     and_i_choose_no
     and_i_click_continue
-    then_i_see_the_check_your_uploaded_files_page_with_two_files
+    then_i_see_the_check_your_uploaded_files_page_with_three_files
 
     when_i_click_delete_on_the_first_document
     and_i_choose_yes
@@ -45,12 +45,15 @@ RSpec.describe "Teacher documents", type: :system do
     click_button "Start now"
   end
 
-  def when_i_click_identity_documents
-    click_link "Upload identity documents"
+  def when_i_click_written_statement
+    click_link "Upload your written statement"
   end
 
   def when_i_upload_a_document
     attach_file "upload-attachment-field",
+                Rails.root.join(file_fixture("upload.txt"))
+    choose "No, I'll upload a translation as well", visible: false
+    attach_file "upload-translated-attachment-field",
                 Rails.root.join(file_fixture("upload.txt"))
   end
 
@@ -65,17 +68,18 @@ RSpec.describe "Teacher documents", type: :system do
 
   def then_i_see_document_form
     expect(page).to have_title("Upload a document")
-    expect(page).to have_content("Upload a valid identification document")
+    expect(page).to have_content("Upload your written statement")
   end
 
   def then_i_see_the_check_your_uploaded_files_page
     expect(page).to have_title("Check your uploaded files")
     expect(page).to have_content("Check your uploaded files")
     expect(page).to have_content("File 1\tupload.txt\tDelete")
+    expect(page).to have_content("File 2\tupload.txt\tDelete")
   end
 
-  def then_i_see_the_check_your_uploaded_files_page_with_two_files
+  def then_i_see_the_check_your_uploaded_files_page_with_three_files
     then_i_see_the_check_your_uploaded_files_page
-    expect(page).to have_content("File 2\tupload.txt\tDelete")
+    expect(page).to have_content("File 3\tupload.txt\tDelete")
   end
 end


### PR DESCRIPTION
This adds the written statement question using the existing document upload controllers and views built for the identity documents. It makes a change to those to support uploading translated versions of the document.

Depends on #275.

[Trello Card](https://trello.com/c/wU7e4Wyf/647-build-upload-your-written-statement-spoke)

## Screenshots

![Screenshot 2022-07-27 at 16 27 00](https://user-images.githubusercontent.com/510498/181287071-1852c646-b6e2-462a-a8d7-d52bbbed9119.png)

![Screenshot 2022-07-27 at 16 27 04](https://user-images.githubusercontent.com/510498/181287083-92e97d7e-0892-42da-acd8-6c71a22495c9.png)

