### PR TITLE
Make signed out link dynamic

### DIFF
--- a/app/views/teachers/sessions/signed_out.html.erb
+++ b/app/views/teachers/sessions/signed_out.html.erb
@@ -18,9 +18,7 @@
   The link will take you to the beginning of the service, but you can use your email address to sign in and continue your application.
 </p>
 
-<p class="govuk-body">
-  <%= govuk_link_to "apply-for-qts-in-england.education.gov.uk", "https://apply-for-qts-in-england.education.gov.uk" %>
-</p>
+<p class="govuk-body"><%= govuk_link_to request.host_with_port, "/" %></p>
 
 <p class="govuk-body">
   If you do not continue your application within 60 days you’ll need to start a new application.


### PR DESCRIPTION
This changes the link that's shown on the signed out page to use the current hostname, so it's always accurate to how the user got here.

Specifically it makes it easier to do user research and testing in the non-production environments.