### PR TITLE
Add libvips-dev to runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,8 @@ RUN apk add --update --no-cache tzdata && \
     echo "Europe/London" > /etc/timezone
 
 # libpq: required to run postgres
-RUN apk add --no-cache libpq
+# vips-dev: dependencies for ruby-vips (image processing library)
+RUN apk add --no-cache libpq vips-dev
 
 # Copy files generated in the builder image
 COPY --from=builder /app /app

--- a/Gemfile
+++ b/Gemfile
@@ -33,11 +33,11 @@ gem "mail-notify"
 
 # this is used in the example data generation task
 gem "factory_bot_rails"
+gem "faker"
 
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails"
-  gem "faker"
 end
 
 group :development do

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -1,5 +1,3 @@
-require "factory_bot"
-
 namespace :example_data do
   desc "Create example data for testing"
   task generate: :environment do
@@ -15,7 +13,6 @@ namespace :example_data do
     Teacher.reset_column_information
     Faker::Config.locale = "en-GB"
     Faker::UniqueGenerator.clear
-    FactoryBot.find_definitions
 
     Country.all.each do |country|
       country.regions.each do |region|


### PR DESCRIPTION
This is required to run the server as the libraries are loaded dynamically. I've tested this by building the Docker image locally.