### PR TITLE
Improve magic link authentication

### DIFF
--- a/app/controllers/teachers/magic_links_controller.rb
+++ b/app/controllers/teachers/magic_links_controller.rb
@@ -29,10 +29,6 @@ class Teachers::MagicLinksController < DeviseController
 
   private
 
-  def create_params
-    resource_params.permit(:email, :remember_me)
-  end
-
   def after_sign_in_path_for(resource)
     stored_location_for(resource) || teacher_interface_root_path
   end

--- a/app/controllers/teachers/registrations_controller.rb
+++ b/app/controllers/teachers/registrations_controller.rb
@@ -8,7 +8,7 @@ class Teachers::RegistrationsController < Devise::RegistrationsController
   def create
     if (resource = Teacher.find_by(email: sign_up_params[:email]))
       if resource.active_for_authentication?
-        resource.send_magic_link(sign_up_params[:remember_me])
+        resource.send_magic_link
       else
         resource.resend_confirmation_instructions
       end

--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -15,7 +15,7 @@ class Teachers::SessionsController < Devise::SessionsController
 
     if resource
       if resource.active_for_authentication?
-        resource.send_magic_link(resource_params[:remember_me])
+        resource.send_magic_link
       else
         resource.resend_confirmation_instructions
       end

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -29,6 +29,11 @@ class Teacher < ApplicationRecord
             },
             valid_for_notify: true
 
+  def send_magic_link(*)
+    token = Devise::Passwordless::LoginToken.encode(self)
+    send_devise_notification(:magic_link, token, {})
+  end
+
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later
   end

--- a/app/views/teachers/mailer/magic_link.text.erb
+++ b/app/views/teachers/mailer/magic_link.text.erb
@@ -2,6 +2,6 @@ Hello <%= @resource.email %>!
 
 You can login using the link below:
 
-<%= teacher_magic_link_url(Hash[@scope_name, {email: @resource.email, token: @token, remember_me: @remember_me}]) %>
+<%= teacher_magic_link_url(email: @resource.email, token: @token) %>
 
 Note that the link will expire in <%= Devise.passwordless_login_within.inspect %>.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -369,3 +369,12 @@ Devise.setup do |config|
   # each time you sign in, all existing magic links will be considered invalid.
   # config.passwordless_expire_old_tokens_on_sign_in = false
 end
+
+# As we only use magic link authentication for teachers, we don't need to unnecessarily
+# include the scope in the magic link URLs.
+# https://github.com/heartcombo/devise/blob/6d32d2447cc0f3739d9732246b5a5bde98d9e032/lib/devise/strategies/authenticatable.rb#L92-L95
+class Devise::Strategies::MagicLinkAuthenticatable
+  def params_auth_hash
+    params
+  end
+end

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe "Teacher authentication", type: :system do
     message = ActionMailer::Base.deliveries.last
     uri = URI.parse(URI.extract(message.body.to_s).second)
     expect(uri.path).to eq("/teacher/magic_link")
-    expect(uri.query).to include("teacher")
+    expect(uri.query).to include("token")
     visit "#{uri.path}?#{uri.query}"
   end
 


### PR DESCRIPTION
This improves our magic link authentication slightly and should resolve [this Sentry issue](https://sentry.io/organizations/dfe-teacher-services/issues/3490207408/?referrer=slack). See individual commits for more details.