### PR TITLE
Add govuk_error_summary to missing forms

### DIFF
--- a/app/views/staff/confirmations/new.html.erb
+++ b/app/views/staff/confirmations/new.html.erb
@@ -1,6 +1,8 @@
 <h1 class="govuk-heading-l">Resend confirmation instructions</h1>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), label: { text: "Email" } %>
   <%= f.govuk_submit "Resend confirmation instructions" %>
 <% end %>

--- a/app/views/staff/invitations/edit.html.erb
+++ b/app/views/staff/invitations/edit.html.erb
@@ -1,6 +1,8 @@
 <h1 class="govuk-heading-l"><%= t "devise.invitations.edit.header" %></h1>
 
 <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put }) do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.hidden_field :invitation_token, readonly: true %>
 
   <% if f.object.class.require_password_on_accepting %>

--- a/app/views/staff/invitations/new.html.erb
+++ b/app/views/staff/invitations/new.html.erb
@@ -1,6 +1,8 @@
 <h1 class="govuk-heading-l"><%= t "devise.invitations.new.header" %></h1>
 
 <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= f.govuk_error_summary %>
+
   <% resource.class.invite_key_fields.each do |field| -%>
     <%= f.govuk_text_field field, label: { text: field.to_s.humanize } %>
   <% end -%>

--- a/app/views/staff/passwords/edit.html.erb
+++ b/app/views/staff/passwords/edit.html.erb
@@ -1,6 +1,8 @@
 <h1 class="govuk-heading-l">Change your password</h1>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.hidden_field :reset_password_token %>
 
   <%= f.govuk_password_field :password, autocomplete: "new-password", label: { text: "Password" } %>

--- a/app/views/staff/passwords/new.html.erb
+++ b/app/views/staff/passwords/new.html.erb
@@ -1,6 +1,7 @@
 <h1 class="govuk-heading-l">Forgot your password?</h1>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= f.govuk_error_summary %>
   <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
   <%= f.govuk_submit "Send me reset password instructions" %>
 <% end %>

--- a/app/views/staff/sessions/new.html.erb
+++ b/app/views/staff/sessions/new.html.erb
@@ -1,6 +1,8 @@
 <h1 class="govuk-heading-l">Log in</h1>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
   <%= f.govuk_password_field :password, autocomplete: "current-password", label: { text: "Password" } %>
 

--- a/app/views/staff/unlocks/new.html.erb
+++ b/app/views/staff/unlocks/new.html.erb
@@ -1,6 +1,7 @@
 <h1 class="govuk-heading-l">Resend unlock instructions</h1>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= f.govuk_error_summary %>
   <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
   <%= f.govuk_submit "Resend unlock instructions" %>
 <% end %>

--- a/app/views/support_interface/countries/edit.html.erb
+++ b/app/views/support_interface/countries/edit.html.erb
@@ -3,6 +3,8 @@
 <h1 class="govuk-heading-l"><%= CountryName.from_country(@country) %></h1>
 
 <%= form_with model: @country, url: confirm_edit_support_interface_country_path(@country), method: "POST" do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= render "shared/teaching_authority_contactable_fields", f: %>
 
   <%= f.govuk_text_field :teaching_authority_certificate, label: { text: "Teaching authority certificate" } %>

--- a/app/views/support_interface/feature_flags/index.html.erb
+++ b/app/views/support_interface/feature_flags/index.html.erb
@@ -43,7 +43,7 @@
         <% feature_url = support_interface_activate_feature_path(feature_name) %>
         <% label = 'Activate ' %>
       <% end %>
-      <%= form_with(url: feature_url) do |f| %>
+      <%= form_with url: feature_url do |f| %>
         <%= f.govuk_submit label + feature_name.humanize, prevent_double_click: false %>
     <% end %>
   <% end %>

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -3,6 +3,8 @@
 <h1 class="govuk-heading-l"><%= CountryName.from_region(@region) %></h1>
 
 <%= form_with model: [:support_interface, @region] do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_check_box :legacy, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Skip eligibility checker (legacy)" } %>
 
   <%= f.govuk_check_box :application_form_enabled, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Application form enabled" } %>

--- a/app/views/teacher_interface/age_range/edit.erb
+++ b/app/views/teacher_interface/age_range/edit.erb
@@ -6,6 +6,8 @@
 <p class="govuk-hint"><%= I18n.t("application_form.age_range.hint") %></p>
 
 <%= form_with model: @age_range_form, url: %i[age_range teacher_interface application_form] do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_number_field :minimum, width: 3 %>
 
   <%= f.govuk_number_field :maximum, width: 3 %>

--- a/app/views/teacher_interface/documents/edit.html.erb
+++ b/app/views/teacher_interface/documents/edit.html.erb
@@ -20,6 +20,8 @@
 end %>
 
 <%= form_with model: [:teacher_interface, :application_form, @document] do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_radio_buttons_fieldset :add_another,
                                      legend: { text: "Do you need to upload another page?" },
                                      hint: { text: "If your document has several pages, you can upload them here. Otherwise, select ‘No’ and then ‘Continue’." } do %>

--- a/app/views/teacher_interface/personal_information/alternative_name.html.erb
+++ b/app/views/teacher_interface/personal_information/alternative_name.html.erb
@@ -4,6 +4,8 @@
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.about_you") %></span>
 
 <%= form_with model: @alternative_name_form, url: [:alternative_name, :teacher_interface, :application_form, :personal_information] do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_radio_buttons_fieldset :has_alternative_name, legend: { size: "l", tag: "h1" } do %>
     <%= f.govuk_radio_button :has_alternative_name, :true, link_errors: true do %>
       <%= f.govuk_text_field :alternative_given_names %>

--- a/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
+++ b/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
@@ -5,6 +5,8 @@
 <h1 class="govuk-heading-l">Personal information</h1>
 
 <%= form_with model: @name_and_date_of_birth_form, url: [:name_and_date_of_birth, :teacher_interface, :application_form, :personal_information] do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_text_field :given_names,
                          label: { text: "Given names", size: "m" },
                          hint: { text: "Enter your full name apart from your family name" } %>

--- a/app/views/teacher_interface/qualifications/_form.html.erb
+++ b/app/views/teacher_interface/qualifications/_form.html.erb
@@ -1,4 +1,6 @@
 <%= form_with model: [:teacher_interface, :application_form, qualification] do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_fieldset legend: { text: I18n.t("application_form.qualifications.form.title.#{qualification.locale_key}") } do %>
     <%= f.govuk_text_field :title, label: { text: I18n.t("application_form.qualifications.form.fields.title.#{qualification.locale_key}") } %>
     <%= f.govuk_text_field :institution_name, label: { text: I18n.t("application_form.qualifications.form.fields.institution_name") } %>

--- a/app/views/teacher_interface/qualifications/add_another.html.erb
+++ b/app/views/teacher_interface/qualifications/add_another.html.erb
@@ -4,9 +4,12 @@
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 
 <%= form_with model: Qualification.new, url: %i[add_another teacher_interface application_form qualifications] do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_collection_radio_buttons :add_another,
                                        [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
                                        :value,
                                        legend: { tag: "h1", size: "l" } %>
+
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teacher_interface/qualifications/delete.html.erb
+++ b/app/views/teacher_interface/qualifications/delete.html.erb
@@ -2,6 +2,8 @@
 <% content_for :back_link_url, teacher_interface_application_form_qualifications_path %>
 
 <%= form_with model: [:teacher_interface, :application_form, @qualification], method: :delete do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_collection_radio_buttons :confirm,
                                        [OpenStruct.new(id: :true, name: "Yes"), OpenStruct.new(id: :false, name: "No")],
                                        :id,

--- a/app/views/teacher_interface/registration_number/edit.html.erb
+++ b/app/views/teacher_interface/registration_number/edit.html.erb
@@ -2,6 +2,8 @@
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
 <%= form_with model: @registration_number_form, url: %i[registration_number teacher_interface application_form] do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_text_field :registration_number, label: { size: "l", tag: "h1" } %>
 
   <%= govuk_details(summary_text: "When we might need more information") do %>

--- a/app/views/teacher_interface/subjects/edit.html.erb
+++ b/app/views/teacher_interface/subjects/edit.html.erb
@@ -6,6 +6,8 @@
 <p class="govuk-hint"><%= I18n.t("application_form.subjects.hint") %></p>
 
 <%= form_with model: @application_form, url: %i[subjects teacher_interface application_form], method: :post do |f| %>
+  <%= f.govuk_error_summary %>
+
   <% if @application_form.subjects.empty? %>
     <%= f.govuk_text_field :subjects, multiple: true %>
   <% else %>

--- a/app/views/teacher_interface/uploads/delete.html.erb
+++ b/app/views/teacher_interface/uploads/delete.html.erb
@@ -2,6 +2,8 @@
 <% content_for :back_link_url, edit_teacher_interface_application_form_document_path(@document) %>
 
 <%= form_with model: [:teacher_interface, :application_form, @document, @upload], method: :delete do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_collection_radio_buttons :confirm,
                                        [OpenStruct.new(id: "true", name: "Yes"), OpenStruct.new(id: "false", name: "No")],
                                        :id,

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -73,6 +73,8 @@
 <% end %>
 
 <%= form_with model: @upload_form, url: [:teacher_interface, :application_form, @document, :uploads] do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_file_field :original_attachment,
                          label: { text: "Select a file to upload" },
                          hint: { text: "You can upload your files in PDF, JPG or DOC format. Each file must be no larger than 50MB." } %>

--- a/app/views/teacher_interface/work_histories/_form.html.erb
+++ b/app/views/teacher_interface/work_histories/_form.html.erb
@@ -1,4 +1,6 @@
 <%= form_with model: [:teacher_interface, application_form, work_history] do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_fieldset legend: { text: I18n.t(work_history.current_or_most_recent_role? ? "application_form.work_history.current_or_most_recent_role" : "application_form.work_history.previous_role") } do %>
     <%= f.govuk_text_field :school_name, label: { text: "School name" } %>
     <%= f.govuk_text_field :city, label: { text: "City" } %>

--- a/app/views/teacher_interface/work_histories/add_another.html.erb
+++ b/app/views/teacher_interface/work_histories/add_another.html.erb
@@ -4,9 +4,12 @@
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.work_history") %></span>
 
 <%= form_with model: WorkHistory.new, url: %i[add_another teacher_interface application_form work_histories] do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_collection_radio_buttons :add_another,
                                        [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
                                        :value,
                                        legend: { tag: "h1", size: "l" } %>
+
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teacher_interface/work_histories/delete.html.erb
+++ b/app/views/teacher_interface/work_histories/delete.html.erb
@@ -2,6 +2,8 @@
 <% content_for :back_link_url, teacher_interface_application_form_work_histories_path %>
 
 <%= form_with model: [:teacher_interface, :application_form, @work_history], method: :delete do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_collection_radio_buttons :confirm,
                                        [OpenStruct.new(id: :true, name: "Yes"), OpenStruct.new(id: :false, name: "No")],
                                        :id,

--- a/app/views/teachers/registrations/new.html.erb
+++ b/app/views/teachers/registrations/new.html.erb
@@ -3,7 +3,9 @@
 
 <h1 class="govuk-heading-xl">Create an account</h1>
 
-<%= form_for resource, as: resource_name, url: registration_path(resource_name) do |f| %>
+<%= form_with model: resource, url: registration_path(resource_name) do |f| %>
+  <%= f.govuk_error_summary %>
+
   <%= f.govuk_email_field :email,
                           autofocus: true,
                           autocomplete: "email",

--- a/app/views/teachers/sessions/new.html.erb
+++ b/app/views/teachers/sessions/new.html.erb
@@ -1,7 +1,8 @@
 <h1 class="govuk-heading-l">Check your eligibility to apply for qualified teacher status (QTS) in England</h1>
 
-<%= form_with(model: @new_session_form, url: session_path(resource_name)) do |f| %>
+<%= form_with model: @new_session_form, url: session_path(resource_name) do |f| %>
   <%= f.govuk_error_summary %>
+
   <%= f.govuk_radio_buttons_fieldset :create_or_sign_in, legend: { size: "m", text: "Have you used the service before?" } do %>
     <%= f.govuk_radio_button :create_or_sign_in, "sign_in", label: { text: "Yes, sign in and continue application" }, link_errors: true do %>
       <%= f.govuk_email_field :email,
@@ -10,7 +11,7 @@
                               label: { text: "Email address" },
                               hint: { text: "Enter the email address you used to register, and we will send you a link to sign in." } %>
     <% end %>
-   
+
     <%= f.govuk_radio_button :create_or_sign_in, "create", label: { text: "No, I need to check my eligibility" } %>
   <% end %>
 


### PR DESCRIPTION
Many of our forms are missing the `govuk_error_summary` line, which means they don't get the red box at the top of the page containing links to all the errors in the form.

We should be doing this as it's part of the design system for forms.

[Trello Card](https://trello.com/c/6xsioSVk/743-application-form-enter-your-email-address)

## Screenshot

<img width="707" alt="Screenshot 2022-08-17 at 14 18 20" src="https://user-images.githubusercontent.com/510498/185144090-622a01dd-733b-4757-8461-6c74f141b24e.png">