### PR TITLE
[800] Basic application show page

### DIFF
--- a/app/controllers/assessor_interface/application_forms_controller.rb
+++ b/app/controllers/assessor_interface/application_forms_controller.rb
@@ -2,4 +2,8 @@ class AssessorInterface::ApplicationFormsController < AssessorInterface::BaseCon
   def index
     @application_forms = ApplicationForm.all
   end
+
+  def show
+    @application_form = ApplicationForm.find(params[:id])
+  end
 end

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -1,0 +1,14 @@
+<% content_for :page_title, "Application forms" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full-from-desktop"> 
+    <h1 class="govuk-heading-xl">Application</h1>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full-from-desktop"> 
+    <div class="govuk-body">
+      <%= @application_form.given_names%> <%= @application_form.family_name %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
   namespace :assessor_interface, path: "/assessor" do
     root to: redirect("/assessor/application_forms")
 
-    resources :application_forms, only: %i[index]
+    resources :application_forms, only: %i[index show]
   end
 
   namespace :eligibility_interface, path: "/eligibility" do

--- a/spec/system/assessor_interface/application_forms_spec.rb
+++ b/spec/system/assessor_interface/application_forms_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 RSpec.describe "Application forms", type: :system do
   it "displays a list of applications" do
     given_the_service_is_staff_http_basic_auth

--- a/spec/system/assessor_interface/view_application_spec.rb
+++ b/spec/system/assessor_interface/view_application_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe "viewing an application", type: :system do
+  it "displays the application overview" do
+    given_the_service_is_staff_http_basic_auth
+    given_there_is_an_application_form
+
+    when_i_am_authorized_as_an_assessor_user
+    when_i_visit_the_application_page
+    then_i_see_the_application
+  end
+
+  private
+
+  def given_the_service_is_staff_http_basic_auth
+    FeatureFlag.activate(:staff_http_basic_auth)
+  end
+
+  def given_there_is_an_application_form
+    application_form
+  end
+
+  def when_i_visit_the_application_page
+    visit assessor_interface_application_form_path(application_form)
+  end
+
+  def then_i_see_the_application
+    expect(page).to have_content(
+      "#{application_form.given_names} #{application_form.family_name}"
+    )
+  end
+
+  def application_form
+    @application_form ||= create(:application_form, :with_personal_information)
+  end
+end


### PR DESCRIPTION
Basic placeholder page for the application overview at `/assessor/application_forms/<id>`

This also fixes the failing build on `main` due to a missing `require` in the index page system spec.

<img width="1036" alt="Screenshot 2022-08-23 at 17 55 20" src="https://user-images.githubusercontent.com/5216/186217871-d45c7b7e-85eb-426f-987b-8fa920dfd2f7.png">