### PR TITLE
Record traces in Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -23,4 +23,6 @@ Sentry.init do |config|
     "ActionDispatch::Http::Parameters::ParseError",
     "Mime::Type::InvalidMimeType"
   ]
+
+  config.traces_sample_rate = 0.1
 end


### PR DESCRIPTION
This allows us to use the performance monitoring features of Sentry to check how our service is doing. I've set the sample rate to 10% as a start, which we can adjust in the future as we see fit.