### PR TITLE
[775] Create example users as 'confirmed'

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-bin/bundle exec rubocop --auto-correct-all
+bin/bundle exec rubocop --autocorrect-all
 yarn prettier --write --ignore-unknown '**/*'

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -17,7 +17,7 @@ namespace :example_data do
     Country.all.each do |country|
       country.regions.each do |region|
         application_form_traits_for(region).each do |traits|
-          teacher = FactoryBot.create(:teacher)
+          teacher = FactoryBot.create(:teacher, confirmed_at: Time.zone.now)
           FactoryBot.create(:application_form, *traits, teacher:, region:)
         end
       end


### PR DESCRIPTION
Confirmation emails were being sent for each user created with the example_data:generate task. We don't want to disable the emails in review as we may want to test that functionality so create the example users as 'confirmed'. They would be in any case if they had started an application.

Also fix a deprecation warning from bin/lint