### PR TITLE
Add sign out link to navigation bar

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -30,6 +30,11 @@
 
     <%= govuk_header(homepage_url: "https://www.gov.uk", service_name: t('service.name'), classes: "app-header--#{HostingEnvironment.name}") do |header| %>
       <% case try(:current_namespace) %>
+      <% when "teacher" %>
+        <% header.navigation_item(
+           text: "Sign out",
+           href: destroy_teacher_session_path
+         ) %>
       <% when "support" %>
         <% header.navigation_item(
           text: "Features",

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -31,10 +31,9 @@
     <%= govuk_header(homepage_url: "https://www.gov.uk", service_name: t('service.name'), classes: "app-header--#{HostingEnvironment.name}") do |header| %>
       <% case try(:current_namespace) %>
       <% when "teacher" %>
-        <% header.navigation_item(
-           text: "Sign out",
-           href: destroy_teacher_session_path
-         ) %>
+        <% if current_teacher %>
+          <% header.navigation_item(text: "Sign out", href: destroy_teacher_session_path) %>
+        <% end %>
       <% when "support" %>
         <% header.navigation_item(
           text: "Features",

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -49,10 +49,8 @@
     <% end %>
   </ol>
 
-  <%= form_with url: destroy_teacher_session_path, method: :delete do |f| %>
-    <div class="govuk-button-group">
-      <%= govuk_button_link_to "Check your answers", edit_teacher_interface_application_form_path %>
-      <%= f.govuk_submit "Save and sign out", secondary: true %>
-    </div>
-  <% end %>
+  <div class="govuk-button-group">
+    <%= govuk_button_link_to "Check your answers", edit_teacher_interface_application_form_path %>
+    <%= govuk_button_link_to "Save and sign out", destroy_teacher_session_path, secondary: true %>
+  </div>
 <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,7 +310,7 @@ Devise.setup do |config|
   # config.navigational_formats = ['*/*', :html]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
-  # config.sign_out_via = :delete
+  config.sign_out_via = :get
 
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -46,6 +46,20 @@ RSpec.describe "Teacher authentication", type: :system do
     when_i_select_a_country
     and_i_click_continue
 
+    when_i_click_save_and_sign_out
+    then_i_see_the_signed_out_page
+  end
+
+  it "sign out with navigation link" do
+    when_i_visit_the_sign_up_page
+
+    when_i_fill_create_teacher_email_address
+    and_i_click_continue
+    then_i_see_the_check_your_email_page
+    and_i_receive_a_teacher_confirmation_email
+
+    when_i_visit_the_teacher_confirmation_email
+
     when_i_click_sign_out
     then_i_see_the_signed_out_page
   end
@@ -167,7 +181,11 @@ RSpec.describe "Teacher authentication", type: :system do
   end
 
   def when_i_click_sign_out
-    click_button "Save and sign out"
+    click_link "Sign out"
+  end
+
+  def when_i_click_save_and_sign_out
+    click_link "Save and sign out"
   end
 
   def then_i_see_the_sign_up_form


### PR DESCRIPTION
This came up in user research as users weren't sure how to sign out and were expecting to see one in the navigation bar. It's also something that exists in the prototype but is missing in this service.

## Screenshot

<img width="286" alt="Screenshot 2022-08-18 at 12 36 33" src="https://user-images.githubusercontent.com/510498/185386586-6c63892f-1640-479f-9f22-a6f8f3ef137f.png">
