### PR TITLE
Add translation rows to check summary

### DIFF
--- a/app/components/check_your_answers_summary_component.html.erb
+++ b/app/components/check_your_answers_summary_component.html.erb
@@ -17,11 +17,11 @@
     <dl class="govuk-summary-list">
       <% rows.each do |row| %>
         <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key"><%= row.fetch(:key) %></dt>
+          <dt class="govuk-summary-list__key"><%= row.fetch(:title) %></dt>
           <dd class="govuk-summary-list__value"><%= row.fetch(:value) %></dd>
           <dd class="govuk-summary-list__actions">
             <%= govuk_link_to(row.fetch(:href)) do %>
-              Change <span class="govuk-visually-hidden"><%= row.fetch(:key).downcase %></span>
+              Change <span class="govuk-visually-hidden"><%= row.fetch(:title).downcase %></span>
             <% end %>
           </dd>
         </div>

--- a/app/views/teacher_interface/age_range/_summary.html.erb
+++ b/app/views/teacher_interface/age_range/_summary.html.erb
@@ -3,11 +3,11 @@
   title: I18n.t("application_form.tasks.items.age_range"),
   fields: {
     age_range_min: {
-      key: "Minimum age",
+      title: "Minimum age",
       href: %i[age_range teacher_interface application_form]
     },
     age_range_max: {
-      key: "Maximum age",
+      title: "Maximum age",
       href: %i[age_range teacher_interface application_form]
     },
   }

--- a/app/views/teacher_interface/identity_document/_summary.html.erb
+++ b/app/views/teacher_interface/identity_document/_summary.html.erb
@@ -1,6 +1,6 @@
 <%= render(CheckYourAnswersSummaryComponent.new(model: application_form, title: "Identity documents", fields: {
   identification_document: {
-    key: "Identity documents",
+    title: "Identity documents",
     href: [:edit, :teacher_interface, application_form, application_form.identification_document]
   },
 })) %>

--- a/app/views/teacher_interface/personal_information/_summary.html.erb
+++ b/app/views/teacher_interface/personal_information/_summary.html.erb
@@ -9,7 +9,7 @@
     href: [:name_and_date_of_birth, :teacher_interface, application_form, :personal_information]
   },
   has_alternative_name: {
-    key: "Name appears differently on your ID documents or qualifications?",
+    title: "Name appears differently on your ID documents or qualifications?",
     href: [:alternative_name, :teacher_interface, application_form, :personal_information]
   },
   alternative_given_names: application_form.has_alternative_name? ? {

--- a/app/views/teacher_interface/qualifications/_summary.html.erb
+++ b/app/views/teacher_interface/qualifications/_summary.html.erb
@@ -4,40 +4,40 @@
     title: I18n.t("application_form.qualifications.heading.title.#{qualification.locale_key}"),
     fields: {
       title: {
-        key: I18n.t("application_form.qualifications.form.fields.title.#{qualification.locale_key}"),
+        title: I18n.t("application_form.qualifications.form.fields.title.#{qualification.locale_key}"),
         href: [:edit, :teacher_interface, :application_form, qualification]
       },
       institution_name: {
-        key: I18n.t("application_form.qualifications.form.fields.institution_name"),
+        title: I18n.t("application_form.qualifications.form.fields.institution_name"),
         href: [:edit, :teacher_interface, :application_form, qualification]
       },
       institution_country: {
-        key: I18n.t("application_form.qualifications.form.fields.institution_country"),
+        title: I18n.t("application_form.qualifications.form.fields.institution_country"),
         href: [:edit, :teacher_interface, :application_form, qualification]
       },
       start_date: {
-        key: I18n.t("application_form.qualifications.form.fields.start_date.#{qualification.locale_key}"),
+        title: I18n.t("application_form.qualifications.form.fields.start_date.#{qualification.locale_key}"),
         format: :without_day,
         href: [:edit, :teacher_interface, :application_form, qualification]
       },
       complete_date: {
-        key: I18n.t("application_form.qualifications.form.fields.complete_date.#{qualification.locale_key}"),
+        title: I18n.t("application_form.qualifications.form.fields.complete_date.#{qualification.locale_key}"),
         format: :without_day,
         href: [:edit, :teacher_interface, :application_form, qualification]
       },
       certificate_date: {
-        key: I18n.t("application_form.qualifications.form.fields.certificate_date.#{qualification.locale_key}"),
+        title: I18n.t("application_form.qualifications.form.fields.certificate_date.#{qualification.locale_key}"),
         format: :without_day,
         href: [:edit, :teacher_interface, :application_form, qualification]
       },
       certificate_document: {
-        href: [:edit, :teacher_interface, :application_form, qualification.certificate_document]
+        href: [:edit, :teacher_interface, :application_form, qualification.certificate_document],
       },
       transcript_document: {
-        href: [:edit, :teacher_interface, :application_form, qualification.transcript_document]
+        href: [:edit, :teacher_interface, :application_form, qualification.transcript_document],
       },
       part_of_university_degree: qualification.is_teaching_qualification? ? {
-        key: "Part of your university degree?",
+        title: "Part of your university degree?",
         href: [:part_of_university_degree, :teacher_interface, :application_form, qualification]
       } : nil,
     },

--- a/app/views/teacher_interface/work_histories/_summary.html.erb
+++ b/app/views/teacher_interface/work_histories/_summary.html.erb
@@ -3,7 +3,7 @@
   title: "Work history",
   fields: {
     has_work_history: {
-      key: "Have you worked professionally as a teacher?",
+      title: "Have you worked professionally as a teacher?",
       href: [:has_work_history, :teacher_interface, application_form, :work_histories]
     },
   }
@@ -18,28 +18,28 @@
         href: [:edit, :teacher_interface, :application_form, work_history]
       },
       city: {
-        key: "City of institution",
+        title: "City of institution",
         href: [:edit, :teacher_interface, :application_form, work_history]
       },
       country: {
-        key: "Country of institution",
+        title: "Country of institution",
         href: [:edit, :teacher_interface, :application_form, work_history]
       },
       job: {
-        key: "Your job role",
+        title: "Your job role",
         href: [:edit, :teacher_interface, :application_form, work_history]
       },
       email: {
-        key: "Contact email address",
+        title: "Contact email address",
         href: [:edit, :teacher_interface, :application_form, work_history]
       },
       start_date: {
-        key: "Role start date",
+        title: "Role start date",
         format: :without_day,
         href: [:edit, :teacher_interface, :application_form, work_history]
       },
       end_date: work_history.still_employed ? {
-        key: "Role end date",
+        title: "Role end date",
         format: :without_day,
         href: [:edit, :teacher_interface, :application_form, work_history]
       } : nil,

--- a/app/views/teacher_interface/written_statement/_summary.html.erb
+++ b/app/views/teacher_interface/written_statement/_summary.html.erb
@@ -1,6 +1,6 @@
 <%= render(CheckYourAnswersSummaryComponent.new(model: application_form, title: "Written statement", fields: {
   identification_document: {
-    key: "Written statement",
+    title: "Written statement",
     href: [:edit, :teacher_interface, application_form, application_form.written_statement_document]
   },
 })) %>

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -17,8 +17,13 @@ RSpec.describe CheckYourAnswersSummaryComponent, type: :component do
       nil_value: nil,
       boolean: true,
       document: create(:document, :with_upload),
-      array: %w[a b c]
+      array: %w[a b c],
+      translatable_document:
     )
+  end
+
+  let(:translatable_document) do
+    create(:document, :translatable, :with_translation, :with_upload)
   end
 
   let(:title) { "Title" }
@@ -39,7 +44,7 @@ RSpec.describe CheckYourAnswersSummaryComponent, type: :component do
         href: "/date_without_day"
       },
       custom_key: {
-        key: "A custom key",
+        title: "A custom key",
         href: "/custom_key"
       },
       nil_value: {
@@ -53,6 +58,9 @@ RSpec.describe CheckYourAnswersSummaryComponent, type: :component do
       },
       array: {
         href: "/array"
+      },
+      translatable_document: {
+        href: "/translatable-document"
       }
     }
   end
@@ -251,6 +259,64 @@ RSpec.describe CheckYourAnswersSummaryComponent, type: :component do
 
       expect(a.text.strip).to eq("Change array")
       expect(a.attribute("href").value).to eq("/array")
+    end
+  end
+
+  describe "translatable row" do
+    describe "original document row" do
+      subject(:row) { component.css(".govuk-summary-list__row")[9] }
+
+      it "renders the key" do
+        expect(row.at_css(".govuk-summary-list__key").text).to eq(
+          "Translatable document"
+        )
+      end
+
+      it "renders the value" do
+        expect(row.at_css(".govuk-summary-list__value").text).to eq(
+          "upload.pdf"
+        )
+      end
+
+      it "renders the change link" do
+        a = row.at_css(".govuk-summary-list__actions .govuk-link")
+
+        expect(a.text.strip).to eq("Change translatable document")
+        expect(a.attribute("href").value).to eq("/translatable-document")
+      end
+    end
+
+    describe "translated row" do
+      subject(:row) { component.css(".govuk-summary-list__row")[10] }
+
+      it "renders the translation title" do
+        expect(row.at_css(".govuk-summary-list__key").text).to eq(
+          "Translatable document translation"
+        )
+      end
+
+      it "renders the value" do
+        expect(row.at_css(".govuk-summary-list__value").text).to eq(
+          "translation_upload.pdf"
+        )
+      end
+
+      it "renders the change link" do
+        a = row.at_css(".govuk-summary-list__actions .govuk-link")
+
+        expect(a.text.strip).to eq("Change translatable document translation")
+        expect(a.attribute("href").value).to eq("/translatable-document")
+      end
+    end
+
+    context "when the translatable document doesn't have any translations" do
+      let(:translatable_document) do
+        create(:document, :translatable, :with_upload)
+      end
+
+      it "does not add a translation row" do
+        expect(component).not_to match(/Translatable document translation/)
+      end
     end
   end
 end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -26,5 +26,11 @@ FactoryBot.define do
     trait :with_upload do
       after(:create) { |document, _evaluator| create(:upload, document:) }
     end
+
+    trait :with_translation do
+      after(:create) do |document, _evaluator|
+        create(:upload, :translation, document:)
+      end
+    end
   end
 end

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -19,6 +19,7 @@
 FactoryBot.define do
   factory :upload do
     association :document
+
     attachment do
       Rack::Test::UploadedFile.new(
         "spec/fixtures/files/upload.pdf",
@@ -29,6 +30,12 @@ FactoryBot.define do
 
     trait :translation do
       translation { true }
+      attachment do
+        Rack::Test::UploadedFile.new(
+          "spec/fixtures/files/translation_upload.pdf",
+          "application/pdf"
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

When a document is uploaded we allow the user to provide a translated version. So 'some' documents may also have a translation.

We need to display these in the `CheckYourAnswersSummaryComponent` as a separate row.

### Changes

* Check document type fields in `CheckYourAnswersSummaryComponent` and add a translation row to the output.
* Don't add a row if the document has no translations

### Review

* Run and add some translations. 
* Added translations should appear in the summary. 
* Deleting a translation file should remove the row from the summary. 
* Documents without a translation should not have an extra row

<img width="675" alt="Screenshot 2022-08-11 at 11 28 47" src="https://user-images.githubusercontent.com/5216/184114551-ceb0f126-6481-462e-a84d-46054510b4b6.png">

