### PR TITLE
Send users to sign in page after re-confirming

### DIFF
--- a/app/controllers/teachers/confirmations_controller.rb
+++ b/app/controllers/teachers/confirmations_controller.rb
@@ -16,10 +16,8 @@ class Teachers::ConfirmationsController < Devise::ConfirmationsController
         redirect_to after_confirmation_path_for(resource_name, resource)
       end
     else
-      respond_with_navigational(
-        resource.errors,
-        status: :unprocessable_entity
-      ) { render :new }
+      set_flash_message!(:notice, :already_confirmed)
+      redirect_to new_teacher_session_path
     end
   end
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -5,6 +5,8 @@ en:
       confirmed: "Your email address has been successfully confirmed."
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+      teacher:
+        already_confirmed: "Your email address is already confirmed, please sign in."
     failure:
       already_authenticated: "You are already signed in."
       inactive: "Your account is not activated yet."

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -845,7 +845,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def then_i_see_the_empty_work_history_summary
-    expect(page).to have_content("Work history")
+    expect(page).to have_content("Your work history in education")
     expect(page).to have_content(
       "Have you worked professionally as a teacher?\tYes"
     )

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -86,6 +86,25 @@ RSpec.describe "Teacher authentication", type: :system do
     and_i_receive_a_teacher_confirmation_email
   end
 
+  it "confirming email twice" do
+    when_i_visit_the_sign_up_page
+    then_i_see_the_sign_up_form
+
+    when_i_fill_teacher_email_address
+    and_i_click_continue
+    then_i_see_the_check_your_email_page
+    and_i_receive_a_teacher_confirmation_email
+
+    when_i_visit_the_teacher_confirmation_email
+    then_i_see_successful_confirmation
+
+    given_i_clear_my_session
+
+    when_i_visit_the_teacher_confirmation_email
+    then_i_see_the_sign_in_form
+    and_i_see_already_confirmed_message
+  end
+
   private
 
   def given_countries_exist
@@ -174,5 +193,11 @@ RSpec.describe "Teacher authentication", type: :system do
 
   def and_i_click_continue
     click_button "Continue", visible: false
+  end
+
+  def and_i_see_already_confirmed_message
+    expect(page).to have_content(
+      "Your email address is already confirmed, please sign in."
+    )
   end
 end

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -94,7 +94,6 @@ RSpec.describe "Teacher authentication", type: :system do
 
   def given_i_clear_my_session
     page.driver.clear_cookies
-    ActionMailer::Base.deliveries = []
   end
 
   def when_i_visit_the_sign_up_page


### PR DESCRIPTION
At the moment users are shown an unstyled Devise page for entering their email address again, but all we need to do is show them the sign in page.

[Trello Card](https://trello.com/c/qOOjg4rM/746-reusing-the-first-confirmation-magic-link-opens-an-unstyled-page)

## Screenshots

<img width="1011" alt="Screenshot 2022-08-15 at 06 55 07" src="https://user-images.githubusercontent.com/510498/184583620-4920380a-3609-4fe9-9573-98354602961a.png">
