### PR TITLE
Improve sign in flow

### DIFF
--- a/app/controllers/eligibility_interface/start_controller.rb
+++ b/app/controllers/eligibility_interface/start_controller.rb
@@ -13,6 +13,11 @@ class EligibilityInterface::StartController < EligibilityInterface::BaseControll
   def create
     @eligibility_check = EligibilityCheck.new if eligibility_check.completed_at?
     eligibility_check.save!
-    redirect_to eligibility_interface_countries_path
+
+    if FeatureFlag.active?(:teacher_applications)
+      redirect_to :new_teacher_session
+    else
+      redirect_to :eligibility_interface_countries
+    end
   end
 end

--- a/app/controllers/teachers/confirmations_controller.rb
+++ b/app/controllers/teachers/confirmations_controller.rb
@@ -25,7 +25,7 @@ class Teachers::ConfirmationsController < Devise::ConfirmationsController
 
   protected
 
-  def after_confirmation_path_for(resource_name, resource)
-    stored_location_for(resource) || super
+  def after_confirmation_path_for(_resource_name, _resource)
+    new_teacher_interface_application_form_path
   end
 end

--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -7,7 +7,7 @@ class Teachers::SessionsController < Devise::SessionsController
 
   def create
     if resource_params[:create_or_sign_in] == "create"
-      redirect_to :new_teacher_registration
+      redirect_to :eligibility_interface_countries
       return
     end
 

--- a/app/views/eligibility_interface/finish/eligible.html.erb
+++ b/app/views/eligibility_interface/finish/eligible.html.erb
@@ -6,7 +6,7 @@
     <%= render "shared/eligible_region_content", region: @region %>
 
     <% if FeatureFlag.active?(:teacher_applications) && @region && !@region.legacy %>
-      <%= govuk_start_button(text: "Apply for QTS", href: new_teacher_interface_application_form_path) %>
+      <%= govuk_start_button(text: "Apply for QTS", href: new_teacher_registration_path) %>
     <% else %>
       <p class="govuk-body">You’ll make your application on the Teaching Regulation Agency website.</p>
       <%= govuk_start_button(text: "Apply for QTS", href: @mutual_recognition_url) %>

--- a/app/views/eligibility_interface/start/show.erb
+++ b/app/views/eligibility_interface/start/show.erb
@@ -21,6 +21,13 @@
 
     <p class="govuk-body">There’s no charge to apply for QTS. You do not need to be in the UK to use this service.</p>
 
+    <% if FeatureFlag.active?(:teacher_applications) %>
+      <p class="govuk-body">
+        If you’ve already started your application using this service, you can
+        <%= govuk_link_to "sign in to continue working on it", new_teacher_session_path %>.
+      </p>
+    <% end %>
+
     <%= form_with url: eligibility_interface_start_path, method: :post do |f| %>
       <button type="submit" formnovalidate="formnovalidate" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-9" data-module="govuk-button" data-prevent-double-click="true">
         Start now

--- a/app/views/teachers/sessions/new.html.erb
+++ b/app/views/teachers/sessions/new.html.erb
@@ -1,10 +1,8 @@
-<% content_for :page_title, "Create an account or sign in" %>
-
-<h1 class="govuk-heading-l">Create an account or sign in</h1>
+<h1 class="govuk-heading-l">Check your eligibility to apply for qualified teacher status (QTS) in England</h1>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <%= f.govuk_radio_buttons_fieldset :create_or_sign_in, legend: { size: "m", text: "Do you already have an account?" } do %>
-    <%= f.govuk_radio_button :create_or_sign_in, "sign_in", label: { text: "Yes, sign in" }, link_errors: true, checked: false do %>
+  <%= f.govuk_radio_buttons_fieldset :create_or_sign_in, legend: { size: "m", text: "Have you used the service before?" } do %>
+    <%= f.govuk_radio_button :create_or_sign_in, "sign_in", label: { text: "Yes, sign in and continue application" }, link_errors: true, checked: false do %>
       <%= f.govuk_email_field :email,
                               autofocus: true,
                               autocomplete: "email",
@@ -12,7 +10,7 @@
                               hint: { text: "Enter the email address you used to register, and we will send you a link to sign in." } %>
     <% end %>
 
-    <%= f.govuk_radio_button :create_or_sign_in, "create", label: { text: "No, I need to create an account" }, checked: false %>
+    <%= f.govuk_radio_button :create_or_sign_in, "create", label: { text: "No, I need to check my eligibility" }, checked: false %>
   <% end %>
 
   <%= f.govuk_submit "Continue" %>

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -84,9 +84,6 @@ module SystemHelpers
   end
 
   def and_i_sign_up
-    choose "No, I need to create an account", visible: false
-    and_i_click_continue
-
     when_i_fill_teacher_email_address
     and_i_click_continue
     and_i_receive_a_teacher_confirmation_email

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -21,6 +21,12 @@ module SystemHelpers
 
     visit "/eligibility/start"
     click_button "Start now"
+
+    if FeatureFlag.active?(:teacher_applications)
+      choose "No, I need to check my eligibility", visible: false
+      and_i_click_continue
+    end
+
     fill_in "eligibility-interface-country-form-location-field",
             with: "Scotland"
     click_button "Continue", visible: false
@@ -79,8 +85,12 @@ module SystemHelpers
 
   def then_i_see_the_sign_in_form
     expect(page).to have_current_path("/teacher/sign_in")
-    expect(page).to have_title("Create an account or sign in")
-    expect(page).to have_content("Create an account or sign in")
+    expect(page).to have_title(
+      "Apply for qualified teacher status (QTS) in England"
+    )
+    expect(page).to have_content("Have you used the service before?")
+    expect(page).to have_content("Yes, sign in and continue application")
+    expect(page).to have_content("No, I need to check my eligibility")
   end
 
   def and_i_sign_up

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe "Teacher application", type: :system do
     given_an_eligible_eligibility_check
 
     when_i_click_apply_for_qts
-    then_i_see_the_sign_in_form
     and_i_sign_up
     then_i_see_the_new_application_page
 


### PR DESCRIPTION
This makes the sign in flow clearer when you're returning to an existing application by asking the question on the eligibility start page.

[Trello Card](https://trello.com/c/wkm8Y6zm/667-build-have-you-signed-in-to-this-service-before-flow)

## Screenshots

<img width="655" alt="Screenshot 2022-07-30 at 17 40 49" src="https://user-images.githubusercontent.com/510498/181933385-9fefceda-afde-452d-98ab-0fa5695aafc4.png">
<img width="710" alt="Screenshot 2022-07-30 at 17 40 59" src="https://user-images.githubusercontent.com/510498/181933387-3cbfedd1-9183-4cb5-b674-48734019f8aa.png">