### PR TITLE
Write application form tasks as actions

### DIFF
--- a/app/controllers/teacher_interface/age_range_controller.rb
+++ b/app/controllers/teacher_interface/age_range_controller.rb
@@ -3,10 +3,7 @@ module TeacherInterface
     before_action :load_application_form
 
     def show
-      unless application_form.subsection_started?(
-               :your_qualifications,
-               :age_range
-             )
+      unless application_form.task_item_started?(:qualifications, :age_range)
         redirect_to [:edit, :teacher_interface, application_form, :age_range]
       end
     end

--- a/app/controllers/teacher_interface/personal_information_controller.rb
+++ b/app/controllers/teacher_interface/personal_information_controller.rb
@@ -3,7 +3,7 @@ module TeacherInterface
     before_action :load_application_form
 
     def show
-      unless application_form.subsection_started?(
+      unless application_form.task_item_started?(
                :about_you,
                :personal_information
              )

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -72,8 +72,8 @@ class ApplicationForm < ApplicationRecord
       begin
         hash = {}
         hash.merge!(about_you: %i[personal_information])
-        hash.merge!(your_qualifications: %i[age_range])
-        hash.merge!(your_work_history: %i[work_history]) if needs_work_history?
+        hash.merge!(qualifications: %i[age_range])
+        hash.merge!(work_history: %i[work_history]) if needs_work_history?
         hash
       end
   end
@@ -123,9 +123,9 @@ class ApplicationForm < ApplicationRecord
     case [section, subsection]
     when %i[about_you personal_information]
       personal_information_status
-    when %i[your_qualifications age_range]
-      age_range_status
-    when %i[your_work_history work_history]
+    when %i[qualifications age_range]
+      status_for_values(age_range_min, age_range_max)
+    when %i[work_history work_history]
       return :not_started if work_histories.empty?
       if work_histories.completed.count == work_histories.count
         return :completed
@@ -152,10 +152,6 @@ class ApplicationForm < ApplicationRecord
     end
 
     status_for_values(*values)
-  end
-
-  def age_range_status
-    status_for_values(age_range_min, age_range_max)
   end
 
   def status_for_values(*values)

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -18,28 +18,28 @@
   </h2>
 
   <p class="govuk-body govuk-!-margin-bottom-7">
-    You have completed <%= @application_form.completed_sections.count %> of <%= @application_form.sections.count %> sections.
+    You have completed <%= @application_form.completed_task_sections.count %> of <%= @application_form.tasks.count %> sections.
   </p>
 
   <ol class="app-task-list">
-    <% @application_form.sections.each_with_index do |(section_key, subsection_keys), index| %>
+    <% @application_form.tasks.each_with_index do |(section, items), index| %>
       <li>
         <h2 class="app-task-list__section">
-          <span class="app-task-list__section-number"><%= index + 1 %>. </span> <%= section_key.to_s.humanize %>
+          <span class="app-task-list__section-number"><%= index + 1 %>. </span> <%= section.to_s.humanize %>
         </h2>
 
         <ul class="app-task-list__items">
-          <% subsection_keys.each do |subsection_key| %>
+          <% items.each do |item| %>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <%= link_to subsection_key.to_s.humanize,
-                            @application_form.path_for_subsection(subsection_key),
-                            aria: { describedby: "#{subsection_key}-status" } %>
+                <%= link_to item.to_s.humanize,
+                            @application_form.path_for_task_item(item),
+                            aria: { describedby: "#{item}-status" } %>
               </span>
 
               <%= render(ApplicationFormStatusTagComponent.new(
-                key: subsection_key,
-                status: @application_form.section_statuses.dig(section_key, subsection_key)
+                key: item,
+                status: @application_form.task_statuses.dig(section, item)
               )) %>
             </li>
           <% end %>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -25,14 +25,15 @@
     <% @application_form.tasks.each_with_index do |(section, items), index| %>
       <li>
         <h2 class="app-task-list__section">
-          <span class="app-task-list__section-number"><%= index + 1 %>. </span> <%= section.to_s.humanize %>
+          <span class="app-task-list__section-number"><%= index + 1 %>. </span>
+          <%= I18n.t("application_form.tasks.sections.#{section}") %>
         </h2>
 
         <ul class="app-task-list__items">
           <% items.each do |item| %>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <%= link_to item.to_s.humanize,
+                <%= link_to I18n.t("application_form.tasks.items.#{item}"),
                             @application_form.path_for_task_item(item),
                             aria: { describedby: "#{item}-status" } %>
               </span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,17 @@ en:
     url: https://apply-for-qts-in-england.education.gov.uk
     phase_banner_text: This is a new service – <a href="https://docs.google.com/forms/d/1OpMhXJ1blJu2qFqW7VWwKnfjIoU-5SmOLXdgI0Z_kZg/viewform?edit_requested=true">your feedback will help us to improve it</a>.
 
+  application_form:
+    tasks:
+      sections:
+        about_you: About you
+        qualifications: Your qualifications
+        work_history: Your work history
+      items:
+        personal_information: Enter personal information
+        age_range: Enter age range
+        work_history: Add work history
+
   activemodel:
     attributes:
       eligibility_check:

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -72,8 +72,8 @@ RSpec.describe ApplicationForm, type: :model do
     end
   end
 
-  describe "#sections" do
-    subject(:sections) { application_form.sections }
+  describe "#tasks" do
+    subject(:tasks) { application_form.tasks }
 
     context "with a country that doesn't need work history" do
       before { application_form.region = create(:region, :online_checks) }
@@ -100,8 +100,8 @@ RSpec.describe ApplicationForm, type: :model do
     end
   end
 
-  describe "#section_statuses" do
-    subject(:section_statuses) { application_form.section_statuses }
+  describe "#task_statuses" do
+    subject(:task_statuses) { application_form.task_statuses }
 
     it do
       is_expected.to eq(
@@ -120,9 +120,9 @@ RSpec.describe ApplicationForm, type: :model do
     end
 
     describe "about you section" do
-      subject(:about_you_status) { section_statuses[:about_you] }
+      subject(:about_you_status) { task_statuses[:about_you] }
 
-      describe "personal information subsection" do
+      describe "personal information item" do
         subject(:personal_information_status) do
           about_you_status[:personal_information]
         end
@@ -165,9 +165,9 @@ RSpec.describe ApplicationForm, type: :model do
     end
 
     describe "qualifications section" do
-      subject(:qualifications_status) { section_statuses[:qualifications] }
+      subject(:qualifications_status) { task_statuses[:qualifications] }
 
-      describe "age range subsection" do
+      describe "age range item" do
         subject(:age_range_status) { qualifications_status[:age_range] }
 
         context "with some age range" do
@@ -187,9 +187,9 @@ RSpec.describe ApplicationForm, type: :model do
     end
 
     describe "work history section" do
-      subject(:work_history_status) { section_statuses[:work_history] }
+      subject(:work_history_status) { task_statuses[:work_history] }
 
-      describe "work history subsection" do
+      describe "work history item" do
         subject(:personal_information_status) do
           work_history_status[:work_history]
         end
@@ -213,8 +213,10 @@ RSpec.describe ApplicationForm, type: :model do
     end
   end
 
-  describe "#completed_sections" do
-    subject(:completed_sections) { application_form.completed_sections }
+  describe "#completed_task_sections" do
+    subject(:completed_task_sections) do
+      application_form.completed_task_sections
+    end
 
     it { is_expected.to be_empty }
   end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -80,10 +80,7 @@ RSpec.describe ApplicationForm, type: :model do
 
       it do
         is_expected.to eq(
-          {
-            about_you: %i[personal_information],
-            your_qualifications: %i[age_range]
-          }
+          { about_you: %i[personal_information], qualifications: %i[age_range] }
         )
       end
     end
@@ -95,8 +92,8 @@ RSpec.describe ApplicationForm, type: :model do
         is_expected.to eq(
           {
             about_you: %i[personal_information],
-            your_qualifications: %i[age_range],
-            your_work_history: %i[work_history]
+            qualifications: %i[age_range],
+            work_history: %i[work_history]
           }
         )
       end
@@ -112,10 +109,10 @@ RSpec.describe ApplicationForm, type: :model do
           about_you: {
             personal_information: :not_started
           },
-          your_qualifications: {
+          qualifications: {
             age_range: :not_started
           },
-          your_work_history: {
+          work_history: {
             work_history: :not_started
           }
         }
@@ -123,11 +120,11 @@ RSpec.describe ApplicationForm, type: :model do
     end
 
     describe "about you section" do
-      subject(:about_you_section_status) { section_statuses[:about_you] }
+      subject(:about_you_status) { section_statuses[:about_you] }
 
       describe "personal information subsection" do
-        subject(:personal_information_subsection_status) do
-          about_you_section_status[:personal_information]
+        subject(:personal_information_status) do
+          about_you_status[:personal_information]
         end
 
         context "with some fields set" do
@@ -167,43 +164,51 @@ RSpec.describe ApplicationForm, type: :model do
       end
     end
 
-    describe "your qualifications section" do
-      subject(:your_qualifications_section_status) do
-        section_statuses[:your_qualifications]
-      end
+    describe "qualifications section" do
+      subject(:qualifications_status) { section_statuses[:qualifications] }
 
-      context "with some age range" do
-        before { application_form.update!(age_range_min: 7) }
+      describe "age range subsection" do
+        subject(:age_range_status) { qualifications_status[:age_range] }
 
-        it { is_expected.to match(a_hash_including(age_range: :in_progress)) }
-      end
+        context "with some age range" do
+          before { application_form.update!(age_range_min: 7) }
 
-      context "with all personal information" do
-        before { application_form.update!(age_range_min: 7, age_range_max: 11) }
+          it { is_expected.to eq(:in_progress) }
+        end
 
-        it { is_expected.to match(a_hash_including(age_range: :completed)) }
+        context "with all personal information" do
+          before do
+            application_form.update!(age_range_min: 7, age_range_max: 11)
+          end
+
+          it { is_expected.to eq(:completed) }
+        end
       end
     end
 
-    describe "your work history section" do
-      subject(:your_work_history_status) do
-        section_statuses[:your_work_history]
-      end
+    describe "work history section" do
+      subject(:work_history_status) { section_statuses[:work_history] }
 
-      context "with no work history" do
-        it { is_expected.to eq(work_history: :not_started) }
-      end
+      describe "work history subsection" do
+        subject(:personal_information_status) do
+          work_history_status[:work_history]
+        end
 
-      context "with some incomplete work history" do
-        before { create(:work_history, application_form:) }
+        context "with no work history" do
+          it { is_expected.to eq(:not_started) }
+        end
 
-        it { is_expected.to eq(work_history: :in_progress) }
-      end
+        context "with some incomplete work history" do
+          before { create(:work_history, application_form:) }
 
-      context "with all complete work history" do
-        before { create(:work_history, :completed, application_form:) }
+          it { is_expected.to eq(:in_progress) }
+        end
 
-        it { is_expected.to eq(work_history: :completed) }
+        context "with all complete work history" do
+          before { create(:work_history, :completed, application_form:) }
+
+          it { is_expected.to eq(:completed) }
+        end
       end
     end
   end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_personal_information
-    click_link "Personal information"
+    click_link "Enter personal information"
   end
 
   def when_i_fill_in_the_name_and_date_of_birth_form
@@ -109,7 +109,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_age_range
-    click_link "Age range"
+    click_link "Enter age range"
   end
 
   def when_i_fill_in_age_range
@@ -118,7 +118,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_work_history
-    click_link "Work history"
+    click_link "Add work history"
   end
 
   def when_i_fill_in_work_history
@@ -152,13 +152,13 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("You have completed 0 of 3 sections.")
 
     expect(page).to have_content("About you")
-    expect(page).to have_content("Personal information\nNOT STARTED")
+    expect(page).to have_content("Enter personal information\nNOT STARTED")
 
     expect(page).to have_content("Your qualifications")
-    expect(page).to have_content("Age range\nNOT STARTED")
+    expect(page).to have_content("Enter age range\nNOT STARTED")
 
     expect(page).to have_content("Your work history")
-    expect(page).to have_content("Work history\nNOT STARTED")
+    expect(page).to have_content("Add work history\nNOT STARTED")
 
     expect(page).to have_content("Check your answers")
   end
@@ -210,7 +210,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def then_i_see_completed_personal_information_section
-    expect(page).to have_content("Personal information\nCOMPLETED")
+    expect(page).to have_content("Enter personal information\nCOMPLETED")
   end
 
   def then_i_see_the_age_range_summary
@@ -220,7 +220,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def then_i_see_completed_age_range_section
-    expect(page).to have_content("Age range\nCOMPLETED")
+    expect(page).to have_content("Enter age range\nCOMPLETED")
   end
 
   def then_i_see_the_work_history_summary
@@ -234,7 +234,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def then_i_see_completed_work_history_section
-    expect(page).to have_content("Work history\nCOMPLETED")
+    expect(page).to have_content("Add work history\nCOMPLETED")
   end
 
   def then_i_see_the_check_your_answers_page


### PR DESCRIPTION
This changes the content of the task list for an application form to write in a more action orientated way (i.e. "Enter age range" rather than "Age range"). I've also refactored the code to better match the naming.

[Trello Card](https://trello.com/c/Lzh4lm7p/669-change-wording-on-task-list-to-be-action-orientated)

## Screenshot

<img width="692" alt="Screenshot 2022-07-28 at 07 39 47" src="https://user-images.githubusercontent.com/510498/181437797-0cdee657-42b8-4daf-8390-ea3f42530293.png">
