### PR TITLE
Require authentication for assessor interface

### DIFF
--- a/app/controllers/assessor_interface/base_controller.rb
+++ b/app/controllers/assessor_interface/base_controller.rb
@@ -1,5 +1,7 @@
 module AssessorInterface
   class BaseController < ApplicationController
+    before_action :authenticate_staff!
+
     def current_namespace
       "assessor"
     end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -50,11 +50,19 @@
           text: "Sidekiq",
           href: support_interface_sidekiq_web_path
         ) %>
+        <% header.navigation_item(
+          text: "Assessor case management",
+          href: assessor_interface_root_path
+        ) %>
       <% when "teacher" %>
         <% if current_teacher %>
           <% header.navigation_item(text: "Sign out", href: destroy_teacher_session_path) %>
         <% end %>
       <% when "assessor" %>
+        <% header.navigation_item(
+          text: "Support console",
+          href: support_interface_root_path
+        ) %>
         <% if current_staff %>
           <% header.navigation_item(text: "Sign out", href: destroy_staff_session_path) %>
         <% end %>

--- a/spec/system/assessor_interface/authentication_spec.rb
+++ b/spec/system/assessor_interface/authentication_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Assessor authentication", type: :system do
     given_the_service_is_open
     given_staff_exist
 
-    when_i_visit_the_sign_in_page
+    when_i_visit_the_assessor_page
     then_i_see_the_sign_in_form
 
     when_i_fill_in_the_sign_in_form
@@ -24,8 +24,8 @@ RSpec.describe "Assessor authentication", type: :system do
     create(:staff, :confirmed, email: "staff@example.com", password: "password")
   end
 
-  def when_i_visit_the_sign_in_page
-    visit new_staff_session_path
+  def when_i_visit_the_assessor_page
+    visit assessor_interface_root_path
   end
 
   def when_i_fill_in_the_sign_in_form


### PR DESCRIPTION
We only want staff users to gain access to the assessor interface if they are authenticated.

I've also added navigation between the assessor and support interface which might be a contentious change, but I think it would be useful if there was a way of switching between these two interfaces since they both require the user to be authenticated as staff.