### PR TITLE
Add file type and size validation to uploads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "3.1.1"
 
 gem "rails", "~> 7.0.3"
 
+gem "active_storage_validations"
 gem "azure-storage-blob"
 gem "bootsnap", require: false
 gem "cssbundling-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_storage_validations (0.9.8)
+      activejob (>= 5.2.0)
+      activemodel (>= 5.2.0)
+      activestorage (>= 5.2.0)
+      activesupport (>= 5.2.0)
     activejob (7.0.3.1)
       activesupport (= 7.0.3.1)
       globalid (>= 0.3.6)
@@ -488,6 +493,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_storage_validations
   annotate
   azure-storage-blob
   bootsnap

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -21,7 +21,12 @@ class Upload < ApplicationRecord
 
   belongs_to :document
   has_one_attached :attachment
-  validates :attachment, presence: true
+  validates :attachment,
+            attached: true,
+            content_type: %i[png jpg jpeg pdf doc docx],
+            size: {
+              less_than: 50.megabytes
+            }
 
   def original?
     !translation?

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -52,7 +52,7 @@
 <%= form_with model: [:teacher_interface, @application_form, @document, @upload] do |f| %>
   <%= f.govuk_file_field :attachment,
                          label: { text: "Select a file to upload" },
-                         hint: { text: "You can upload your files in PDF, JPG or DOC format. Each file must be no larger than 20MB." } %>
+                         hint: { text: "You can upload your files in PDF, JPG or DOC format. Each file must be no larger than 50MB." } %>
 
   <% if @document.translatable? %>
     <%= f.govuk_radio_buttons_fieldset :written_in_english, legend: { size: "m", text: "Is your document written in English?" } do %>
@@ -61,7 +61,7 @@
       <%= f.govuk_radio_button :written_in_english, "false", label: { text: "No, I'll upload a translation as well" }, checked: false do %>
         <%= f.govuk_file_field :translated_attachment,
                                label: { text: "Select a file to upload" },
-                               hint: { text: "You can upload your files in PDF, JPG or DOC format. Each file must be no larger than 20MB." } %>
+                               hint: { text: "You can upload your files in PDF, JPG or DOC format. Each file must be no larger than 50MB." } %>
       <% end %>
     <% end %>
   <% end %>

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe CheckYourAnswersSummaryComponent, type: :component do
     end
 
     it "renders the value" do
-      expect(row.at_css(".govuk-summary-list__value").text).to eq("upload.txt")
+      expect(row.at_css(".govuk-summary-list__value").text).to eq("upload.pdf")
     end
 
     it "renders the change link" do

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -21,8 +21,8 @@ FactoryBot.define do
     association :document
     attachment do
       Rack::Test::UploadedFile.new(
-        "spec/fixtures/files/upload.txt",
-        "text/plain"
+        "spec/fixtures/files/upload.pdf",
+        "application/pdf"
       )
     end
     translation { false }

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -24,6 +24,25 @@ RSpec.describe Upload, type: :model do
   describe "validations" do
     it { is_expected.to be_valid }
     it { is_expected.to validate_presence_of(:attachment) }
+
+    context "with an invalid content type" do
+      before do
+        upload.attachment =
+          Rack::Test::UploadedFile.new(file_fixture("upload.txt"), "text/plain")
+      end
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context "with a large file" do
+      before do
+        allow(upload.attachment.blob).to receive(:byte_size).and_return(
+          50 * 1024 * 1024
+        )
+      end
+
+      it { is_expected.to_not be_valid }
+    end
   end
 
   describe "#original?" do

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -136,7 +136,7 @@ RSpec.describe "Teacher application", type: :system do
 
   def when_i_fill_in_the_upload_name_change_form
     attach_file "upload-attachment-field",
-                Rails.root.join(file_fixture("upload.txt"))
+                Rails.root.join(file_fixture("upload.pdf"))
   end
 
   def when_i_click_identity_documents
@@ -145,7 +145,7 @@ RSpec.describe "Teacher application", type: :system do
 
   def when_i_fill_in_the_upload_identification_form
     attach_file "upload-attachment-field",
-                Rails.root.join(file_fixture("upload.txt"))
+                Rails.root.join(file_fixture("upload.pdf"))
   end
 
   def when_i_click_age_range
@@ -178,7 +178,7 @@ RSpec.describe "Teacher application", type: :system do
 
   def when_i_fill_in_the_upload_written_statement_form
     attach_file "upload-attachment-field",
-                Rails.root.join(file_fixture("upload.txt"))
+                Rails.root.join(file_fixture("upload.pdf"))
   end
 
   def then_i_see_the_new_application_page
@@ -239,7 +239,7 @@ RSpec.describe "Teacher application", type: :system do
   def then_i_see_the_check_your_name_change_uploads
     expect(page).to have_title("Check your uploaded files")
     expect(page).to have_content("Check your uploaded files")
-    expect(page).to have_content("File 1\tupload.txt\tDelete")
+    expect(page).to have_content("File 1\tupload.pdf\tDelete")
   end
 
   def then_i_see_the_upload_identification_form
@@ -250,7 +250,7 @@ RSpec.describe "Teacher application", type: :system do
   def then_i_see_the_check_your_identification_uploads
     expect(page).to have_title("Check your uploaded files")
     expect(page).to have_content("Check your uploaded files")
-    expect(page).to have_content("File 1\tupload.txt\tDelete")
+    expect(page).to have_content("File 1\tupload.pdf\tDelete")
   end
 
   def then_i_see_the_age_range_form
@@ -275,7 +275,7 @@ RSpec.describe "Teacher application", type: :system do
   def then_i_see_the_check_your_written_statement_uploads
     expect(page).to have_title("Check your uploaded files")
     expect(page).to have_content("Check your uploaded files")
-    expect(page).to have_content("File 1\tupload.txt\tDelete")
+    expect(page).to have_content("File 1\tupload.pdf\tDelete")
   end
 
   def then_i_see_the_personal_information_summary

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -51,15 +51,15 @@ RSpec.describe "Teacher documents", type: :system do
 
   def when_i_upload_a_document
     attach_file "upload-attachment-field",
-                Rails.root.join(file_fixture("upload.txt"))
+                Rails.root.join(file_fixture("upload.pdf"))
     choose "No, I'll upload a translation as well", visible: false
     attach_file "upload-translated-attachment-field",
-                Rails.root.join(file_fixture("upload.txt"))
+                Rails.root.join(file_fixture("upload.pdf"))
   end
 
   def when_i_upload_a_document_with_error
     attach_file "upload-attachment-field-error",
-                Rails.root.join(file_fixture("upload.txt"))
+                Rails.root.join(file_fixture("upload.pdf"))
   end
 
   def when_i_click_delete_on_the_first_document
@@ -74,12 +74,12 @@ RSpec.describe "Teacher documents", type: :system do
   def then_i_see_the_check_your_uploaded_files_page
     expect(page).to have_title("Check your uploaded files")
     expect(page).to have_content("Check your uploaded files")
-    expect(page).to have_content("File 1\tupload.txt\tDelete")
-    expect(page).to have_content("File 2\tupload.txt\tDelete")
+    expect(page).to have_content("File 1\tupload.pdf\tDelete")
+    expect(page).to have_content("File 2\tupload.pdf\tDelete")
   end
 
   def then_i_see_the_check_your_uploaded_files_page_with_three_files
     then_i_see_the_check_your_uploaded_files_page
-    expect(page).to have_content("File 3\tupload.txt\tDelete")
+    expect(page).to have_content("File 3\tupload.pdf\tDelete")
   end
 end


### PR DESCRIPTION
This uses the https://github.com/igorkasyanchuk/active_storage_validations Gem to ensure that any uploaded files are of a type we accept and within a file size that we deem acceptable.

I've also refactored how translations are uploaded to ensure any errors are shown to the user.

[Trello Card](https://trello.com/c/HwV6rpNv/665-limit-uploads-by-file-type-or-size)