### PR TITLE
Fix work_history back link

### DIFF
--- a/app/views/teacher_interface/work_histories/edit_has_work_history.html.erb
+++ b/app/views/teacher_interface/work_histories/edit_has_work_history.html.erb
@@ -1,5 +1,8 @@
 <% content_for :page_title, I18n.t("application_form.tasks.sections.work_history") %>
-<% content_for :back_link_url, teacher_interface_application_form_work_histories_path %>
+<% content_for :back_link_url,  @application_form.work_histories.empty? ?
+                                 teacher_interface_application_form_path :
+                                 teacher_interface_application_form_work_histories_path %>
+                                 
 
 <%= form_with model: @has_work_history_form, url: [:has_work_history, :teacher_interface, :application_form, :work_histories] do |f| %>
   <%= f.govuk_error_summary %>
@@ -12,4 +15,5 @@
                                        hint: { text: "If you’re a recent university graduate, or you've just completed your teacher training, you may not have held a professional teaching position yet." } %>
 
   <%= render "shared/save_submit_buttons", f: %>
+  
 <% end %>


### PR DESCRIPTION
Fix work_history back link in 'edit_has_work_history' by adding logic to check if the application_form is empty