### PR TITLE
Improve the check your answers page

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -142,14 +142,6 @@ class ApplicationForm < ApplicationRecord
     end
   end
 
-  private
-
-  def build_documents
-    build_identification_document(document_type: :identification)
-    build_name_change_document(document_type: :name_change)
-    build_written_statement_document(document_type: :written_statement)
-  end
-
   def needs_work_history?
     region.status_check_none? || region.sanction_check_none?
   end
@@ -160,6 +152,14 @@ class ApplicationForm < ApplicationRecord
 
   def needs_written_statement?
     region.status_check_written? || region.sanction_check_written?
+  end
+
+  private
+
+  def build_documents
+    build_identification_document(document_type: :identification)
+    build_name_change_document(document_type: :name_change)
+    build_written_statement_document(document_type: :written_statement)
   end
 
   def task_item_status(key)

--- a/app/views/teacher_interface/application_forms/edit.html.erb
+++ b/app/views/teacher_interface/application_forms/edit.html.erb
@@ -10,12 +10,20 @@
 <h2 class="govuk-heading-m">Who you can teach</h2>
 <%= render "teacher_interface/age_range/summary", application_form: @application_form %>
 
-<h2 class="govuk-heading-m">Your work history</h2>
-<%= render "teacher_interface/work_histories/summary", application_form: @application_form, work_histories: @application_form.work_histories %>
+<% if @application_form.needs_work_history? %>
+  <h2 class="govuk-heading-m">Your work history</h2>
+  <%= render "teacher_interface/work_histories/summary", application_form: @application_form, work_histories: @application_form.work_histories %>
+<% end %>
 
-<h2 class="govuk-heading-m">Proof that you’re recognised as a teacher</h2>
-<%= render "teacher_interface/registration_number/summary", application_form: @application_form %>
-<%= render "teacher_interface/written_statement/summary", application_form: @application_form %>
+<% if @application_form.needs_written_statement? || @application_form.needs_registration_number? %>
+  <h2 class="govuk-heading-m">Proof that you’re recognised as a teacher</h2>
+  <% if @application_form.needs_registration_number? %>
+    <%= render "teacher_interface/registration_number/summary", application_form: @application_form %>
+  <% end %>
+  <% if @application_form.needs_written_statement? %>
+    <%= render "teacher_interface/written_statement/summary", application_form: @application_form %>
+  <% end %>
+<% end %>
 
 <% if @application_form.can_submit? %>
   <h2 class="govuk-heading-m">Submitting your application</h2>

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -371,4 +371,68 @@ RSpec.describe ApplicationForm, type: :model do
 
     it { is_expected.to eq(false) }
   end
+
+  describe "#needs_work_history?" do
+    subject(:needs_work_history?) { application_form.needs_work_history? }
+
+    context "with none checks" do
+      it { is_expected.to be true }
+    end
+
+    context "with written checks" do
+      before { application_form.region = create(:region, :written_checks) }
+
+      it { is_expected.to be false }
+    end
+
+    context "with online checks" do
+      before { application_form.region = create(:region, :online_checks) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#needs_registration_number?" do
+    subject(:needs_registration_number?) do
+      application_form.needs_registration_number?
+    end
+
+    context "with none checks" do
+      it { is_expected.to be false }
+    end
+
+    context "with written checks" do
+      before { application_form.region = create(:region, :written_checks) }
+
+      it { is_expected.to be false }
+    end
+
+    context "with online checks" do
+      before { application_form.region = create(:region, :online_checks) }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "#needs_written_statement?" do
+    subject(:needs_written_statement?) do
+      application_form.needs_written_statement?
+    end
+
+    context "with none checks" do
+      it { is_expected.to be false }
+    end
+
+    context "with written checks" do
+      before { application_form.region = create(:region, :written_checks) }
+
+      it { is_expected.to be true }
+    end
+
+    context "with online checks" do
+      before { application_form.region = create(:region, :online_checks) }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_click_check_your_answers
     then_i_see_the_check_your_answers_page
+    and_i_see_check_your_work_history
 
     when_i_click_submit
     then_i_see_the_submitted_application_page
@@ -147,6 +148,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_click_check_your_answers
     then_i_see_the_check_your_answers_page
+    and_i_see_check_proof_of_recognition
 
     when_i_click_submit
     then_i_see_the_submitted_application_page
@@ -218,6 +220,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_click_check_your_answers
     then_i_see_the_check_your_answers_page
+    and_i_see_check_proof_of_recognition
 
     when_i_click_submit
     then_i_see_the_submitted_application_page
@@ -519,7 +522,13 @@ RSpec.describe "Teacher application", type: :system do
     )
     expect(page).to have_content("About you")
     expect(page).to have_content("Who you can teach")
+  end
+
+  def and_i_see_check_your_work_history
     expect(page).to have_content("Your work history")
+  end
+
+  def and_i_see_check_proof_of_recognition
     expect(page).to have_content("Proof that you’re recognised as a teacher")
   end
 


### PR DESCRIPTION
At the moment on the "Check your answers" page we see summaries of all the questions even if it's not a question that's required on this application. This PR changes that so it uses the `needs_` methods of the application form to determine what to show.

[Trello Card](https://trello.com/c/wLzL1EYO/642-build-check-my-answers)