### PR TITLE
Expire magic links after they're used

### DIFF
--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -6,7 +6,12 @@
 #  confirmation_sent_at :datetime
 #  confirmation_token   :string
 #  confirmed_at         :datetime
+#  current_sign_in_at   :datetime
+#  current_sign_in_ip   :string
 #  email                :string           default(""), not null
+#  last_sign_in_at      :datetime
+#  last_sign_in_ip      :string
+#  sign_in_count        :integer          default(0), not null
 #  unconfirmed_email    :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -21,7 +21,11 @@
 #  index_teachers_on_email  (email) UNIQUE
 #
 class Teacher < ApplicationRecord
-  devise :magic_link_authenticatable, :confirmable, :registerable, :timeoutable
+  devise :magic_link_authenticatable,
+         :confirmable,
+         :registerable,
+         :timeoutable,
+         :trackable
 
   has_one :application_form
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -133,6 +133,11 @@
     - confirmed_at
     - confirmation_sent_at
     - unconfirmed_email
+    - sign_in_count
+    - current_sign_in_at
+    - last_sign_in_at
+    - current_sign_in_ip
+    - last_sign_in_ip
   :uploads:
     - id
     - document_id

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -26,12 +26,14 @@
     - part_of_university_degree
   :staff:
     - email
+    - unconfirmed_email
     - current_sign_in_ip
     - last_sign_in_ip
-    - unconfirmed_email
   :teachers:
     - email
     - unconfirmed_email
+    - current_sign_in_ip
+    - last_sign_in_ip
   :work_histories:
     - school_name
     - city

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -367,7 +367,7 @@ Devise.setup do |config|
   # When using the :trackable module, set to true to consider magic link tokens
   # generated before the user's current sign in time to be expired. In other words,
   # each time you sign in, all existing magic links will be considered invalid.
-  # config.passwordless_expire_old_tokens_on_sign_in = false
+  config.passwordless_expire_old_tokens_on_sign_in = true
 end
 
 # As we only use magic link authentication for teachers, we don't need to unnecessarily

--- a/db/migrate/20220815075810_add_devise_trackable_to_teachers.rb
+++ b/db/migrate/20220815075810_add_devise_trackable_to_teachers.rb
@@ -1,0 +1,11 @@
+class AddDeviseTrackableToTeachers < ActiveRecord::Migration[7.0]
+  def change
+    change_table :teachers, bulk: true do |t|
+      t.integer :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_08_131029) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_15_075810) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -185,6 +185,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_08_131029) do
     t.datetime "confirmed_at", precision: nil
     t.datetime "confirmation_sent_at", precision: nil
     t.string "unconfirmed_email"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at", precision: nil
+    t.datetime "last_sign_in_at", precision: nil
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
     t.index ["email"], name: "index_teachers_on_email", unique: true
   end
 

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -6,7 +6,12 @@
 #  confirmation_sent_at :datetime
 #  confirmation_token   :string
 #  confirmed_at         :datetime
+#  current_sign_in_at   :datetime
+#  current_sign_in_ip   :string
 #  email                :string           default(""), not null
+#  last_sign_in_at      :datetime
+#  last_sign_in_ip      :string
+#  sign_in_count        :integer          default(0), not null
 #  unconfirmed_email    :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -6,7 +6,12 @@
 #  confirmation_sent_at :datetime
 #  confirmation_token   :string
 #  confirmed_at         :datetime
+#  current_sign_in_at   :datetime
+#  current_sign_in_ip   :string
 #  email                :string           default(""), not null
+#  last_sign_in_at      :datetime
+#  last_sign_in_ip      :string
+#  sign_in_count        :integer          default(0), not null
 #  unconfirmed_email    :string
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -110,7 +110,6 @@ module SystemHelpers
   end
 
   def then_i_see_the_sign_in_form
-    expect(page).to have_current_path("/teacher/sign_in")
     expect(page).to have_title(
       "Apply for qualified teacher status (QTS) in England"
     )

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -105,6 +105,33 @@ RSpec.describe "Teacher authentication", type: :system do
     and_i_see_already_confirmed_message
   end
 
+  it "sign in with same token" do
+    given_countries_exist
+
+    when_i_visit_the_sign_up_page
+    then_i_see_the_sign_up_form
+    and_i_sign_up
+
+    given_i_clear_my_session
+
+    when_i_visit_the_sign_in_page
+    then_i_see_the_sign_in_form
+
+    when_i_choose_yes_sign_in
+    and_i_fill_teacher_email_address
+    and_i_click_continue
+    then_i_see_the_check_your_email_page
+    and_i_receive_a_magic_link_email
+
+    when_i_visit_the_magic_link_email
+    then_i_see_the_new_application_form
+
+    given_i_clear_my_session
+
+    when_i_visit_the_magic_link_email
+    then_i_see_the_sign_in_form
+  end
+
   private
 
   def given_countries_exist


### PR DESCRIPTION
This PR changes the configuration for Devise and Devise Passwordless to ensure that once a magic link token has been used to sign in, it's not possible to use it again.

[Trello Card](https://trello.com/c/XJMiXVsZ/745-magic-link-should-expire-when-used)