### PR TITLE
Fix use of association in migration

### DIFF
--- a/db/migrate/20220801091806_add_region_to_application_form.rb
+++ b/db/migrate/20220801091806_add_region_to_application_form.rb
@@ -2,13 +2,11 @@ class AddRegionToApplicationForm < ActiveRecord::Migration[7.0]
   def up
     add_reference :application_forms, :region, foreign_key: true, null: true
 
-    ApplicationForm
-      .includes(:eligibility_check)
-      .find_each do |application_form|
-        application_form.update!(
-          region_id: application_form.eligibility_check.region.id
-        )
-      end
+    ApplicationForm.find_each do |application_form|
+      eligibility_check =
+        EligibilityCheck.find(application_form.eligibility_check_id)
+      application_form.update!(region_id: eligibility_check.region_id)
+    end
 
     change_column_null :application_forms, :region_id, false
   end


### PR DESCRIPTION
We can't rely on the association here as it may have been removed from the models when the migration runs. Instead we need to be explicit about fetching the related model.

We don't need to use a join here as in all environments except dev, there aren't any application forms.