### PR TITLE
Refactor how we authenticate as a test user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,14 +3,35 @@ class ApplicationController < ActionController::Base
 
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
 
-  before_action :authenticate_staff!,
-                unless: -> { FeatureFlag.active?(:service_open) }
-  protect_from_forgery prepend: true,
-                       unless: -> { FeatureFlag.active?(:service_open) }
+  before_action :authenticate, unless: -> { FeatureFlag.active?(:service_open) }
 
   def current_user
     nil
   end
 
   helper_method :current_namespace
+
+  private
+
+  def authenticate
+    valid_credentials = [
+      {
+        username: ENV.fetch("SUPPORT_USERNAME", "support"),
+        password: ENV.fetch("SUPPORT_PASSWORD", "support")
+      }
+    ]
+
+    if FeatureFlag.active?(:staff_test_user)
+      valid_credentials.push(
+        {
+          username: ENV.fetch("TEST_USERNAME", "test"),
+          password: ENV.fetch("TEST_PASSWORD", "test")
+        }
+      )
+    end
+
+    authenticate_or_request_with_http_basic do |username, password|
+      valid_credentials.include?({ username:, password: })
+    end
+  end
 end

--- a/app/controllers/eligibility_interface/completed_requirements_controller.rb
+++ b/app/controllers/eligibility_interface/completed_requirements_controller.rb
@@ -14,7 +14,7 @@ module EligibilityInterface
       if @completed_requirements_form.save
         redirect_to paths[:qualification]
       else
-        render :new
+        render :new, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/eligibility_interface/countries_controller.rb
+++ b/app/controllers/eligibility_interface/countries_controller.rb
@@ -12,7 +12,7 @@ module EligibilityInterface
       if @country_form.save
         redirect_to next_url
       else
-        render :new
+        render :new, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/eligibility_interface/degrees_controller.rb
+++ b/app/controllers/eligibility_interface/degrees_controller.rb
@@ -12,7 +12,7 @@ module EligibilityInterface
       if @degree_form.save
         redirect_to paths[:teach_children]
       else
-        render :new
+        render :new, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/eligibility_interface/misconduct_controller.rb
+++ b/app/controllers/eligibility_interface/misconduct_controller.rb
@@ -12,7 +12,7 @@ module EligibilityInterface
       if @misconduct_form.save
         redirect_to next_url
       else
-        render :new
+        render :new, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/eligibility_interface/qualifications_controller.rb
+++ b/app/controllers/eligibility_interface/qualifications_controller.rb
@@ -14,7 +14,7 @@ module EligibilityInterface
       if @qualification_form.save
         redirect_to paths[:degree]
       else
-        render :new
+        render :new, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/eligibility_interface/region_controller.rb
+++ b/app/controllers/eligibility_interface/region_controller.rb
@@ -14,7 +14,7 @@ module EligibilityInterface
       if @region_form.save
         redirect_to next_url
       else
-        render :new
+        render :new, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/eligibility_interface/teach_children_controller.rb
+++ b/app/controllers/eligibility_interface/teach_children_controller.rb
@@ -14,7 +14,7 @@ module EligibilityInterface
       if @teach_children_form.save
         redirect_to paths[:misconduct]
       else
-        render :new
+        render :new, status: :unprocessable_entity
       end
     end
 

--- a/app/lib/staff_http_basic_auth_strategy.rb
+++ b/app/lib/staff_http_basic_auth_strategy.rb
@@ -32,27 +32,13 @@ class StaffHttpBasicAuthStrategy < Warden::Strategies::Base
   SUPPORT_PASSWORD =
     Digest::SHA256.hexdigest(ENV.fetch("SUPPORT_PASSWORD", "support"))
 
-  TEST_USERNAME = Digest::SHA256.hexdigest(ENV.fetch("TEST_USERNAME", "test"))
-  TEST_PASSWORD = Digest::SHA256.hexdigest(ENV.fetch("TEST_PASSWORD", "test"))
-
   ANONYMOUS_SUPPORT_USER = AnonymousSupportUser.new
-
-  def valid_users
-    users = [{ username: SUPPORT_USERNAME, password: SUPPORT_PASSWORD }]
-
-    if FeatureFlag.active?(:staff_test_user)
-      users.push({ username: TEST_USERNAME, password: TEST_PASSWORD })
-    end
-    users
-  end
 
   def credentials_valid?(auth)
     return false unless auth.provided? && auth.basic? && auth.credentials
 
-    valid_users.any? do |user|
-      valid_comparison?(user[:username], auth.credentials.first) &&
-        valid_comparison?(user[:password], auth.credentials.last)
-    end
+    valid_comparison?(SUPPORT_USERNAME, auth.credentials.first) &&
+      valid_comparison?(SUPPORT_PASSWORD, auth.credentials.last)
   end
 
   def valid_comparison?(correct_value, given_value)


### PR DESCRIPTION
This partially reverts https://github.com/DFE-Digital/apply-for-qualified-teacher-status/commit/a14b7b587b47abf905f7fae6beaeb3609b3dd2f7 and https://github.com/DFE-Digital/apply-for-qualified-teacher-status/commit/28a9936571e1f406bdd6a3a84cbfc5557952eb74 to try and solve an issue where Devise seems to be affecting the session, which means that when the service is not open it's not possible to complete an eligibility check.

This refactors how we authenticate as a test user to instead not use Devise in the base application controller and stick with simple Rails HTTP Basic authentication. Some benefits of this is that we don't need to get Devise involved for the eligibility check, and it simplifies the staff auth strategy. It also means that if someone were to authenticate using the test credentials, they wouldn't get access to the support interface (if we accidentally left the feature flag on for example).

There is a downside which is that authentication as a support user is duplicated in two places, but I think that's an okay trade-off. However, I do like that it restricts the staff authentication strategy to just authenticating as a staff user, with only access to the support interface.