### PR TITLE
Don't upload name change if not required

### DIFF
--- a/app/controllers/teacher_interface/personal_information_controller.rb
+++ b/app/controllers/teacher_interface/personal_information_controller.rb
@@ -59,12 +59,7 @@ module TeacherInterface
           alternative_name_params.merge(application_form:)
         )
       if @alternative_name_form.save
-        redirect_to_if_save_and_continue [
-                                           :edit,
-                                           :teacher_interface,
-                                           :application_form,
-                                           application_form.name_change_document
-                                         ]
+        redirect_to_if_save_and_continue alternative_name_next_url
       else
         render :alternative_name, status: :unprocessable_entity
       end
@@ -86,6 +81,19 @@ module TeacherInterface
         :alternative_given_names,
         :alternative_family_name
       )
+    end
+
+    def alternative_name_next_url
+      if application_form.has_alternative_name
+        [
+          :edit,
+          :teacher_interface,
+          :application_form,
+          application_form.name_change_document
+        ]
+      else
+        %i[teacher_interface application_form personal_information]
+      end
     end
   end
 end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -450,6 +450,28 @@ RSpec.describe "Teacher application", type: :system do
     then_i_see_completed_subjects_section
   end
 
+  it "allows skipping name change document" do
+    given_an_eligible_eligibility_check_with_none_country_checks
+
+    when_i_click_apply_for_qts
+    and_i_sign_up
+    then_i_see_the_new_application_page
+    and_i_click_continue
+    then_i_see_the_active_application_page
+    and_i_see_the_work_history_is_not_started
+
+    when_i_click_personal_information
+    then_i_see_the_name_and_date_of_birth_form
+
+    when_i_fill_in_the_name_and_date_of_birth_form
+    and_i_click_continue
+    then_i_see_the_alternative_name_form
+
+    when_i_choose_no
+    and_i_click_continue
+    then_i_see_the_personal_information_summary_without_name_change
+  end
+
   private
 
   def when_i_click_apply_for_qts
@@ -773,6 +795,16 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("Alternative given names\tName")
     expect(page).to have_content("Alternative family name\tName")
     expect(page).to have_content("Name change document")
+  end
+
+  def then_i_see_the_personal_information_summary_without_name_change
+    expect(page).to have_content("Check your answers")
+    expect(page).to have_content("Given names\tName")
+    expect(page).to have_content("Family name\tName")
+    expect(page).to have_content("Date of birth\t1 January 2000")
+    expect(page).to have_content(
+      "Name appears differently on your ID documents or qualifications?\tNo"
+    )
   end
 
   def then_i_see_completed_personal_information_section


### PR DESCRIPTION
This changes the alternative name form so if a user has said they don't need to upload a name change document, we should take them to the check your answers page rather than asking to upload a document.