### PR TITLE
Improve sign out and return flow

### DIFF
--- a/app/controllers/teachers/magic_links_controller.rb
+++ b/app/controllers/teachers/magic_links_controller.rb
@@ -11,7 +11,6 @@ class Teachers::MagicLinksController < DeviseController
 
   def show
     self.resource = warden.authenticate!(auth_options)
-    set_flash_message!(:notice, :signed_in)
     sign_in(resource_name, resource)
     yield resource if block_given?
     redirect_to after_sign_in_path_for(resource)

--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -28,6 +28,12 @@ class Teachers::SessionsController < Devise::SessionsController
     end
   end
 
+  def destroy
+    Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+    yield if block_given?
+    respond_to_on_destroy
+  end
+
   def check_email
   end
 
@@ -38,6 +44,10 @@ class Teachers::SessionsController < Devise::SessionsController
 
   def after_sign_in_path_for(resource)
     stored_location_for(resource) || teacher_interface_root_path
+  end
+
+  def after_sign_out_path_for(_resource)
+    teacher_signed_out_path
   end
 
   def translation_scope

--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -31,6 +31,9 @@ class Teachers::SessionsController < Devise::SessionsController
   def check_email
   end
 
+  def signed_out
+  end
+
   protected
 
   def after_sign_in_path_for(resource)

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -30,11 +30,6 @@
 
     <%= govuk_header(homepage_url: "https://www.gov.uk", service_name: t('service.name'), classes: "app-header--#{HostingEnvironment.name}") do |header| %>
       <% case try(:current_namespace) %>
-      <% when "teacher" %>
-        <% header.navigation_item(
-           text: "Sign out",
-           href: destroy_teacher_session_path
-         ) %>
       <% when "support" %>
         <% header.navigation_item(
           text: "Features",

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -49,5 +49,10 @@
     <% end %>
   </ol>
 
-  <%= govuk_button_link_to "Check your answers", edit_teacher_interface_application_form_path %>
+  <%= form_with url: destroy_teacher_session_path, method: :delete do |f| %>
+    <div class="govuk-button-group">
+      <%= govuk_button_link_to "Check your answers", edit_teacher_interface_application_form_path %>
+      <%= f.govuk_submit "Save and sign out", secondary: true %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/teachers/sessions/signed_out.html.erb
+++ b/app/views/teachers/sessions/signed_out.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, "We’ve saved your in-progress QTS application" %>
+
+<h1 class="govuk-heading-xl">We’ve saved your in-progress QTS application</h1>
+
+<p class="govuk-body-m">
+  We’ve signed you out of the Apply for qualified teacher status (QTS) service.
+</p>
+
+<p class="govuk-body">
+  We’ve saved the information you’ve added to your application so far.
+</p>
+
+<p class="govuk-body">
+  We’ll keep your in-progress application open for 60 days. During that time you can continue your application using the link below.
+</p>
+
+<p class="govuk-body">
+  The link will take you to the beginning of the service, but you can use your email address to sign in and continue your application.
+</p>
+
+<p class="govuk-body">
+  <%= govuk_link_to "apply-for-qts-in-england.education.gov.uk", "https://apply-for-qts-in-england.education.gov.uk" %>
+</p>
+
+<p class="govuk-body">
+  If you do not continue your application within 60 days you’ll need to start a new application.
+</p>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,7 +310,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  config.sign_out_via = :get
+  # config.sign_out_via = :delete
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -127,6 +127,9 @@ Rails.application.routes.draw do
     get "/teacher/check_email",
         to: "teachers/sessions#check_email",
         as: "teacher_check_email"
+    get "/teacher/signed_out",
+        to: "teachers/sessions#signed_out",
+        as: "teacher_signed_out"
   end
 
   resources :autocomplete_locations, only: %i[index]

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Teacher authentication", type: :system do
     then_i_see_the_new_application_form
 
     when_i_click_sign_out
-    then_i_see_the_signed_out_message
+    then_i_see_the_signed_out_page
   end
 
   it "sign up with invalid email address" do
@@ -142,8 +142,13 @@ RSpec.describe "Teacher authentication", type: :system do
     expect(page).to have_content("Enter your email address")
   end
 
-  def then_i_see_the_signed_out_message
-    expect(page).to have_content("Signed out successfully.")
+  def then_i_see_the_signed_out_page
+    expect(page).to have_content(
+      "We’ve signed you out of the Apply for qualified teacher status (QTS) service."
+    )
+    expect(page).to have_content(
+      "We’ve saved the information you’ve added to your application so far."
+    )
   end
 
   alias_method :and_i_fill_teacher_email_address,

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe "Teacher authentication", type: :system do
   end
 
   it "allows signing up and signing in" do
+    given_countries_exist
+
     when_i_visit_the_sign_up_page
     then_i_see_the_sign_up_form
 
@@ -44,6 +46,9 @@ RSpec.describe "Teacher authentication", type: :system do
 
     when_i_visit_the_magic_link_email
     then_i_see_the_new_application_form
+
+    when_i_select_a_country
+    and_i_click_continue
 
     when_i_click_sign_out
     then_i_see_the_signed_out_page
@@ -86,6 +91,10 @@ RSpec.describe "Teacher authentication", type: :system do
 
   private
 
+  def given_countries_exist
+    create(:country, :with_national_region, code: "GB-SCT")
+  end
+
   def given_i_clear_my_session
     page.driver.clear_cookies
     ActionMailer::Base.deliveries = []
@@ -111,8 +120,13 @@ RSpec.describe "Teacher authentication", type: :system do
     choose "Yes, sign in", visible: false
   end
 
+  def when_i_select_a_country
+    fill_in "teacher-interface-country-region-form-location-field",
+            with: "Scotland"
+  end
+
   def when_i_click_sign_out
-    click_link "Sign out"
+    click_button "Save and sign out"
   end
 
   def then_i_see_the_sign_up_form
@@ -160,5 +174,9 @@ RSpec.describe "Teacher authentication", type: :system do
 
     expect(message.subject).to eq("Here's your magic login link")
     expect(message.to).to include("test@example.com")
+  end
+
+  def and_i_click_continue
+    click_button "Continue", visible: false
   end
 end

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Teacher authentication", type: :system do
     and_i_receive_a_magic_link_email
 
     when_i_visit_the_magic_link_email
-    then_i_see_successful_magic_link_message
+    then_i_see_the_new_application_form
 
     given_i_clear_my_session
 
@@ -43,7 +43,7 @@ RSpec.describe "Teacher authentication", type: :system do
     and_i_receive_a_magic_link_email
 
     when_i_visit_the_magic_link_email
-    then_i_see_successful_magic_link_message
+    then_i_see_the_new_application_form
 
     when_i_click_sign_out
     then_i_see_the_signed_out_message
@@ -132,8 +132,10 @@ RSpec.describe "Teacher authentication", type: :system do
     )
   end
 
-  def then_i_see_successful_magic_link_message
-    expect(page).to have_content("Signed in successfully.")
+  def then_i_see_the_new_application_form
+    expect(page).to have_content(
+      "In which country are you currently recognised as a teacher?"
+    )
   end
 
   def then_i_see_the_blank_email_address_message


### PR DESCRIPTION
This adds a new page which shows when a user signs out, and adds a button beside the continue button which users can use to sign out.

[Trello Card](https://trello.com/c/dylRMwax/687-add-to-save-and-return-journey-to-tell-users-what-happens-after-they-hit-save-and-come-back-later)

## Screenshots

<img width="483" alt="Screenshot 2022-08-03 at 17 05 49" src="https://user-images.githubusercontent.com/510498/182656471-b5a6188d-b0c6-4bac-8375-b057209f2cbb.png">

<img width="700" alt="Screenshot 2022-08-03 at 17 04 24" src="https://user-images.githubusercontent.com/510498/182656459-d238730f-4c26-4de7-bb2a-ac358a22a5bf.png">
