### PR TITLE
[684] Example data generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,7 +165,7 @@ jobs:
           pr_id: ${{ github.event.pull_request.number }}
       - name: Seed the DB
         shell: bash
-        run: cf run-task apply-for-qts-in-england-review-pr-${{ github.event.pull_request.number }} --command "cd /app && bundle exec rails db:seed"
+        run: cf run-task apply-for-qts-in-england-review-pr-${{ github.event.pull_request.number }} --command "cd /app && bundle exec rails db:seed example_data:generate" --wait
       - name: Post sticky pull request comment
         if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "mail-notify"
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails"
+  gem "faker"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (2.22.0)
+      i18n (>= 1.8.11, < 2)
     faraday (1.10.1)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -474,6 +476,7 @@ DEPENDENCIES
   dfe-analytics!
   dotenv-rails
   factory_bot_rails
+  faker
   govuk-components
   govuk_design_system_formbuilder
   govuk_markdown

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -1,0 +1,88 @@
+require_relative Rails.root.join("config/environment")
+require "factory_bot"
+
+namespace :example_data do
+  desc "Create example data for testing"
+  task generate: :environment do
+    raise "THIS TASK CANNOT BE RUN IN PRODUCTION" if Rails.env.production?
+
+    if Teacher.any?
+      puts "Noop as DB already contains data"
+      exit
+    end
+
+    Teacher.reset_column_information
+    Faker::Config.locale = "en-GB"
+    Faker::UniqueGenerator.clear
+    FactoryBot.find_definitions
+
+    Country.all.each do |country|
+      country.regions.each do |region|
+        application_form_traits_for(region).each do |traits|
+          teacher = FactoryBot.create(:teacher)
+          FactoryBot.create(:application_form, *traits, teacher:, region:)
+        end
+      end
+    end
+  end
+end
+
+def evidential_traits_for(status_check, sanction_check)
+  args = [status_check, sanction_check]
+
+  traits = {
+    %w[none none] => [:with_work_history],
+    %w[online none] => %i[with_reference_number with_work_history],
+    %w[written none] => [:with_written_statement],
+    %w[online written] => %i[with_written_statement with_reference_number],
+    %w[written written] => [:with_written_statement],
+    %w[online online] => [:with_reference_number]
+  }
+
+  raise "unknown evidence combination for #{args}" if traits[args].nil?
+
+  traits[args]
+end
+
+def application_form_traits_for(region)
+  evidential_traits =
+    evidential_traits_for(region.status_check, region.sanction_check)
+
+  [
+    [],
+    [:with_personal_information],
+    %i[with_personal_information with_completed_qualification],
+    %i[
+      with_personal_information
+      with_completed_qualification
+      with_identification_document
+    ],
+    %i[
+      with_personal_information
+      with_completed_qualification
+      with_identification_document
+      with_age_range
+    ],
+    %i[
+      with_personal_information
+      with_completed_qualification
+      with_identification_document
+      with_age_range
+      with_subjects
+    ],
+    %i[
+      with_personal_information
+      with_completed_qualification
+      with_identification_document
+      with_age_range
+      with_subjects
+    ] + evidential_traits,
+    %i[
+      with_personal_information
+      with_completed_qualification
+      with_identification_document
+      with_age_range
+      with_subjects
+    ] + evidential_traits << :submitted
+  ]
+end

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -1,10 +1,11 @@
-require_relative Rails.root.join("config/environment")
 require "factory_bot"
 
 namespace :example_data do
   desc "Create example data for testing"
   task generate: :environment do
-    raise "THIS TASK CANNOT BE RUN IN PRODUCTION" if Rails.env.production?
+    if HostingEnvironment.production?
+      raise "THIS TASK CANNOT BE RUN IN PRODUCTION"
+    end
 
     if Teacher.any?
       puts "Noop as DB already contains data"
@@ -30,18 +31,11 @@ end
 def evidential_traits_for(status_check, sanction_check)
   args = [status_check, sanction_check]
 
-  traits = {
-    %w[none none] => [:with_work_history],
-    %w[online none] => %i[with_reference_number with_work_history],
-    %w[written none] => [:with_written_statement],
-    %w[online written] => %i[with_written_statement with_reference_number],
-    %w[written written] => [:with_written_statement],
-    %w[online online] => [:with_reference_number]
-  }
-
-  raise "unknown evidence combination for #{args}" if traits[args].nil?
-
-  traits[args]
+  [].tap do |traits|
+    traits << :with_work_history if args.include?("none")
+    traits << :with_written_statement if args.include?("written")
+    traits << :with_registration_number if args.include?("online")
+  end
 end
 
 def application_form_traits_for(region)

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -44,14 +44,53 @@ FactoryBot.define do
       status { "submitted" }
     end
 
+    trait :with_age_range do
+      age_range_min { Faker::Number.between(from: 5, to: 11) }
+      age_range_max { Faker::Number.between(from: age_range_min, to: 18) }
+    end
+
+    trait :with_subjects do
+      transient { number_of_subjects { Faker::Number.between(from: 1, to: 3) } }
+
+      subjects do
+        ([-> { Faker::Educator.subject }] * number_of_subjects).map(&:call)
+      end
+    end
+
+    trait :with_identification_document do
+      identification_document do
+        build(:document, :identification_document, :with_upload)
+      end
+    end
+
     trait :with_personal_information do
-      given_names { "Given names" }
-      family_name { "Family name" }
-      date_of_birth { Date.new(2000, 1, 1) }
+      given_names { Faker::Name.name }
+      family_name { Faker::Name.last_name }
+      date_of_birth do
+        Faker::Date.between(from: 65.years.ago, to: 21.years.ago)
+      end
     end
 
     trait :with_registration_number do
-      registration_number { "12345689" }
+      registration_number do
+        Faker::Number.unique.leading_zero_number(digits: 8)
+      end
+    end
+
+    trait :with_completed_qualification do
+      after(:create) do |application_form, _evaluator|
+        application_form.qualifications << build(:qualification, :completed)
+      end
+    end
+
+    trait :with_work_history do
+      has_work_history { true }
+    end
+
+    trait :with_written_statement do
+      written_statement_document do
+        build(:document, :written_statement, :with_upload)
+      end
     end
   end
 end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -32,5 +32,21 @@ FactoryBot.define do
         create(:upload, :translation, document:)
       end
     end
+
+    trait :written_statement do
+      document_type { "written_statement" }
+    end
+
+    trait :qualification_certificate do
+      document_type { "qualification_certificate" }
+    end
+
+    trait :qualification_transcript do
+      document_type { "qualification_transcript" }
+    end
+
+    trait :identification_document do
+      document_type { "identification" }
+    end
   end
 end

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -27,9 +27,9 @@ FactoryBot.define do
     association :application_form
 
     trait :completed do
-      title { "Title" }
-      institution_name { "Institution name" }
-      institution_country { "Institution country" }
+      title { Faker::Educator.degree }
+      institution_name { Faker::University.name }
+      institution_country { Faker::Address.country }
       start_date { Date.new(2020, 1, 1) }
       complete_date { Date.new(2021, 1, 1) }
       certificate_date { Date.new(2021, 1, 1) }


### PR DESCRIPTION
### Context

We want to be able to do meaningful acceptance testing in the review apps without laborious setup. 

### Changes

* Add an example_data:generate rake task that generates teachers with application form in varying degrees of completion for each region
* Update the factories so as we can use them for creating the data
* Call the task when a review app is created

### Review

This creates ~1300 teachers with an application each which may be a bit over the top but it runs pretty quickly currently. I'm intending this as a starting point. Once we can actually see this data in the interface it'll become clear where we need to change the data to make it meaningful. e.g. we'll probably want to set created_at dates differently etc.

To test locally:

```
bundle exec rails db:schema:load #clear the local DB
bundle exec rails db:seed #set up the countries and regions
bundle exec rails example_data:generate
```

Take samples from the `Teacher`-ses and login with their email addresses to view the various states of the application forms. The review app should have data too but it's tricky to see at the moment as logging in is required. 