### PR TITLE
Refactor country codes and names

### DIFF
--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -150,9 +150,9 @@ module TeacherInterface
           :certificate_date
         )
         .tap do |params|
-          params[:institution_country_code] = params[
-            :institution_country_code
-          ].split(":").last
+          params[:institution_country_code] = CountryCode.from_location(
+            params[:institution_country_code]
+          )
         end
     end
 

--- a/app/controllers/teacher_interface/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/work_histories_controller.rb
@@ -135,7 +135,9 @@ module TeacherInterface
           :still_employed
         )
         .tap do |params|
-          params[:country_code] = params[:country_code].split(":").last
+          params[:country_code] = CountryCode.from_location(
+            params[:country_code]
+          )
         end
     end
   end

--- a/app/forms/eligibility_interface/country_form.rb
+++ b/app/forms/eligibility_interface/country_form.rb
@@ -9,7 +9,7 @@ class EligibilityInterface::CountryForm
   def save
     return false unless valid?
 
-    eligibility_check.country_code = location.split(":")[1]
+    eligibility_check.country_code = CountryCode.from_location(location)
     eligibility_check.save!
   end
 end

--- a/app/forms/teacher_interface/country_region_form.rb
+++ b/app/forms/teacher_interface/country_region_form.rb
@@ -34,8 +34,6 @@ class TeacherInterface::CountryRegionForm
   private
 
   def country_code
-    location.split(":")[1]
-  rescue StandardError
-    nil
+    CountryCode.from_location(location)
   end
 end

--- a/app/lib/country_code.rb
+++ b/app/lib/country_code.rb
@@ -1,0 +1,16 @@
+class CountryCode
+  class << self
+    def from_location(location)
+      location&.split(":")&.last || ""
+    end
+
+    def to_location(code)
+      LOCATIONS_BY_COUNTRY_CODE[code]
+    end
+
+    LOCATIONS_BY_COUNTRY_CODE =
+      Country::LOCATION_AUTOCOMPLETE_CANONICAL_LIST
+        .map { |row| [CountryCode.from_location(row.last), row.last] }
+        .to_h
+  end
+end

--- a/app/lib/country_name.rb
+++ b/app/lib/country_name.rb
@@ -1,7 +1,7 @@
 class CountryName
   class << self
     def from_code(code, with_definite_article: false)
-      name = Country::COUNTRIES.fetch(code, "")
+      name = NAMES_BY_COUNTRY_CODE.fetch(code, "")
       return name unless with_definite_article
       COUNTRIES_WITH_DEFINITE_ARTICLE.include?(code) ? "the #{name}" : name
     end
@@ -22,6 +22,11 @@ class CountryName
         from_code(eligibility_check.country_code, with_definite_article:)
       end
     end
+
+    NAMES_BY_COUNTRY_CODE =
+      Country::LOCATION_AUTOCOMPLETE_CANONICAL_LIST
+        .map { |row| [CountryCode.from_location(row.last), row.first] }
+        .to_h
 
     COUNTRIES_WITH_DEFINITE_ARTICLE =
       YAML.load(File.read("lib/countries-with-definite-article.yaml"))

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -25,12 +25,12 @@ class Country < ApplicationRecord
   LOCATION_AUTOCOMPLETE_CANONICAL_LIST =
     JSON.parse(File.read("public/location-autocomplete-canonical-list.json"))
 
-  COUNTRIES =
-    LOCATION_AUTOCOMPLETE_CANONICAL_LIST
-      .map { |row| [CountryCode.from_location(row.last), row.first] }
-      .to_h
+  CODES =
+    LOCATION_AUTOCOMPLETE_CANONICAL_LIST.map do |row|
+      CountryCode.from_location(row.last)
+    end
 
-  validates :code, inclusion: { in: COUNTRIES.keys }
+  validates :code, inclusion: { in: CODES }
 
   alias_method :country, :itself
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -27,12 +27,7 @@ class Country < ApplicationRecord
 
   COUNTRIES =
     LOCATION_AUTOCOMPLETE_CANONICAL_LIST
-      .map { |row| [row.last.split(":").last, row.first] }
-      .to_h
-
-  LOCATIONS_BY_COUNTRY_CODE =
-    LOCATION_AUTOCOMPLETE_CANONICAL_LIST
-      .map { |row| [row.last.split(":").last, row.last] }
+      .map { |row| [CountryCode.from_location(row.last), row.first] }
       .to_h
 
   validates :code, inclusion: { in: COUNTRIES.keys }

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -58,7 +58,7 @@ class EligibilityCheck < ApplicationRecord
   end
 
   def location
-    Country::LOCATIONS_BY_COUNTRY_CODE[country_code]
+    CountryCode.to_location(country_code)
   end
 
   def ineligible_reasons

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -92,7 +92,7 @@ class Qualification < ApplicationRecord
   end
 
   def institution_country_location
-    Country::LOCATIONS_BY_COUNTRY_CODE[institution_country_code]
+    CountryCode.to_location(institution_country_code)
   end
 
   def certificate_document

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -62,6 +62,6 @@ class WorkHistory < ApplicationRecord
   end
 
   def country_location
-    Country::LOCATIONS_BY_COUNTRY_CODE[country_code]
+    CountryCode.to_location(country_code)
   end
 end

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -19,7 +19,7 @@
   :qualifications:
     - title
     - institution_name
-    - institution_country
+    - institution_country_code
     - start_date
     - complete_date
     - certificate_date
@@ -37,7 +37,7 @@
   :work_histories:
     - school_name
     - city
-    - country
+    - country_code
     - job
     - email
     - start_date

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -19,7 +19,7 @@
 #
 FactoryBot.define do
   factory :country do
-    sequence :code, Country::COUNTRIES.keys.cycle
+    sequence :code, Country::CODES.cycle
 
     trait :with_national_region do
       after(:create) do |country, _evaluator|

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -29,7 +29,7 @@ FactoryBot.define do
     trait :completed do
       title { Faker::Educator.degree }
       institution_name { Faker::University.name }
-      institution_country_code { Country::COUNTRIES.keys.cycle }
+      institution_country_code { Country::CODES.cycle }
       start_date { Date.new(2020, 1, 1) }
       complete_date { Date.new(2021, 1, 1) }
       certificate_date { Date.new(2021, 1, 1) }

--- a/spec/factories/work_histories.rb
+++ b/spec/factories/work_histories.rb
@@ -30,7 +30,7 @@ FactoryBot.define do
     trait :completed do
       school_name { "School" }
       city { "City" }
-      country_code { "FR" }
+      country_code { Country::CODES.cycle }
       job { "Job" }
       email { "school@example.com" }
       start_date { Date.new(2020, 1, 1) }

--- a/spec/lib/country_code_spec.rb
+++ b/spec/lib/country_code_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CountryCode do
+  describe "#from_location" do
+    subject(:from_location) { described_class.from_location(location) }
+
+    context "with a nil location" do
+      let(:location) { nil }
+      it { is_expected.to eq("") }
+    end
+
+    context "with a blank location" do
+      let(:location) { "" }
+      it { is_expected.to eq("") }
+    end
+
+    context "with a location" do
+      let(:location) { "country:US" }
+      it { is_expected.to eq("US") }
+    end
+  end
+
+  describe "#to_location" do
+    subject(:to_location) { described_class.to_location(code) }
+
+    context "with a nil code" do
+      let(:code) { nil }
+      it { is_expected.to be_nil }
+    end
+
+    context "with a blank code" do
+      let(:code) { "" }
+      it { is_expected.to be_nil }
+    end
+
+    context "with a code" do
+      let(:code) { "US" }
+      it { is_expected.to eq("country:US") }
+    end
+  end
+end


### PR DESCRIPTION
This makes a few changes to the country codes and country names to refactor how we generate and use them to remove duplication. I did this to fix a Sentry issue and it turned in to a larger refactor, but I think it's worth it: https://sentry.io/organizations/dfe-teacher-services/issues/3528181248/