### PR TITLE
Run rspec against built docker image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -96,7 +96,7 @@ jobs:
   rspec:
     name: Rspec
     runs-on: ubuntu-latest
-
+    needs: [docker]
     services:
       postgres:
         image: postgres
@@ -121,29 +121,42 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-    env:
-      DATABASE_URL: postgres://postgres:postgres@localhost:5432/apply_for_qts_test
-      RAILS_ENV: test
-      REDIS_URL: redis://localhost:6379/0
+    container:
+      image: ${{ needs.docker.outputs.docker_image }}
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      env:
+        RAILS_ENV: test
+        DB_HOSTNAME: postgres
+        DB_USERNAME: postgres
+        DB_PASSWORD: postgres
+        REDIS_URL: redis://redis:6379/0
+        DB_PORT: 5432
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Prepare application environment
-        uses: ./.github/actions/prepare-app-env
+      # - name: Prepare application environment
+      #   uses: ./.github/actions/prepare-app-env
 
-      - name: Build frontend
-        run: yarn build && yarn build:css
+      # - name: Build frontend
+      #   run: yarn build && yarn build:css
 
-      - name: Setup DB
-        run: bin/rails db:test:prepare
+      # - name: Setup DB
+      #   run: bin/rails db:test:prepare
 
-      - name: Run DfE Analytics
-        run: bin/bundle exec rails dfe:analytics:check
+      # - name: Run DfE Analytics
+      #   run: bin/bundle exec rails dfe:analytics:check
 
       - name: Run tests
-        run: bin/test
+        run: |
+          bundle install
+          bundle install --with test
+          bundle exec bin/test
+        env:
+          RAILS_ENV: test
 
   deploy_review:
     name: Deploy to review environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ FROM ruby:3.1.2-alpine as production
 WORKDIR /app
 
 # Set Rails environment to production
-ENV RAILS_ENV=production
+# ENV RAILS_ENV=production
 
 # Add the commit sha to the env
 ARG SHA

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -3,7 +3,7 @@ locals {
     data.azurerm_key_vault_secret.secrets["APPLY-QTS-APP-VARIABLES"].value
   ), {})
 
-  app_environment_variables = merge(local.azure_environment_variables, {
+  app_environment_variables = merge(local.azure_environment_variables, local.app_config, {
     HOSTING_ENVIRONMENT = var.environment_name,
     REDIS_URL           = cloudfoundry_service_key.redis_key.credentials.uri,
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -98,6 +98,10 @@ variable "region_name" {
   type    = string
 }
 
+variable env_config {}
+
+variable app_config_file { default = "workspace_variables/app_config.yml" }
+
 locals {
   apply_qts_routes = flatten([
     cloudfoundry_route.apply_qts_public,
@@ -124,4 +128,5 @@ locals {
     restore_from_point_in_time_of     = var.paas_restore_db_from_db_instance
     restore_from_point_in_time_before = var.paas_restore_db_from_point_in_time_before
   } : {}
+  app_config    = yamldecode(file(var.app_config_file))[var.env_config]
 }

--- a/terraform/workspace_variables/app_config.yml
+++ b/terraform/workspace_variables/app_config.yml
@@ -1,0 +1,2 @@
+review:
+  RAILS_ENV: review

--- a/terraform/workspace_variables/review.tfvars.json
+++ b/terraform/workspace_variables/review.tfvars.json
@@ -1,4 +1,5 @@
 {
+  "env_config": "test",
   "environment_name": "review",
   "key_vault_name": "s165d01-afqts-dv-kv",
   "resource_group_name": "s165d01-afqts-dv-rg",


### PR DESCRIPTION
Rspec should run against the docker image built in the build step. This
ensures that the build output is ready to deploy.