### PR TITLE
Move "Add another" question to separate page

### DIFF
--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -1,7 +1,8 @@
 module TeacherInterface
   class QualificationsController < BaseController
     before_action :load_application_form
-    before_action :load_qualification, except: %i[index new create]
+    before_action :load_qualification,
+                  except: %i[index new create add_another submit_add_another]
 
     def index
       @qualifications = application_form.qualifications.ordered
@@ -16,16 +17,6 @@ module TeacherInterface
     end
 
     def create
-      unless params.include?(:qualification)
-        if ActiveModel::Type::Boolean.new.cast(params[:add_another])
-          redirect_to %i[new teacher_interface application_form qualification]
-        else
-          redirect_to %i[teacher_interface application_form]
-        end
-
-        return
-      end
-
       @qualification = application_form.qualifications.new(qualification_params)
       if @qualification.save
         redirect_to_if_save_and_continue [
@@ -36,6 +27,17 @@ module TeacherInterface
                                          ]
       else
         render :new, status: :unprocessable_entity
+      end
+    end
+
+    def add_another
+    end
+
+    def submit_add_another
+      if ActiveModel::Type::Boolean.new.cast(params[:add_another])
+        redirect_to %i[new teacher_interface application_form qualification]
+      else
+        redirect_to %i[teacher_interface application_form]
       end
     end
 

--- a/app/controllers/teacher_interface/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/work_histories_controller.rb
@@ -20,6 +20,30 @@ module TeacherInterface
       end
     end
 
+    def new
+      @work_history = WorkHistory.new(application_form:)
+    end
+
+    def create
+      @work_history = application_form.work_histories.new(work_history_params)
+      if @work_history.save
+        redirect_to %i[teacher_interface application_form work_histories]
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def add_another
+    end
+
+    def submit_add_another
+      if ActiveModel::Type::Boolean.new.cast(params[:add_another])
+        redirect_to %i[new teacher_interface application_form work_history]
+      else
+        redirect_to %i[teacher_interface application_form]
+      end
+    end
+
     def edit_has_work_history
       @has_work_history_form =
         HasWorkHistoryForm.new(
@@ -41,29 +65,6 @@ module TeacherInterface
                                          ]
       else
         render :edit_has_work_history, status: :unprocessable_entity
-      end
-    end
-
-    def new
-      @work_history = WorkHistory.new(application_form:)
-    end
-
-    def create
-      unless params.include?(:work_history)
-        if ActiveModel::Type::Boolean.new.cast(params[:add_another])
-          redirect_to %i[new teacher_interface application_form work_history]
-        else
-          redirect_to [:teacher_interface, application_form]
-        end
-
-        return
-      end
-
-      @work_history = application_form.work_histories.new(work_history_params)
-      if @work_history.save
-        redirect_to %i[teacher_interface application_form work_histories]
-      else
-        render :new, status: :unprocessable_entity
       end
     end
 

--- a/app/views/teacher_interface/qualifications/add_another.html.erb
+++ b/app/views/teacher_interface/qualifications/add_another.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, I18n.t("application_form.qualifications.heading.caption") %>
+<% content_for :back_link_url, teacher_interface_application_form_path %>
+
+<%= form_with url: [:add_another, :teacher_interface, :application_form, :qualifications] do |f| %>
+  <%= f.govuk_radio_buttons_fieldset :add_another,
+                                     legend: { text: "Add another qualification?", tag: "h1", size: "l" },
+                                     hint: { text: "You can use the next section to tell us about additional degrees if you want to." } do %>
+    <%= f.govuk_radio_button :add_another, :true, label: { text: "Yes" } %>
+    <%= f.govuk_radio_button :add_another, :false, label: { text: "No" } %>
+  <% end %>
+
+  <%= f.govuk_submit "Continue", prevent_double_click: false %>
+<% end %>

--- a/app/views/teacher_interface/qualifications/index.html.erb
+++ b/app/views/teacher_interface/qualifications/index.html.erb
@@ -6,13 +6,4 @@
 
 <%= render "summary", application_form: @application_form, qualifications: @qualifications %>
 
-<%= form_with url: [:teacher_interface, :application_form, :qualifications] do |f| %>
-  <%= f.govuk_radio_buttons_fieldset :add_another,
-                                     legend: { text: "Add another qualification?" },
-                                     hint: { text: "You can use the next section to tell us about additional degrees if you want to." } do %>
-    <%= f.govuk_radio_button :add_another, "true", label: { text: "Yes" } %>
-    <%= f.govuk_radio_button :add_another, "false", label: { text: "No" } %>
-  <% end %>
-
-  <%= f.govuk_submit "Continue", prevent_double_click: false %>
-<% end %>
+<%= govuk_button_link_to "Continue", %i[add_another teacher_interface application_form qualifications] %>

--- a/app/views/teacher_interface/work_histories/add_another.html.erb
+++ b/app/views/teacher_interface/work_histories/add_another.html.erb
@@ -1,0 +1,12 @@
+<% content_for :page_title, "Your work history in education" %>
+<% content_for :back_link_url, teacher_interface_application_form_path %>
+
+<%= form_with url: [:add_another, :teacher_interface, :application_form, :work_histories] do |f| %>
+  <%= f.govuk_radio_buttons_fieldset :add_another,
+                                     legend: { text: "Add another workplace?", tag: "h1", size: "l" } do %>
+    <%= f.govuk_radio_button :add_another, :true, label: { text: "Yes" } %>
+    <%= f.govuk_radio_button :add_another, :false, label: { text: "No" } %>
+  <% end %>
+
+  <%= f.govuk_submit "Continue", prevent_double_click: false %>
+<% end %>

--- a/app/views/teacher_interface/work_histories/index.html.erb
+++ b/app/views/teacher_interface/work_histories/index.html.erb
@@ -6,14 +6,7 @@
 <%= render "summary", application_form: @application_form, work_histories: @work_histories %>
 
 <% if @application_form.has_work_history? %>
-  <%= form_with url: [:teacher_interface, :application_form, :work_histories] do |f| %>
-    <%= f.govuk_radio_buttons_fieldset :add_another, legend: { text: @work_histories.empty? ? "Add a workplace?" : "Add another workplace?" } do %>
-      <%= f.govuk_radio_button :add_another, "true", label: { text: "Yes" } %>
-      <%= f.govuk_radio_button :add_another, "false", label: { text: "No" } %>
-    <% end %>
-
-    <%= f.govuk_submit "Continue", prevent_double_click: false %>
-  <% end %>
+  <%= govuk_button_link_to "Continue", add_another_teacher_interface_application_form_work_histories_path %>
 <% else %>
   <%= govuk_button_link_to "Continue", teacher_interface_application_form_path %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,11 @@ Rails.application.routes.draw do
       end
 
       resources :qualifications, except: %i[show] do
+        collection do
+          get "add_another", to: "qualifications#add_another"
+          post "add_another", to: "qualifications#submit_add_another"
+        end
+
         member do
           get "part_of_university_degree",
               to: "qualifications#edit_part_of_university_degree"
@@ -102,6 +107,9 @@ Rails.application.routes.draw do
 
       resources :work_histories, except: %i[show] do
         collection do
+          get "add_another", to: "work_histories#add_another"
+          post "add_another", to: "work_histories#submit_add_another"
+
           get "has_work_history", to: "work_histories#edit_has_work_history"
           post "has_work_history", to: "work_histories#update_has_work_history"
         end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -76,7 +76,8 @@ RSpec.describe "Teacher application", type: :system do
     and_i_click_continue
     then_i_see_the_qualifications_summary
 
-    when_i_choose_no
+    when_i_click_continue
+    and_i_choose_no
     and_i_click_continue
     then_i_see_completed_qualifications_section
 
@@ -101,7 +102,8 @@ RSpec.describe "Teacher application", type: :system do
     and_i_click_continue
     then_i_see_the_work_history_summary
 
-    when_i_choose_no
+    when_i_click_continue
+    and_i_choose_no
     and_i_click_continue
     then_i_see_completed_work_history_section
 
@@ -182,7 +184,8 @@ RSpec.describe "Teacher application", type: :system do
     and_i_click_continue
     then_i_see_the_qualifications_summary
 
-    when_i_choose_no
+    when_i_click_continue
+    and_i_choose_no
     and_i_click_continue
     then_i_see_completed_qualifications_section
 
@@ -283,7 +286,8 @@ RSpec.describe "Teacher application", type: :system do
     and_i_click_continue
     then_i_see_the_qualifications_summary
 
-    when_i_choose_no
+    when_i_click_continue
+    and_i_choose_no
     and_i_click_continue
     then_i_see_completed_qualifications_section
 


### PR DESCRIPTION
Currently at the bottom of the work history and qualification summary page we've got a form asking the user if they'd like to add another, with a continue button.

After design and research we'd like to change this so instead the form appears on its own separate page after the user presses the continue button.

[Trello Card](https://trello.com/c/wVLuCnOY/712-get-application-form-ready-for-user-research)

## Screenshot

<img width="677" alt="Screenshot 2022-08-08 at 08 58 15" src="https://user-images.githubusercontent.com/510498/183369409-b1924bbf-80e4-44c0-9edb-58cfb2e1bb5f.png">
