### PR TITLE
Move "Providing certified translations" in to an accordion

### DIFF
--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -111,26 +111,26 @@
       <% end %>
     <% end %>
 
+    <% accordion.section(heading_text: "4. Certified translations") do %>
+      <p class="govuk-body">If your documents are not written in English, you must provide certified translations (at your own cost) for your:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>qualifications</li>
+        <li>transcripts</li>
+        <li>proof that you’re recognised as a teacher.</li>
+      </ul>
+      <p class="govuk-body">You do not need translations for ID or change of name documents.</p>
+
+      <h3 class="govuk-heading-s">About certified translations</h3>
+      <p class="govuk-body">Translations must be carried out by a certified translator, who must state (on the document or a separate certification page) that the translation is a true, accurate and correct rendering of the original.</p>
+      <p class="govuk-body">Each one must include the date of the translation as well as the certified translator’s:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>signature</li>
+        <li>name and contact details</li>
+        <li>official certification seal/stamp or ID number.</li>
+      </ul>
+
+      <h3 class="govuk-heading-s">Finding a certified translator</h3>
+      <p class="govuk-body">We cannot recommend translation providers. You may want to explore translators who are members of the <a href="http://www.iti.org.uk/component/itisearch/?view=translators" class="govuk-link" rel="noreferrer noopener" target="_blank">Institute of Translating and Interpretation (opens in a new tab)</a>. Sometimes a university’s language department can also help.</p>
+    <% end %>
   <% end %>
 <% end %>
-
-<h2 class="govuk-heading-m">Providing certified translations</h2>
-<p class="govuk-body">If your documents are not written in English, you must provide certified translations (at your own cost) for your:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>qualifications</li>
-  <li>transcripts</li>
-  <li>proof that you’re recognised as a teacher.</li>
-</ul>
-<p class="govuk-body">You do not need translations for ID or change of name documents.</p>
-
-<h3 class="govuk-heading-s">About certified translations</h3>
-<p class="govuk-body">Translations must be carried out by a certified translator, who must state (on the document or a separate certification page) that the translation is a true, accurate and correct rendering of the original.</p>
-<p class="govuk-body">Each one must include the date of the translation as well as the certified translator’s:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>signature</li>
-  <li>name and contact details</li>
-  <li>official certification seal/stamp or ID number.</li>
-</ul>
-
-<h3 class="govuk-heading-s">Finding a certified translator</h3>
-<p class="govuk-body">We cannot recommend translation providers. You may want to explore translators who are members of the <a href="http://www.iti.org.uk/component/itisearch/?view=translators" class="govuk-link" rel="noreferrer noopener" target="_blank">Institute of Translating and Interpretation (opens in a new tab)</a>. Sometimes a university’s language department can also help.</p>

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "Countries support", type: :system do
     expect(page).to have_title("Preview California")
     expect(page).to have_content("You’re eligible to apply")
     expect(page).to have_content("Preparing to apply")
-    expect(page).to have_content("Providing certified translations")
+    expect(page).to have_content("Certified translations")
   end
 
   def when_i_fill_regions


### PR DESCRIPTION
The eligible page is already pretty long so we want to move this bit of text in to its own collapsible accordion. The change has been approved by our content designer.

## Screenshots

![Screenshot 2022-08-11 at 11 26 52](https://user-images.githubusercontent.com/510498/184114795-c9277b47-65e5-4600-a018-ba3948930c1b.png)
![Screenshot 2022-08-11 at 11 26 57](https://user-images.githubusercontent.com/510498/184114799-e5730407-4115-4bfc-a90b-45c482e531ec.png)
