### PR TITLE
Prepend protect from forgery

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,11 @@ class ApplicationController < ActionController::Base
   include DfE::Analytics::Requests
 
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
+
   before_action :authenticate_staff!,
                 unless: -> { FeatureFlag.active?(:service_open) }
+  protect_from_forgery prepend: true,
+                       unless: -> { FeatureFlag.active?(:service_open) }
 
   def current_user
     nil

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -161,6 +161,13 @@ RSpec.describe "Eligibility check", type: :system do
     given_the_service_is_open
     when_i_visit_the_start_page
     then_i_see_the_start_page
+
+    when_i_press_start_now
+    then_i_see_the_countries_page
+
+    when_i_select_a_country
+    and_i_submit
+    then_i_see_the_qualifications_page
   end
 
   it "service cannot be started" do


### PR DESCRIPTION
This is necessary when we use Devise to authenticate as a staff user as `authenticate_staff!` is called before the forgery protection is called and this leads to CSRF errors.

It's noted in the Devise documentation: https://github.com/heartcombo/devise#controller-filters-and-helpers