### PR TITLE
Add basic smoke test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,4 +56,4 @@ jobs:
         run: bin/bundle exec rails dfe:analytics:check
 
       - name: Run tests
-        run: bin/bundle exec rspec --format documentation
+        run: bin/test

--- a/bin/smoke
+++ b/bin/smoke
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+bundle exec rspec spec/system/smoke_spec.rb --tag smoke_test

--- a/bin/test
+++ b/bin/test
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-bundle exec rspec --format documentation
+bundle exec rspec --format documentation  --tag ~smoke_test

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+require "spec_helper"
+require "capybara/rspec"
+require "capybara/cuprite"
+
+Capybara.javascript_driver = :cuprite
+
+describe "Smoke test", type: :system, js: true, smoke_test: true do
+  before do
+    page.driver.basic_authorize(
+      ENV["SUPPORT_USERNAME"],
+      ENV["SUPPORT_PASSWORD"]
+    )
+  end
+
+  it "runs" do
+    when_i_visit_the_service_domain
+    and_i_click_the_start_button
+    and_i_enter_a_country
+    and_i_select_a_state
+    and_i_have_a_teaching_qualification
+    and_i_have_a_university_degree
+    and_i_am_qualified_to_teach
+    and_i_dont_have_sanctions
+    then_i_should_be_eligible_to_apply
+  end
+
+  private
+
+  def when_i_visit_the_service_domain
+    page.visit(ENV["HOSTING_DOMAIN"])
+  end
+
+  def and_i_click_the_start_button
+    click_button("Start now")
+  end
+
+  def and_i_enter_a_country
+    fill_in "eligibility-interface-country-form-location-field", with: "Canada"
+    continue
+  end
+
+  def and_i_select_a_state
+    choose "Ontario", visible: false
+    continue
+  end
+
+  def and_i_have_a_teaching_qualification
+    choose "Yes", visible: false
+    continue
+  end
+
+  def and_i_have_a_university_degree
+    choose "Yes", visible: false
+    continue
+  end
+
+  def and_i_am_qualified_to_teach
+    choose "Yes", visible: false
+    continue
+  end
+
+  def and_i_dont_have_sanctions
+    choose "No", visible: false
+    continue
+  end
+
+  def then_i_should_be_eligible_to_apply
+    expect(page).to have_content("You’re eligible to apply")
+  end
+
+  private
+
+  def continue
+    click_button("Continue")
+  end
+end


### PR DESCRIPTION
### Context

We want to run some smoke tests post deploy to non-production environments as a step towards moving to CD.

### Changes

* Add spec to run through the eligibility checker flow as a smoke test
* Add bin/smoke
* Modify bin/test to exclude the smoke test
* Update test GitHub workflow to use bin/test

### Review guidance

These specs will be run from https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/283/files 

To run locally run `bin/smoke` with the following environment variables set:

HOSTING_DOMAIN - non-prod domain
SUPPORT_USERNAME
SUPPORT_PASSWORD
