### PR TITLE
Application form overview component

### DIFF
--- a/app/components/application_form_overview_component.html.erb
+++ b/app/components/application_form_overview_component.html.erb
@@ -1,0 +1,2 @@
+<h2 class="govuk-heading-l"><%= title %></h2>
+<%= render(GovukComponent::SummaryListComponent.new(rows: summary_rows)) %>

--- a/app/components/application_form_overview_component.rb
+++ b/app/components/application_form_overview_component.rb
@@ -1,0 +1,39 @@
+class ApplicationFormOverviewComponent < ViewComponent::Base
+  def initialize(application_form)
+    super
+    @application_form = application_form
+  end
+
+  def title
+    I18n.t("application_form.overview.title")
+  end
+
+  def summary_rows
+    application_form_summary_rows(
+      application_form,
+      include_name: true,
+      include_reference: true,
+      include_notes: false
+    ) +
+      [
+        {
+          key: {
+            text: I18n.t("application_form.overview.application_history")
+          },
+          value: {
+            text:
+              govuk_link_to(
+                I18n.t("application_form.overview.view_timeline"),
+                "#"
+              )
+          }
+        }
+      ]
+  end
+
+  private
+
+  attr_reader :application_form
+
+  delegate :application_form_summary_rows, to: :helpers
+end

--- a/app/components/application_form_search_result_component.rb
+++ b/app/components/application_form_search_result_component.rb
@@ -13,7 +13,12 @@ class ApplicationFormSearchResultComponent < ViewComponent::Base
   end
 
   def summary_rows
-    application_form_summary_rows(application_form)
+    application_form_summary_rows(
+      application_form,
+      include_name: false,
+      include_reference: false,
+      include_notes: true
+    )
   end
 
   private

--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -3,8 +3,21 @@ module ApplicationFormHelper
     "#{application_form.given_names} #{application_form.family_name}"
   end
 
-  def application_form_summary_rows(application_form)
+  def application_form_summary_rows(
+    application_form,
+    include_name:,
+    include_reference:,
+    include_notes:
+  )
     [
+      (
+        if include_name
+          [
+            I18n.t("application_form.summary.name"),
+            application_form_full_name(application_form)
+          ]
+        end
+      ),
       [
         I18n.t("application_form.summary.country"),
         CountryName.from_country(application_form.region.country)
@@ -18,8 +31,24 @@ module ApplicationFormHelper
         I18n.t("application_form.summary.days_remaining_sla"),
         "Not implemented"
       ],
-      [I18n.t("application_form.summary.assignee"), "Not implemented"],
-      [I18n.t("application_form.summary.reviewer"), "Not implemented"],
+      [
+        I18n.t("application_form.summary.assignee"),
+        "Not implemented",
+        [{ href: "#" }]
+      ],
+      [
+        I18n.t("application_form.summary.reviewer"),
+        "Not implemented",
+        [{ href: "#" }]
+      ],
+      (
+        if include_reference
+          [
+            I18n.t("application_form.summary.reference"),
+            application_form.reference
+          ]
+        end
+      ),
       [
         I18n.t("application_form.summary.status"),
         render(
@@ -29,7 +58,13 @@ module ApplicationFormHelper
           )
         )
       ],
-      [I18n.t("application_form.summary.notes"), "Not implemented"]
-    ].map { |key, value| { key: { text: key }, value: { text: value } } }
+      (
+        if include_notes
+          [I18n.t("application_form.summary.notes"), "Not implemented"]
+        end
+      )
+    ].compact.map do |key, value, actions|
+      { key: { text: key }, value: { text: value }, actions: actions || [] }
+    end
   end
 end

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -1,14 +1,15 @@
-<% content_for :page_title, "Application forms" %>
+<% content_for :page_title, "Application" %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full-from-desktop"> 
+  <div class="govuk-grid-column-full-from-desktop">
     <h1 class="govuk-heading-xl">Application</h1>
   </div>
 </div>
+
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full-from-desktop"> 
+  <div class="govuk-grid-column-full-from-desktop">
     <div class="govuk-body">
-      <%= @application_form.given_names%> <%= @application_form.family_name %>
+      <%= render(ApplicationFormOverviewComponent.new(@application_form)) %>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,10 @@ en:
       reference: Reference
       status: Status
       notes: Notes
+    overview:
+      title: Overview
+      application_history: Application history
+      view_timeline: View timeline of this applications actions
 
   document:
     document_type:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,12 +70,14 @@ en:
       current_or_most_recent_role: Your current or most recent role
       previous_role: Previous role
     summary:
+      name: Name
       country: Country trained in
       region: State/territory trained in
       created_at: Created on
       days_remaining_sla: Days remaining in SLA
       assignee: Assigned to
       reviewer: Reviewer
+      reference: Reference
       status: Status
       notes: Notes
 

--- a/spec/components/application_form_overview_component_spec.rb
+++ b/spec/components/application_form_overview_component_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationFormOverviewComponent, type: :component do
+  subject(:component) { render_inline(described_class.new(application_form)) }
+
+  let(:application_form) { create(:application_form) }
+
+  describe "heading" do
+    subject(:text) { component.at_css("h2").text.strip }
+
+    it { is_expected.to eq("Overview") }
+  end
+
+  describe "summary list" do
+    subject(:dl) { component.at_css("dl") }
+
+    it { is_expected.to_not be_nil }
+
+    describe "text" do
+      subject(:text) { dl.text.strip }
+
+      it { is_expected.to include("Name") }
+      it { is_expected.to include("Country trained in") }
+      it { is_expected.to include("State/territory trained in") }
+      it { is_expected.to include("Created on") }
+      it { is_expected.to include("Days remaining in SLA") }
+      it { is_expected.to include("Assigned to") }
+      it { is_expected.to include("Reviewer") }
+      it { is_expected.to include("Reference") }
+      it { is_expected.to include("Status") }
+    end
+  end
+end

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ApplicationFormHelper do
     create(
       :application_form,
       region:,
+      reference: "0000001",
       created_at: Date.new(2020, 1, 1),
       given_names: "Given",
       family_name: "Family"
@@ -24,18 +25,35 @@ RSpec.describe ApplicationFormHelper do
   end
 
   describe "#application_form_summary_rows" do
-    subject(:summary_rows) { application_form_summary_rows(application_form) }
+    subject(:summary_rows) do
+      application_form_summary_rows(
+        application_form,
+        include_name: true,
+        include_reference: true,
+        include_notes: true
+      )
+    end
 
     it do
       is_expected.to eq(
         [
           {
             key: {
+              text: "Name"
+            },
+            value: {
+              text: "Given Family"
+            },
+            actions: []
+          },
+          {
+            key: {
               text: "Country trained in"
             },
             value: {
               text: "United States"
-            }
+            },
+            actions: []
           },
           {
             key: {
@@ -43,19 +61,54 @@ RSpec.describe ApplicationFormHelper do
             },
             value: {
               text: "Region"
-            }
+            },
+            actions: []
           },
-          { key: { text: "Created on" }, value: { text: " 1 January 2020" } },
+          {
+            key: {
+              text: "Created on"
+            },
+            value: {
+              text: " 1 January 2020"
+            },
+            actions: []
+          },
           {
             key: {
               text: "Days remaining in SLA"
             },
             value: {
               text: "Not implemented"
-            }
+            },
+            actions: []
           },
-          { key: { text: "Assigned to" }, value: { text: "Not implemented" } },
-          { key: { text: "Reviewer" }, value: { text: "Not implemented" } },
+          {
+            key: {
+              text: "Assigned to"
+            },
+            value: {
+              text: "Not implemented"
+            },
+            actions: [{ href: "#" }]
+          },
+          {
+            key: {
+              text: "Reviewer"
+            },
+            value: {
+              text: "Not implemented"
+            },
+            actions: [{ href: "#" }]
+          },
+          {
+            key: {
+              text: "Reference"
+            },
+            value: {
+              text: "0000001"
+            },
+            actions: []
+          },
           {
             key: {
               text: "Status"
@@ -63,9 +116,18 @@ RSpec.describe ApplicationFormHelper do
             value: {
               text:
                 "<strong class=\"govuk-tag govuk-tag--blue\">Not implemented</strong>"
-            }
+            },
+            actions: []
           },
-          { key: { text: "Notes" }, value: { text: "Not implemented" } }
+          {
+            key: {
+              text: "Notes"
+            },
+            value: {
+              text: "Not implemented"
+            },
+            actions: []
+          }
         ]
       )
     end

--- a/spec/system/assessor_interface/view_application_spec.rb
+++ b/spec/system/assessor_interface/view_application_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe "viewing an application", type: :system do
     expect(page).to have_content(
       "#{application_form.given_names} #{application_form.family_name}"
     )
+    expect(page).to have_content(application_form.reference)
   end
 
   def application_form


### PR DESCRIPTION
This adds a new component for rendering an overview of an application suitable for the show page.

Depends on #413.

## Screenshot

![Screenshot 2022-08-24 at 13 52 29](https://user-images.githubusercontent.com/510498/186423466-9f22421b-70f6-4e40-a7da-1af329173879.png)
