### PR TITLE
[778] Set correct `HostingEnvironment.host` for review

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,37 +1,51 @@
 module HostingEnvironment
-  def self.name
-    ENV.fetch("HOSTING_ENVIRONMENT", "dev")
-  end
+  class << self
+    def name
+      ENV.fetch("HOSTING_ENVIRONMENT", "dev")
+    end
 
-  def self.phase
-    return "Beta" if production?
-    return "Development" if development?
-    return "Pre-production" if preprod?
+    def phase
+      return "Beta" if production?
+      return "Development" if development?
+      return "Pre-production" if preprod?
 
-    name.capitalize
-  end
+      name.capitalize
+    end
 
-  def self.phase_text
-    return I18n.t("service.phase_banner_text") if production?
+    def phase_text
+      return I18n.t("service.phase_banner_text") if production?
 
-    "This is a '#{phase}' version of the service."
-  end
+      "This is a '#{phase}' version of the service."
+    end
 
-  def self.host
-    return "apply-for-qts-in-england.education.gov.uk" if production?
+    def host
+      return "apply-for-qts-in-england.education.gov.uk" if production?
+      return "#{application_name}.london.cloudapps.digital" if review?
 
-    "#{name}.apply-for-qts-in-england.education.gov.uk"
-  end
+      "#{name}.apply-for-qts-in-england.education.gov.uk"
+    end
 
-  def self.production?
-    name == "production"
-  end
+    def production?
+      name == "production"
+    end
 
-  def self.preprod?
-    name == "preprod"
-  end
+    def preprod?
+      name == "preprod"
+    end
 
-  def self.development?
-    name == "dev"
+    def development?
+      name == "dev"
+    end
+
+    def review?
+      name == "review"
+    end
+
+    def application_name
+      vcap_json = ENV.fetch("VCAP_APPLICATION", "{}")
+      vcap_config = JSON.parse(vcap_json)
+
+      (vcap_config["application_name"] || name).gsub(/-worker$/, "")
+    end
   end
 end

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -2,11 +2,14 @@ require "rails_helper"
 
 RSpec.describe HostingEnvironment do
   let(:hosting_environment) { nil }
+  let(:application_name) { "apply-for-qts-in-england-review-pr-292" }
+  let(:vcap_application) { "{\"application_name\":\"#{application_name}\"}" }
 
   around do |example|
-    ClimateControl.modify(HOSTING_ENVIRONMENT: hosting_environment) do
-      example.run
-    end
+    ClimateControl.modify(
+      HOSTING_ENVIRONMENT: hosting_environment,
+      VCAP_APPLICATION: vcap_application
+    ) { example.run }
   end
 
   describe "#name" do
@@ -50,6 +53,28 @@ RSpec.describe HostingEnvironment do
       let(:hosting_environment) { "dev" }
 
       it { is_expected.to eq("dev.apply-for-qts-in-england.education.gov.uk") }
+    end
+
+    context "when the environment is review" do
+      let(:hosting_environment) { "review" }
+
+      it do
+        is_expected.to eq(
+          "apply-for-qts-in-england-review-pr-292.london.cloudapps.digital"
+        )
+      end
+
+      context "running on a worker" do
+        let(:application_name) do
+          "apply-for-qts-in-england-review-pr-292-worker"
+        end
+
+        it do
+          is_expected.to eq(
+            "apply-for-qts-in-england-review-pr-292.london.cloudapps.digital"
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The `HostingEnvironment.host` is used to generate the login email URLs. For all other envs the env name is the prefix and the URL is an `education.gov.uk` one but review apps are prefixed with the application name and have a cloud apps URL so need to be treated differently.

The mails are sent from a worker instance so we need to handle that if we go with this method.

This will fix the login and confirmation email links

<img width="586" alt="Screenshot 2022-08-19 at 16 27 56" src="https://user-images.githubusercontent.com/5216/185653653-3402e437-78df-4457-8701-eb3565539be5.png">
.