### PR TITLE
[802][SPIKE]  Application form status management

### DIFF
--- a/app/lib/application_form_state.rb
+++ b/app/lib/application_form_state.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module TransitionRules
+  class Awarded
+    def self.can_transition?(application_form:, to:)
+      if application_form.current.state == ApplicationFormState::AWARDED &&
+           to == ApplicationFormState::DECLINED
+        return false
+      end
+
+      true
+    end
+  end
+
+  class Declined
+    def self.can_transition?(application_form:, to:)
+      if application_form.current.state == ApplicationFormState::DECLINED &&
+           to == ApplicationFormState::AWARDED
+        return false
+      end
+
+      true
+    end
+  end
+end
+
+class ApplicationFormState
+  SUBMITTED = "submitted"
+  AWARDED = "awarded"
+  DECLINED = "declined"
+  REVIEW_COMPLETE = "review_complete"
+
+  TRANSITION_RULES = [
+    TransitionRules::Awarded,
+    TransitionRules::Declined
+  ].freeze
+
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+  def current
+    # should this always call update first to pick up any implicit changes?
+    state_changes.last
+  end
+
+  # explicit state changes ie from a user action like submitting the application or awarding
+  def change(to:)
+    raise "invalid state transition" unless can_transition?(to:)
+
+    ApplicationForm.transaction do
+      #store the current state string on the application_form so as we can easily filter?
+      application_form.update!(state: to) # should we just set it rather than saving the application_form?
+      ApplicationFormStateChange.create!(application_form:, state: to)
+    end
+
+    current #reload the state_changes and return
+  end
+
+  #implicit changes e.g. all sections have been marked done
+  def update
+    change(to: REVIEW_COMPLETE) if application_sections_all_checked? # this could be rules like the TRANSITION_RULES
+  end
+
+  private
+
+  attr_reader :application_form
+
+  def state_changes
+    ApplicationFormStateChange.where(application_form:).order(:created_at)
+  end
+
+  def can_transition?(to:)
+    TRANSITION_RULES.reject { |rule| rule.can_transition?(application_form:, to:) }.any?
+  end
+
+  def application_sections_all_checked?
+    # something, something, type some stuff...
+  end
+end

--- a/app/lib/application_form_state.rb
+++ b/app/lib/application_form_state.rb
@@ -52,6 +52,7 @@ class ApplicationFormState
       #store the current state string on the application_form so as we can easily filter?
       application_form.update!(state: to) # should we just set it rather than saving the application_form?
       ApplicationFormStateChange.create!(application_form:, state: to)
+      TimelineEvent.create!(event_type: TimelineEvent::STATE_CHANGED, annotation: to.to_s)
     end
 
     current #reload the state_changes and return

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -14,6 +14,7 @@
 #  has_work_history        :boolean
 #  reference               :string(31)       not null
 #  registration_number     :text
+#  state                   :string
 #  status                  :string           default("active"), not null
 #  subjects                :text             default([]), not null, is an Array
 #  created_at              :datetime         not null

--- a/app/models/application_form_state_change.rb
+++ b/app/models/application_form_state_change.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: application_form_state_changes
+#
+#  id                  :bigint           not null, primary key
+#  state               :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  application_form_id :bigint           not null
+#
+# Indexes
+#
+#  index_application_form_state_changes_on_application_form_id  (application_form_id)
+#  index_application_form_state_changes_on_state                (state)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (application_form_id => application_forms.id)
+#
 class ApplicationFormStateChange < ApplicationRecord
   belongs_to :application_form
 end

--- a/app/models/application_form_state_change.rb
+++ b/app/models/application_form_state_change.rb
@@ -1,0 +1,3 @@
+class ApplicationFormStateChange < ApplicationRecord
+  belongs_to :application_form
+end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: timeline_events
+#
+#  id                  :bigint           not null, primary key
+#  annotation          :string
+#  event_type          :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  application_form_id :bigint
+#  staff_id            :integer
+#
+# Indexes
+#
+#  index_timeline_events_on_application_form_id  (application_form_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (application_form_id => application_forms.id)
+#
+class TimelineEvent < ApplicationRecord
+  belongs_to :application_form
+
+  STATE_CHANGED = "state_changed"
+end

--- a/app/services/application_forms/award.rb
+++ b/app/services/application_forms/award.rb
@@ -1,0 +1,17 @@
+module ApplicationForms
+  class Award
+    include ServicePattern
+
+    def initialize(application_form:)
+      @application_form = application_form
+    end
+
+    def call
+      ApplicationFormState.new(application_form:).change(to: ApplicationFormState::AWARDED)
+    end
+
+    private
+
+    attr_reader :application_form
+  end
+end

--- a/app/services/application_forms/update.rb
+++ b/app/services/application_forms/update.rb
@@ -1,0 +1,23 @@
+module ApplicationForms
+  class Update
+    include ServicePattern
+
+    def initialize(application_form:, params:)
+      @application_form = application_form
+      @params = params
+    end
+
+    def call
+      ApplicationForm.transaction do
+        application_form.update!
+        #update the state. Maybe everything is complete now
+        #maybe we shouldn't call this update as it's upsetting rubocop
+        ApplicationFormState.new(application_form:).update
+      end
+    end
+
+    private
+
+    attr_reader :application_form, :params
+  end
+end

--- a/db/migrate/20220824154903_create_application_form_state_changes.rb
+++ b/db/migrate/20220824154903_create_application_form_state_changes.rb
@@ -1,0 +1,11 @@
+class CreateApplicationFormStateChanges < ActiveRecord::Migration[7.0]
+  def change
+    create_table :application_form_state_changes do |t|
+      t.string :state, null: false
+      t.references :application_form, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :application_form_state_changes, :state
+  end
+end

--- a/db/migrate/20220824163503_add_state_to_application_forms.rb
+++ b/db/migrate/20220824163503_add_state_to_application_forms.rb
@@ -1,0 +1,5 @@
+class AddStateToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_forms, :state, :string
+  end
+end

--- a/db/migrate/20220824172503_create_timeline_events.rb
+++ b/db/migrate/20220824172503_create_timeline_events.rb
@@ -1,0 +1,11 @@
+class CreateTimelineEvents < ActiveRecord::Migration[7.0]
+  def change
+    create_table :timeline_events do |t|
+      t.string :event_type, null: false
+      t.references :application_form, foreign_key: true
+      t.string :annotation, null: true
+      t.integer :staff_id, null:true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_24_163503) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_24_172503) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "citext"
   enable_extension "plpgsql"
+  enable_extension "uuid-ossp"
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -206,6 +208,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_24_163503) do
     t.index ["email"], name: "index_teachers_on_email", unique: true
   end
 
+  create_table "timeline_events", force: :cascade do |t|
+    t.string "event_type", null: false
+    t.bigint "application_form_id"
+    t.string "annotation"
+    t.integer "staff_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
+  end
+
   create_table "uploads", force: :cascade do |t|
     t.bigint "document_id", null: false
     t.boolean "translation", null: false
@@ -237,6 +249,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_24_163503) do
   add_foreign_key "eligibility_checks", "regions"
   add_foreign_key "qualifications", "application_forms"
   add_foreign_key "regions", "countries"
+  add_foreign_key "timeline_events", "application_forms"
   add_foreign_key "uploads", "documents"
   add_foreign_key "work_histories", "application_forms"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_24_132339) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_24_154903) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_24_132339) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "application_form_state_changes", force: :cascade do |t|
+    t.string "state", null: false
+    t.bigint "application_form_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["application_form_id"], name: "index_application_form_state_changes_on_application_form_id"
+    t.index ["state"], name: "index_application_form_state_changes_on_state"
   end
 
   create_table "application_forms", force: :cascade do |t|
@@ -221,6 +230,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_24_132339) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "application_form_state_changes", "application_forms"
   add_foreign_key "application_forms", "regions"
   add_foreign_key "application_forms", "teachers"
   add_foreign_key "eligibility_checks", "regions"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_24_154903) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_24_163503) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -69,6 +69,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_24_154903) do
     t.text "registration_number"
     t.boolean "has_work_history"
     t.text "subjects", default: [], null: false, array: true
+    t.string "state"
     t.index ["reference"], name: "index_application_forms_on_reference", unique: true
     t.index ["region_id"], name: "index_application_forms_on_region_id"
     t.index ["status"], name: "index_application_forms_on_status"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -14,6 +14,7 @@
 #  has_work_history        :boolean
 #  reference               :string(31)       not null
 #  registration_number     :text
+#  state                   :string
 #  status                  :string           default("active"), not null
 #  subjects                :text             default([]), not null, is an Array
 #  created_at              :datetime         not null

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -14,6 +14,7 @@
 #  has_work_history        :boolean
 #  reference               :string(31)       not null
 #  registration_number     :text
+#  state                   :string
 #  status                  :string           default("active"), not null
 #  subjects                :text             default([]), not null, is an Array
 #  created_at              :datetime         not null


### PR DESCRIPTION
Applications will go through various states from their initial creation to an end state, likely award or decline. Many of these states e.g. 'Submitted' or 'Declined' will be set as a result of a user action. So... 'explicitly' set. Some states may be set by the system e.g. 'Expired' so explicitly set but not by a user.

We intend to make 'an assessment' a series of steps that will also have some sort of state. The state of the application may be set by a combination of the sub-states of the application sections. This is an emerging design and isn't fully formed yet but I've included some code that would handle that.

### Storing state 'on the application form' 

We could use an enum or simple state machine on the `ApplicationForm` model initially. I did consider this but whether we do that or not really depends on if we decide we need to keep a history of state changes in the service. We've discussed adding the Audited gem to keep an audit of changes so a combination of an enum + Audited would give us that and be much simpler. We will also have a history of state changes in BigQuery but that won't be accessible from within the service. The main reason for keeping it in the service that I can see at the moment is the requirement for SLA calculations. The state of the application form is crucial for working that out and the rules for SLA calculation are quite fluid currently so keeping all of the state changes will allow us to refine the rules with all of the data required in service.

The code here still stores a state string on the application form. This is largely redundant but we have requirements for state filtering in combination with other filters and it will greatly simplify the queries for that. It will also simplify the analytics queries in BigQuery.

### Transition rules

I've split these out into separate classes that will be simple to test and easy to understand. I expect we could do the same with rules for setting implicit states which would again make them easily testable and scalable. I'm not sure of the requirements there so I haven't included that, just some comments where it would go.

### Timeline events

We have designs for displaying a timeline. I've included a simple `TimelineEvent` class that we would use for this to show how it would run alongside the state. This may meet the need for a history of events within the service by itself in some ways but based on experience with similar functionality in other DfE services there's a good chance we'll end up wanting to log state changes that we don't want to surface in the timeline so keeping this separate will avoid that and doesn't add too much complexity.

### Using a state machine gem

There are loads and I had a look over some that I haven't used before. We could get some of the functionality here and lots of extra features (many of which we'd also get with enums) but didn't seem to have much by way of options for storing state history separately.

### Not covered in this spike

We will likely want to attribute events and possibly state changes to a user. I've added a staff_id column to the events table but not tackled how we pass the user into the model layer. We also have two types of user so in reality this may need to be polymorphic.

### Recommendations

I think something like the approach sketched out here would be flexible but probably only worth the bother if we decide we definitely need a state history in the service. I feel like we probably do given the SLA calculation requirement. It would be possible to derive this from some sort of TimelineEvent implementation or from Audited audit data but that seems like overloading those things to me.

Given the requirements for SLA etc are still in flux we could also start with an enum implementation or similar and expand to something like this when the requirements are clearer.