### PR TITLE
Remove service_start feature

### DIFF
--- a/app/controllers/eligibility_interface/base_controller.rb
+++ b/app/controllers/eligibility_interface/base_controller.rb
@@ -25,8 +25,5 @@ module EligibilityInterface
     def current_namespace
       "eligibility"
     end
-
-    MUTUAL_RECOGNITION_URL =
-      "https://teacherservices.education.gov.uk/MutualRecognition/".freeze
   end
 end

--- a/app/controllers/eligibility_interface/finish_controller.rb
+++ b/app/controllers/eligibility_interface/finish_controller.rb
@@ -14,6 +14,9 @@ class EligibilityInterface::FinishController < EligibilityInterface::BaseControl
 
   private
 
+  MUTUAL_RECOGNITION_URL =
+    "https://teacherservices.education.gov.uk/MutualRecognition/".freeze
+
   def ensure_eligibility_check_status
     if eligibility_check.status != :eligibility
       redirect_to eligibility_interface_start_path

--- a/app/controllers/eligibility_interface/start_controller.rb
+++ b/app/controllers/eligibility_interface/start_controller.rb
@@ -1,10 +1,6 @@
 class EligibilityInterface::StartController < EligibilityInterface::BaseController
   def root
-    if FeatureFlag.active?(:service_start)
-      redirect_to eligibility_interface_start_url
-    else
-      redirect_to MUTUAL_RECOGNITION_URL, allow_other_host: true
-    end
+    redirect_to eligibility_interface_start_url
   end
 
   def show

--- a/app/models/feature_flag.rb
+++ b/app/models/feature_flag.rb
@@ -34,17 +34,8 @@ class FeatureFlag
     ]
   ].freeze
 
-  TEMPORARY_FEATURE_FLAGS = [
-    [
-      :service_start,
-      "Allow users to use the service, rather than being sent to the " \
-        "legacy mutual recognition site",
-      "Thomas Leese"
-    ]
-  ].freeze
-
   FEATURES =
-    (PERMANENT_SETTINGS + TEMPORARY_FEATURE_FLAGS)
+    PERMANENT_SETTINGS
       .to_h do |name, description, owner|
         [name, FeatureFlag.new(description:, name:, owner:)]
       end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -7,10 +7,6 @@ module SystemHelpers
     FeatureFlag.deactivate(:service_open)
   end
 
-  def given_the_service_is_startable
-    FeatureFlag.activate(:service_start)
-  end
-
   def given_the_service_allows_teacher_applications
     FeatureFlag.activate(:teacher_applications)
   end

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe "Eligibility check", type: :system do
   before do
     given_countries_exist
     given_the_service_is_open
-    given_the_service_can_be_started
   end
 
   it "happy path" do
@@ -170,13 +169,6 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the_qualifications_page
   end
 
-  it "service cannot be started" do
-    given_the_service_cannot_be_started
-    when_i_visit_the_start_page
-    then_i_do_not_see_the_start_page
-    then_i_see_the_legacy_service
-  end
-
   it "test user is disabled" do
     given_the_test_user_is_disabled
     when_i_visit_the_start_page
@@ -204,14 +196,6 @@ RSpec.describe "Eligibility check", type: :system do
     it = create(:country, code: "IT")
     create(:region, country: it, name: "Region")
     create(:region, country: it, name: "Other Region")
-  end
-
-  def given_the_service_cannot_be_started
-    FeatureFlag.deactivate(:service_start)
-  end
-
-  def given_the_service_can_be_started
-    FeatureFlag.activate(:service_start)
   end
 
   def when_i_choose_region

--- a/spec/system/support_interface/staff_spec.rb
+++ b/spec/system/support_interface/staff_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Staff support", type: :system do
   it "allows inviting a user" do
-    given_the_service_is_startable
     given_the_service_is_staff_http_basic_auth
 
     when_i_am_authorized_as_a_support_user

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe "Teacher application", type: :system do
   before do
     given_the_service_is_open
-    given_the_service_is_startable
     given_the_service_allows_teacher_applications
   end
 

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -1,10 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Teacher authentication", type: :system do
-  before do
-    given_the_service_is_open
-    given_the_service_is_startable
-  end
+  before { given_the_service_is_open }
 
   it "allows signing up and signing in" do
     given_countries_exist

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe "Teacher documents", type: :system do
   before do
     given_the_service_is_open
-    given_the_service_is_startable
     given_the_service_allows_teacher_applications
     given_an_active_application
   end


### PR DESCRIPTION
Since we're pretty far in with the launch of this service now, I don't think we need this feature anymore. This makes the review apps and local development easier as it means we don't have to enable this feature flag before being able to test the service.

Thanks @tvararu for prompting me to do this!