### PR TITLE
Use autocompleting country picker

### DIFF
--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -139,14 +139,21 @@ module TeacherInterface
     end
 
     def qualification_params
-      params.require(:qualification).permit(
-        :title,
-        :institution_name,
-        :institution_country,
-        :start_date,
-        :complete_date,
-        :certificate_date
-      )
+      params
+        .require(:qualification)
+        .permit(
+          :title,
+          :institution_name,
+          :institution_country_code,
+          :start_date,
+          :complete_date,
+          :certificate_date
+        )
+        .tap do |params|
+          params[:institution_country_code] = params[
+            :institution_country_code
+          ].split(":").last
+        end
     end
 
     def part_of_university_degree_form_params

--- a/app/controllers/teacher_interface/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/work_histories_controller.rb
@@ -122,16 +122,21 @@ module TeacherInterface
     end
 
     def work_history_params
-      params.require(:work_history).permit(
-        :city,
-        :country,
-        :email,
-        :end_date,
-        :job,
-        :school_name,
-        :start_date,
-        :still_employed
-      )
+      params
+        .require(:work_history)
+        .permit(
+          :city,
+          :country_code,
+          :email,
+          :end_date,
+          :job,
+          :school_name,
+          :start_date,
+          :still_employed
+        )
+        .tap do |params|
+          params[:country_code] = params[:country_code].split(":").last
+        end
     end
   end
 end

--- a/app/helpers/qualification_helper.rb
+++ b/app/helpers/qualification_helper.rb
@@ -1,7 +1,7 @@
 module QualificationHelper
   def qualification_title(qualification)
     qualification.title.presence || qualification.institution_name.presence ||
-      qualification.institution_country.presence ||
+      qualification.institution_country_name.presence ||
       I18n.t(
         "application_form.qualifications.heading.title.#{qualification.locale_key}"
       )

--- a/app/helpers/work_history_helper.rb
+++ b/app/helpers/work_history_helper.rb
@@ -1,7 +1,7 @@
 module WorkHistoryHelper
   def work_history_title(work_history)
     work_history.school_name.presence || work_history.city.presence ||
-      work_history.country.presence || work_history.job.presence ||
+      work_history.country_name.presence || work_history.job.presence ||
       I18n.t(
         (
           if work_history.current_or_most_recent_role?

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -16,6 +16,12 @@ var loadCountryAutoComplete = () => {
     ) ??
     document.getElementById(
       "teacher-interface-country-region-form-location-field-error"
+    ) ??
+    document.getElementById("work-history-country-code-field") ??
+    document.getElementById("work-history-country-code-field-error") ??
+    document.getElementById("qualification-institution-country-code-field") ??
+    document.getElementById(
+      "qualification-institution-country-code-field-error"
     );
 
   if (locationPicker) {

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -30,6 +30,11 @@ class Country < ApplicationRecord
       .map { |row| [row.last.split(":").last, row.first] }
       .to_h
 
+  LOCATIONS_BY_COUNTRY_CODE =
+    LOCATION_AUTOCOMPLETE_CANONICAL_LIST
+      .map { |row| [row.last.split(":").last, row.last] }
+      .to_h
+
   validates :code, inclusion: { in: COUNTRIES.keys }
 
   alias_method :country, :itself

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -57,13 +57,8 @@ class EligibilityCheck < ApplicationRecord
     self.region = regions.count == 1 ? regions.first : nil
   end
 
-  LOCATIONS_BY_COUNTRY_CODE =
-    Country::LOCATION_AUTOCOMPLETE_CANONICAL_LIST
-      .map { |row| [row.last.split(":").last, row.last] }
-      .to_h
-
   def location
-    LOCATIONS_BY_COUNTRY_CODE[country_code]
+    Country::LOCATIONS_BY_COUNTRY_CODE[country_code]
   end
 
   def ineligible_reasons

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -5,7 +5,7 @@
 #  id                        :bigint           not null, primary key
 #  certificate_date          :date
 #  complete_date             :date
-#  institution_country       :text             default(""), not null
+#  institution_country_code  :text             default(""), not null
 #  institution_name          :text             default(""), not null
 #  part_of_university_degree :boolean
 #  start_date                :date

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -100,6 +100,10 @@ class Qualification < ApplicationRecord
     CountryName.from_code(institution_country_code)
   end
 
+  def institution_country_location
+    Country::LOCATIONS_BY_COUNTRY_CODE[institution_country_code]
+  end
+
   private
 
   def build_documents

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -96,6 +96,10 @@ class Qualification < ApplicationRecord
     application_form.qualifications.ordered.second != self
   end
 
+  def institution_country_name
+    CountryName.from_code(institution_country_code)
+  end
+
   private
 
   def build_documents

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -56,7 +56,7 @@ class Qualification < ApplicationRecord
     values = [
       title,
       institution_name,
-      institution_country,
+      institution_country_code,
       start_date,
       complete_date,
       certificate_date,

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -71,4 +71,8 @@ class WorkHistory < ApplicationRecord
     application_form.work_histories.empty? ||
       application_form.work_histories.ordered.first == self
   end
+
+  def country_name
+    CountryName.from_code(country_code)
+  end
 end

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -32,7 +32,13 @@ class WorkHistory < ApplicationRecord
   scope :completed,
         -> {
           where
-            .not(school_name: "", city: "", country: "", job: "", email: "")
+            .not(
+              school_name: "",
+              city: "",
+              country_code: "",
+              job: "",
+              email: ""
+            )
             .where.not(start_date: nil)
             .where(still_employed: true)
             .or(where(still_employed: false).where.not(end_date: nil))
@@ -44,7 +50,7 @@ class WorkHistory < ApplicationRecord
     values = [
       school_name,
       city,
-      country,
+      country_code,
       job,
       email,
       start_date,

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -4,7 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  city                :text             default(""), not null
-#  country             :text             default(""), not null
+#  country_code        :text             default(""), not null
 #  email               :text             default(""), not null
 #  end_date            :date
 #  job                 :text             default(""), not null

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -75,4 +75,8 @@ class WorkHistory < ApplicationRecord
   def country_name
     CountryName.from_code(country_code)
   end
+
+  def country_location
+    Country::LOCATIONS_BY_COUNTRY_CODE[country_code]
+  end
 end

--- a/app/views/teacher_interface/qualifications/_form.html.erb
+++ b/app/views/teacher_interface/qualifications/_form.html.erb
@@ -4,7 +4,11 @@
   <%= f.govuk_fieldset legend: { text: I18n.t("application_form.qualifications.form.title.#{qualification.locale_key}") } do %>
     <%= f.govuk_text_field :title, label: { text: I18n.t("application_form.qualifications.form.fields.title.#{qualification.locale_key}") } %>
     <%= f.govuk_text_field :institution_name, label: { text: I18n.t("application_form.qualifications.form.fields.institution_name") } %>
-    <%= f.govuk_text_field :institution_country, label: { text: I18n.t("application_form.qualifications.form.fields.institution_country") } %>
+
+    <%= f.govuk_select :institution_country_code,
+                       options_for_select(locations, qualification.institution_country_location),
+                       label: { text: I18n.t("application_form.qualifications.form.fields.institution_country") },
+                       options: { include_blank: true } %>
   <% end %>
 
   <% if qualification.is_teaching_qualification? %>

--- a/app/views/teacher_interface/qualifications/_summary.html.erb
+++ b/app/views/teacher_interface/qualifications/_summary.html.erb
@@ -11,7 +11,7 @@
         title: I18n.t("application_form.qualifications.form.fields.institution_name"),
         href: [:edit, :teacher_interface, :application_form, qualification]
       },
-      institution_country: {
+      institution_country_name: {
         title: I18n.t("application_form.qualifications.form.fields.institution_country"),
         href: [:edit, :teacher_interface, :application_form, qualification]
       },

--- a/app/views/teacher_interface/work_histories/_form.html.erb
+++ b/app/views/teacher_interface/work_histories/_form.html.erb
@@ -4,7 +4,12 @@
   <%= f.govuk_fieldset legend: { text: I18n.t(work_history.current_or_most_recent_role? ? "application_form.work_history.current_or_most_recent_role" : "application_form.work_history.previous_role") } do %>
     <%= f.govuk_text_field :school_name, label: { text: "School name" } %>
     <%= f.govuk_text_field :city, label: { text: "City" } %>
-    <%= f.govuk_text_field :country, label: { text: "Country" } %>
+
+    <%= f.govuk_select :country_code,
+                       options_for_select(locations, work_history.country_location),
+                       label: { text: "Country" },
+                       options: { include_blank: true } %>
+
     <%= f.govuk_text_field :job, label: { text: "Your job role" } %>
     <%= f.govuk_text_field :email, label: { text: "Contact email address for this organisation" } %>
   <% end %>

--- a/app/views/teacher_interface/work_histories/_summary.html.erb
+++ b/app/views/teacher_interface/work_histories/_summary.html.erb
@@ -21,7 +21,7 @@
         title: "City of institution",
         href: [:edit, :teacher_interface, :application_form, work_history]
       },
-      country: {
+      country_name: {
         title: "Country of institution",
         href: [:edit, :teacher_interface, :application_form, work_history]
       },

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -81,7 +81,7 @@
     - application_form_id
     - title
     - institution_name
-    - institution_country
+    - institution_country_code
     - start_date
     - complete_date
     - certificate_date
@@ -151,7 +151,7 @@
     - application_form_id
     - school_name
     - city
-    - country
+    - country_code
     - job
     - email
     - start_date

--- a/db/migrate/20220817125214_rename_country_to_country_code.rb
+++ b/db/migrate/20220817125214_rename_country_to_country_code.rb
@@ -1,0 +1,8 @@
+class RenameCountryToCountryCode < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :qualifications,
+                  :institution_country,
+                  :institution_country_code
+    rename_column :work_histories, :country, :country_code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_16_061643) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_17_125214) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -114,7 +114,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_16_061643) do
     t.bigint "application_form_id", null: false
     t.text "title", default: "", null: false
     t.text "institution_name", default: "", null: false
-    t.text "institution_country", default: "", null: false
+    t.text "institution_country_code", default: "", null: false
     t.date "start_date"
     t.date "complete_date"
     t.date "certificate_date"
@@ -207,7 +207,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_16_061643) do
     t.bigint "application_form_id", null: false
     t.text "school_name", default: "", null: false
     t.text "city", default: "", null: false
-    t.text "country", default: "", null: false
+    t.text "country_code", default: "", null: false
     t.text "job", default: "", null: false
     t.text "email", default: "", null: false
     t.date "start_date"

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -5,7 +5,7 @@
 #  id                        :bigint           not null, primary key
 #  certificate_date          :date
 #  complete_date             :date
-#  institution_country       :text             default(""), not null
+#  institution_country_code  :text             default(""), not null
 #  institution_name          :text             default(""), not null
 #  part_of_university_degree :boolean
 #  start_date                :date

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
     trait :completed do
       title { Faker::Educator.degree }
       institution_name { Faker::University.name }
-      institution_country { Faker::Address.country }
+      institution_country_code { Country::COUNTRIES.keys.cycle }
       start_date { Date.new(2020, 1, 1) }
       complete_date { Date.new(2021, 1, 1) }
       certificate_date { Date.new(2021, 1, 1) }

--- a/spec/factories/work_histories.rb
+++ b/spec/factories/work_histories.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
     trait :completed do
       school_name { "School" }
       city { "City" }
-      country { "Country" }
+      country_code { "FR" }
       job { "Job" }
       email { "school@example.com" }
       start_date { Date.new(2020, 1, 1) }

--- a/spec/factories/work_histories.rb
+++ b/spec/factories/work_histories.rb
@@ -4,7 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  city                :text             default(""), not null
-#  country             :text             default(""), not null
+#  country_code        :text             default(""), not null
 #  email               :text             default(""), not null
 #  end_date            :date
 #  job                 :text             default(""), not null

--- a/spec/helpers/qualification_helper_spec.rb
+++ b/spec/helpers/qualification_helper_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe QualificationHelper do
     end
 
     context "with an institution country" do
-      before { qualification.institution_country = "Country" }
+      before { qualification.institution_country_code = "FR" }
 
-      it { is_expected.to eq("Country") }
+      it { is_expected.to eq("France") }
     end
   end
 end

--- a/spec/helpers/work_history_spec.rb
+++ b/spec/helpers/work_history_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe WorkHistoryHelper do
     end
 
     context "with a country" do
-      before { work_history.country = "Country" }
+      before { work_history.country_code = "FR" }
 
-      it { is_expected.to eq("Country") }
+      it { is_expected.to eq("France") }
     end
 
     context "with a job" do

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -140,4 +140,18 @@ RSpec.describe Qualification, type: :model do
       end
     end
   end
+
+  describe "#institution_country_location" do
+    subject(:institution_country_location) do
+      qualification.institution_country_location
+    end
+
+    it { is_expected.to be_nil }
+
+    context "with a country code" do
+      before { qualification.institution_country_code = "GB-SCT" }
+
+      it { is_expected.to eq("country:GB-SCT") }
+    end
+  end
 end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -5,7 +5,7 @@
 #  id                        :bigint           not null, primary key
 #  certificate_date          :date
 #  complete_date             :date
-#  institution_country       :text             default(""), not null
+#  institution_country_code  :text             default(""), not null
 #  institution_name          :text             default(""), not null
 #  part_of_university_degree :boolean
 #  start_date                :date

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Qualification, type: :model do
         qualification.update!(
           title: "Title",
           institution_name: "Institution name",
-          institution_country: "Institution country",
+          institution_country_code: "FR",
           start_date: Date.new(2020, 1, 1),
           complete_date: Date.new(2021, 1, 1),
           certificate_date: Date.new(2021, 1, 1),

--- a/spec/models/work_history_spec.rb
+++ b/spec/models/work_history_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe WorkHistory, type: :model do
     it { is_expected.to eq(:not_started) }
 
     context "when partially filled out" do
-      before { work_history.update!(country: "Country") }
+      before { work_history.update!(country_code: "FR") }
 
       it { is_expected.to eq(:in_progress) }
     end
@@ -62,7 +62,7 @@ RSpec.describe WorkHistory, type: :model do
         work_history.update!(
           school_name: "School",
           city: "City",
-          country: "Country",
+          country_code: "FR",
           job: "Job",
           email: "school@example.com",
           start_date: Date.new(2020, 1, 1),
@@ -78,7 +78,7 @@ RSpec.describe WorkHistory, type: :model do
         work_history.update!(
           school_name: "School",
           city: "City",
-          country: "Country",
+          country_code: "FR",
           job: "Job",
           email: "school@example.com",
           start_date: Date.new(2020, 1, 1),

--- a/spec/models/work_history_spec.rb
+++ b/spec/models/work_history_spec.rb
@@ -118,4 +118,16 @@ RSpec.describe WorkHistory, type: :model do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe "#country_location" do
+    subject(:country_location) { work_history.country_location }
+
+    it { is_expected.to be_nil }
+
+    context "with a country code" do
+      before { work_history.country_code = "GB-SCT" }
+
+      it { is_expected.to eq("country:GB-SCT") }
+    end
+  end
 end

--- a/spec/models/work_history_spec.rb
+++ b/spec/models/work_history_spec.rb
@@ -4,7 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  city                :text             default(""), not null
-#  country             :text             default(""), not null
+#  country_code        :text             default(""), not null
 #  email               :text             default(""), not null
 #  end_date            :date
 #  job                 :text             default(""), not null

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -539,7 +539,7 @@ RSpec.describe "Teacher application", type: :system do
   def when_i_fill_in_qualifications
     fill_in "qualification-title-field", with: "Title"
     fill_in "qualification-institution-name-field", with: "Name"
-    select "France", from: "qualification-institution-country-code-field"
+    fill_in "qualification-institution-country-code-field", with: "France"
     fill_in "qualification_start_date_2i", with: "1"
     fill_in "qualification_start_date_1i", with: "2000"
     fill_in "qualification_complete_date_2i", with: "1"
@@ -590,7 +590,7 @@ RSpec.describe "Teacher application", type: :system do
   def when_i_fill_in_work_history
     fill_in "work-history-school-name-field", with: "School name"
     fill_in "work-history-city-field", with: "City"
-    select "France", from: "work-history-country-code-field"
+    fill_in "work-history-country-code-field", with: "France"
     fill_in "work-history-job-field", with: "Job"
     fill_in "work-history-email-field", with: "test@example.com"
     fill_in "work_history_start_date_2i", with: "1"

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -539,7 +539,7 @@ RSpec.describe "Teacher application", type: :system do
   def when_i_fill_in_qualifications
     fill_in "qualification-title-field", with: "Title"
     fill_in "qualification-institution-name-field", with: "Name"
-    fill_in "qualification-institution-country-field", with: "Country"
+    select "France", from: "qualification-institution-country-code-field"
     fill_in "qualification_start_date_2i", with: "1"
     fill_in "qualification_start_date_1i", with: "2000"
     fill_in "qualification_complete_date_2i", with: "1"
@@ -590,7 +590,7 @@ RSpec.describe "Teacher application", type: :system do
   def when_i_fill_in_work_history
     fill_in "work-history-school-name-field", with: "School name"
     fill_in "work-history-city-field", with: "City"
-    fill_in "work-history-country-field", with: "Country"
+    select "France", from: "work-history-country-code-field"
     fill_in "work-history-job-field", with: "Job"
     fill_in "work-history-email-field", with: "test@example.com"
     fill_in "work_history_start_date_2i", with: "1"
@@ -858,7 +858,7 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("Check your answers")
     expect(page).to have_content("Qualification title\tTitle")
     expect(page).to have_content("Name of institution\tName")
-    expect(page).to have_content("Country of institution\tCountry")
+    expect(page).to have_content("Country of institution\tFrance")
   end
 
   def then_i_see_completed_qualifications_section
@@ -881,7 +881,7 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("Your current or most recent role")
     expect(page).to have_content("School name\tSchool name")
     expect(page).to have_content("City of institution\tCity")
-    expect(page).to have_content("Country of institution\tCountry")
+    expect(page).to have_content("Country of institution\tFrance")
     expect(page).to have_content("Your job role\tJob")
     expect(page).to have_content("Contact email address\ttest@example.com")
     expect(page).to have_content("Role start date\tJanuary 2000")


### PR DESCRIPTION
This changes the qualifications and work history views to use the autocomplete country picker component, and stores the codes in our database so we can send them to DQT.

[Trello Card](https://trello.com/c/ykXfmUX6/758-make-the-qualification-country-field-and-autocomplete)

## Screenshots

<img width="681" alt="Screenshot 2022-08-17 at 15 07 40" src="https://user-images.githubusercontent.com/510498/185157654-436f446c-129f-4f44-8249-32f62b9b9f36.png">

<img width="676" alt="Screenshot 2022-08-17 at 15 10 02" src="https://user-images.githubusercontent.com/510498/185157658-9f37a083-b449-4ecb-8de9-8cebda68ba82.png">
