### PR TITLE
Update smoke tests

### DIFF
--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -17,6 +17,7 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
   it "runs" do
     when_i_visit_the_service_domain
     and_i_click_the_start_button
+    and_i_need_to_check_my_eligibility
     and_i_enter_a_country
     and_i_select_a_state
     and_i_have_a_teaching_qualification
@@ -34,6 +35,15 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
 
   def and_i_click_the_start_button
     click_button("Start now")
+  end
+
+  def and_i_need_to_check_my_eligibility
+    # dev & test environments have this feature enabled currently but production does
+    # not. We can remove this conditional when the feature is released
+    if page.has_content?("Have you used the service before?")
+      choose "No, I need to check my eligibility", visible: false
+      continue
+    end
   end
 
   def and_i_enter_a_country

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -4,6 +4,7 @@ require "capybara/rspec"
 require "capybara/cuprite"
 
 Capybara.javascript_driver = :cuprite
+Capybara.always_include_port = false
 
 describe "Smoke test", type: :system, js: true, smoke_test: true do
   before do


### PR DESCRIPTION
Fix some smoke test issues.

* Stop capybara appending a port to the URL (causing a timeout)
* Add extra 'optional' step that is currently inconsistently feature flagged across the environments.

### Review

To run locally configure the `HOSTING_DOMAIN` (e.g. https://apply-for-qts-in-england-test.london.cloudapps.digital) environment variable and run `bin/smoke`