### PR TITLE
Refactor DfE analytics inclusion

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -33,8 +33,6 @@
 #  fk_rails_...  (teacher_id => teachers.id)
 #
 class ApplicationForm < ApplicationRecord
-  include DfE::Analytics::Entities
-
   belongs_to :teacher
   belongs_to :region
   has_many :work_histories

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,5 @@
 class ApplicationRecord < ActiveRecord::Base
+  include DfE::Analytics::Entities
+
   primary_abstract_class
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -18,7 +18,6 @@
 #  index_countries_on_code  (code) UNIQUE
 #
 class Country < ApplicationRecord
-  include DfE::Analytics::Entities
   include TeachingAuthorityContactable
 
   has_many :regions

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -15,8 +15,6 @@
 #  index_documents_on_documentable   (documentable_type,documentable_id)
 #
 class Document < ApplicationRecord
-  include DfE::Analytics::Entities
-
   belongs_to :documentable, polymorphic: true
 
   has_many :uploads

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -19,8 +19,6 @@
 #  fk_rails_...  (region_id => regions.id)
 #
 class EligibilityCheck < ApplicationRecord
-  include DfE::Analytics::Entities
-
   belongs_to :region, optional: true
   has_one :application
 

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -13,7 +13,5 @@
 #  index_features_on_name  (name) UNIQUE
 #
 class Feature < ApplicationRecord
-  include DfE::Analytics::Entities
-
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -22,8 +22,6 @@
 #  fk_rails_...  (application_form_id => application_forms.id)
 #
 class Qualification < ApplicationRecord
-  include DfE::Analytics::Entities
-
   belongs_to :application_form
 
   has_one :certificate_document,

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -25,7 +25,6 @@
 #  fk_rails_...  (country_id => countries.id)
 #
 class Region < ApplicationRecord
-  include DfE::Analytics::Entities
   include TeachingAuthorityContactable
 
   belongs_to :country

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -17,8 +17,6 @@
 #  fk_rails_...  (document_id => documents.id)
 #
 class Upload < ApplicationRecord
-  include DfE::Analytics::Entities
-
   belongs_to :document
   has_one_attached :attachment
   validates :attachment,

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -24,8 +24,6 @@
 #  fk_rails_...  (application_form_id => application_forms.id)
 #
 class WorkHistory < ApplicationRecord
-  include DfE::Analytics::Entities
-
   belongs_to :application_form
 
   validates :email, valid_for_notify: true, allow_blank: true


### PR DESCRIPTION
* Move the module inclusion into application_record.rb

A few models didn't have the module included:

* Staff
* Teacher

They are included in `analytics_blocked.yml` so should be fine for now.

We'll review all fields soon and can update and backfill if necessary then. [review all the things trello ticket](https://trello.com/c/Mb2xsuXZ/683-remove-pii-from-bigquery-config)
