### PR TITLE
Add institution name to document upload title

### DIFF
--- a/app/views/teacher_interface/documents/edit.html.erb
+++ b/app/views/teacher_interface/documents/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "Check your uploaded files" %>
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
-<h1 class="govuk-heading-l">Check your uploaded files</h1>
+<h1 class="govuk-heading-l">Check your uploaded files – <%= I18n.t("document.document_type.#{@document.document_type}") %> document</h1>
 
 <h2 class="govuk-heading-m">Files added</h2>
 

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -61,10 +61,29 @@
     <% end %>
   <% elsif @document.qualification_certificate? %>
     <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
-    <h1 class="govuk-heading-l"><%= I18n.t("application_form.qualifications.upload.certificate.title.#{@document.documentable.locale_key}") %></h1>
+
+    <h1 class="govuk-heading-l">
+      <% if @document.documentable.institution_name.present? %>
+        Upload your <%= I18n.t("document.document_type.qualification_certificate") %> for <%= @document.documentable.institution_name %>
+      <% elsif @document.documentable.is_teaching_qualification? %>
+        Upload your teaching qualification certificate
+      <% else %>
+        Upload your university degree certificate
+      <% end %>
+    </h1>
   <% elsif @document.qualification_transcript? %>
     <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
-    <h1 class="govuk-heading-l"><%= I18n.t("application_form.qualifications.upload.transcript.title.#{@document.documentable.locale_key}") %></h1>
+
+    <h1 class="govuk-heading-l">
+      <% if @document.documentable.institution_name.present? %>
+        Upload your <%= I18n.t("document.document_type.qualification_transcript") %> for <%= @document.documentable.institution_name %>
+      <% elsif @document.documentable.is_teaching_qualification? %>
+        Upload your teaching qualification transcript
+      <% else %>
+        Upload your university degree transcript
+      <% end %>
+    </h1>
+
     <p class="govuk-body"><%= I18n.t("application_form.qualifications.upload.transcript.description") %></p>
   <% end %>
 <% else %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,14 +54,7 @@ en:
             teaching_qualification: What is the date on your teaching qualification certificate?
             university_degree: What is the date on your university degree certificate?
       upload:
-        certificate:
-          title:
-            teaching_qualification: Upload your teaching qualification certificate
-            university_degree: Upload your university degree certificate
         transcript:
-          title:
-            teaching_qualification: Upload your teaching qualification transcript
-            university_degree: Upload your university degree transcript
           description: Upload a transcript of your teaching qualification, issued by the awarding body. If your teaching qualification was completed as part of your degree, you should supply your degree transcript.
     age_range:
       heading: What age range are you qualified to teach?

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -763,26 +763,22 @@ RSpec.describe "Teacher application", type: :system do
 
   def then_i_see_the_upload_certificate_form
     expect(page).to have_title("Upload a document")
-    expect(page).to have_content(
-      "Upload your teaching qualification certificate"
-    )
+    expect(page).to have_content("Upload your certificate for Name")
   end
 
   def then_i_see_the_upload_degree_certificate_form
     expect(page).to have_title("Upload a document")
-    expect(page).to have_content("Upload your university degree certificate")
+    expect(page).to have_content("Upload your certificate for Name")
   end
 
   def then_i_see_the_upload_transcript_form
     expect(page).to have_title("Upload a document")
-    expect(page).to have_content(
-      "Upload your teaching qualification transcript"
-    )
+    expect(page).to have_content("Upload your transcript for Name")
   end
 
   def then_i_see_the_upload_degree_transcript_form
     expect(page).to have_title("Upload a document")
-    expect(page).to have_content("Upload your university degree transcript")
+    expect(page).to have_content("Upload your transcript for Name")
   end
 
   def then_i_see_the_age_range_form

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_name_change_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_name_change_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -41,7 +41,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_identification_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_identification_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -56,7 +56,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_certificate_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_certificate_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -64,7 +64,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_transcript_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_transcript_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -138,7 +138,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_name_change_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_name_change_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -152,7 +152,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_identification_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_identification_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -167,7 +167,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_certificate_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_certificate_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -175,7 +175,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_transcript_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_transcript_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -241,7 +241,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_name_change_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_name_change_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -255,7 +255,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_identification_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_identification_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -270,7 +270,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_certificate_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_certificate_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -278,7 +278,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_transcript_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_transcript_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -311,7 +311,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_written_statement_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_written_statement_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -370,7 +370,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_certificate_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_certificate_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -378,7 +378,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_transcript_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_transcript_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -398,7 +398,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_certificate_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_certificate_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -406,7 +406,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_fill_in_the_upload_transcript_form
     and_i_click_continue
-    then_i_see_the_check_your_uploads
+    then_i_see_the_check_your_transcript_uploads
 
     when_i_choose_no
     and_i_click_continue
@@ -705,9 +705,43 @@ RSpec.describe "Teacher application", type: :system do
     expect(page).to have_content("Upload a valid identification document")
   end
 
-  def then_i_see_the_check_your_uploads
+  def then_i_see_the_check_your_identification_uploads
     expect(page).to have_title("Check your uploaded files")
-    expect(page).to have_content("Check your uploaded files")
+    expect(page).to have_content(
+      "Check your uploaded files – identity document"
+    )
+    expect(page).to have_content("File 1\tupload.pdf\tDelete")
+  end
+
+  def then_i_see_the_check_your_name_change_uploads
+    expect(page).to have_title("Check your uploaded files")
+    expect(page).to have_content(
+      "Check your uploaded files – name change document"
+    )
+    expect(page).to have_content("File 1\tupload.pdf\tDelete")
+  end
+
+  def then_i_see_the_check_your_certificate_uploads
+    expect(page).to have_title("Check your uploaded files")
+    expect(page).to have_content(
+      "Check your uploaded files – certificate document"
+    )
+    expect(page).to have_content("File 1\tupload.pdf\tDelete")
+  end
+
+  def then_i_see_the_check_your_transcript_uploads
+    expect(page).to have_title("Check your uploaded files")
+    expect(page).to have_content(
+      "Check your uploaded files – transcript document"
+    )
+    expect(page).to have_content("File 1\tupload.pdf\tDelete")
+  end
+
+  def then_i_see_the_check_your_written_statement_uploads
+    expect(page).to have_title("Check your uploaded files")
+    expect(page).to have_content(
+      "Check your uploaded files – written statement document"
+    )
     expect(page).to have_content("File 1\tupload.pdf\tDelete")
   end
 

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -70,7 +70,9 @@ RSpec.describe "Teacher documents", type: :system do
 
   def then_i_see_the_check_your_uploaded_files_page
     expect(page).to have_title("Check your uploaded files")
-    expect(page).to have_content("Check your uploaded files")
+    expect(page).to have_content(
+      "Check your uploaded files – written statement document"
+    )
     expect(page).to have_content("File 1\tupload.pdf\tDelete")
     expect(page).to have_content("File 2\tupload.pdf\tDelete")
   end


### PR DESCRIPTION
This adds the name of the institution (if provided) to the title of the document upload page, so users can understand clearly what they're uploading the document for.

[Trello Card](https://trello.com/c/Z9za7BqU/750-upload-certificate-for-university-name)

I've also added it to the "Check your uploads" page to make it clearer what document the user is supposed to be checking, as there's a section in the form where we have two document uploads back to back and it can look like it's the same page.

[Trello Card](https://trello.com/c/MNEmn3r1/755-check-your-uploaded-files-pages-are-identical)

## Screenshots

<img width="668" alt="Screenshot 2022-08-18 at 08 27 31" src="https://user-images.githubusercontent.com/510498/185335714-bc941aca-8c0d-4ac0-b6a0-ea039f937f9c.png">

<img width="678" alt="Screenshot 2022-08-18 at 08 03 31" src="https://user-images.githubusercontent.com/510498/185332131-3151807e-f149-49f8-97ea-60a561ca397c.png">
