### PR TITLE
[779] Configure review apps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,7 +165,7 @@ jobs:
           pr_id: ${{ github.event.pull_request.number }}
       - name: Seed the DB
         shell: bash
-        run: cf run-task apply-for-qts-in-england-review-pr-${{ github.event.pull_request.number }} --command "cd /app && bundle exec rails db:seed example_data:generate" --wait
+        run: cf run-task apply-for-qts-in-england-review-pr-${{ github.event.pull_request.number }} --command "cd /app && bundle exec rails db:seed example_data:generate review_app:configure" --wait
       - name: Post sticky pull request comment
         if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2

--- a/lib/tasks/review_app.rake
+++ b/lib/tasks/review_app.rake
@@ -1,0 +1,11 @@
+namespace :review_app do
+  desc "Set some default configuration in the review environment"
+  task configure: :environment do
+    if HostingEnvironment.production?
+      raise "THIS TASK CANNOT BE RUN IN PRODUCTION"
+    end
+
+    FeatureFlag.activate(:teacher_applications)
+    Region.update_all(application_form_enabled: true)
+  end
+end


### PR DESCRIPTION
When a review app is deployed we seed it with example data. We almost always will want to enable some features and this will likely be the same for most review apps but may change as the service develops.

Run a task to set some features and update some data when we deploy the review app.