### PR TITLE
Add region specific certificate field

### DIFF
--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -41,6 +41,7 @@ module SupportInterface
         :teaching_authority_address,
         :teaching_authority_emails_string,
         :teaching_authority_websites_string,
+        :teaching_authority_certificate,
         :teaching_authority_other
       )
     end

--- a/app/helpers/region_helper.rb
+++ b/app/helpers/region_helper.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module RegionHelper
+  def region_certificate_phrase(region)
+    certificate =
+      region.teaching_authority_certificate.presence ||
+        region.country.teaching_authority_certificate.presence || "certificate"
+    "#{certificate.indefinite_article} #{tag.span(certificate, lang: region.country.code)}".html_safe
+  end
+end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -2,20 +2,21 @@
 #
 # Table name: regions
 #
-#  id                          :bigint           not null, primary key
-#  application_form_enabled    :boolean          default(FALSE)
-#  legacy                      :boolean          default(TRUE), not null
-#  name                        :string           default(""), not null
-#  sanction_check              :string           default("none"), not null
-#  status_check                :string           default("none"), not null
-#  teaching_authority_address  :text             default(""), not null
-#  teaching_authority_emails   :text             default([]), not null, is an Array
-#  teaching_authority_name     :text             default(""), not null
-#  teaching_authority_other    :text             default(""), not null
-#  teaching_authority_websites :text             default([]), not null, is an Array
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
-#  country_id                  :bigint           not null
+#  id                             :bigint           not null, primary key
+#  application_form_enabled       :boolean          default(FALSE)
+#  legacy                         :boolean          default(TRUE), not null
+#  name                           :string           default(""), not null
+#  sanction_check                 :string           default("none"), not null
+#  status_check                   :string           default("none"), not null
+#  teaching_authority_address     :text             default(""), not null
+#  teaching_authority_certificate :text             default(""), not null
+#  teaching_authority_emails      :text             default([]), not null, is an Array
+#  teaching_authority_name        :text             default(""), not null
+#  teaching_authority_other       :text             default(""), not null
+#  teaching_authority_websites    :text             default([]), not null, is an Array
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  country_id                     :bigint           not null
 #
 # Indexes
 #

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -75,7 +75,7 @@
 
       <% if region.status_check_written? || region.sanction_check_written? %>
         <p class="govuk-body">
-          You’ll need to provide <%= region.country.teaching_authority_certificate.indefinite_article || "a" %> <span lang="<%= region.country.code %>"><%= region.country.teaching_authority_certificate.presence || "certificate" %></span>, which you can obtain by contacting:
+          You’ll need to provide <%= region_certificate_phrase(region) %>, which you can obtain by contacting:
         </p>
 
         <%= render "shared/teaching_authority_contact_information", region: %>

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -23,6 +23,8 @@
 
   <%= render "shared/teaching_authority_contactable_fields", f: %>
 
+  <%= f.govuk_text_field :teaching_authority_certificate, label: { text: "Teaching authority certificate" } %>
+
   <%= f.govuk_submit "Save", prevent_double_click: false do %>
     <%= f.govuk_submit "Save and preview", prevent_double_click: false, name: "preview", value: "preview" %>
     <%= govuk_button_link_to "Ignore changes and preview", preview_support_interface_region_path(@region), secondary: true %>

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -35,7 +35,7 @@
     </p>
 
     <p class="govuk-body">
-      This is called <%= @application_form.region.country.teaching_authority_certificate.indefinite_article || "a" %> <span lang="<%= @application_form.region.country.code %>"><%= @application_form.region.country.teaching_authority_certificate.presence || "certificate" %></span>.
+      This is called <%= region_certificate_phrase(@application_form.region) %>.
     </p>
 
     <div class="govuk-inset-text">If this document is not written in English, you’ll also need to upload a translation.</div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -102,6 +102,7 @@
     - teaching_authority_websites
     - teaching_authority_name
     - teaching_authority_other
+    - teaching_authority_certificate
     - application_form_enabled
   :staff:
     - id

--- a/db/migrate/20220824132339_add_teaching_authority_certificate_to_regions.rb
+++ b/db/migrate/20220824132339_add_teaching_authority_certificate_to_regions.rb
@@ -1,0 +1,9 @@
+class AddTeachingAuthorityCertificateToRegions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :regions,
+               :teaching_authority_certificate,
+               :text,
+               default: "",
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_17_125214) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_24_132339) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -138,6 +138,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_17_125214) do
     t.text "teaching_authority_name", default: "", null: false
     t.text "teaching_authority_other", default: "", null: false
     t.boolean "application_form_enabled", default: false
+    t.text "teaching_authority_certificate", default: "", null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
     t.index ["country_id"], name: "index_regions_on_country_id"
   end

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -2,20 +2,21 @@
 #
 # Table name: regions
 #
-#  id                          :bigint           not null, primary key
-#  application_form_enabled    :boolean          default(FALSE)
-#  legacy                      :boolean          default(TRUE), not null
-#  name                        :string           default(""), not null
-#  sanction_check              :string           default("none"), not null
-#  status_check                :string           default("none"), not null
-#  teaching_authority_address  :text             default(""), not null
-#  teaching_authority_emails   :text             default([]), not null, is an Array
-#  teaching_authority_name     :text             default(""), not null
-#  teaching_authority_other    :text             default(""), not null
-#  teaching_authority_websites :text             default([]), not null, is an Array
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
-#  country_id                  :bigint           not null
+#  id                             :bigint           not null, primary key
+#  application_form_enabled       :boolean          default(FALSE)
+#  legacy                         :boolean          default(TRUE), not null
+#  name                           :string           default(""), not null
+#  sanction_check                 :string           default("none"), not null
+#  status_check                   :string           default("none"), not null
+#  teaching_authority_address     :text             default(""), not null
+#  teaching_authority_certificate :text             default(""), not null
+#  teaching_authority_emails      :text             default([]), not null, is an Array
+#  teaching_authority_name        :text             default(""), not null
+#  teaching_authority_other       :text             default(""), not null
+#  teaching_authority_websites    :text             default([]), not null, is an Array
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  country_id                     :bigint           not null
 #
 # Indexes
 #

--- a/spec/helpers/region_helper_spec.rb
+++ b/spec/helpers/region_helper_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RegionHelper do
+  describe "#region_certificate_phrase" do
+    subject(:phrase) { region_certificate_phrase(region) }
+
+    let(:region) { build(:region, country: build(:country, code: "FR")) }
+
+    it { is_expected.to eq("a <span lang=\"FR\">certificate</span>") }
+
+    context "with a region certificate" do
+      before { region.teaching_authority_certificate = "region certificate" }
+
+      it { is_expected.to eq("a <span lang=\"FR\">region certificate</span>") }
+    end
+
+    context "with a country certificate" do
+      before do
+        region.country.teaching_authority_certificate = "country certificate"
+      end
+
+      it { is_expected.to eq("a <span lang=\"FR\">country certificate</span>") }
+    end
+
+    context "with a region and country certificate" do
+      before do
+        region.teaching_authority_certificate = "region certificate"
+        region.country.teaching_authority_certificate = "country certificate"
+      end
+
+      it { is_expected.to eq("a <span lang=\"FR\">region certificate</span>") }
+    end
+  end
+end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -2,20 +2,21 @@
 #
 # Table name: regions
 #
-#  id                          :bigint           not null, primary key
-#  application_form_enabled    :boolean          default(FALSE)
-#  legacy                      :boolean          default(TRUE), not null
-#  name                        :string           default(""), not null
-#  sanction_check              :string           default("none"), not null
-#  status_check                :string           default("none"), not null
-#  teaching_authority_address  :text             default(""), not null
-#  teaching_authority_emails   :text             default([]), not null, is an Array
-#  teaching_authority_name     :text             default(""), not null
-#  teaching_authority_other    :text             default(""), not null
-#  teaching_authority_websites :text             default([]), not null, is an Array
-#  created_at                  :datetime         not null
-#  updated_at                  :datetime         not null
-#  country_id                  :bigint           not null
+#  id                             :bigint           not null, primary key
+#  application_form_enabled       :boolean          default(FALSE)
+#  legacy                         :boolean          default(TRUE), not null
+#  name                           :string           default(""), not null
+#  sanction_check                 :string           default("none"), not null
+#  status_check                   :string           default("none"), not null
+#  teaching_authority_address     :text             default(""), not null
+#  teaching_authority_certificate :text             default(""), not null
+#  teaching_authority_emails      :text             default([]), not null, is an Array
+#  teaching_authority_name        :text             default(""), not null
+#  teaching_authority_other       :text             default(""), not null
+#  teaching_authority_websites    :text             default([]), not null, is an Array
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  country_id                     :bigint           not null
 #
 # Indexes
 #

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_address
     when_i_fill_teaching_authority_emails
     when_i_fill_teaching_authority_websites
-    when_i_fill_teaching_authority_certificate
     when_i_fill_teaching_authority_other
+    when_i_fill_teaching_authority_certificate
     when_i_fill_regions
     and_i_save
     then_i_see_country_contact_preview
@@ -37,6 +37,7 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_emails
     when_i_fill_teaching_authority_websites
     when_i_fill_teaching_authority_other
+    when_i_fill_teaching_authority_certificate
     and_i_save_and_preview
     then_i_see_the_preview
     and_i_see_a_success_banner
@@ -160,14 +161,16 @@ RSpec.describe "Countries support", type: :system do
     fill_in "country-teaching-authority-websites-string-field", with: "Website"
   end
 
-  def when_i_fill_teaching_authority_certificate
-    fill_in "country-teaching-authority-certificate-field", with: "Certificate"
-  end
-
   def when_i_fill_teaching_authority_other
     fill_in "region-teaching-authority-other-field", with: "Other"
   rescue Capybara::ElementNotFound
     fill_in "country-teaching-authority-other-field", with: "Other"
+  end
+
+  def when_i_fill_teaching_authority_certificate
+    fill_in "region-teaching-authority-certificate-field", with: "Certificate"
+  rescue Capybara::ElementNotFound
+    fill_in "country-teaching-authority-certificate-field", with: "Certificate"
   end
 
   def and_i_save


### PR DESCRIPTION
This adds a new field to regions allowing us to set a certificate for an individual region rather than an overall country. For the most part the certificate is the same across all regions, but occasionally there will be a region that requires a custom certificate.