### PR TITLE
Expose deployed commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,7 @@ jobs:
           context: .
           push: false
           tags: ${{ steps.image.outputs.tag }}
+          build-args: SHA=${{ github.sha }}
 
       - name: Run Snyk to check Docker image for vulnerabilities
         if: github.actor != 'dependabot[bot]'

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,10 @@ WORKDIR /app
 # Set Rails environment to production
 ENV RAILS_ENV=production
 
+# Add the commit sha to the env
+ARG SHA
+ENV SHA=$SHA
+
 # Add the timezone (prod image) as it's not configured by default in Alpine
 RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \


### PR DESCRIPTION
While we're deploying manually it's helpful to be able to quickly diff main HEAD with the currently deployed commit.

~~* Add /sha route that renders the currently deployed commit sha.~~

UPDATE: expose SHA instead to fix OKComputer