### PR TITLE
Delete work history and qualifications

### DIFF
--- a/app/components/check_your_answers_summary_component.html.erb
+++ b/app/components/check_your_answers_summary_component.html.erb
@@ -1,6 +1,16 @@
 <div class="govuk-summary-list__card">
   <div class="govuk-summary-list__card-title-wrapper">
     <h2 class="govuk-summary-list__card-title"><%= title %></h2>
+
+    <% if @delete_link_to.present? %>
+      <div class="govuk-summary-list__card-actions">
+        <ul class="govuk-summary-list__card-actions-list">
+          <li class="govuk-summary-list__card-actions-list-item">
+            <%= govuk_link_to("Delete", @delete_link_to) %>
+          </li>
+        </ul>
+      </div>
+    <% end %>
   </div>
 
   <div class="govuk-summary-list__card-content">

--- a/app/components/check_your_answers_summary_component.rb
+++ b/app/components/check_your_answers_summary_component.rb
@@ -1,9 +1,10 @@
 class CheckYourAnswersSummaryComponent < ViewComponent::Base
-  def initialize(model:, title:, fields:)
+  def initialize(model:, title:, fields:, delete_link_to: nil)
     super
     @model = model
     @title = title
     @fields = fields
+    @delete_link_to = delete_link_to
   end
 
   attr_reader :title

--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -97,8 +97,16 @@ module TeacherInterface
       end
     end
 
+    def delete
+    end
+
     def destroy
-      @qualification.destroy!
+      if ActiveModel::Type::Boolean.new.cast(
+           params.dig(:qualification, :confirm)
+         )
+        @qualification.destroy!
+      end
+
       redirect_to %i[teacher_interface application_form qualifications]
     end
 

--- a/app/controllers/teacher_interface/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/work_histories_controller.rb
@@ -1,7 +1,7 @@
 module TeacherInterface
   class WorkHistoriesController < BaseController
     before_action :load_application_form
-    before_action :load_work_history, only: %i[edit update destroy]
+    before_action :load_work_history, only: %i[edit update delete destroy]
 
     def index
       unless application_form.task_item_started?(:work_history, :work_history)
@@ -79,8 +79,16 @@ module TeacherInterface
       end
     end
 
+    def delete
+    end
+
     def destroy
-      @work_history.destroy!
+      if ActiveModel::Type::Boolean.new.cast(
+           params.dig(:work_history, :confirm)
+         )
+        @work_history.destroy!
+      end
+
       redirect_to %i[teacher_interface application_form work_histories]
     end
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -151,6 +151,10 @@ class ApplicationForm < ApplicationRecord
     region.status_check_written? || region.sanction_check_written?
   end
 
+  def teaching_qualification
+    qualifications.ordered.first
+  end
+
   private
 
   def build_documents
@@ -201,8 +205,7 @@ class ApplicationForm < ApplicationRecord
   def qualifications_status
     return :not_started if qualifications.empty?
 
-    part_of_university_degree =
-      qualifications.ordered.first.part_of_university_degree
+    part_of_university_degree = teaching_qualification.part_of_university_degree
     if part_of_university_degree.nil? ||
          (!part_of_university_degree && qualifications.count == 1)
       return :in_progress

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -93,6 +93,12 @@ class Qualification < ApplicationRecord
     is_teaching_qualification? ? "teaching_qualification" : "university_degree"
   end
 
+  def summary_title
+    title.presence || institution_name.presence ||
+      institution_country.presence ||
+      I18n.t("application_form.qualifications.heading.title.#{locale_key}")
+  end
+
   private
 
   def build_documents

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -99,6 +99,16 @@ class Qualification < ApplicationRecord
       I18n.t("application_form.qualifications.heading.title.#{locale_key}")
   end
 
+  def can_delete?
+    return false if is_teaching_qualification?
+
+    part_of_university_degree =
+      application_form.teaching_qualification&.part_of_university_degree
+    return true if part_of_university_degree.nil? || part_of_university_degree
+
+    application_form.qualifications.ordered.second != self
+  end
+
   private
 
   def build_documents

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -65,4 +65,17 @@ class WorkHistory < ApplicationRecord
     application_form.work_histories.empty? ||
       application_form.work_histories.ordered.first == self
   end
+
+  def summary_title
+    school_name.presence || city.presence || country.presence || job.presence ||
+      I18n.t(
+        (
+          if current_or_most_recent_role?
+            "application_form.work_history.current_or_most_recent_role"
+          else
+            "application_form.work_history.previous_role"
+          end
+        )
+      )
+  end
 end

--- a/app/views/teacher_interface/qualifications/_summary.html.erb
+++ b/app/views/teacher_interface/qualifications/_summary.html.erb
@@ -40,6 +40,7 @@
         key: "Part of your university degree?",
         href: [:part_of_university_degree, :teacher_interface, :application_form, qualification]
       } : nil,
-    }
+    },
+    delete_link_to: qualification.can_delete? ? [:delete, :teacher_interface, :application_form, qualification] : nil,
   )) %>
 <% end %>

--- a/app/views/teacher_interface/qualifications/delete.html.erb
+++ b/app/views/teacher_interface/qualifications/delete.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, "Delete qualification" %>
+<% content_for :back_link_url, teacher_interface_application_form_qualifications_path %>
+
+<%= form_with model: [:teacher_interface, :application_form, @qualification], method: :delete do |f| %>
+  <%= f.govuk_collection_radio_buttons :confirm,
+                                       [OpenStruct.new(id: :true, name: "Yes"), OpenStruct.new(id: :false, name: "No")],
+                                       :id,
+                                       :name,
+                                       inline: true,
+                                       legend: { text: "Are you sure you want to delete #{@qualification.summary_title}?", size: "l", tag: "h1" } %>
+
+  <%= f.govuk_submit "Continue", prevent_double_click: false %>
+<% end %>

--- a/app/views/teacher_interface/work_histories/_form.html.erb
+++ b/app/views/teacher_interface/work_histories/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: [:teacher_interface, application_form, work_history] do |f| %>
-  <%= f.govuk_fieldset legend: { text: work_history.current_or_most_recent_role? ? "Your current or most recent role" : "Previous workplace" } do %>
+  <%= f.govuk_fieldset legend: { text: I18n.t(work_history.current_or_most_recent_role? ? "application_form.work_history.current_or_most_recent_role" : "application_form.work_history.previous_role") } do %>
     <%= f.govuk_text_field :school_name, label: { text: "School name" } %>
     <%= f.govuk_text_field :city, label: { text: "City" } %>
     <%= f.govuk_text_field :country, label: { text: "Country" } %>

--- a/app/views/teacher_interface/work_histories/_summary.html.erb
+++ b/app/views/teacher_interface/work_histories/_summary.html.erb
@@ -43,6 +43,7 @@
         format: :without_day,
         href: [:edit, :teacher_interface, :application_form, work_history]
       } : nil,
-    }
+    },
+    delete_link_to: [:delete, :teacher_interface, :application_form, work_history]
   )) %>
 <% end %>

--- a/app/views/teacher_interface/work_histories/_summary.html.erb
+++ b/app/views/teacher_interface/work_histories/_summary.html.erb
@@ -12,7 +12,7 @@
 <% work_histories.each do |work_history| %>
   <%= render(CheckYourAnswersSummaryComponent.new(
     model: work_history,
-    title: work_history.current_or_most_recent_role? ? "Your current or most recent role" : "Previous role",
+    title: I18n.t(work_history.current_or_most_recent_role? ? "application_form.work_history.current_or_most_recent_role" : "application_form.work_history.previous_role"),
     fields: {
       school_name: {
         href: [:edit, :teacher_interface, :application_form, work_history]

--- a/app/views/teacher_interface/work_histories/delete.html.erb
+++ b/app/views/teacher_interface/work_histories/delete.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, "Delete work history" %>
+<% content_for :back_link_url, teacher_interface_application_form_work_histories_path %>
+
+<%= form_with model: [:teacher_interface, :application_form, @work_history], method: :delete do |f| %>
+  <%= f.govuk_collection_radio_buttons :confirm,
+                                       [OpenStruct.new(id: :true, name: "Yes"), OpenStruct.new(id: :false, name: "No")],
+                                       :id,
+                                       :name,
+                                       inline: true,
+                                       legend: { text: "Are you sure you want to delete #{@work_history.summary_title}?", size: "l", tag: "h1" } %>
+
+  <%= f.govuk_submit "Continue", prevent_double_click: false %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,9 @@ en:
         work_history: Add your work history
         registration_number: Enter your registration number
         written_statement: Upload your written statement
+    work_history:
+      current_or_most_recent_role: Your current or most recent role
+      previous_role: Previous role
     qualifications:
       heading:
         title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,8 @@ Rails.application.routes.draw do
         end
 
         member do
+          get "delete"
+
           get "part_of_university_degree",
               to: "qualifications#edit_part_of_university_degree"
           post "part_of_university_degree",
@@ -106,6 +108,8 @@ Rails.application.routes.draw do
       resource :age_range, controller: :age_range, only: %i[show edit update]
 
       resources :work_histories, except: %i[show] do
+        get "delete", on: :member
+
         collection do
           get "add_another", to: "work_histories#add_another"
           post "add_another", to: "work_histories#submit_add_another"

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe CheckYourAnswersSummaryComponent, type: :component do
   subject(:component) do
-    render_inline(described_class.new(model:, title:, fields:))
+    render_inline(described_class.new(model:, title:, fields:, delete_link_to:))
   end
 
   let(:model) do
@@ -53,8 +53,20 @@ RSpec.describe CheckYourAnswersSummaryComponent, type: :component do
     }
   end
 
+  let(:delete_link_to) { nil }
+
   it "renders the title" do
     expect(component.css(".govuk-summary-list__card-title").text).to eq("Title")
+  end
+
+  describe "with a delete link" do
+    let(:delete_link_to) { "/delete" }
+
+    it "renders a link" do
+      a = component.at_css(".govuk-summary-list__card-actions a")
+      expect(a.text.strip).to eq("Delete")
+      expect(a.attribute("href").value).to eq("/delete")
+    end
   end
 
   describe "string row" do

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -120,4 +120,28 @@ RSpec.describe Qualification, type: :model do
       it { is_expected.to be true }
     end
   end
+
+  describe "#summary_title" do
+    subject(:summary_title) { qualification.summary_title }
+
+    it { is_expected.to eq("Your teaching qualification") }
+
+    context "with a title" do
+      before { qualification.title = "Title" }
+
+      it { is_expected.to eq("Title") }
+    end
+
+    context "with an institution name" do
+      before { qualification.institution_name = "Name" }
+
+      it { is_expected.to eq("Name") }
+    end
+
+    context "with an institution country" do
+      before { qualification.institution_country = "Country" }
+
+      it { is_expected.to eq("Country") }
+    end
+  end
 end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -144,4 +144,32 @@ RSpec.describe Qualification, type: :model do
       it { is_expected.to eq("Country") }
     end
   end
+
+  describe "#can_delete?" do
+    subject(:can_delete?) { qualification.can_delete? }
+
+    it { is_expected.to be false }
+
+    context "is a university degree" do
+      before { qualification.save! }
+
+      subject(:can_delete?) { second_qualification.can_delete? }
+
+      let(:second_qualification) do
+        create(:qualification, application_form: qualification.application_form)
+      end
+
+      context "with qualification part of degree" do
+        before { qualification.update!(part_of_university_degree: true) }
+
+        it { is_expected.to be true }
+      end
+
+      context "with qualification not part of degree" do
+        before { qualification.update!(part_of_university_degree: false) }
+
+        it { is_expected.to be false }
+      end
+    end
+  end
 end

--- a/spec/models/work_history_spec.rb
+++ b/spec/models/work_history_spec.rb
@@ -118,4 +118,34 @@ RSpec.describe WorkHistory, type: :model do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe "#summary_title" do
+    subject(:summary_title) { work_history.summary_title }
+
+    it { is_expected.to eq("Your current or most recent role") }
+
+    context "with a school name" do
+      before { work_history.school_name = "Name" }
+
+      it { is_expected.to eq("Name") }
+    end
+
+    context "with a city" do
+      before { work_history.city = "City" }
+
+      it { is_expected.to eq("City") }
+    end
+
+    context "with a country" do
+      before { work_history.country = "Country" }
+
+      it { is_expected.to eq("Country") }
+    end
+
+    context "with a job" do
+      before { work_history.job = "Job" }
+
+      it { is_expected.to eq("Job") }
+    end
+  end
 end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -320,6 +320,104 @@ RSpec.describe "Teacher application", type: :system do
     then_i_see_the_submitted_application_page
   end
 
+  it "allows deleting work history" do
+    given_an_eligible_eligibility_check_with_none_country_checks
+
+    when_i_click_apply_for_qts
+    and_i_sign_up
+    then_i_see_the_new_application_page
+    and_i_click_continue
+    then_i_see_the_active_application_page
+    and_i_see_the_work_history_is_not_started
+
+    when_i_click_work_history
+    then_i_see_the_has_work_history_form
+
+    when_i_fill_in_has_work_history
+    and_i_click_continue
+    then_i_see_the_work_history_form
+
+    when_i_fill_in_work_history
+    and_i_click_continue
+    then_i_see_the_work_history_summary
+
+    when_i_click_delete
+    then_i_see_delete_confirmation_form
+
+    when_i_choose_yes
+    and_i_click_continue
+    then_i_see_the_work_history_form
+  end
+
+  it "allows delete qualifications" do
+    given_an_eligible_eligibility_check_with_none_country_checks
+
+    when_i_click_apply_for_qts
+    and_i_sign_up
+    then_i_see_the_new_application_page
+    and_i_click_continue
+    then_i_see_the_active_application_page
+    and_i_see_the_work_history_is_not_started
+
+    when_i_click_qualifications
+    then_i_see_the_qualifications_form
+
+    when_i_fill_in_qualifications
+    and_i_click_continue
+    then_i_see_the_upload_certificate_form
+
+    when_i_fill_in_the_upload_certificate_form
+    and_i_click_continue
+    then_i_see_the_check_your_uploads
+
+    when_i_choose_no
+    and_i_click_continue
+    then_i_see_the_upload_transcript_form
+
+    when_i_fill_in_the_upload_transcript_form
+    and_i_click_continue
+    then_i_see_the_check_your_uploads
+
+    when_i_choose_no
+    and_i_click_continue
+
+    when_i_choose_yes
+    and_i_click_continue
+    then_i_see_the_qualifications_summary
+
+    when_i_click_continue
+    and_i_choose_yes
+    and_i_click_continue
+    then_i_see_the_degree_qualifications_form
+
+    when_i_fill_in_qualifications
+    and_i_click_continue
+    then_i_see_the_upload_degree_certificate_form
+
+    when_i_fill_in_the_upload_certificate_form
+    and_i_click_continue
+    then_i_see_the_check_your_uploads
+
+    when_i_choose_no
+    and_i_click_continue
+    then_i_see_the_upload_degree_transcript_form
+
+    when_i_fill_in_the_upload_transcript_form
+    and_i_click_continue
+    then_i_see_the_check_your_uploads
+
+    when_i_choose_no
+    and_i_click_continue
+    then_i_see_the_qualifications_summary
+
+    when_i_click_delete
+    then_i_see_delete_confirmation_form
+
+    when_i_choose_yes
+    and_i_click_continue
+    then_i_see_the_qualifications_summary
+  end
+
   private
 
   def when_i_click_apply_for_qts
@@ -448,6 +546,10 @@ RSpec.describe "Teacher application", type: :system do
     click_link "Upload your written statement"
   end
 
+  def when_i_click_delete
+    click_link "Delete"
+  end
+
   def when_i_fill_in_the_upload_written_statement_form
     attach_file "upload-attachment-field",
                 Rails.root.join(file_fixture("upload.pdf"))
@@ -536,6 +638,14 @@ RSpec.describe "Teacher application", type: :system do
     )
   end
 
+  def then_i_see_the_degree_qualifications_form
+    expect(page).to have_title("Your qualifications")
+    expect(page).to have_content("Your university degree")
+    expect(page).to have_content(
+      "Tell us about your university degree qualification."
+    )
+  end
+
   def then_i_see_the_upload_certificate_form
     expect(page).to have_title("Upload a document")
     expect(page).to have_content(
@@ -543,11 +653,21 @@ RSpec.describe "Teacher application", type: :system do
     )
   end
 
+  def then_i_see_the_upload_degree_certificate_form
+    expect(page).to have_title("Upload a document")
+    expect(page).to have_content("Upload your university degree certificate")
+  end
+
   def then_i_see_the_upload_transcript_form
     expect(page).to have_title("Upload a document")
     expect(page).to have_content(
       "Upload your teaching qualification transcript"
     )
+  end
+
+  def then_i_see_the_upload_degree_transcript_form
+    expect(page).to have_title("Upload a document")
+    expect(page).to have_content("Upload your university degree transcript")
   end
 
   def then_i_see_the_age_range_form
@@ -681,5 +801,10 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("Application complete")
     expect(page).to have_content("Your reference number")
     expect(page).to have_content(application_form.reference)
+  end
+
+  def then_i_see_delete_confirmation_form
+    expect(page).to have_title("Delete")
+    expect(page).to have_content("Are you sure you want to delete")
   end
 end


### PR DESCRIPTION
This adds the ability for users to delete work history and qualification entries from their application form, if they decide they no longer need them. For qualifications, it's not possible to delete the teaching qualification, or the university degree if it's separate.

[Trello Card](https://trello.com/c/wVLuCnOY/712-get-application-form-ready-for-user-research)

## Screenshots

<img width="681" alt="Screenshot 2022-08-08 at 08 32 30" src="https://user-images.githubusercontent.com/510498/183364663-ac9b8487-03f0-452f-95fb-f4fd40a1b0ff.png">
<img width="665" alt="Screenshot 2022-08-08 at 08 32 34" src="https://user-images.githubusercontent.com/510498/183364669-5b2ee974-81d4-46d3-9562-021bc168dce2.png">
