### PR TITLE
Fix failing test

### DIFF
--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -845,7 +845,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def then_i_see_the_empty_work_history_summary
-    expect(page).to have_content("Work history")
+    expect(page).to have_content("Your work history in education")
     expect(page).to have_content(
       "Have you worked professionally as a teacher?\tYes"
     )


### PR DESCRIPTION
After d8f0a00f55e976fea78706700490a46b0368a3ca was merged in this test has started failing, I'm not entirely sure why it didn't fail in the original PR.