### PR TITLE
Improve single question forms

### DIFF
--- a/app/controllers/teacher_interface/age_range_controller.rb
+++ b/app/controllers/teacher_interface/age_range_controller.rb
@@ -6,14 +6,14 @@ module TeacherInterface
       @age_range_form =
         AgeRangeForm.new(
           application_form:,
-          age_range_min: application_form.age_range_min,
-          age_range_max: application_form.age_range_max
+          minimum: application_form.age_range_min,
+          maximum: application_form.age_range_max
         )
     end
 
     def update
       @age_range_form =
-        AgeRangeForm.new(age_range_params.merge(application_form:))
+        AgeRangeForm.new(age_range_form_params.merge(application_form:))
       if @age_range_form.save
         redirect_to %i[teacher_interface application_form]
       else
@@ -23,10 +23,10 @@ module TeacherInterface
 
     private
 
-    def age_range_params
+    def age_range_form_params
       params.require(:teacher_interface_age_range_form).permit(
-        :age_range_min,
-        :age_range_max
+        :minimum,
+        :maximum
       )
     end
   end

--- a/app/controllers/teacher_interface/age_range_controller.rb
+++ b/app/controllers/teacher_interface/age_range_controller.rb
@@ -2,12 +2,6 @@ module TeacherInterface
   class AgeRangeController < BaseController
     before_action :load_application_form
 
-    def show
-      unless application_form.task_item_started?(:qualifications, :age_range)
-        redirect_to %i[edit teacher_interface application_form age_range]
-      end
-    end
-
     def edit
       @age_range_form =
         AgeRangeForm.new(
@@ -21,11 +15,7 @@ module TeacherInterface
       @age_range_form =
         AgeRangeForm.new(age_range_params.merge(application_form:))
       if @age_range_form.save
-        redirect_to_if_save_and_continue %i[
-                                           teacher_interface
-                                           application_form
-                                           age_range
-                                         ]
+        redirect_to %i[teacher_interface application_form]
       else
         render :edit, status: :unprocessable_entity
       end

--- a/app/controllers/teacher_interface/registration_number_controller.rb
+++ b/app/controllers/teacher_interface/registration_number_controller.rb
@@ -2,20 +2,6 @@ module TeacherInterface
   class RegistrationNumberController < BaseController
     before_action :load_application_form
 
-    def show
-      unless application_form.task_item_started?(
-               :proof_of_recognition,
-               :registration_number
-             )
-        redirect_to %i[
-                      edit
-                      teacher_interface
-                      application_form
-                      registration_number
-                    ]
-      end
-    end
-
     def edit
       @registration_number_form =
         RegistrationNumberForm.new(
@@ -27,14 +13,10 @@ module TeacherInterface
     def update
       @registration_number_form =
         RegistrationNumberForm.new(
-          registration_number_params.merge(application_form:)
+          registration_number_form_params.merge(application_form:)
         )
       if @registration_number_form.save
-        redirect_to_if_save_and_continue %i[
-                                           teacher_interface
-                                           application_form
-                                           registration_number
-                                         ]
+        redirect_to %i[teacher_interface application_form]
       else
         render :edit, status: :unprocessable_entity
       end
@@ -42,7 +24,7 @@ module TeacherInterface
 
     private
 
-    def registration_number_params
+    def registration_number_form_params
       params.require(:teacher_interface_registration_number_form).permit(
         :registration_number
       )

--- a/app/controllers/teacher_interface/subjects_controller.rb
+++ b/app/controllers/teacher_interface/subjects_controller.rb
@@ -2,12 +2,6 @@ module TeacherInterface
   class SubjectsController < BaseController
     before_action :load_application_form
 
-    def show
-      unless application_form.task_item_started?(:qualifications, :subjects)
-        redirect_to %i[edit teacher_interface application_form subjects]
-      end
-    end
-
     def edit
     end
 
@@ -17,9 +11,9 @@ module TeacherInterface
           application_form.subjects.push("")
           application_form.save!
 
-          redirect_to %i[edit teacher_interface application_form subjects]
+          redirect_to %i[subjects teacher_interface application_form]
         else
-          redirect_to %i[teacher_interface application_form subjects]
+          redirect_to %i[teacher_interface application_form]
         end
       else
         render :new, status: unprocessable_entity
@@ -30,7 +24,7 @@ module TeacherInterface
       application_form.subjects.delete_at(params[:index].to_i)
       application_form.save!
 
-      redirect_to %i[edit teacher_interface application_form subjects]
+      redirect_to %i[subjects teacher_interface application_form]
     end
 
     private

--- a/app/forms/teacher_interface/age_range_form.rb
+++ b/app/forms/teacher_interface/age_range_form.rb
@@ -1,36 +1,30 @@
 class TeacherInterface::AgeRangeForm
   include ActiveModel::Model
+  include ActiveModel::Attributes
 
   attr_accessor :application_form
-  attr_reader :age_range_min, :age_range_max
+  attribute :minimum, :integer
+  attribute :maximum, :integer
 
   validates :application_form, presence: true
-  validates :age_range_min,
+  validates :minimum,
             numericality: {
               only_integer: true,
               allow_nil: true,
               greater_than_or_equal_to: 0
             }
-  validates :age_range_max,
+  validates :maximum,
             numericality: {
               only_integer: true,
               allow_nil: true,
-              greater_than_or_equal_to: :age_range_min
+              greater_than_or_equal_to: :minimum
             }
-
-  def age_range_min=(value)
-    @age_range_min = ActiveModel::Type::Integer.new.cast(value)
-  end
-
-  def age_range_max=(value)
-    @age_range_max = ActiveModel::Type::Integer.new.cast(value)
-  end
 
   def save
     return false unless valid?
 
-    application_form.age_range_min = age_range_min
-    application_form.age_range_max = age_range_max
+    application_form.age_range_min = minimum
+    application_form.age_range_max = maximum
     application_form.save!
   end
 end

--- a/app/forms/teacher_interface/registration_number_form.rb
+++ b/app/forms/teacher_interface/registration_number_form.rb
@@ -3,7 +3,6 @@ class TeacherInterface::RegistrationNumberForm
   include ActiveModel::Attributes
 
   attr_accessor :application_form
-
   attribute :registration_number, :string
 
   validates :application_form, presence: true

--- a/app/views/teacher_interface/age_range/_summary.html.erb
+++ b/app/views/teacher_interface/age_range/_summary.html.erb
@@ -1,6 +1,6 @@
 <%= render(CheckYourAnswersSummaryComponent.new(
   model: application_form,
-  title: "Age range",
+  title: I18n.t("application_form.tasks.items.age_range"),
   fields: {
     age_range_min: {
       key: "Minimum age",

--- a/app/views/teacher_interface/age_range/_summary.html.erb
+++ b/app/views/teacher_interface/age_range/_summary.html.erb
@@ -1,10 +1,14 @@
-<%= render(CheckYourAnswersSummaryComponent.new(model: application_form, title: "Age range", fields: {
-  age_range_min: {
-    key: "Minimum age",
-    href: [:edit, :teacher_interface, :application_form, :age_range]
-  },
-  age_range_max: {
-    key: "Maximum age",
-    href: [:edit, :teacher_interface, :application_form, :age_range]
-  },
-})) %>
+<%= render(CheckYourAnswersSummaryComponent.new(
+  model: application_form,
+  title: "Age range",
+  fields: {
+    age_range_min: {
+      key: "Minimum age",
+      href: %i[age_range teacher_interface application_form]
+    },
+    age_range_max: {
+      key: "Maximum age",
+      href: %i[age_range teacher_interface application_form]
+    },
+  }
+)) %>

--- a/app/views/teacher_interface/age_range/edit.erb
+++ b/app/views/teacher_interface/age_range/edit.erb
@@ -6,9 +6,9 @@
 <p class="govuk-hint">Tell us about the age range of the children you’re qualified to teach. for example, from 5 to 11.</p>
 
 <%= form_with model: @age_range_form, url: %i[age_range teacher_interface application_form] do |f| %>
-  <%= f.govuk_number_field :age_range_min, width: 3, label: { text: "From" } %>
+  <%= f.govuk_number_field :minimum, width: 3, label: { text: "From" } %>
 
-  <%= f.govuk_number_field :age_range_max, width: 3, label: { text: "To" } %>
+  <%= f.govuk_number_field :maximum, width: 3, label: { text: "To" } %>
 
   <%= govuk_details(summary_text: "About age ranges and grades") do %>
     <p>

--- a/app/views/teacher_interface/age_range/edit.erb
+++ b/app/views/teacher_interface/age_range/edit.erb
@@ -5,7 +5,7 @@
 <h1 class="govuk-heading-l">What age range are you qualified to teach?</h1>
 <p class="govuk-hint">Tell us about the age range of the children you’re qualified to teach. for example, from 5 to 11.</p>
 
-<%= form_with model: @age_range_form, url: [:teacher_interface, :application_form, :age_range], method: :put do |f| %>
+<%= form_with model: @age_range_form, url: %i[age_range teacher_interface application_form] do |f| %>
   <%= f.govuk_number_field :age_range_min, width: 3, label: { text: "From" } %>
 
   <%= f.govuk_number_field :age_range_max, width: 3, label: { text: "To" } %>

--- a/app/views/teacher_interface/age_range/edit.erb
+++ b/app/views/teacher_interface/age_range/edit.erb
@@ -1,14 +1,14 @@
-<% content_for :page_title, "Age range" %>
+<% content_for :page_title, I18n.t("application_form.tasks.items.age_range") %>
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
-<span class="govuk-caption-l">Who you can teach</span>
-<h1 class="govuk-heading-l">What age range are you qualified to teach?</h1>
-<p class="govuk-hint">Tell us about the age range of the children you’re qualified to teach. for example, from 5 to 11.</p>
+<span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
+<h1 class="govuk-heading-l"><%= I18n.t("application_form.age_range.heading") %></h1>
+<p class="govuk-hint"><%= I18n.t("application_form.age_range.hint") %></p>
 
 <%= form_with model: @age_range_form, url: %i[age_range teacher_interface application_form] do |f| %>
-  <%= f.govuk_number_field :minimum, width: 3, label: { text: "From" } %>
+  <%= f.govuk_number_field :minimum, width: 3 %>
 
-  <%= f.govuk_number_field :maximum, width: 3, label: { text: "To" } %>
+  <%= f.govuk_number_field :maximum, width: 3 %>
 
   <%= govuk_details(summary_text: "About age ranges and grades") do %>
     <p>

--- a/app/views/teacher_interface/age_range/show.erb
+++ b/app/views/teacher_interface/age_range/show.erb
@@ -1,8 +1,0 @@
-<% content_for :page_title, "Check your answers" %>
-<% content_for :back_link_url, edit_teacher_interface_application_form_age_range_path %>
-
-<h1 class="govuk-heading-l">Check your answers</h1>
-
-<%= render "summary", application_form: @application_form %>
-
-<%= govuk_button_link_to "Continue", teacher_interface_application_form_path %>

--- a/app/views/teacher_interface/registration_number/_summary.html.erb
+++ b/app/views/teacher_interface/registration_number/_summary.html.erb
@@ -1,6 +1,9 @@
-<%= render(CheckYourAnswersSummaryComponent.new(model: application_form, title: "Registration number", fields: {
-  registration_number: {
-    key: "Registration number",
-    href: [:edit, :teacher_interface, application_form, :registration_number]
-  },
-})) %>
+<%= render(CheckYourAnswersSummaryComponent.new(
+  model: application_form,
+  title: I18n.t("application_form.tasks.items.registration_number"),
+  fields: {
+    registration_number: {
+      href: %i[registration_number teacher_interface application_form]
+    },
+  }
+)) %>

--- a/app/views/teacher_interface/registration_number/edit.html.erb
+++ b/app/views/teacher_interface/registration_number/edit.html.erb
@@ -1,10 +1,8 @@
-<% content_for :page_title, "Registration number" %>
+<% content_for :page_title, I18n.t("application_form.tasks.items.registration_number") %>
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
 <%= form_with model: @registration_number_form, url: %i[registration_number teacher_interface application_form] do |f| %>
-  <%= f.govuk_text_field :registration_number,
-                         label: { text: "What is your registration number?", size: "l", tag: "h1" },
-                        hint: { text: "Your country has an online register of teachers. If you have a reference number, enter it on this screen. If you do not have one, just select ‘Continue’." } %>
+  <%= f.govuk_text_field :registration_number, label: { size: "l", tag: "h1" } %>
 
   <%= govuk_details(summary_text: "When we might need more information") do %>
     <p>

--- a/app/views/teacher_interface/registration_number/edit.html.erb
+++ b/app/views/teacher_interface/registration_number/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "Registration number" %>
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
-<%= form_with model: @registration_number_form, url: [:teacher_interface, :application_form, :registration_number], method: :put do |f| %>
+<%= form_with model: @registration_number_form, url: %i[registration_number teacher_interface application_form] do |f| %>
   <%= f.govuk_text_field :registration_number,
                          label: { text: "What is your registration number?", size: "l", tag: "h1" },
                         hint: { text: "Your country has an online register of teachers. If you have a reference number, enter it on this screen. If you do not have one, just select ‘Continue’." } %>

--- a/app/views/teacher_interface/registration_number/show.html.erb
+++ b/app/views/teacher_interface/registration_number/show.html.erb
@@ -1,8 +1,0 @@
-<% content_for :page_title, "Check your answers" %>
-<% content_for :back_link_url, edit_teacher_interface_application_form_registration_number_path %>
-
-<h1 class="govuk-heading-l">Check your answers</h1>
-
-<%= render "summary", application_form: @application_form %>
-
-<%= govuk_button_link_to "Continue", teacher_interface_application_form_path %>

--- a/app/views/teacher_interface/subjects/_summary.html.erb
+++ b/app/views/teacher_interface/subjects/_summary.html.erb
@@ -1,9 +1,9 @@
 <%= render(CheckYourAnswersSummaryComponent.new(
   model: application_form,
-  title: "Subjects",
+  title: I18n.t("application_form.tasks.items.subjects"),
   fields: {
     subjects: {
-      href: [:edit, :teacher_interface, :application_form, :subjects]
+      href: %i[subjects teacher_interface application_form]
     },
   }
 )) %>

--- a/app/views/teacher_interface/subjects/edit.html.erb
+++ b/app/views/teacher_interface/subjects/edit.html.erb
@@ -2,8 +2,8 @@
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
-<h1 class="govuk-heading-l">What subjects are you qualified to teach?</h1>
-<p class="govuk-hint">You can enter up to three</p>
+<h1 class="govuk-heading-l"><%= I18n.t("application_form.subjects.heading") %></h1>
+<p class="govuk-hint"><%= I18n.t("application_form.subjects.hint") %></p>
 
 <%= form_with model: @application_form, url: %i[subjects teacher_interface application_form], method: :post do |f| %>
   <% if @application_form.subjects.empty? %>

--- a/app/views/teacher_interface/subjects/edit.html.erb
+++ b/app/views/teacher_interface/subjects/edit.html.erb
@@ -5,7 +5,7 @@
 <h1 class="govuk-heading-l">What subjects are you qualified to teach?</h1>
 <p class="govuk-hint">You can enter up to three</p>
 
-<%= form_with model: @application_form, url: [:teacher_interface, :application_form, :subjects], method: :put do |f| %>
+<%= form_with model: @application_form, url: %i[subjects teacher_interface application_form], method: :post do |f| %>
   <% if @application_form.subjects.empty? %>
     <%= f.govuk_text_field :subjects, multiple: true %>
   <% else %>
@@ -20,7 +20,7 @@
                          class: "govuk-input",
                          value: %>
         <% if index != 0 %>
-          <%= govuk_link_to "Remove", delete_teacher_interface_application_form_subjects_path(index:) %>
+          <%= govuk_link_to "Remove", subjects_delete_teacher_interface_application_form_path(index:) %>
         <% end %>
       </div>
     <% end %>

--- a/app/views/teacher_interface/subjects/show.html.erb
+++ b/app/views/teacher_interface/subjects/show.html.erb
@@ -1,8 +1,0 @@
-<% content_for :page_title, "Check your answers" %>
-<% content_for :back_link_url, edit_teacher_interface_application_form_subjects_path %>
-
-<h1 class="govuk-heading-l">Check your answers</h1>
-
-<%= render "summary", application_form: @application_form %>
-
-<%= govuk_button_link_to "Continue", teacher_interface_application_form_path %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,9 @@ en:
     age_range:
       heading: What age range are you qualified to teach?
       hint: Tell us about the age range of the children you’re qualified to teach. for example, from 5 to 11.
+    subjects:
+      heading: What subjects are you qualified to teach?
+      hint: You can enter up to three.
     work_history:
       current_or_most_recent_role: Your current or most recent role
       previous_role: Previous role

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -26,9 +26,6 @@ en:
         work_history: Add your work history
         registration_number: Enter your registration number
         written_statement: Upload your written statement
-    work_history:
-      current_or_most_recent_role: Your current or most recent role
-      previous_role: Previous role
     qualifications:
       heading:
         title:
@@ -66,6 +63,12 @@ en:
             teaching_qualification: Upload your teaching qualification transcript
             university_degree: Upload your university degree transcript
           description: Upload a transcript of your teaching qualification, issued by the awarding body. If your teaching qualification was completed as part of your degree, you should supply your degree transcript.
+    age_range:
+      heading: What age range are you qualified to teach?
+      hint: Tell us about the age range of the children you’re qualified to teach. for example, from 5 to 11.
+    work_history:
+      current_or_most_recent_role: Your current or most recent role
+      previous_role: Previous role
 
   document:
     document_type:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -21,6 +21,9 @@ en:
           false: "No"
         alternative_given_names: Alternate given names
         alternative_family_name: Alternate family name
+      teacher_interface_age_range_form:
+        minimum: From
+        maximum: To
       work_history:
         add_another_options:
           true: "Yes"

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -8,6 +8,8 @@ en:
         has_alternative_name: If your name appears differently on your ID documents or qualifications you need to upload proof of your name change, for example, your marriage or civil partnership certificate.
         alternative_given_names: Enter your full name apart from your family name
         alternative_family_name: Enter just your family name
+      teacher_interface_registration_number_form:
+        registration_number: Your country has an online register of teachers. If you have a reference number, enter it on this screen. If you do not have one, just select ‘Continue’.
       work_history:
         add_another: You can use the next section to tell us about additional work history.
     label:
@@ -24,6 +26,8 @@ en:
       teacher_interface_age_range_form:
         minimum: From
         maximum: To
+      teacher_interface_registration_number_form:
+        registration_number: What is your registration number?
       work_history:
         add_another_options:
           true: "Yes"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -112,6 +112,9 @@ Rails.application.routes.draw do
         get "subjects", to: "subjects#edit"
         post "subjects", to: "subjects#update"
         get "subjects/delete", to: "subjects#delete"
+
+        get "registration_number", to: "registration_number#edit"
+        post "registration_number", to: "registration_number#update"
       end
 
       resources :work_histories, except: %i[show] do
@@ -125,10 +128,6 @@ Rails.application.routes.draw do
           post "has_work_history", to: "work_histories#update_has_work_history"
         end
       end
-
-      resource :registration_number,
-               controller: :registration_number,
-               only: %i[show edit update]
 
       resources :documents, only: %i[edit update] do
         resources :uploads, only: %i[new create destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,10 +108,10 @@ Rails.application.routes.draw do
       member do
         get "age_range", to: "age_range#edit"
         post "age_range", to: "age_range#update"
-      end
 
-      resource :subjects, only: %i[show edit update] do
-        get "delete"
+        get "subjects", to: "subjects#edit"
+        post "subjects", to: "subjects#update"
+        get "subjects/delete", to: "subjects#delete"
       end
 
       resources :work_histories, except: %i[show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,7 +105,10 @@ Rails.application.routes.draw do
         end
       end
 
-      resource :age_range, controller: :age_range, only: %i[show edit update]
+      member do
+        get "age_range", to: "age_range#edit"
+        post "age_range", to: "age_range#update"
+      end
 
       resource :subjects, only: %i[show edit update] do
         get "delete"

--- a/spec/forms/teacher_interface/age_range_form_spec.rb
+++ b/spec/forms/teacher_interface/age_range_form_spec.rb
@@ -10,29 +10,33 @@ RSpec.describe TeacherInterface::AgeRangeForm, type: :model do
   describe "#valid?" do
     subject(:valid?) { form.valid? }
 
-    let(:form) do
-      described_class.new(application_form:, age_range_min:, age_range_max:)
-    end
-    let(:age_range_min) { "" }
-    let(:age_range_max) { "" }
+    let(:form) { described_class.new(application_form:, minimum:, maximum:) }
 
-    it { is_expected.to be_truthy }
+    context "when the fields are blank" do
+      let(:minimum) { "" }
+      let(:maximum) { "" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when the fields are numbers" do
+      let(:minimum) { "7" }
+      let(:maximum) { "11" }
+
+      it { is_expected.to be true }
+    end
 
     context "when age range max is less than age range min" do
-      let(:age_range_min) { "11" }
-      let(:age_range_max) { "7" }
+      let(:minimum) { "11" }
+      let(:maximum) { "7" }
 
-      it { is_expected.to be_falsy }
+      it { is_expected.to be false }
     end
   end
 
   describe "#save" do
     let(:form) do
-      described_class.new(
-        application_form:,
-        age_range_min: 7,
-        age_range_max: 11
-      )
+      described_class.new(application_form:, minimum: 7, maximum: 11)
     end
 
     before { form.save }

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -92,9 +92,6 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_subjects
     and_i_click_continue
-    then_i_see_the_subjects_summary
-
-    when_i_click_continue
     then_i_see_completed_subjects_section
 
     when_i_click_work_history
@@ -207,9 +204,6 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_subjects
     and_i_click_continue
-    then_i_see_the_subjects_summary
-
-    when_i_click_continue
     then_i_see_completed_subjects_section
 
     when_i_click_registration_number
@@ -316,9 +310,6 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_subjects
     and_i_click_continue
-    then_i_see_the_subjects_summary
-
-    when_i_click_continue
     then_i_see_completed_subjects_section
 
     when_i_click_written_statement
@@ -458,9 +449,6 @@ RSpec.describe "Teacher application", type: :system do
     when_i_click_remove
     then_i_see_the_subjects_form
     and_i_click_continue
-    then_i_see_the_subjects_summary
-
-    when_i_click_continue
     then_i_see_completed_subjects_section
   end
 
@@ -812,11 +800,6 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("Enter the age range you can teach\nCOMPLETED")
   end
 
-  def then_i_see_the_subjects_summary
-    expect(page).to have_content("Check your answers")
-    expect(page).to have_content("Subjects\tSubject")
-  end
-
   def then_i_see_completed_subjects_section
     expect(page).to have_content("Enter the subjects you can teach\nCOMPLETED")
   end
@@ -861,6 +844,7 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("Who you can teach")
     expect(page).to have_content("Minimum age\t7")
     expect(page).to have_content("Maximum age\t11")
+    expect(page).to have_content("Subjects\tSubject")
     expect(page).to have_content("Your teaching qualification")
   end
 

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -753,7 +753,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def then_i_see_the_registration_number_form
-    expect(page).to have_title("Registration number")
+    expect(page).to have_title("Enter your registration number")
     expect(page).to have_content("What is your registration number?")
   end
 

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -211,14 +211,12 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_registration_number
     and_i_click_continue
-    then_i_see_the_registration_number_summary
-
-    when_i_click_continue
     then_i_see_completed_registration_number_section
 
     when_i_click_check_your_answers
     then_i_see_the_check_your_answers_page
     and_i_see_check_proof_of_recognition
+    and_i_see_check_registration_number
 
     when_i_click_submit
     then_i_see_the_submitted_application_page
@@ -822,11 +820,6 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("Add your work history\nCOMPLETED")
   end
 
-  def then_i_see_the_registration_number_summary
-    expect(page).to have_content("Registration number")
-    expect(page).to have_content("Registration number\tABC")
-  end
-
   def then_i_see_completed_registration_number_section
     expect(page).to have_content("Enter your registration number\nCOMPLETED")
   end
@@ -854,6 +847,11 @@ RSpec.describe "Teacher application", type: :system do
 
   def and_i_see_check_proof_of_recognition
     expect(page).to have_content("Proof that you’re recognised as a teacher")
+  end
+
+  def and_i_see_check_registration_number
+    expect(page).to have_content("Registration number")
+    expect(page).to have_content("Registration number\tABC")
   end
 
   def then_i_see_the_submitted_application_page

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -560,8 +560,8 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_fill_in_age_range
-    fill_in "teacher-interface-age-range-form-age-range-min-field", with: "7"
-    fill_in "teacher-interface-age-range-form-age-range-max-field", with: "11"
+    fill_in "teacher-interface-age-range-form-minimum-field", with: "7"
+    fill_in "teacher-interface-age-range-form-maximum-field", with: "11"
   end
 
   def when_i_click_subjects

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -735,8 +735,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def then_i_see_the_age_range_form
-    expect(page).to have_title("Age range")
-    expect(page).to have_content("Who you can teach")
+    expect(page).to have_title("Enter the age range you can teach")
     expect(page).to have_content("What age range are you qualified to teach?")
     expect(page).to have_content("From")
     expect(page).to have_content("To")

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -85,9 +85,6 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_age_range
     and_i_click_continue
-    then_i_see_the_age_range_summary
-
-    when_i_click_continue
     then_i_see_completed_age_range_section
 
     when_i_click_subjects
@@ -203,9 +200,6 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_age_range
     and_i_click_continue
-    then_i_see_the_age_range_summary
-
-    when_i_click_continue
     then_i_see_completed_age_range_section
 
     when_i_click_subjects
@@ -315,9 +309,6 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_age_range
     and_i_click_continue
-    then_i_see_the_age_range_summary
-
-    when_i_click_continue
     then_i_see_completed_age_range_section
 
     when_i_click_subjects
@@ -818,12 +809,6 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("Add your teaching qualifications\nCOMPLETED")
   end
 
-  def then_i_see_the_age_range_summary
-    expect(page).to have_content("Check your answers")
-    expect(page).to have_content("Minimum age\t7")
-    expect(page).to have_content("Maximum age\t11")
-  end
-
   def then_i_see_completed_age_range_section
     expect(page).to have_content("Enter the age range you can teach\nCOMPLETED")
   end
@@ -875,6 +860,8 @@ RSpec.describe "Teacher application", type: :system do
     )
     expect(page).to have_content("About you")
     expect(page).to have_content("Who you can teach")
+    expect(page).to have_content("Minimum age\t7")
+    expect(page).to have_content("Maximum age\t11")
     expect(page).to have_content("Your teaching qualification")
   end
 


### PR DESCRIPTION
This makes a few changes to improve the single question forms. Specifically, it removes the "Check your answers" page for the individual questions as they're not part of the design, and moves hard coded strings in to locale files.

[Trello Card](https://trello.com/c/fhqwhs5i/730-personal-the-link-should-open-the-form-if-the-section-is-in-progress-not-the-confirmation-page)