### PR TITLE
Set a content security policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,25 +1,15 @@
-# Be sure to restart your server when you modify this file.
+Rails.application.config do |config|
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.font_src :self
+    policy.img_src :self
+    policy.object_src :none
+    policy.script_src :self
+    policy.style_src :self
+  end
 
-# Define an application-wide content security policy.
-# See the Securing Rails Applications Guide for more information:
-# https://guides.rubyonrails.org/security.html#content-security-policy-header
-
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+  config.content_security_policy_nonce_generator = ->(request) do
+    request.session.id.to_s
+  end
+  config.content_security_policy_nonce_directives = %w[script-src]
+end


### PR DESCRIPTION
This configures the application with a content security policy that disallows access to any third party scripts, styles, images and fonts as we serve everything directly.

[Trello Card](https://trello.com/c/BiMDhkRo/719-ensure-csp-headers-are-set)