### PR TITLE
Ask applicants for their country/state

### DIFF
--- a/app/controllers/eligibility_interface/countries_controller.rb
+++ b/app/controllers/eligibility_interface/countries_controller.rb
@@ -30,11 +30,5 @@ module EligibilityInterface
     def location_form_params
       params.require(:eligibility_interface_country_form).permit(:location)
     end
-
-    def locations
-      Country::LOCATION_AUTOCOMPLETE_CANONICAL_LIST
-    end
-
-    helper_method :locations
   end
 end

--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -41,7 +41,8 @@ class TeacherInterface::ApplicationFormsController < TeacherInterface::BaseContr
   def application_form_params
     {
       teacher: current_teacher,
-      eligibility_check_id: session[:eligibility_check_id]
+      eligibility_check_id: session[:eligibility_check_id],
+      region_id: EligibilityCheck.find(session[:eligibility_check_id]).region_id
     }
   end
 end

--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -7,12 +7,12 @@ class TeacherInterface::ApplicationFormsController < TeacherInterface::BaseContr
   end
 
   def new
-    @application_form = ApplicationForm.new
+    @application_form = ApplicationForm.new(application_form_params)
   end
 
   def create
-    @application_form = ApplicationForm.new
-    if @application_form.update(application_form_params)
+    @application_form = ApplicationForm.new(application_form_params)
+    if @application_form.save
       redirect_to teacher_interface_application_form_path(@application_form)
     else
       flash[:warning] = "Could not start application."
@@ -41,8 +41,8 @@ class TeacherInterface::ApplicationFormsController < TeacherInterface::BaseContr
   def application_form_params
     {
       teacher: current_teacher,
-      eligibility_check_id: session[:eligibility_check_id],
-      region_id: EligibilityCheck.find(session[:eligibility_check_id]).region_id
+      region_id:
+        EligibilityCheck.find_by(id: session[:eligibility_check_id])&.region_id
     }
   end
 end

--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -1,48 +1,69 @@
-class TeacherInterface::ApplicationFormsController < TeacherInterface::BaseController
-  before_action :load_application_form, only: %i[show edit update]
+module TeacherInterface
+  class ApplicationFormsController < BaseController
+    before_action :load_application_form, only: %i[show edit update]
+    before_action :load_eligibility_check, only: %i[new create]
 
-  def index
-    @application_forms =
-      ApplicationForm.where(teacher: current_teacher).order(created_at: :desc)
-  end
+    def index
+      @application_forms =
+        ApplicationForm.where(teacher: current_teacher).order(created_at: :desc)
 
-  def new
-    @application_form = ApplicationForm.new(application_form_params)
-  end
+      if @application_forms.empty?
+        redirect_to %i[new teacher_interface application_form]
+      elsif @application_forms.count == 1
+        redirect_to [:teacher_interface, @application_forms.first]
+      end
+    end
 
-  def create
-    @application_form = ApplicationForm.new(application_form_params)
-    if @application_form.save
+    def new
+      @application_form = ApplicationForm.new
+      @country_region_form = CountryRegionForm.new
+    end
+
+    def create
+      @application_form = ApplicationForm.new(teacher: current_teacher)
+
+      @country_region_form =
+        CountryRegionForm.new(
+          country_region_form_params.merge(application_form: @application_form)
+        )
+
+      if @country_region_form.needs_region?
+        render :new
+      elsif @country_region_form.save
+        redirect_to teacher_interface_application_form_path(@application_form)
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def show
+    end
+
+    def edit
+    end
+
+    def update
+      unless @application_form.can_submit?
+        redirect_to [:teacher_interface, @application_form]
+        return
+      end
+
+      @application_form.submitted!
       redirect_to teacher_interface_application_form_path(@application_form)
-    else
-      flash[:warning] = "Could not start application."
-      render :new, status: :unprocessable_entity
-    end
-  end
-
-  def show
-  end
-
-  def edit
-  end
-
-  def update
-    unless @application_form.can_submit?
-      redirect_to [:teacher_interface, @application_form]
-      return
     end
 
-    @application_form.submitted!
-    redirect_to teacher_interface_application_form_path(@application_form)
-  end
+    private
 
-  private
+    def load_eligibility_check
+      @eligibility_check =
+        EligibilityCheck.find_by(id: session[:eligibility_check_id])
+    end
 
-  def application_form_params
-    {
-      teacher: current_teacher,
-      region_id:
-        EligibilityCheck.find_by(id: session[:eligibility_check_id])&.region_id
-    }
+    def country_region_form_params
+      params.require(:teacher_interface_country_region_form).permit(
+        :location,
+        :region_id
+      )
+    end
   end
 end

--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -33,6 +33,10 @@ class Teachers::SessionsController < Devise::SessionsController
 
   protected
 
+  def after_sign_in_path_for(resource)
+    stored_location_for(resource) || teacher_interface_root_path
+  end
+
   def translation_scope
     if action_name == "create"
       "devise.passwordless"

--- a/app/forms/teacher_interface/country_region_form.rb
+++ b/app/forms/teacher_interface/country_region_form.rb
@@ -1,0 +1,41 @@
+class TeacherInterface::CountryRegionForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :application_form
+
+  attribute :location, :string
+  attribute :region_id, :integer
+
+  validates :application_form, presence: true
+  validates :location, presence: true
+  validates :region_id, presence: true, if: -> { location.present? }
+
+  def location=(value)
+    super(value)
+    self.region_id = regions.count == 1 ? regions.first.id : nil
+  end
+
+  def regions
+    Region.joins(:country).where(country: { code: country_code }).order(:name)
+  end
+
+  def needs_region?
+    location.present? && region_id.blank?
+  end
+
+  def save
+    return false unless valid?
+
+    application_form.region_id = region_id
+    application_form.save!
+  end
+
+  private
+
+  def country_code
+    location.split(":")[1]
+  rescue StandardError
+    nil
+  end
+end

--- a/app/helpers/locations_helper.rb
+++ b/app/helpers/locations_helper.rb
@@ -1,0 +1,5 @@
+module LocationsHelper
+  def locations
+    Country::LOCATION_AUTOCOMPLETE_CANONICAL_LIST
+  end
+end

--- a/app/helpers/pages_helper.rb
+++ b/app/helpers/pages_helper.rb
@@ -1,2 +1,0 @@
-module PagesHelper
-end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -10,6 +10,12 @@ var loadCountryAutoComplete = () => {
     ) ??
     document.getElementById(
       "eligibility-interface-country-form-location-field-error"
+    ) ??
+    document.getElementById(
+      "teacher-interface-country-region-form-location-field"
+    ) ??
+    document.getElementById(
+      "teacher-interface-country-region-form-location-field-error"
     );
 
   if (locationPicker) {

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -15,21 +15,18 @@
 #  status                  :string           default("active"), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  eligibility_check_id    :bigint           not null
 #  region_id               :bigint           not null
 #  teacher_id              :bigint           not null
 #
 # Indexes
 #
-#  index_application_forms_on_eligibility_check_id  (eligibility_check_id)
-#  index_application_forms_on_reference             (reference) UNIQUE
-#  index_application_forms_on_region_id             (region_id)
-#  index_application_forms_on_status                (status)
-#  index_application_forms_on_teacher_id            (teacher_id)
+#  index_application_forms_on_reference   (reference) UNIQUE
+#  index_application_forms_on_region_id   (region_id)
+#  index_application_forms_on_status      (status)
+#  index_application_forms_on_teacher_id  (teacher_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (eligibility_check_id => eligibility_checks.id)
 #  fk_rails_...  (region_id => regions.id)
 #  fk_rails_...  (teacher_id => teachers.id)
 #
@@ -37,7 +34,6 @@ class ApplicationForm < ApplicationRecord
   include DfE::Analytics::Entities
 
   belongs_to :teacher
-  belongs_to :eligibility_check
   belongs_to :region
   has_many :work_histories
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -16,18 +16,21 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  eligibility_check_id    :bigint           not null
+#  region_id               :bigint           not null
 #  teacher_id              :bigint           not null
 #
 # Indexes
 #
 #  index_application_forms_on_eligibility_check_id  (eligibility_check_id)
 #  index_application_forms_on_reference             (reference) UNIQUE
+#  index_application_forms_on_region_id             (region_id)
 #  index_application_forms_on_status                (status)
 #  index_application_forms_on_teacher_id            (teacher_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (eligibility_check_id => eligibility_checks.id)
+#  fk_rails_...  (region_id => regions.id)
 #  fk_rails_...  (teacher_id => teachers.id)
 #
 class ApplicationForm < ApplicationRecord
@@ -35,8 +38,8 @@ class ApplicationForm < ApplicationRecord
 
   belongs_to :teacher
   belongs_to :eligibility_check
+  belongs_to :region
   has_many :work_histories
-  has_one :region, through: :eligibility_check
 
   has_one :identification_document,
           -> { where(document_type: :identification) },

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -59,6 +59,15 @@ class EligibilityCheck < ApplicationRecord
     self.region = regions.count == 1 ? regions.first : nil
   end
 
+  LOCATIONS_BY_COUNTRY_CODE =
+    Country::LOCATION_AUTOCOMPLETE_CANONICAL_LIST
+      .map { |row| [row.last.split(":").last, row.last] }
+      .to_h
+
+  def location
+    LOCATIONS_BY_COUNTRY_CODE[country_code]
+  end
+
   def ineligible_reasons
     [
       region.nil? ? :country : nil,

--- a/app/views/eligibility_interface/countries/new.html.erb
+++ b/app/views/eligibility_interface/countries/new.html.erb
@@ -1,15 +1,15 @@
-<% content_for :page_title, "#{'Error: ' if @country_form.errors.any?}In which country are you currently recognised as a teacher?" %>
+<% content_for :page_title, "#{'Error: ' if @country_form.errors.any?}#{I18n.t('eligibility_check.country.label')}" %>
 <% content_for :back_link_url, back_link_url(eligibility_interface_start_url) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @country_form, url: eligibility_interface_countries_url, method: :post do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_select :location, options_for_select(locations),
-            hint: { text: "This means you have all the qualifications needed to teach in a state school. You'll need to provide evidence of this if you apply for QTS." },
-            label: { size: 'l', tag: 'h1', text: "In which country are you currently recognised as a teacher?" },
-            options: { include_blank: true }
-      %>
+      <%= f.govuk_select :location,
+                         options_for_select(locations),
+                         hint: { text: I18n.t("eligibility_check.country.hint") },
+                         label: { text: I18n.t("eligibility_check.country.label"), size: "l", tag: "h1" },
+                         options: { include_blank: true } %>
       <%= f.govuk_submit prevent_double_click: false %>
     <% end %>
   </div>

--- a/app/views/eligibility_interface/region/new.html.erb
+++ b/app/views/eligibility_interface/region/new.html.erb
@@ -1,18 +1,16 @@
-<% content_for :page_title, "#{'Error: ' if @region_form.errors.any?}In which state/territory are you currently recognised as a teacher?" %>
+<% content_for :page_title, "#{'Error: ' if @region_form.errors.any?}#{I18n.t('eligibility_check.region.label')}" %>
 <% content_for :back_link_url, back_link_url(eligibility_interface_countries_url) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: @region_form, url: eligibility_interface_region_url, method: :post do |f| %>
       <%= f.govuk_error_summary %>
-      <%= f.govuk_collection_radio_buttons(
-        :region_id,
-        @regions,
-        :id,
-        :name,
-        legend: { size: 'l', tag: 'h1', text: 'In which state/territory are you currently recognised as a teacher?' },
-        hint: { text: "This means you have all the qualifications needed to teach in a state school. You'll need to provide evidence of this if you apply for QTS." }
-      ) %>
+      <%= f.govuk_collection_radio_buttons :region_id,
+                                           @regions,
+                                           :id,
+                                           :name,
+                                           legend: { text: I18n.t("eligibility_check.region.label"), size: "l", tag: "h1" },
+                                           hint: { text: I18n.t("eligibility_check.region.hint") } %>
       <%= f.govuk_submit prevent_double_click: false %>
     <% end %>
   </div>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -30,7 +30,12 @@
 
     <%= govuk_header(homepage_url: "https://www.gov.uk", service_name: t('service.name'), classes: "app-header--#{HostingEnvironment.name}") do |header| %>
       <% case try(:current_namespace) %>
-      <% when 'support' %>
+      <% when "teacher" %>
+        <% header.navigation_item(
+           text: "Sign out",
+           href: destroy_teacher_session_path
+         ) %>
+      <% when "support" %>
         <% header.navigation_item(
           text: "Features",
           href: support_interface_features_path,

--- a/app/views/teacher_interface/application_forms/index.html.erb
+++ b/app/views/teacher_interface/application_forms/index.html.erb
@@ -2,6 +2,8 @@
 
 <h1 class="govuk-heading-l">Your applications</h1>
 
+<%= govuk_button_link_to "Start new application", new_teacher_interface_application_form_path %>
+
 <%= govuk_table do |table|
   table.caption(size: 'm', text: 'List of applications')
 

--- a/app/views/teacher_interface/application_forms/new.html.erb
+++ b/app/views/teacher_interface/application_forms/new.html.erb
@@ -1,7 +1,33 @@
-<% content_for :page_title, "Start your application" %>
+<% if @country_region_form.needs_region? %>
+  <% content_for :page_title, I18n.t("eligibility_check.region.label") %>
+<% else %>
+  <% content_for :page_title, I18n.t("eligibility_check.country.label") %>
+<% end %>
 
-<h1 class="govuk-heading-xl">Start your application</h1>
+<%= form_with model: @country_region_form, url: [:teacher_interface, @application_form], method: :post do |f| %>
+  <%= f.govuk_error_summary %>
 
-<p class="govuk-body">Click the button below to start your application.</p>
+  <% if @country_region_form.needs_region? %>
+    <%= f.hidden_field :location %>
 
-<%= govuk_start_button(text: "Start now", href: teacher_interface_application_forms_path, as_button: true) %>
+    <%= f.govuk_radio_buttons_fieldset :region_id,
+                                       legend: { text: I18n.t("eligibility_check.region.label"), size: "l", tag: "h1" },
+                                       hint: { text: I18n.t("eligibility_check.region.hint") } do %>
+      <% @country_region_form.regions.each_with_index do |region, i| %>
+        <%= f.govuk_radio_button :region_id,
+                                 region.id,
+                                 label: { text: region.name },
+                                 link_errors: i == 0,
+                                 checked: region.id == @eligibility_check&.region_id %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= f.govuk_select :location,
+                       options_for_select(locations, @eligibility_check&.location),
+                       hint: { text: I18n.t("eligibility_check.country.hint") },
+                       label: { text: I18n.t("eligibility_check.country.label"), size: "l", tag: "h1" },
+                       options: { include_blank: true } %>
+  <% end %>
+
+  <%= f.govuk_submit prevent_double_click: false %>
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -48,6 +48,7 @@
     - status
     - teacher_id
     - eligibility_check_id
+    - region_id
     - created_at
     - updated_at
     - given_names

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -47,7 +47,6 @@
     - reference
     - status
     - teacher_id
-    - eligibility_check_id
     - region_id
     - created_at
     - updated_at

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,7 +310,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,6 +24,14 @@ en:
         work_history: Add your work history
         written_statement: Upload your written statement
 
+  eligibility_check:
+    country:
+      label: In which country are you currently recognised as a teacher?
+      hint: This means you have all the qualifications needed to teach in a state school. You'll need to provide evidence of this if you apply for QTS.
+    region:
+      label: In which state/territory are you currently recognised as a teacher?
+      hint: This means you have all the qualifications needed to teach in a state school. You'll need to provide evidence of this if you apply for QTS.
+
   activemodel:
     attributes:
       eligibility_check:

--- a/db/migrate/20220801091806_add_region_to_application_form.rb
+++ b/db/migrate/20220801091806_add_region_to_application_form.rb
@@ -1,0 +1,19 @@
+class AddRegionToApplicationForm < ActiveRecord::Migration[7.0]
+  def up
+    add_reference :application_forms, :region, foreign_key: true, null: true
+
+    ApplicationForm
+      .includes(:eligibility_check)
+      .find_each do |application_form|
+        application_form.update!(
+          region_id: application_form.eligibility_check.region.id
+        )
+      end
+
+    change_column_null :application_forms, :region_id, false
+  end
+
+  def down
+    remove_reference :application_forms, :region
+  end
+end

--- a/db/migrate/20220801093628_remove_eligibility_check_from_application_form.rb
+++ b/db/migrate/20220801093628_remove_eligibility_check_from_application_form.rb
@@ -1,0 +1,8 @@
+class RemoveEligibilityCheckFromApplicationForm < ActiveRecord::Migration[7.0]
+  def change
+    remove_reference :application_forms,
+                     :eligibility_check,
+                     null: false,
+                     foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_01_091806) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_01_093628) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -46,7 +46,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_01_091806) do
     t.string "reference", limit: 31, null: false
     t.string "status", default: "active", null: false
     t.bigint "teacher_id", null: false
-    t.bigint "eligibility_check_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "given_names", default: "", null: false
@@ -58,7 +57,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_01_091806) do
     t.text "alternative_given_names", default: "", null: false
     t.text "alternative_family_name", default: "", null: false
     t.bigint "region_id", null: false
-    t.index ["eligibility_check_id"], name: "index_application_forms_on_eligibility_check_id"
     t.index ["reference"], name: "index_application_forms_on_reference", unique: true
     t.index ["region_id"], name: "index_application_forms_on_region_id"
     t.index ["status"], name: "index_application_forms_on_status"
@@ -198,7 +196,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_01_091806) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "application_forms", "eligibility_checks"
   add_foreign_key "application_forms", "regions"
   add_foreign_key "application_forms", "teachers"
   add_foreign_key "eligibility_checks", "regions"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_26_140931) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_01_091806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -57,8 +57,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_26_140931) do
     t.boolean "has_alternative_name"
     t.text "alternative_given_names", default: "", null: false
     t.text "alternative_family_name", default: "", null: false
+    t.bigint "region_id", null: false
     t.index ["eligibility_check_id"], name: "index_application_forms_on_eligibility_check_id"
     t.index ["reference"], name: "index_application_forms_on_reference", unique: true
+    t.index ["region_id"], name: "index_application_forms_on_region_id"
     t.index ["status"], name: "index_application_forms_on_status"
     t.index ["teacher_id"], name: "index_application_forms_on_teacher_id"
   end
@@ -197,6 +199,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_26_140931) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "application_forms", "eligibility_checks"
+  add_foreign_key "application_forms", "regions"
   add_foreign_key "application_forms", "teachers"
   add_foreign_key "eligibility_checks", "regions"
   add_foreign_key "regions", "countries"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -15,21 +15,18 @@
 #  status                  :string           default("active"), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  eligibility_check_id    :bigint           not null
 #  region_id               :bigint           not null
 #  teacher_id              :bigint           not null
 #
 # Indexes
 #
-#  index_application_forms_on_eligibility_check_id  (eligibility_check_id)
-#  index_application_forms_on_reference             (reference) UNIQUE
-#  index_application_forms_on_region_id             (region_id)
-#  index_application_forms_on_status                (status)
-#  index_application_forms_on_teacher_id            (teacher_id)
+#  index_application_forms_on_reference   (reference) UNIQUE
+#  index_application_forms_on_region_id   (region_id)
+#  index_application_forms_on_status      (status)
+#  index_application_forms_on_teacher_id  (teacher_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (eligibility_check_id => eligibility_checks.id)
 #  fk_rails_...  (region_id => regions.id)
 #  fk_rails_...  (teacher_id => teachers.id)
 #
@@ -38,7 +35,6 @@ FactoryBot.define do
     sequence(:reference) { |n| "ref#{n}" }
     status { "active" }
     association :teacher
-    association :eligibility_check, :eligible
     association :region, :national
 
     trait :submitted do

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -16,18 +16,21 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  eligibility_check_id    :bigint           not null
+#  region_id               :bigint           not null
 #  teacher_id              :bigint           not null
 #
 # Indexes
 #
 #  index_application_forms_on_eligibility_check_id  (eligibility_check_id)
 #  index_application_forms_on_reference             (reference) UNIQUE
+#  index_application_forms_on_region_id             (region_id)
 #  index_application_forms_on_status                (status)
 #  index_application_forms_on_teacher_id            (teacher_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (eligibility_check_id => eligibility_checks.id)
+#  fk_rails_...  (region_id => regions.id)
 #  fk_rails_...  (teacher_id => teachers.id)
 #
 FactoryBot.define do
@@ -36,6 +39,7 @@ FactoryBot.define do
     status { "active" }
     association :teacher
     association :eligibility_check, :eligible
+    association :region, :national
 
     trait :submitted do
       status { "submitted" }

--- a/spec/forms/teacher_interface/country_region_form_spec.rb
+++ b/spec/forms/teacher_interface/country_region_form_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe TeacherInterface::CountryRegionForm, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:application_form) }
+    it { is_expected.to validate_presence_of(:location) }
+
+    context "with a location" do
+      subject(:form) { described_class.new(location: "country:GB") }
+
+      it { is_expected.to validate_presence_of(:region_id) }
+    end
+  end
+
+  describe "#location=" do
+    let(:form) { described_class.new(location: "country:#{country.code}") }
+
+    context "with a single region" do
+      let(:country) { create(:country, :with_national_region) }
+
+      it "sets the region" do
+        expect(form.region_id).to eq(country.regions.first.id)
+      end
+    end
+
+    context "with multiple regions" do
+      let(:country) do
+        country = create(:country)
+        create(:region, country:)
+        create(:region, country:)
+        country
+      end
+
+      it "doesn't set the region" do
+        expect(form.region_id).to be_nil
+      end
+    end
+  end
+
+  describe "#regions" do
+    subject(:regions) { form.regions }
+
+    let(:form) { described_class.new(location: "country:#{country.code}") }
+    let(:country) { create(:country) }
+    let(:region_a) { create(:region, country:, name: "A") }
+    let(:region_b) { create(:region, country:, name: "B") }
+
+    it { is_expected.to eq([region_a, region_b]) }
+  end
+
+  describe "#needs_region?" do
+    subject(:needs_region?) { form.needs_region? }
+
+    let(:form) { described_class.new }
+
+    it { is_expected.to be(false) }
+
+    context "with a location set" do
+      before { form.location = "country:GB" }
+
+      it { is_expected.to be(true) }
+
+      context "and a region set" do
+        before { form.region_id = 1 }
+
+        it { is_expected.to be(false) }
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:application_form) { build(:application_form) }
+    let(:region) { create(:region, :national) }
+
+    let(:form) do
+      described_class.new(
+        application_form:,
+        location: "country:#{region.country.code}",
+        region_id: region.id
+      )
+    end
+
+    before { form.save }
+
+    it "saves the application form" do
+      expect(application_form.region).to eq(region)
+    end
+  end
+end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -15,21 +15,18 @@
 #  status                  :string           default("active"), not null
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
-#  eligibility_check_id    :bigint           not null
 #  region_id               :bigint           not null
 #  teacher_id              :bigint           not null
 #
 # Indexes
 #
-#  index_application_forms_on_eligibility_check_id  (eligibility_check_id)
-#  index_application_forms_on_reference             (reference) UNIQUE
-#  index_application_forms_on_region_id             (region_id)
-#  index_application_forms_on_status                (status)
-#  index_application_forms_on_teacher_id            (teacher_id)
+#  index_application_forms_on_reference   (reference) UNIQUE
+#  index_application_forms_on_region_id   (region_id)
+#  index_application_forms_on_status      (status)
+#  index_application_forms_on_teacher_id  (teacher_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (eligibility_check_id => eligibility_checks.id)
 #  fk_rails_...  (region_id => regions.id)
 #  fk_rails_...  (teacher_id => teachers.id)
 #

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -16,18 +16,21 @@
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  eligibility_check_id    :bigint           not null
+#  region_id               :bigint           not null
 #  teacher_id              :bigint           not null
 #
 # Indexes
 #
 #  index_application_forms_on_eligibility_check_id  (eligibility_check_id)
 #  index_application_forms_on_reference             (reference) UNIQUE
+#  index_application_forms_on_region_id             (region_id)
 #  index_application_forms_on_status                (status)
 #  index_application_forms_on_teacher_id            (teacher_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (eligibility_check_id => eligibility_checks.id)
+#  fk_rails_...  (region_id => regions.id)
 #  fk_rails_...  (teacher_id => teachers.id)
 #
 require "rails_helper"

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -23,6 +23,18 @@ require "rails_helper"
 RSpec.describe EligibilityCheck, type: :model do
   let(:eligibility_check) { EligibilityCheck.new }
 
+  describe "#location" do
+    subject(:location) { eligibility_check.location }
+
+    it { is_expected.to be_nil }
+
+    context "with a country code" do
+      before { eligibility_check.country_code = "GB-SCT" }
+
+      it { is_expected.to eq("country:GB-SCT") }
+    end
+  end
+
   describe "#ineligible_reasons" do
     subject(:ineligible_reasons) { eligibility_check.ineligible_reasons }
 

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe "Teacher application", type: :system do
     when_i_click_apply_for_qts
     and_i_sign_up
     then_i_see_the_new_application_page
-
-    when_i_click_start_now
+    and_i_click_continue
     then_i_see_the_active_application_page
 
     when_i_click_personal_information
@@ -182,8 +181,12 @@ RSpec.describe "Teacher application", type: :system do
 
   def then_i_see_the_new_application_page
     expect(page).to have_current_path("/teacher/applications/new")
-    expect(page).to have_title("Start your application")
-    expect(page).to have_content("Start your application")
+    expect(page).to have_title(
+      "In which country are you currently recognised as a teacher?"
+    )
+    expect(page).to have_content(
+      "In which country are you currently recognised as a teacher?"
+    )
   end
 
   def then_i_see_the_active_application_page

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -44,6 +44,9 @@ RSpec.describe "Teacher authentication", type: :system do
 
     when_i_visit_the_magic_link_email
     then_i_see_successful_magic_link_message
+
+    when_i_click_sign_out
+    then_i_see_the_signed_out_message
   end
 
   it "sign up with invalid email address" do
@@ -108,6 +111,10 @@ RSpec.describe "Teacher authentication", type: :system do
     choose "Yes, sign in", visible: false
   end
 
+  def when_i_click_sign_out
+    click_link "Sign out"
+  end
+
   def then_i_see_the_sign_up_form
     expect(page).to have_current_path("/teacher/sign_up")
     expect(page).to have_title("Create an account")
@@ -131,6 +138,10 @@ RSpec.describe "Teacher authentication", type: :system do
 
   def then_i_see_the_blank_email_address_message
     expect(page).to have_content("Enter your email address")
+  end
+
+  def then_i_see_the_signed_out_message
+    expect(page).to have_content("Signed out successfully.")
   end
 
   alias_method :and_i_fill_teacher_email_address,

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Teacher documents", type: :system do
     given_an_eligible_eligibility_check
     click_link "Apply for QTS"
     and_i_sign_up
-    click_button "Start now"
+    click_button "Continue"
   end
 
   def when_i_click_written_statement


### PR DESCRIPTION
This modifies how we start an application to first ask the user for their country/state. This allows us to support users who have signed in from a different browser session to the one they put their email address in, and we don't have an eligibility check to get this information from. If there is an eligibility check available we pre-populate the form.

I've also added a sign out button.

[Trello Card](https://trello.com/c/FL9JhCMr/666-capture-state-country-at-start-of-application-form)

## Screenshots

![Screenshot 2022-08-01 at 12 35 37](https://user-images.githubusercontent.com/510498/182139956-7b33d547-1493-4d9f-a974-f6d7dc67ca1a.png)
![Screenshot 2022-08-01 at 12 35 40](https://user-images.githubusercontent.com/510498/182139961-7d67db37-7329-47f8-8938-9f254c7f6077.png)
