### PR TITLE
Update content on translations

### DIFF
--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -114,5 +114,23 @@
   <% end %>
 <% end %>
 
-<h2 class="govuk-heading-m">You might need to provide translations</h2>
-<p class="govuk-body">If your documents are not in English, you’ll need to provide a certified translation of each one. Identity documents do not need to be translated and can be submitted in their original language.</p>
+<h2 class="govuk-heading-m">Providing certified translations</h2>
+<p class="govuk-body">If your documents are not written in English, you must provide certified translations (at your own cost) for your:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>qualifications</li>
+  <li>transcripts</li>
+  <li>proof that you’re recognised as a teacher.</li>
+</ul>
+<p class="govuk-body">You do not need translations for ID or change of name documents.</p>
+
+<h3 class="govuk-heading-s">About certified translations</h3>
+<p class="govuk-body">Translations must be carried out by a certified translator, who must state (on the document or a separate certification page) that the translation is a true, accurate and correct rendering of the original.</p>
+<p class="govuk-body">Each one must include the date of the translation as well as the certified translator’s:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>signature</li>
+  <li>name and contact details</li>
+  <li>official certification seal/stamp or ID number.</li>
+</ul>
+
+<h3 class="govuk-heading-s">Finding a certified translator</h3>
+<p class="govuk-body">We cannot recommend translation providers. You may want to explore translators who are members of the <a href="http://www.iti.org.uk/component/itisearch/?view=translators" class="govuk-link" rel="noreferrer noopener" target="_blank">Institute of Translating and Interpretation (opens in a new tab)</a>. Sometimes a university’s language department can also help.</p>

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "Countries support", type: :system do
     expect(page).to have_title("Preview California")
     expect(page).to have_content("You’re eligible to apply")
     expect(page).to have_content("Preparing to apply")
-    expect(page).to have_content("You might need to provide translations")
+    expect(page).to have_content("Providing certified translations")
   end
 
   def when_i_fill_regions


### PR DESCRIPTION
We need to make a change to the content on translations for documents which has been signed off by our content designer.

[Trello Card](https://trello.com/c/BkWJMddb/676-update-the-translations-copy-in-the-eligibility-checker)

## Screenshot

![Screenshot 2022-08-01 at 12 52 20](https://user-images.githubusercontent.com/510498/182142316-00fe4816-f8b2-48a4-b103-215b6c933e06.png)
