### PR TITLE
Application form search result component

### DIFF
--- a/app/assets/stylesheets/_application_forms.scss
+++ b/app/assets/stylesheets/_application_forms.scss
@@ -1,4 +1,4 @@
-.app-applications__filters {
+.app-application-forms__filters {
   background-color: govuk-colour("light-grey");
   padding: govuk-spacing(3);
 }

--- a/app/assets/stylesheets/_description_list.scss
+++ b/app/assets/stylesheets/_description_list.scss
@@ -1,0 +1,71 @@
+%app-description-list {
+  @include govuk-clearfix;
+  margin-top: 0;
+
+  &__label:after {
+    display: inline-block;
+  }
+}
+
+%app-description-list > dt {
+  @include govuk-font($size: 19, $weight: bold);
+  vertical-align: top;
+
+  @include govuk-media-query($from: desktop) {
+    clear: left;
+    float: left;
+    margin-bottom: govuk-spacing(1);
+    width: 35%;
+  }
+}
+
+.app-description-list--search-result > dt {
+  @include govuk-font($size: 19, $weight: regular);
+  color: $govuk-secondary-text-colour;
+}
+
+%app-description-list > dd {
+  @include govuk-font($size: 19, $weight: normal);
+  margin: 0 0 govuk-spacing(2) 0;
+  vertical-align: top;
+
+  @include govuk-media-query($from: desktop) {
+    float: left;
+    margin-bottom: govuk-spacing(1);
+    width: 65%;
+  }
+
+  .govuk-details,
+  .govuk-details__summary {
+    margin-bottom: 0;
+  }
+
+  .govuk-body {
+    margin-bottom: govuk-spacing(1);
+  }
+
+  .govuk-hint {
+    @include govuk-font($size: 16, $weight: normal);
+    margin-top: govuk-spacing(1);
+    margin-bottom: govuk-spacing(1);
+  }
+
+  .govuk-details__text {
+    margin-bottom: govuk-spacing(2);
+  }
+}
+
+.app-description-list {
+  @extend %app-description-list;
+
+  &__label:after {
+    display: inline-block;
+  }
+
+  &__hint {
+    @include govuk-font($size: 16, $weight: normal);
+    color: $govuk-secondary-text-colour;
+    display: block;
+    margin-bottom: govuk-space(1);
+  }
+}

--- a/app/assets/stylesheets/_search_results.scss
+++ b/app/assets/stylesheets/_search_results.scss
@@ -1,0 +1,22 @@
+.app-search-results {
+  @include govuk-responsive-padding(4, "top");
+  margin: 0;
+  padding-left: 0;
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.app-search-results__item {
+  @include govuk-responsive-margin(4, "bottom");
+  border-bottom: 1px solid $govuk-border-colour;
+  display: block;
+}
+
+.app-search-result__item-title {
+  @include govuk-font($size: 24, $weight: bold);
+  @include govuk-responsive-margin(4, "bottom");
+  margin-top: 0;
+
+  a {
+    text-decoration: none;
+  }
+}

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -5,6 +5,7 @@ $govuk-assets-path: "/";
 @import "govuk-frontend/govuk/all";
 @import "location-autocomplete.min";
 
+@import "_description_list";
 @import "_environments";
 @import "_summary_list_card";
 @import "_support";

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -5,13 +5,13 @@ $govuk-assets-path: "/";
 @import "govuk-frontend/govuk/all";
 @import "location-autocomplete.min";
 
+@import "_application_forms";
 @import "_description_list";
 @import "_environments";
 @import "_search_results";
 @import "_summary_list_card";
 @import "_support";
 @import "_task_list";
-@import "_applications";
 
 ul.autocomplete__menu {
   li {

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -7,6 +7,7 @@ $govuk-assets-path: "/";
 
 @import "_description_list";
 @import "_environments";
+@import "_search_results";
 @import "_summary_list_card";
 @import "_support";
 @import "_task_list";

--- a/app/components/application_form_search_result_component.html.erb
+++ b/app/components/application_form_search_result_component.html.erb
@@ -1,0 +1,10 @@
+<li class="app-search-results__item">
+  <h2 class="app-search-result__item-title">
+    <%= govuk_link_to full_name, href %>
+  </h2>
+
+  <%= render(DescriptionListComponent.new(
+    rows: summary_rows,
+    classes: ["app-description-list--search-result"]
+  )) %>
+</li>

--- a/app/components/application_form_search_result_component.rb
+++ b/app/components/application_form_search_result_component.rb
@@ -1,0 +1,25 @@
+class ApplicationFormSearchResultComponent < ViewComponent::Base
+  def initialize(application_form)
+    super
+    @application_form = application_form
+  end
+
+  def full_name
+    application_form_full_name(application_form)
+  end
+
+  def href
+    assessor_interface_application_form_path(application_form)
+  end
+
+  def summary_rows
+    application_form_summary_rows(application_form)
+  end
+
+  private
+
+  attr_reader :application_form
+
+  delegate :application_form_full_name, to: :helpers
+  delegate :application_form_summary_rows, to: :helpers
+end

--- a/app/components/description_list_component.html.erb
+++ b/app/components/description_list_component.html.erb
@@ -1,0 +1,6 @@
+<dl class="<%= classes.join(" ") %>">
+  <%- rows.each do |row| %>
+    <dt class="app-description-list__label"><%= row.fetch(:key).fetch(:text) %></dt>
+    <dd><%= row.fetch(:value).fetch(:text) %></dd>
+  <% end %>
+</dl>

--- a/app/components/description_list_component.rb
+++ b/app/components/description_list_component.rb
@@ -1,0 +1,13 @@
+class DescriptionListComponent < ViewComponent::Base
+  def initialize(rows:, classes: [])
+    super
+    @rows = rows
+    @classes = classes
+  end
+
+  def classes
+    ["app-description-list"] + @classes
+  end
+
+  attr_reader :rows
+end

--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -1,0 +1,35 @@
+module ApplicationFormHelper
+  def application_form_full_name(application_form)
+    "#{application_form.given_names} #{application_form.family_name}"
+  end
+
+  def application_form_summary_rows(application_form)
+    [
+      [
+        I18n.t("application_form.summary.country"),
+        CountryName.from_country(application_form.region.country)
+      ],
+      [I18n.t("application_form.summary.region"), application_form.region.name],
+      [
+        I18n.t("application_form.summary.created_at"),
+        application_form.created_at.strftime("%e %B %Y")
+      ],
+      [
+        I18n.t("application_form.summary.days_remaining_sla"),
+        "Not implemented"
+      ],
+      [I18n.t("application_form.summary.assignee"), "Not implemented"],
+      [I18n.t("application_form.summary.reviewer"), "Not implemented"],
+      [
+        I18n.t("application_form.summary.status"),
+        render(
+          GovukComponent::TagComponent.new(
+            text: "Not implemented",
+            colour: "blue"
+          )
+        )
+      ],
+      [I18n.t("application_form.summary.notes"), "Not implemented"]
+    ].map { |key, value| { key: { text: key }, value: { text: value } } }
+  end
+end

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -8,7 +8,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full-from-desktop">
-    <div class="govuk-grid-column-one-third app-applications__filters">
+    <div class="govuk-grid-column-one-third app-application-forms__filters">
       <h2 class="govuk-heading-m">Filters</h2>
     </div>
 

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -1,22 +1,23 @@
-<% content_for :page_title, "Application forms" %>
+<% content_for :page_title, "Applications" %>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full-from-desktop"> 
-      <h1 class="govuk-heading-xl">Applications</h1>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full-from-desktop">
+    <h1 class="govuk-heading-xl">Applications</h1>
   </div>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full-from-desktop"> 
-      <div class="govuk-grid-column-one-third app-applications__filters">
-        <h2 class="govuk-heading-m">Filters</h2>
-      </div>
-      <div class="govuk-grid-column-two-thirds">
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full-from-desktop">
+    <div class="govuk-grid-column-one-third app-applications__filters">
+      <h2 class="govuk-heading-m">Filters</h2>
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+      <ul class="app-search-results">
         <%- @application_forms.each do |application_form| -%>
-          <h2 class="govuk-heading-m">
-            <%= application_form.given_names%> <%= application_form.family_name %>
-          </h2>
+          <%= render(ApplicationFormSearchResultComponent.new(application_form)) %>
         <%- end -%>
-      </div>
+      </ul>
     </div>
   </div>
-
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,6 +69,15 @@ en:
     work_history:
       current_or_most_recent_role: Your current or most recent role
       previous_role: Previous role
+    summary:
+      country: Country trained in
+      region: State/territory trained in
+      created_at: Created on
+      days_remaining_sla: Days remaining in SLA
+      assignee: Assigned to
+      reviewer: Reviewer
+      status: Status
+      notes: Notes
 
   document:
     document_type:

--- a/spec/components/application_form_search_result_component_spec.rb
+++ b/spec/components/application_form_search_result_component_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationFormSearchResultComponent, type: :component do
+  subject(:component) { render_inline(described_class.new(application_form)) }
+
+  let(:application_form) do
+    create(:application_form, given_names: "Given", family_name: "Family")
+  end
+
+  describe "heading text" do
+    subject(:text) { component.at_css("h2").text.strip }
+
+    it { is_expected.to eq("Given Family") }
+  end
+
+  describe "heading link" do
+    subject(:href) { component.at_css("h2 > a")["href"] }
+
+    it do
+      is_expected.to eq("/assessor/application_forms/#{application_form.id}")
+    end
+  end
+
+  describe "description list" do
+    subject(:dl) { component.at_css("dl") }
+
+    it { is_expected.to_not be_nil }
+
+    describe "text" do
+      subject(:text) { dl.text.strip }
+
+      it { is_expected.to include("Country trained in") }
+      it { is_expected.to include("State/territory trained in") }
+      it { is_expected.to include("Created on") }
+      it { is_expected.to include("Days remaining in SLA") }
+      it { is_expected.to include("Assigned to") }
+      it { is_expected.to include("Reviewer") }
+      it { is_expected.to include("Status") }
+      it { is_expected.to include("Notes") }
+    end
+  end
+end

--- a/spec/components/description_list_component_spec.rb
+++ b/spec/components/description_list_component_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DescriptionListComponent, type: :component do
+  subject(:component) { render_inline(described_class.new(rows:)) }
+
+  let(:rows) do
+    [
+      { key: { text: "Label 1" }, value: { text: "Value 1" } },
+      { key: { text: "Label 2" }, value: { text: "Value 2" } }
+    ]
+  end
+
+  subject(:dl) { component.at_css("dl") }
+
+  it "has the class" do
+    expect(dl["class"]).to eq("app-description-list")
+  end
+
+  describe "first item" do
+    let(:dt) { component.css("dt")[0] }
+    let(:dd) { component.css("dd")[0] }
+
+    it "has the class" do
+      expect(dt["class"]).to eq("app-description-list__label")
+    end
+
+    it "has the label text" do
+      expect(dt.text.strip).to eq("Label 1")
+    end
+
+    it "has the value text" do
+      expect(dd.text.strip).to eq("Value 1")
+    end
+  end
+
+  describe "second item" do
+    let(:dt) { component.css("dt")[1] }
+    let(:dd) { component.css("dd")[1] }
+
+    it "has the class" do
+      expect(dt["class"]).to eq("app-description-list__label")
+    end
+
+    it "has the label text" do
+      expect(dt.text.strip).to eq("Label 2")
+    end
+
+    it "has the value text" do
+      expect(dd.text.strip).to eq("Value 2")
+    end
+  end
+end

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationFormHelper do
+  let(:region) do
+    create(:region, name: "Region", country: create(:country, code: "US"))
+  end
+
+  let(:application_form) do
+    create(
+      :application_form,
+      region:,
+      created_at: Date.new(2020, 1, 1),
+      given_names: "Given",
+      family_name: "Family"
+    )
+  end
+
+  describe "#application_form_full_name" do
+    subject(:full_name) { application_form_full_name(application_form) }
+
+    it { is_expected.to eq("Given Family") }
+  end
+
+  describe "#application_form_summary_rows" do
+    subject(:summary_rows) { application_form_summary_rows(application_form) }
+
+    it do
+      is_expected.to eq(
+        [
+          {
+            key: {
+              text: "Country trained in"
+            },
+            value: {
+              text: "United States"
+            }
+          },
+          {
+            key: {
+              text: "State/territory trained in"
+            },
+            value: {
+              text: "Region"
+            }
+          },
+          { key: { text: "Created on" }, value: { text: " 1 January 2020" } },
+          {
+            key: {
+              text: "Days remaining in SLA"
+            },
+            value: {
+              text: "Not implemented"
+            }
+          },
+          { key: { text: "Assigned to" }, value: { text: "Not implemented" } },
+          { key: { text: "Reviewer" }, value: { text: "Not implemented" } },
+          {
+            key: {
+              text: "Status"
+            },
+            value: {
+              text:
+                "<strong class=\"govuk-tag govuk-tag--blue\">Not implemented</strong>"
+            }
+          },
+          { key: { text: "Notes" }, value: { text: "Not implemented" } }
+        ]
+      )
+    end
+  end
+end

--- a/spec/system/assessor_interface/application_forms_spec.rb
+++ b/spec/system/assessor_interface/application_forms_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
-RSpec.describe "Application forms", type: :system do
+RSpec.describe "Assessor application forms", type: :system do
   it "displays a list of applications" do
     given_the_service_is_staff_http_basic_auth
     given_there_are_application_forms

--- a/spec/system/assessor_interface/authentication_spec.rb
+++ b/spec/system/assessor_interface/authentication_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Assessor", type: :system do
+RSpec.describe "Assessor authentication", type: :system do
   it "allows signing in and signing out" do
     given_the_service_is_open
     given_staff_exist


### PR DESCRIPTION
This adds a new component which renders an application form search result in the list of applications. To extract the information from the application forms I've put that in a helper so it can be used in other components (for example a summary card component).

Depends on #412 for the link in the search result.

## Screenshot

![Screenshot 2022-08-24 at 11 57 27](https://user-images.githubusercontent.com/510498/186401764-a1f6b40a-b79b-4115-b8d0-651809eecb7d.png)