### PR TITLE
Disable flash messages for teachers

### DIFF
--- a/app/controllers/teachers/confirmations_controller.rb
+++ b/app/controllers/teachers/confirmations_controller.rb
@@ -10,7 +10,6 @@ class Teachers::ConfirmationsController < Devise::ConfirmationsController
     yield resource if block_given?
 
     if resource.errors.empty?
-      set_flash_message!(:notice, :confirmed)
       sign_in(resource)
       respond_with_navigational(resource) do
         redirect_to after_confirmation_path_for(resource_name, resource)

--- a/app/controllers/teachers/registrations_controller.rb
+++ b/app/controllers/teachers/registrations_controller.rb
@@ -25,6 +25,10 @@ class Teachers::RegistrationsController < Devise::RegistrationsController
 
   protected
 
+  def set_flash_message(*args, **kwargs)
+    # We want to disable the built-in Devise flash messages for teachers.
+  end
+
   def after_inactive_sign_up_path_for(_resource)
     teacher_check_email_path
   end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -85,7 +85,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Teacher authentication", type: :system do
     and_i_receive_a_teacher_confirmation_email
 
     when_i_visit_the_teacher_confirmation_email
-    then_i_see_successful_confirmation_message
+    then_i_see_successful_confirmation
 
     given_i_clear_my_session
 
@@ -140,9 +140,9 @@ RSpec.describe "Teacher authentication", type: :system do
     expect(page).to have_content("Check your email")
   end
 
-  def then_i_see_successful_confirmation_message
+  def then_i_see_successful_confirmation
     expect(page).to have_content(
-      "Your email address has been successfully confirmed."
+      "In which country are you currently recognised as a teacher?"
     )
   end
 


### PR DESCRIPTION
Devise sends a lot of flash messages which we don't want to see as they're not part of our designs. Unfortunately there isn't a way of turning these off with configuration, so we have to override methods.

We can't remove the locale strings as we still use these flash messages for the staff authentication which is closer to standard Devise.

I've also enabled paranoid mode for Devise which avoids leaking information about which email addresses we know about in the system.