### PR TITLE
Update seeds and run in review

### DIFF
--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -71,3 +71,10 @@ runs:
         TF_VAR_apply_qts_docker_image: ${{ inputs.docker_image }}
         pr_id: ${{ inputs.pr_id }}
       shell: bash
+
+    - uses: DFE-Digital/github-actions/setup-cf-cli@master
+      with:
+        CF_USERNAME: ${{ steps.get_secrets.outputs.PAAS-USER }}
+        CF_PASSWORD: ${{ steps.get_secrets.outputs.PAAS-PASSWORD }}
+        CF_SPACE_NAME: ${{ steps.config.outputs.paas_space }}
+        INSTALL_CONDUIT: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,7 +163,9 @@ jobs:
           docker_image: ${{ needs.docker.outputs.docker_image }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
           pr_id: ${{ github.event.pull_request.number }}
-
+      - name: Seed the DB
+        shell: bash
+        run: cf run-task apply-for-qts-in-england-review-pr-${{ github.event.pull_request.number }} --command "cd /app && bundle exec rails db:seed"
       - name: Post sticky pull request comment
         if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,180 +6,705 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
+# regenerate from production database with
+#
+# Country.all.to_h do |country|
+#   [
+#     country.code,
+#     country.regions.filter_map do |region|
+#       next if region.name.blank?
+#       {
+#         name: region.name,
+#         status_check: region.status_check,
+#         sanction_check: region.sanction_check,
+#         application_form_enabled: region.application_form_enabled,
+#         legacy: region.legacy
+#       }
+#     end
+#   ]
+# end
+
 COUNTRIES = {
-  AT: [],
-  BE: ["Flemish region", "French region", "German region"],
-  BG: [],
-  HR: [],
-  CY: [],
-  CZ: [],
-  DK: [],
-  EE: [],
-  FI: [],
-  FR: [],
-  DE: [
-    "Baden-Wurttemberg",
-    "Bavaria",
-    "Berlin",
-    "Brandenburg",
-    "Bremen",
-    "Hamburg",
-    "Hessen",
-    "Lower Saxony",
-    "Mecklenburg-Vorpommern",
-    "Saxony-Anhalt",
-    "Schleswig-Holstein",
-    "Thuringia",
-    "North Rhine-Westphalia",
-    "Saxony",
-    "Rhineland-Palatinate",
-    "Saarland"
+  "BE" => [
+    {
+      name: "Flemish region",
+      status_check: "none",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "French region",
+      status_check: "none",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "German region",
+      status_check: "none",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: true
+    }
   ],
-  GR: [],
-  HU: [],
-  IS: [],
-  IT: [],
-  LV: [],
-  LI: [],
-  LT: [],
-  LU: [],
-  MT: [],
-  NL: [],
-  NO: [],
-  PL: [],
-  PT: [],
-  IE: [],
-  RO: [
-    "Alba",
-    "Arad",
-    "Arges",
-    "Bacau",
-    "Bihor",
-    "Bistrita-Nasaud",
-    "Botosani",
-    "Braila",
-    "Brasov",
-    "Bucuresti (Bucharest)",
-    "Buzau",
-    "Calarasi",
-    "Caras-Severin",
-    "Cluj",
-    "Constanta",
-    "Covasna",
-    "Dambovita",
-    "Dolj",
-    "Galati",
-    "Giurgiu",
-    "Gorj",
-    "Harghita",
-    "Hunedoara",
-    "Ialomita",
-    "Iasi",
-    "Ilfov",
-    "Maramures",
-    "Mehedinti",
-    "Mures",
-    "Neamt",
-    "Olt",
-    "Prahova",
-    "Salaj",
-    "Satu Mare",
-    "Sibiu",
-    "Suceava",
-    "Teleorman",
-    "Timis",
-    "Tulcea",
-    "Vaslui",
-    "Valcea",
-    "Vrancea"
+  "CZ" => [],
+  "EE" => [],
+  "FR" => [],
+  "IS" => [],
+  "LV" => [],
+  "LI" => [],
+  "LU" => [],
+  "MT" => [],
+  "SI" => [],
+  "NZ" => [],
+  "GI" => [],
+  "GB-SCT" => [],
+  "GB-NIR" => [],
+  "AT" => [],
+  "CH" => [],
+  "GR" => [],
+  "US" => [
+    {
+      name: "Kentucky",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Mississippi",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Maryland",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Nevada",
+      status_check: "online",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Iowa",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Massachusetts",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Michigan",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Missouri",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "New York",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "North Carolina",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Oklahoma",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Oregon",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Pennsylvania",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Tennessee",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Texas",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Utah",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Washington",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Washington DC",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Maine",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Wyoming",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "North Dakota",
+      status_check: "online",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "South Dakota",
+      status_check: "online",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Nebraska",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "New Mexico",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Alabama",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Hawaii",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Colorado",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Alaska",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Arkansas",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "California",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Delaware",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Florida",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Georgia",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Idaho",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Illinois",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Louisiana",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Indiana",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Connecticut",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "West Virginia",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Minnesota",
+      status_check: "online",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "New Hampshire",
+      status_check: "online",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Rhode Island",
+      status_check: "online",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Vermont",
+      status_check: "online",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Virginia",
+      status_check: "online",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Wisconsin",
+      status_check: "online",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Arizona",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Kansas",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Montana",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "Ohio",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "South Carolina",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    },
+    {
+      name: "New Jersey",
+      status_check: "online",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: true
+    }
   ],
-  SK: [],
-  SI: [],
-  ES: [],
-  SE: [],
-  CH: [],
-  AU: [
-    "Victoria",
-    "Queensland",
-    "Northern Territory",
-    "Western Australia",
-    "Tasmania",
-    "New South Wales",
-    "South Australia",
-    "Australian Capital Territory"
+  "HU" => [],
+  "DE" => [
+    {
+      name: "North Rhine-Westphalia",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Lower Saxony",
+      status_check: "written",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Baden-Wurttemberg",
+      status_check: "written",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Bremen",
+      status_check: "written",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Hessen",
+      status_check: "written",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Saxony-Anhalt",
+      status_check: "written",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Saarland",
+      status_check: "written",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Berlin",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Brandenburg",
+      status_check: "written",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Bavaria",
+      status_check: "written",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Schleswig-Holstein",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Hamburg",
+      status_check: "written",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Saxony",
+      status_check: "written",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Mecklenburg-Vorpommern",
+      status_check: "written",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Rhineland-Palatinate",
+      status_check: "written",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Thuringia",
+      status_check: "written",
+      sanction_check: "none",
+      application_form_enabled: false,
+      legacy: false
+    }
   ],
-  CA: [
-    "Ontario",
-    "Alberta",
-    "British Columbia",
-    "Manitoba",
-    "Nunavut",
-    "New Brunswick",
-    "Newfoundland and Labrador",
-    "Northwest Territories",
-    "Nova Scotia",
-    "Prince Edward Island",
-    "Quebec",
-    "Saskatchewan",
-    "Yukon"
+  "HR" => [],
+  "BG" => [],
+  "NL" => [],
+  "IT" => [],
+  "PL" => [],
+  "IE" => [],
+  "ES" => [],
+  "AU" => [
+    {
+      name: "New South Wales",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "South Australia",
+      status_check: "online",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Australian Capital Territory",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Queensland",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Victoria",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Northern Territory",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Western Australia",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Tasmania",
+      status_check: "online",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    }
   ],
-  NZ: [],
-  US: [
-    "Alabama",
-    "Alaska",
-    "Arizona",
-    "Arkansas",
-    "California",
-    "Colorado",
-    "Connecticut",
-    "Delaware",
-    "Florida",
-    "Georgia",
-    "Hawaii",
-    "Idaho",
-    "Illinois",
-    "Indiana",
-    "Kentucky",
-    "Kansas",
-    "Louisiana",
-    "Maine",
-    "Iowa",
-    "Maryland",
-    "Massachusetts",
-    "Montana",
-    "Michigan",
-    "Minnesota",
-    "Mississippi",
-    "Missouri",
-    "Nebraska",
-    "Nevada",
-    "New Hampshire",
-    "New Jersey",
-    "New Mexico",
-    "New York",
-    "North Carolina",
-    "North Dakota",
-    "Ohio",
-    "Oklahoma",
-    "Oregon",
-    "Pennsylvania",
-    "Rhode Island",
-    "South Carolina",
-    "South Dakota",
-    "Tennessee",
-    "Texas",
-    "Utah",
-    "Vermont",
-    "Virginia",
-    "Washington",
-    "Washington DC",
-    "West Virginia",
-    "Wisconsin",
-    "Wyoming"
+  "CA" => [
+    {
+      name: "Manitoba",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Newfoundland and Labrador",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "New Brunswick",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Northwest Territories",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Nova Scotia",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Prince Edward Island",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Quebec",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Alberta",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "British Columbia",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Ontario",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Saskatchewan",
+      status_check: "online",
+      sanction_check: "online",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Yukon",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    },
+    {
+      name: "Nunavut",
+      status_check: "written",
+      sanction_check: "written",
+      application_form_enabled: false,
+      legacy: false
+    }
   ],
-  GI: [],
-  "GB-SCT": [],
-  "GB-NIR": []
+  "LT" => [],
+  "CY" => [],
+  "RO" => [],
+  "NO" => [],
+  "SK" => [],
+  "SE" => [],
+  "PT" => [],
+  "DK" => [],
+  "FI" => []
 }.freeze
 
 COUNTRIES.each do |code, regions|
@@ -191,11 +716,10 @@ COUNTRIES.each do |code, regions|
       .find_or_create_by!(name: "")
       .update!(legacy: false, application_form_enabled: true)
   else
-    regions.each do |name|
-      country
-        .regions
-        .find_or_create_by!(name:)
-        .update!(legacy: false, application_form_enabled: true)
+    regions.each do |region|
+      next if country.regions.where(name: region[:name]).any?
+
+      country.regions.create!(region)
     end
   end
 end


### PR DESCRIPTION
Update the seeds.rb file to match the production country lists. We need to seed review (and dev) environments and generate example data for them so we should have something approaching the production country config.

I've split this off from the example data work as it's useful on its own and can be extended with the other stuff.

On top of adding more 'production' state to the seeds file I've also amended the loop to skip regions that already exist to avoid overwriting existing configured regions.

Seems to be working ok -> https://apply-for-qts-in-england-review-pr-367.london.cloudapps.digital/support/countries