### PR TITLE
Add "teaching authority other" to regions

### DIFF
--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -40,7 +40,8 @@ module SupportInterface
         :teaching_authority_name,
         :teaching_authority_address,
         :teaching_authority_emails_string,
-        :teaching_authority_websites_string
+        :teaching_authority_websites_string,
+        :teaching_authority_other
       )
     end
   end

--- a/app/models/concerns/teaching_authority_contactable.rb
+++ b/app/models/concerns/teaching_authority_contactable.rb
@@ -21,6 +21,7 @@ module TeachingAuthorityContactable
 
   def teaching_authority_present?
     teaching_authority_name.present? || teaching_authority_address.present? ||
-      teaching_authority_emails.present? || teaching_authority_websites.present?
+      teaching_authority_emails.present? ||
+      teaching_authority_websites.present? || teaching_authority_other.present?
   end
 end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -11,6 +11,7 @@
 #  teaching_authority_address  :text             default(""), not null
 #  teaching_authority_emails   :text             default([]), not null, is an Array
 #  teaching_authority_name     :text             default(""), not null
+#  teaching_authority_other    :text             default(""), not null
 #  teaching_authority_websites :text             default([]), not null, is an Array
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -86,10 +86,6 @@
 
         <%= render "shared/teaching_authority_contactable", contactable: region %>
 
-        <% if region.country.teaching_authority_other.present? %>
-          <%= raw GovukMarkdown.render(region.country.teaching_authority_other) %>
-        <% end %>
-
         <p class="govuk-body">This must be dated within 3 months of you applying for QTS.</p>
       <% end %>
 

--- a/app/views/shared/_teaching_authority_contactable.html.erb
+++ b/app/views/shared/_teaching_authority_contactable.html.erb
@@ -21,3 +21,7 @@
     <% end %>
   </p>
 <% end %>
+
+<% if contactable.teaching_authority_other.present? %>
+  <%= raw GovukMarkdown.render(contactable.teaching_authority_other) %>
+<% end %>

--- a/app/views/shared/_teaching_authority_contactable_fields.html.erb
+++ b/app/views/shared/_teaching_authority_contactable_fields.html.erb
@@ -5,3 +5,5 @@
 <%= f.govuk_text_area :teaching_authority_emails_string, label: { text: "Teaching authority emails" }, hint: { text: "One on each line." } %>
 
 <%= f.govuk_text_area :teaching_authority_websites_string, label: { text: "Teaching authority websites" }, hint: { text: "One on each line." } %>
+
+<%= f.govuk_text_area :teaching_authority_other, label: { text: "Teaching authority other" } %>

--- a/app/views/support_interface/countries/confirm_edit.html.erb
+++ b/app/views/support_interface/countries/confirm_edit.html.erb
@@ -10,8 +10,6 @@
   <%= render "shared/teaching_authority_contactable", contactable: @country %>
 
   <p class="govuk-body"><%= @country.teaching_authority_certificate %></p>
-
-  <%= raw GovukMarkdown.render(@country.teaching_authority_other) %>
 <% end %>
 
 <% if @diff_actions.present? %>

--- a/app/views/support_interface/countries/edit.html.erb
+++ b/app/views/support_interface/countries/edit.html.erb
@@ -7,8 +7,6 @@
 
   <%= f.govuk_text_field :teaching_authority_certificate, label: { text: "Teaching authority certificate" } %>
 
-  <%= f.govuk_text_area :teaching_authority_other, label: { text: "Teaching authority other" } %>
-
   <%= f.govuk_text_area :all_regions,
                         value: @all_regions,
                         label: { text: "Regions" },

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -101,6 +101,7 @@
     - teaching_authority_emails
     - teaching_authority_websites
     - teaching_authority_name
+    - teaching_authority_other
     - application_form_enabled
   :staff:
     - id

--- a/db/migrate/20220815204606_add_teaching_authority_other_to_regions.rb
+++ b/db/migrate/20220815204606_add_teaching_authority_other_to_regions.rb
@@ -1,0 +1,9 @@
+class AddTeachingAuthorityOtherToRegions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :regions,
+               :teaching_authority_other,
+               :text,
+               default: "",
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -136,6 +136,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_16_061643) do
     t.text "teaching_authority_emails", default: [], null: false, array: true
     t.text "teaching_authority_websites", default: [], null: false, array: true
     t.text "teaching_authority_name", default: "", null: false
+    t.text "teaching_authority_other", default: "", null: false
     t.boolean "application_form_enabled", default: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
     t.index ["country_id"], name: "index_regions_on_country_id"

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -11,6 +11,7 @@
 #  teaching_authority_address  :text             default(""), not null
 #  teaching_authority_emails   :text             default([]), not null, is an Array
 #  teaching_authority_name     :text             default(""), not null
+#  teaching_authority_other    :text             default(""), not null
 #  teaching_authority_websites :text             default([]), not null, is an Array
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -129,5 +129,11 @@ RSpec.describe Country, type: :model do
 
       it { is_expected.to eq(true) }
     end
+
+    context "with other information" do
+      before { country.update(teaching_authority_other: "Other") }
+
+      it { is_expected.to eq(true) }
+    end
   end
 end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -11,6 +11,7 @@
 #  teaching_authority_address  :text             default(""), not null
 #  teaching_authority_emails   :text             default([]), not null, is an Array
 #  teaching_authority_name     :text             default(""), not null
+#  teaching_authority_other    :text             default(""), not null
 #  teaching_authority_websites :text             default([]), not null, is an Array
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -145,5 +145,11 @@ RSpec.describe Region, type: :model do
 
       it { is_expected.to eq(true) }
     end
+
+    context "with other information" do
+      before { region.update(teaching_authority_other: "Other") }
+
+      it { is_expected.to eq(true) }
+    end
   end
 end

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_address
     when_i_fill_teaching_authority_emails
     when_i_fill_teaching_authority_websites
+    when_i_fill_teaching_authority_other
     and_i_save_and_preview
     then_i_see_the_preview
     and_i_see_a_success_banner
@@ -164,6 +165,8 @@ RSpec.describe "Countries support", type: :system do
   end
 
   def when_i_fill_teaching_authority_other
+    fill_in "region-teaching-authority-other-field", with: "Other"
+  rescue Capybara::ElementNotFound
     fill_in "country-teaching-authority-other-field", with: "Other"
   end
 

--- a/spec/views/eligibility_interface/shared/teaching_authority_contactable_spec.rb
+++ b/spec/views/eligibility_interface/shared/teaching_authority_contactable_spec.rb
@@ -11,13 +11,15 @@ RSpec.describe "Teaching authority contactable", type: :view do
         :country,
         teaching_authority_address: "Address",
         teaching_authority_emails: ["test@example.com"],
-        teaching_authority_websites: ["https://www.example.com"]
+        teaching_authority_websites: ["https://www.example.com"],
+        teaching_authority_other: "Other"
       )
     end
 
     it { is_expected.to match(/Address/) }
     it { is_expected.to match(/test@example\.com/) }
     it { is_expected.to match(/www\.example\.com/) }
+    it { is_expected.to match(/Other/) }
   end
 
   context "with a region" do
@@ -26,12 +28,14 @@ RSpec.describe "Teaching authority contactable", type: :view do
         :region,
         teaching_authority_address: "Address",
         teaching_authority_emails: ["test@example.com"],
-        teaching_authority_websites: ["https://www.example.com"]
+        teaching_authority_websites: ["https://www.example.com"],
+        teaching_authority_other: "Other"
       )
     end
 
     it { is_expected.to match(/Address/) }
     it { is_expected.to match(/test@example\.com/) }
     it { is_expected.to match(/www\.example\.com/) }
+    it { is_expected.to match(/Other/) }
   end
 end


### PR DESCRIPTION
This field, which we currently have on countries, is used to display generic information on how to contact the teaching authority which doesn't fit in any of the other fields. The reason we need it now is to explain that some region's websites are only accessible in the country.

[Trello Card](https://trello.com/c/z8AMhJ1c/763-add-teaching-authority-other-information-for-regions)