### PR TITLE
Fix shoulda_matchers configuration

### DIFF
--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,3 +1,5 @@
+require "shoulda/matchers"
+
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec


### PR DESCRIPTION
In d3d2623d4be920bc0097d79fe51ea09de3c41a1b the file was moved to the `spec/support` directory and that seems to have [caused an issue with importing this file while running the smoke tests](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/runs/7974135504?check_suite_focus=true).

To fix this I've made the require statements explicit as described in: https://github.com/thoughtbot/shoulda-matchers/issues/480#issuecomment-43252802.