### PR TITLE
[816] Create application form earlier

### DIFF
--- a/app/controllers/teachers/confirmations_controller.rb
+++ b/app/controllers/teachers/confirmations_controller.rb
@@ -11,7 +11,6 @@ class Teachers::ConfirmationsController < Devise::ConfirmationsController
 
     if resource.errors.empty?
       sign_in(resource)
-      create_application_form(resource)
       respond_with_navigational(resource) do
         redirect_to after_confirmation_path_for(resource_name, resource)
       end
@@ -22,14 +21,6 @@ class Teachers::ConfirmationsController < Devise::ConfirmationsController
   end
 
   protected
-
-  def create_application_form(teacher)
-    eligibility_check =
-      EligibilityCheck.find_by(id: session[:eligibility_check_id])
-    if eligibility_check.present? && eligibility_check.region.present?
-      ApplicationForm.create!(teacher:, region: eligibility_check.region)
-    end
-  end
 
   def after_confirmation_path_for(_resource_name, _resource)
     teacher_interface_application_form_path


### PR DESCRIPTION
* Create an application form when a user first registers rather than when they confirm their email.

This means that if they confirm on another browser/machine then they won't have to redo their eligibility check.

### Review

I've not added any new tests here for this change. The existing system spec checks that the application is present when the user logs in. As this hasn't changed the tests still provide coverage I think. I could maybe add a test that they don't have to redo the eligibility check but I'm not sure there's much value in that.