### PR TITLE
Specify GOVUK_NOTIFY_TEMPLATE_ID_DEVISE in Terraform

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -11,6 +11,8 @@ locals {
     BIGQUERY_DATASET    = local.bigquery_dataset,
     BIGQUERY_TABLE_NAME = local.bigquery_table_name,
 
+    GOVUK_NOTIFY_TEMPLATE_ID_DEVISE = var.govuk_notify_template_id_devise,
+
     RAILS_SERVE_STATIC_FILES = "true"
 
     AZURE_STORAGE_ACCOUNT_NAME = azurerm_storage_account.forms.name,

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -93,6 +93,11 @@ variable "forms_storage_account_name" {
   default = null
 }
 
+variable "govuk_notify_template_id_devise" {
+  default = null
+  type    = string
+}
+
 variable "region_name" {
   default = "west europe"
   type    = string

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -5,5 +5,6 @@
   "paas_space": "tra-dev",
   "education_hostnames": ["dev"],
   "prometheus_app": "prometheus-tra-monitoring-dev",
-  "forms_storage_account_name": "s165d01afqtsformsdv"
+  "forms_storage_account_name": "s165d01afqtsformsdv",
+  "govuk_notify_template_id_devise": "a1ccbcf1-963d-41e3-b0ea-08e25d640ca7"
 }

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -5,6 +5,7 @@
   "paas_space": "tra-test",
   "education_hostnames": ["preprod"],
   "forms_storage_account_name": "s165t01afqtsformspp",
+  "govuk_notify_template_id_devise": "8331da6b-6e8a-4782-ab56-2a74200d51d2",
   "statuscake_alerts": {
     "tra-apply-for-qts-preprod": {
       "website_name": "apply-for-qts-in-england-preprod",

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -9,6 +9,7 @@
   "prometheus_app": "prometheus-tra-monitoring-prod",
   "forms_storage_account_name": "s165p01afqtsformspd",
   "forms_container_delete_retention_days": 30,
+  "govuk_notify_template_id_devise": "8331da6b-6e8a-4782-ab56-2a74200d51d2",
   "statuscake_alerts": {
     "tra-apply-for-qts-prod": {
       "website_name": "apply-for-qts-in-england-production",

--- a/terraform/workspace_variables/review.tfvars.json
+++ b/terraform/workspace_variables/review.tfvars.json
@@ -2,5 +2,6 @@
   "environment_name": "review",
   "key_vault_name": "s165d01-afqts-dv-kv",
   "resource_group_name": "s165d01-afqts-dv-rg",
-  "paas_space": "tra-dev"
+  "paas_space": "tra-dev",
+  "govuk_notify_template_id_devise": "a1ccbcf1-963d-41e3-b0ea-08e25d640ca7"
 }

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -5,6 +5,7 @@
   "paas_space": "tra-test",
   "education_hostnames": ["test"],
   "forms_storage_account_name": "s165t01afqtsformsts",
+  "govuk_notify_template_id_devise": "8331da6b-6e8a-4782-ab56-2a74200d51d2",
   "statuscake_alerts": {
     "tra-apply-for-qts-test": {
       "website_name": "apply-for-qts-in-england-test",


### PR DESCRIPTION
This sets the environment variable via Terraform so we can customise it. The dev and review environments are going to use a template where personalisation is visible in the logs, whereas the other environments will use one where personalisation is not visible. This ensures that we don't leak any secret tokens in the logs.

[Trello Card](https://trello.com/c/qQtrd0R2/726-dont-log-login-token)