### PR TITLE
Enable application form for each region

### DIFF
--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -34,6 +34,7 @@ module SupportInterface
     def region_params
       params.require(:region).permit(
         :legacy,
+        :application_form_enabled,
         :sanction_check,
         :status_check,
         :teaching_authority_name,

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -3,6 +3,7 @@
 # Table name: regions
 #
 #  id                          :bigint           not null, primary key
+#  application_form_enabled    :boolean          default(FALSE)
 #  legacy                      :boolean          default(TRUE), not null
 #  name                        :string           default(""), not null
 #  sanction_check              :string           default("none"), not null

--- a/app/views/eligibility_interface/finish/eligible.html.erb
+++ b/app/views/eligibility_interface/finish/eligible.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "shared/eligible_region_content", region: @region %>
 
-    <% if FeatureFlag.active?(:teacher_applications) && @region && !@region.legacy %>
+    <% if FeatureFlag.active?(:teacher_applications) && @region && @region.application_form_enabled %>
       <%= govuk_start_button(text: "Apply for QTS", href: new_teacher_registration_path) %>
     <% else %>
       <p class="govuk-body">You’ll make your application on the Teaching Regulation Agency website.</p>

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -3,9 +3,9 @@
 <h1 class="govuk-heading-l"><%= CountryName.from_region(@region) %></h1>
 
 <%= form_with model: [:support_interface, @region] do |f| %>
-  <%= f.govuk_check_box :legacy, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Legacy" } %>
+  <%= f.govuk_check_box :legacy, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Skip eligibility checker (legacy)" } %>
 
-  <%= f.govuk_check_box :application_form_enabled, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Application Form Enabled" } %>
+  <%= f.govuk_check_box :application_form_enabled, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Application form enabled" } %>
 
   <%= f.govuk_collection_select :sanction_check, [
     OpenStruct.new(id: 'online', name: 'Online'),

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -5,6 +5,8 @@
 <%= form_with model: [:support_interface, @region] do |f| %>
   <%= f.govuk_check_box :legacy, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Legacy" } %>
 
+  <%= f.govuk_check_box :application_form_enabled, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Application Form Enabled" } %>
+
   <%= f.govuk_collection_select :sanction_check, [
     OpenStruct.new(id: 'online', name: 'Online'),
     OpenStruct.new(id: 'written', name: 'Written'),

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -101,6 +101,7 @@
     - teaching_authority_emails
     - teaching_authority_websites
     - teaching_authority_name
+    - application_form_enabled
   :staff:
     - id
     - email

--- a/db/migrate/20220816061643_add_application_form_enabled_to_regions.rb
+++ b/db/migrate/20220816061643_add_application_form_enabled_to_regions.rb
@@ -1,0 +1,5 @@
+class AddApplicationFormEnabledToRegions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :regions, :application_form_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_15_075810) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_16_061643) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -136,6 +136,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_15_075810) do
     t.text "teaching_authority_emails", default: [], null: false, array: true
     t.text "teaching_authority_websites", default: [], null: false, array: true
     t.text "teaching_authority_name", default: "", null: false
+    t.boolean "application_form_enabled", default: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
     t.index ["country_id"], name: "index_regions_on_country_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -186,10 +186,16 @@ COUNTRIES.each do |code, regions|
   country = Country.find_or_create_by!(code:)
 
   if regions.empty?
-    country.regions.find_or_create_by!(name: "").update!(legacy: false)
+    country
+      .regions
+      .find_or_create_by!(name: "")
+      .update!(legacy: false, application_form_enabled: true)
   else
     regions.each do |name|
-      country.regions.find_or_create_by!(name:).update!(legacy: false)
+      country
+        .regions
+        .find_or_create_by!(name:)
+        .update!(legacy: false, application_form_enabled: true)
     end
   end
 end

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -3,6 +3,7 @@
 # Table name: regions
 #
 #  id                          :bigint           not null, primary key
+#  application_form_enabled    :boolean          default(FALSE)
 #  legacy                      :boolean          default(TRUE), not null
 #  name                        :string           default(""), not null
 #  sanction_check              :string           default("none"), not null

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -40,6 +40,10 @@ FactoryBot.define do
       legacy { true }
     end
 
+    trait :application_form_enabled do
+      application_form_enabled { true }
+    end
+
     trait :online_checks do
       sanction_check { :online }
       status_check { :online }

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -3,6 +3,7 @@
 # Table name: regions
 #
 #  id                          :bigint           not null, primary key
+#  application_form_enabled    :boolean          default(FALSE)
 #  legacy                      :boolean          default(TRUE), not null
 #  name                        :string           default(""), not null
 #  sanction_check              :string           default("none"), not null

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -14,6 +14,7 @@ module SystemHelpers
   def given_an_eligible_eligibility_check(country_check:)
     country = create(:country, :with_national_region, code: "GB-SCT")
     country.regions.first.update!(
+      application_form_enabled: true,
       status_check: country_check,
       sanction_check: country_check
     )

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Countries support", type: :system do
     when_i_click_on_a_region
     then_i_see_a_region
 
+    when_i_check_application_form_enabled
     when_i_select_sanction_check
     when_i_select_status_check
     when_i_fill_teaching_authority_name
@@ -118,6 +119,10 @@ RSpec.describe "Countries support", type: :system do
 
   def when_i_fill_regions
     fill_in "country-all-regions-field", with: "California"
+  end
+
+  def when_i_check_application_form_enabled
+    check "region-application-form-enabled-1-field", visible: false
   end
 
   def when_i_select_sanction_check


### PR DESCRIPTION
This makes it possible to enable/disable the application form on a per-region basis, allowing us to launch the service slowly by switching over which regions are taken to the new application form one by one.

[Trello Card](https://trello.com/c/peVIXy86/735-enable-application-form-on-a-country-by-country-basis)

## Screenshots

![Screenshot 2022-08-16 at 08 23 10](https://user-images.githubusercontent.com/510498/184822201-9a44ce97-69fa-4048-aa10-67b8d8461488.png)