### PR TITLE
Add upper bound for date of birth validation

### DIFF
--- a/app/forms/teacher_interface/name_and_date_of_birth_form.rb
+++ b/app/forms/teacher_interface/name_and_date_of_birth_form.rb
@@ -9,7 +9,9 @@ class TeacherInterface::NameAndDateOfBirthForm
   attribute :date_of_birth, :date
 
   validates :application_form, presence: true
-  validate :validate_date_of_birth
+  validates :date_of_birth,
+            allow_blank: true,
+            inclusion: 100.years.ago..18.years.ago
 
   def save
     return false unless valid?
@@ -18,18 +20,5 @@ class TeacherInterface::NameAndDateOfBirthForm
     application_form.family_name = family_name
     application_form.date_of_birth = date_of_birth
     application_form.save!
-  end
-
-  private
-
-  def validate_date_of_birth
-    if date_of_birth.present? && date_of_birth >= 18.years.ago
-      errors.add(
-        :date_of_birth,
-        I18n.t(
-          "activemodel.errors.models.teacher_interface/name_and_date_of_birth_form.attributes.date_of_birth.inclusion"
-        )
-      )
-    end
   end
 end

--- a/spec/forms/teacher_interface/name_and_date_of_birth_form_spec.rb
+++ b/spec/forms/teacher_interface/name_and_date_of_birth_form_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe TeacherInterface::NameAndDateOfBirthForm, type: :model do
 
       it { is_expected.to be false }
     end
+
+    context "when date of birth is greater than 100 years ago" do
+      let(:date_of_birth) { Date.new(1900, 1, 1) }
+
+      it { is_expected.to be false }
+    end
   end
 
   describe "#save" do


### PR DESCRIPTION
At the moment we only check that the teacher is at least 18 years old, but we want to ensure the teacher is not really old as well. I've set it at 100 years old, but that's an arbitrary number.