### PR TITLE
Refactor document uploads

### DIFF
--- a/app/controllers/teacher_interface/documents_controller.rb
+++ b/app/controllers/teacher_interface/documents_controller.rb
@@ -17,7 +17,7 @@ module TeacherInterface
                       @document
                     )
       else
-        redirect_to continue_url
+        redirect_to document.continue_url
       end
     end
 
@@ -25,34 +25,6 @@ module TeacherInterface
 
     def document_params
       params.require(:document).permit(:add_another)
-    end
-
-    def continue_url
-      case document.document_type
-      when "name_change"
-        %i[teacher_interface application_form personal_information]
-      when "qualification_certificate"
-        [
-          :edit,
-          :teacher_interface,
-          :application_form,
-          document.documentable.transcript_document
-        ]
-      when "qualification_transcript"
-        qualification = document.documentable
-        if qualification.is_teaching_qualification?
-          [
-            :part_of_university_degree,
-            :teacher_interface,
-            :application_form,
-            document.documentable
-          ]
-        else
-          %i[teacher_interface application_form qualifications]
-        end
-      else
-        %i[teacher_interface application_form]
-      end
     end
   end
 end

--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -1,0 +1,68 @@
+class TeacherInterface::UploadForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveStorageValidations
+
+  attr_accessor :document
+
+  attribute :original_attachment
+  attribute :translated_attachment
+
+  validates :document, presence: true
+
+  validates :original_attachment,
+            content_type: %i[png jpg jpeg pdf doc docx],
+            size: {
+              less_than: 50.megabytes
+            },
+            allow_nil: true
+
+  validates :translated_attachment,
+            content_type: %i[png jpg jpeg pdf doc docx],
+            size: {
+              less_than: 50.megabytes
+            },
+            allow_nil: true
+
+  def present?
+    original_attachment.present? || translated_attachment.present?
+  end
+
+  def save
+    return false unless valid?
+    return false if blank?
+
+    if original_attachment.present?
+      document.uploads.create!(
+        attachment: original_attachment,
+        translation: false
+      )
+    end
+
+    if translated_attachment.present?
+      document.uploads.create!(
+        attachment: translated_attachment,
+        translation: true
+      )
+    end
+
+    true
+  end
+end
+
+# The following is required as we're using a validation library which is
+# usually used directly on a model and received an ActiveStorage::Blob
+# rather than an ActionDispatch::Http::UploadedFile.
+class ActionDispatch::Http::UploadedFile
+  def attached?
+    true
+  end
+
+  def blob
+    self
+  end
+
+  def byte_size
+    size
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -46,4 +46,31 @@ class Document < ApplicationRecord
   def uploaded?
     !uploads.empty?
   end
+
+  def continue_url
+    case document_type
+    when "name_change"
+      %i[teacher_interface application_form personal_information]
+    when "qualification_certificate"
+      [
+        :edit,
+        :teacher_interface,
+        :application_form,
+        documentable.transcript_document
+      ]
+    when "qualification_transcript"
+      if documentable.is_teaching_qualification?
+        [
+          :part_of_university_degree,
+          :teacher_interface,
+          :application_form,
+          documentable
+        ]
+      else
+        %i[teacher_interface application_form qualifications]
+      end
+    else
+      %i[teacher_interface application_form]
+    end
+  end
 end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -18,13 +18,9 @@
 #
 class Upload < ApplicationRecord
   belongs_to :document
+
   has_one_attached :attachment
-  validates :attachment,
-            attached: true,
-            content_type: %i[png jpg jpeg pdf doc docx],
-            size: {
-              less_than: 50.megabytes
-            }
+  validates :attachment, presence: true
 
   def original?
     !translation?

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -56,8 +56,8 @@
   <p class="govuk-body"><%= I18n.t("application_form.qualifications.upload.transcript.description") %></p>
 <% end %>
 
-<%= form_with model: [:teacher_interface, :application_form, @document, @upload] do |f| %>
-  <%= f.govuk_file_field :attachment,
+<%= form_with model: @upload_form, url: [:teacher_interface, :application_form, @document, :uploads] do |f| %>
+  <%= f.govuk_file_field :original_attachment,
                          label: { text: "Select a file to upload" },
                          hint: { text: "You can upload your files in PDF, JPG or DOC format. Each file must be no larger than 50MB." } %>
 
@@ -69,9 +69,9 @@
 
   <% if @document.translatable? %>
     <%= f.govuk_radio_buttons_fieldset :written_in_english, legend: { size: "m", text: "Is your document written in English?" } do %>
-      <%= f.govuk_radio_button :written_in_english, "true", label: { text: "Yes" }, link_errors: true, checked: false %>
+      <%= f.govuk_radio_button :written_in_english, :true, label: { text: "Yes" }, link_errors: true, checked: false %>
 
-      <%= f.govuk_radio_button :written_in_english, "false", label: { text: "No, I'll upload a translation as well" }, checked: false do %>
+      <%= f.govuk_radio_button :written_in_english, :false, label: { text: "No, I'll upload a translation as well" }, checked: false do %>
         <%= f.govuk_file_field :translated_attachment,
                                label: { text: "Select a file to upload" },
                                hint: { text: "You can upload your files in PDF, JPG or DOC format. Each file must be no larger than 50MB." } %>

--- a/spec/forms/teacher_interface/upload_form_spec.rb
+++ b/spec/forms/teacher_interface/upload_form_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe TeacherInterface::UploadForm, type: :model do
+  subject(:upload_form) do
+    described_class.new(document:, original_attachment:, translated_attachment:)
+  end
+
+  let(:document) { create(:document) }
+  let(:original_attachment) { nil }
+  let(:translated_attachment) { nil }
+
+  it { is_expected.to validate_presence_of(:document) }
+
+  describe "#valid?" do
+    subject(:valid?) { upload_form.valid? }
+
+    context "with nil attachments" do
+      it { is_expected.to be true }
+    end
+
+    context "with an original attachment" do
+      let(:original_attachment) do
+        ActionDispatch::Http::UploadedFile.new(
+          tempfile: file_fixture("upload.pdf"),
+          type: "application/pdf"
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "with an translated attachment" do
+      let(:translated_attachment) do
+        ActionDispatch::Http::UploadedFile.new(
+          tempfile: file_fixture("upload.pdf"),
+          type: "application/pdf"
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "with an invalid content type" do
+      let(:original_attachment) do
+        ActionDispatch::Http::UploadedFile.new(
+          tempfile: file_fixture("upload.txt"),
+          type: "text/plain"
+        )
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "with a large file" do
+      let(:original_attachment) do
+        ActionDispatch::Http::UploadedFile.new(
+          tempfile: file_fixture("upload.pdf"),
+          type: "application/pdf"
+        )
+      end
+
+      before do
+        allow(original_attachment).to receive(:size).and_return(
+          50 * 1024 * 1024
+        )
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#save" do
+    before { upload_form.save }
+
+    context "with an original attachment" do
+      let(:original_attachment) do
+        ActionDispatch::Http::UploadedFile.new(
+          tempfile: file_fixture("upload.pdf"),
+          filename: "upload.pdf",
+          type: "application/pdf"
+        )
+      end
+
+      it "creates an upload" do
+        expect(document.uploads.count).to eq(1)
+        expect(document.uploads.first.translation).to be(false)
+      end
+    end
+
+    context "with a translated attachment" do
+      let(:translated_attachment) do
+        ActionDispatch::Http::UploadedFile.new(
+          tempfile: file_fixture("upload.pdf"),
+          filename: "upload.pdf",
+          type: "application/pdf"
+        )
+      end
+
+      it "creates an upload" do
+        expect(document.uploads.count).to eq(1)
+        expect(document.uploads.first.translation).to be(true)
+      end
+    end
+  end
+end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -92,4 +92,60 @@ RSpec.describe Document, type: :model do
       it { is_expected.to be(true) }
     end
   end
+
+  describe "#continue_url" do
+    subject(:continue_url) { document.continue_url }
+
+    context "with an identity document" do
+      before { document.document_type = :identification }
+
+      it { is_expected.to eq(%i[teacher_interface application_form]) }
+    end
+
+    context "with a name change document" do
+      before { document.document_type = :name_change }
+
+      it do
+        is_expected.to eq(
+          %i[teacher_interface application_form personal_information]
+        )
+      end
+    end
+
+    context "with a qualification" do
+      let(:qualification) { build(:qualification) }
+
+      before { document.documentable = qualification }
+
+      context "and a certificate document" do
+        before { document.document_type = :qualification_certificate }
+
+        it do
+          is_expected.to eq(
+            [
+              :edit,
+              :teacher_interface,
+              :application_form,
+              qualification.transcript_document
+            ]
+          )
+        end
+      end
+
+      context "with a transcript document" do
+        before { document.document_type = :qualification_transcript }
+
+        it do
+          is_expected.to eq(
+            [
+              :part_of_university_degree,
+              :teacher_interface,
+              :application_form,
+              qualification
+            ]
+          )
+        end
+      end
+    end
+  end
 end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -24,25 +24,6 @@ RSpec.describe Upload, type: :model do
   describe "validations" do
     it { is_expected.to be_valid }
     it { is_expected.to validate_presence_of(:attachment) }
-
-    context "with an invalid content type" do
-      before do
-        upload.attachment =
-          Rack::Test::UploadedFile.new(file_fixture("upload.txt"), "text/plain")
-      end
-
-      it { is_expected.to_not be_valid }
-    end
-
-    context "with a large file" do
-      before do
-        allow(upload.attachment.blob).to receive(:byte_size).and_return(
-          50 * 1024 * 1024
-        )
-      end
-
-      it { is_expected.to_not be_valid }
-    end
   end
 
   describe "#original?" do

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_fill_in_the_upload_name_change_form
-    attach_file "upload-attachment-field",
+    attach_file "teacher-interface-upload-form-original-attachment-field",
                 Rails.root.join(file_fixture("upload.pdf"))
   end
 
@@ -377,7 +377,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_fill_in_the_upload_identification_form
-    attach_file "upload-attachment-field",
+    attach_file "teacher-interface-upload-form-original-attachment-field",
                 Rails.root.join(file_fixture("upload.pdf"))
   end
 
@@ -398,12 +398,12 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_fill_in_the_upload_certificate_form
-    attach_file "upload-attachment-field",
+    attach_file "teacher-interface-upload-form-original-attachment-field",
                 Rails.root.join(file_fixture("upload.pdf"))
   end
 
   def when_i_fill_in_the_upload_transcript_form
-    attach_file "upload-attachment-field",
+    attach_file "teacher-interface-upload-form-original-attachment-field",
                 Rails.root.join(file_fixture("upload.pdf"))
   end
 
@@ -449,7 +449,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_fill_in_the_upload_written_statement_form
-    attach_file "upload-attachment-field",
+    attach_file "teacher-interface-upload-form-original-attachment-field",
                 Rails.root.join(file_fixture("upload.pdf"))
   end
 

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -20,10 +20,7 @@ RSpec.describe "Teacher documents", type: :system do
     and_i_click_continue
     then_i_see_document_form
 
-    and_i_click_continue
-    then_i_see_document_form
-
-    when_i_upload_a_document_with_error
+    when_i_upload_a_document
     and_i_click_continue
     then_i_see_the_check_your_uploaded_files_page_with_three_files
 
@@ -50,15 +47,10 @@ RSpec.describe "Teacher documents", type: :system do
   end
 
   def when_i_upload_a_document
-    attach_file "upload-attachment-field",
+    attach_file "teacher-interface-upload-form-original-attachment-field",
                 Rails.root.join(file_fixture("upload.pdf"))
     choose "No, I'll upload a translation as well", visible: false
-    attach_file "upload-translated-attachment-field",
-                Rails.root.join(file_fixture("upload.pdf"))
-  end
-
-  def when_i_upload_a_document_with_error
-    attach_file "upload-attachment-field-error",
+    attach_file "teacher-interface-upload-form-translated-attachment-field",
                 Rails.root.join(file_fixture("upload.pdf"))
   end
 


### PR DESCRIPTION
This refactors how document uploads are implemented to use the form pattern. The main benefit being that the logic for validation is better encapsulated and it means the uploads can be optional.