### PR TITLE
Remove unnecessary import

### DIFF
--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require "spec_helper"
+
 require "capybara/rspec"
 require "capybara/cuprite"
 


### PR DESCRIPTION
Since we're importing this automatically in the rspec configuration file.