### PR TITLE
Update content related to emails

### DIFF
--- a/app/views/teachers/mailer/confirmation_instructions.text.erb
+++ b/app/views/teachers/mailer/confirmation_instructions.text.erb
@@ -1,5 +1,5 @@
-Welcome <%= @email %>!
+Hello <%= @email %>
 
-You can confirm your account email through the link below:
+Use the link below to log in and continue your QTS application.
 
 <%= confirmation_url(@resource, confirmation_token: @token) %>

--- a/app/views/teachers/mailer/magic_link.text.erb
+++ b/app/views/teachers/mailer/magic_link.text.erb
@@ -1,6 +1,6 @@
-Hello <%= @resource.email %>!
+Hello <%= @resource.email %>
 
-You can login using the link below:
+Use the link below to log in and continue your QTS application.
 
 <%= teacher_magic_link_url(email: @resource.email, token: @token) %>
 

--- a/app/views/teachers/registrations/new.html.erb
+++ b/app/views/teachers/registrations/new.html.erb
@@ -1,16 +1,12 @@
-<% content_for :page_title, "Create an account" %>
+<% content_for :page_title, I18n.t("teacher.registration.title") %>
 <% content_for :back_link_url, new_teacher_session_path %>
 
-<h1 class="govuk-heading-xl">Create an account</h1>
+<h1 class="govuk-heading-xl">
+  <%= I18n.t("teacher.registration.title") %>
+</h1>
 
 <%= form_with model: resource, url: registration_path(resource_name) do |f| %>
   <%= f.govuk_error_summary %>
-
-  <%= f.govuk_email_field :email,
-                          autofocus: true,
-                          autocomplete: "email",
-                          label: { text: "Email address", size: "m" },
-                          hint: { text: "Do not use a work or university email address you might lose access to." } %>
-
-  <%= f.govuk_submit "Continue" %>
+  <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { size: "m" } %>
+  <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teachers/sessions/check_email.html.erb
+++ b/app/views/teachers/sessions/check_email.html.erb
@@ -4,9 +4,9 @@
 
 <p class="govuk-body-m">
   <% if @email.present? %>
-    You asked us to send a link to <%= @email %>. If we have a record of that email address, we’ll send you a link to sign in.
+    You asked us to send a link to <%= @email %>. If we have a record of that email address, we’ll send you an email containing a link to continue with your QTS application.
   <% else %>
-    You should have received a link by email. Follow the link to confirm your email address.
+    We’ve sent you an email containing a link to continue with your QTS application.
   <% end %>
 </p>
 

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -20,7 +20,7 @@ en:
       magic_link_invalid: "Invalid or expired login link."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "Your QTS application link"
       reset_password_instructions:
         subject: "Reset password instructions"
       unlock_instructions:
@@ -30,7 +30,7 @@ en:
       password_change:
         subject: "Password Changed"
       magic_link:
-        subject: "Here's your magic login link"
+        subject: "Your QTS application link"
     omniauth_callbacks:
       failure: 'Could not authenticate you from %{kind} because "%{reason}".'
       success: "Successfully authenticated from %{kind} account."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,10 @@ en:
     url: https://apply-for-qts-in-england.education.gov.uk
     phase_banner_text: This is a new service – <a href="https://docs.google.com/forms/d/1OpMhXJ1blJu2qFqW7VWwKnfjIoU-5SmOLXdgI0Z_kZg/viewform?edit_requested=true">your feedback will help us to improve it</a>.
 
+  teacher:
+    registration:
+      title: Your email address
+
   application_form:
     tasks:
       sections:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -4,6 +4,8 @@ en:
     hint:
       qualification:
         add_another: You can use the next section to tell us about additional degrees if you want to.
+      teacher:
+        email: We’ll use this to send you a link to continue with your QTS application. Do not use a work or university email that you might lose access to.
       teacher_interface_alternative_name_form:
         has_alternative_name: If your name appears differently on your ID documents or qualifications you need to upload proof of your name change, for example, your marriage or civil partnership certificate.
         alternative_given_names: Enter your full name apart from your family name
@@ -17,6 +19,8 @@ en:
         add_another_options:
           true: "Yes"
           false: "No"
+      teacher:
+        email: Email address
       teacher_interface_alternative_name_form:
         has_alternative_name_options:
           true: Yes – I’ll upload another document to prove this

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -103,13 +103,13 @@ module SystemHelpers
     message = ActionMailer::Base.deliveries.last
     expect(message).to_not be_nil
 
-    expect(message.subject).to eq("Confirmation instructions")
+    expect(message.subject).to eq("Your QTS application link")
     expect(message.to).to include("test@example.com")
   end
 
   def when_i_visit_the_teacher_confirmation_email
     message = ActionMailer::Base.deliveries.last
-    uri = URI.parse(URI.extract(message.body.to_s).second)
+    uri = URI.parse(URI.extract(message.body.encoded).first)
     expect(uri.path).to eq("/teacher/confirmation")
     expect(uri.query).to include("confirmation_token=")
     visit "#{uri.path}?#{uri.query}"

--- a/spec/system/support_interface/staff_spec.rb
+++ b/spec/system/support_interface/staff_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Staff support", type: :system do
 
   def when_i_visit_the_invitation_email
     message = ActionMailer::Base.deliveries.first
-    uri = URI.parse(URI.extract(message.body.to_s).second)
+    uri = URI.parse(URI.extract(message.body.encoded).second)
     expect(uri.path).to eq("/staff/invitation/accept")
     expect(uri.query).to include("invitation_token=")
     visit "#{uri.path}?#{uri.query}"

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "Teacher authentication", type: :system do
 
   def when_i_visit_the_magic_link_email
     message = ActionMailer::Base.deliveries.last
-    uri = URI.parse(URI.extract(message.body.to_s).second)
+    uri = URI.parse(URI.extract(message.body.encoded).first)
     expect(uri.path).to eq("/teacher/magic_link")
     expect(uri.query).to include("token")
     visit "#{uri.path}?#{uri.query}"
@@ -218,7 +218,7 @@ RSpec.describe "Teacher authentication", type: :system do
     message = ActionMailer::Base.deliveries.last
     expect(message).to_not be_nil
 
-    expect(message.subject).to eq("Here's your magic login link")
+    expect(message.subject).to eq("Your QTS application link")
     expect(message.to).to include("test@example.com")
   end
 

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -171,9 +171,11 @@ RSpec.describe "Teacher authentication", type: :system do
   end
 
   def then_i_see_the_sign_up_form
-    expect(page).to have_current_path("/teacher/sign_up")
-    expect(page).to have_title("Create an account")
-    expect(page).to have_content("Create an account")
+    expect(page).to have_title("Your email address")
+    expect(page).to have_content("Your email address")
+    expect(page).to have_content(
+      "We’ll use this to send you a link to continue with your QTS application."
+    )
   end
 
   def then_i_see_the_check_your_email_page


### PR DESCRIPTION
This updates the various bits of content associated with emails as per https://docs.google.com/presentation/d/1PNkNrr4Tm6thV_7jlBTbqUhNbweMljh6XaNOMcxs0uE/edit#slide=id.g1457f65ff1a_0_5.

[Trello Card](https://trello.com/c/WDEoFpcb/753-magic-link-email-content-review)

## Screenshots

<img width="716" alt="Screenshot 2022-08-18 at 09 34 46" src="https://user-images.githubusercontent.com/510498/185354423-d084f203-023e-423a-ae9c-bb6fa0593e6c.png">

<img width="586" alt="Screenshot 2022-08-18 at 09 42 00" src="https://user-images.githubusercontent.com/510498/185354429-ada91d79-25c9-4682-a392-94a424f50d3a.png">
