### PR TITLE
Assign applications to assessors or reviewers

### DIFF
--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -33,12 +33,14 @@ module ApplicationFormHelper
       ],
       [
         I18n.t("application_form.summary.assessor"),
-        "Not implemented",
+        application_form.assessor&.email ||
+          I18n.t("application_form.summary.unassigned"),
         [{ href: "#" }]
       ],
       [
         I18n.t("application_form.summary.reviewer"),
-        "Not implemented",
+        application_form.reviewer&.email ||
+          I18n.t("application_form.summary.unassigned"),
         [{ href: "#" }]
       ],
       (

--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -32,7 +32,7 @@ module ApplicationFormHelper
         "Not implemented"
       ],
       [
-        I18n.t("application_form.summary.assignee"),
+        I18n.t("application_form.summary.assessor"),
         "Not implemented",
         [{ href: "#" }]
       ],

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -51,6 +51,10 @@ class ApplicationForm < ApplicationRecord
   before_validation :assign_reference
   validates :reference, presence: true, uniqueness: true, length: 3..31
 
+  belongs_to :assessor, class_name: "Staff", optional: true
+  belongs_to :reviewer, class_name: "Staff", optional: true
+  validate :assessor_and_reviewer_must_be_different
+
   enum status: { active: "active", submitted: "submitted" }
 
   def assign_reference
@@ -170,6 +174,13 @@ class ApplicationForm < ApplicationRecord
     documents.build(document_type: :identification)
     documents.build(document_type: :name_change)
     documents.build(document_type: :written_statement)
+  end
+
+  def assessor_and_reviewer_must_be_different
+    if assessor_id.present? && reviewer_id.present? &&
+         assessor_id == reviewer_id
+      errors.add(:reviewer, :same_as_assessor)
+    end
   end
 
   def task_item_status(key)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -18,19 +18,25 @@
 #  subjects                :text             default([]), not null, is an Array
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  assessor_id             :bigint
 #  region_id               :bigint           not null
+#  reviewer_id             :bigint
 #  teacher_id              :bigint           not null
 #
 # Indexes
 #
-#  index_application_forms_on_reference   (reference) UNIQUE
-#  index_application_forms_on_region_id   (region_id)
-#  index_application_forms_on_status      (status)
-#  index_application_forms_on_teacher_id  (teacher_id)
+#  index_application_forms_on_assessor_id  (assessor_id)
+#  index_application_forms_on_reference    (reference) UNIQUE
+#  index_application_forms_on_region_id    (region_id)
+#  index_application_forms_on_reviewer_id  (reviewer_id)
+#  index_application_forms_on_status       (status)
+#  index_application_forms_on_teacher_id   (teacher_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (assessor_id => staff.id)
 #  fk_rails_...  (region_id => regions.id)
+#  fk_rails_...  (reviewer_id => staff.id)
 #  fk_rails_...  (teacher_id => teachers.id)
 #
 class ApplicationForm < ApplicationRecord

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -11,15 +11,18 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  application_form_id :bigint           not null
+#  assignee_id         :bigint
 #  creator_id          :integer
 #
 # Indexes
 #
 #  index_timeline_events_on_application_form_id  (application_form_id)
+#  index_timeline_events_on_assignee_id          (assignee_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (application_form_id => application_forms.id)
+#  fk_rails_...  (assignee_id => staff.id)
 #
 class TimelineEvent < ApplicationRecord
   belongs_to :application_form
@@ -30,4 +33,12 @@ class TimelineEvent < ApplicationRecord
          reviewer_assigned: "reviewer_assigned"
        }
   validates :event_type, inclusion: { in: event_types.values }
+
+  belongs_to :assignee, class_name: "Staff", optional: true
+  validates :assignee,
+            presence: true,
+            if: -> { assessor_assigned? || reviewer_assigned? }
+  validates :assignee,
+            absence: true,
+            unless: -> { assessor_assigned? || reviewer_assigned? }
 end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -25,5 +25,9 @@ class TimelineEvent < ApplicationRecord
   belongs_to :application_form
   belongs_to :creator, polymorphic: true, optional: true
 
-  enum event_type: { assessor_assigned: "assessor_assigned" }
+  enum event_type: {
+         assessor_assigned: "assessor_assigned",
+         reviewer_assigned: "reviewer_assigned"
+       }
+  validates :event_type, inclusion: { in: event_types.values }
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -152,6 +152,7 @@
     - creator_type
     - created_at
     - updated_at
+    - assignee_id
   :uploads:
     - id
     - document_id

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -40,6 +40,8 @@
     - registration_number
     - has_work_history
     - subjects
+    - assessor_id
+    - reviewer_id
   :countries:
     - id
     - code

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -75,7 +75,7 @@ en:
       region: State/territory trained in
       created_at: Created on
       days_remaining_sla: Days remaining in SLA
-      assignee: Assigned to
+      assessor: Assigned to
       reviewer: Reviewer
       reference: Reference
       status: Status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,6 +78,7 @@ en:
       assessor: Assigned to
       reviewer: Reviewer
       reference: Reference
+      unassigned: Unassigned
       status: Status
       notes: Notes
     overview:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -158,6 +158,10 @@ en:
           attributes:
             email:
               blank: Enter your email address
+        application_form:
+          attributes:
+            reviewer:
+              same_as_assessor: can’t be assigned to the same person
 
   errors:
     messages:

--- a/db/migrate/20220825094810_add_assigners_to_application_forms.rb
+++ b/db/migrate/20220825094810_add_assigners_to_application_forms.rb
@@ -1,0 +1,8 @@
+class AddAssignersToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    change_table :application_forms, bulk: true do |t|
+      t.references :assessor, foreign_key: { to_table: :staff }
+      t.references :reviewer, foreign_key: { to_table: :staff }
+    end
+  end
+end

--- a/db/migrate/20220825110557_add_assignee_to_timeline_event.rb
+++ b/db/migrate/20220825110557_add_assignee_to_timeline_event.rb
@@ -1,0 +1,5 @@
+class AddAssigneeToTimelineEvent < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :timeline_events, :assignee, foreign_key: { to_table: :staff }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_25_094810) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_25_110557) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -208,7 +208,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_094810) do
     t.string "creator_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "assignee_id"
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
+    t.index ["assignee_id"], name: "index_timeline_events_on_assignee_id"
   end
 
   create_table "uploads", force: :cascade do |t|
@@ -244,6 +246,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_094810) do
   add_foreign_key "qualifications", "application_forms"
   add_foreign_key "regions", "countries"
   add_foreign_key "timeline_events", "application_forms"
+  add_foreign_key "timeline_events", "staff", column: "assignee_id"
   add_foreign_key "uploads", "documents"
   add_foreign_key "work_histories", "application_forms"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_24_172503) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_25_094810) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,8 +60,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_24_172503) do
     t.text "registration_number"
     t.boolean "has_work_history"
     t.text "subjects", default: [], null: false, array: true
+    t.bigint "assessor_id"
+    t.bigint "reviewer_id"
+    t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["reference"], name: "index_application_forms_on_reference", unique: true
     t.index ["region_id"], name: "index_application_forms_on_region_id"
+    t.index ["reviewer_id"], name: "index_application_forms_on_reviewer_id"
     t.index ["status"], name: "index_application_forms_on_status"
     t.index ["teacher_id"], name: "index_application_forms_on_teacher_id"
   end
@@ -233,6 +237,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_24_172503) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "application_forms", "regions"
+  add_foreign_key "application_forms", "staff", column: "assessor_id"
+  add_foreign_key "application_forms", "staff", column: "reviewer_id"
   add_foreign_key "application_forms", "teachers"
   add_foreign_key "eligibility_checks", "regions"
   add_foreign_key "qualifications", "application_forms"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -18,19 +18,25 @@
 #  subjects                :text             default([]), not null, is an Array
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  assessor_id             :bigint
 #  region_id               :bigint           not null
+#  reviewer_id             :bigint
 #  teacher_id              :bigint           not null
 #
 # Indexes
 #
-#  index_application_forms_on_reference   (reference) UNIQUE
-#  index_application_forms_on_region_id   (region_id)
-#  index_application_forms_on_status      (status)
-#  index_application_forms_on_teacher_id  (teacher_id)
+#  index_application_forms_on_assessor_id  (assessor_id)
+#  index_application_forms_on_reference    (reference) UNIQUE
+#  index_application_forms_on_region_id    (region_id)
+#  index_application_forms_on_reviewer_id  (reviewer_id)
+#  index_application_forms_on_status       (status)
+#  index_application_forms_on_teacher_id   (teacher_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (assessor_id => staff.id)
 #  fk_rails_...  (region_id => regions.id)
+#  fk_rails_...  (reviewer_id => staff.id)
 #  fk_rails_...  (teacher_id => teachers.id)
 #
 FactoryBot.define do

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -9,19 +9,25 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  application_form_id :bigint           not null
+#  assignee_id         :bigint
 #  creator_id          :integer
 #
 # Indexes
 #
 #  index_timeline_events_on_application_form_id  (application_form_id)
+#  index_timeline_events_on_assignee_id          (assignee_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (application_form_id => application_forms.id)
+#  fk_rails_...  (assignee_id => staff.id)
 #
 FactoryBot.define do
   factory :timeline_event do
     association :application_form
     event_type { TimelineEvent.event_types.keys.sample }
+
+    # all our event types require this field for now
+    association :assignee, factory: :staff
   end
 end

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe ApplicationFormHelper do
               text: "Assigned to"
             },
             value: {
-              text: "Not implemented"
+              text: "Unassigned"
             },
             actions: [{ href: "#" }]
           },
@@ -96,7 +96,7 @@ RSpec.describe ApplicationFormHelper do
               text: "Reviewer"
             },
             value: {
-              text: "Not implemented"
+              text: "Unassigned"
             },
             actions: [{ href: "#" }]
           },

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -18,19 +18,25 @@
 #  subjects                :text             default([]), not null, is an Array
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
+#  assessor_id             :bigint
 #  region_id               :bigint           not null
+#  reviewer_id             :bigint
 #  teacher_id              :bigint           not null
 #
 # Indexes
 #
-#  index_application_forms_on_reference   (reference) UNIQUE
-#  index_application_forms_on_region_id   (region_id)
-#  index_application_forms_on_status      (status)
-#  index_application_forms_on_teacher_id  (teacher_id)
+#  index_application_forms_on_assessor_id  (assessor_id)
+#  index_application_forms_on_reference    (reference) UNIQUE
+#  index_application_forms_on_region_id    (region_id)
+#  index_application_forms_on_reviewer_id  (reviewer_id)
+#  index_application_forms_on_status       (status)
+#  index_application_forms_on_teacher_id   (teacher_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (assessor_id => staff.id)
 #  fk_rails_...  (region_id => regions.id)
+#  fk_rails_...  (reviewer_id => staff.id)
 #  fk_rails_...  (teacher_id => teachers.id)
 #
 require "rails_helper"

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -68,6 +68,17 @@ RSpec.describe ApplicationForm, type: :model do
         submitted: "submitted"
       ).backed_by_column_of_type(:string)
     end
+
+    context "with the same assessor and reviewer" do
+      let(:staff) { create(:staff) }
+
+      before do
+        application_form.assessor = staff
+        application_form.reviewer = staff
+      end
+
+      it { is_expected.to_not be_valid }
+    end
   end
 
   it "attaches empty documents" do

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -26,5 +26,12 @@ RSpec.describe TimelineEvent do
 
   describe "validations" do
     it { is_expected.to be_valid }
+
+    it do
+      is_expected.to define_enum_for(:event_type).with_values(
+        assessor_assigned: "assessor_assigned",
+        reviewer_assigned: "reviewer_assigned"
+      ).backed_by_column_of_type(:string)
+    end
   end
 end

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -9,15 +9,18 @@
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  application_form_id :bigint           not null
+#  assignee_id         :bigint
 #  creator_id          :integer
 #
 # Indexes
 #
 #  index_timeline_events_on_application_form_id  (application_form_id)
+#  index_timeline_events_on_assignee_id          (assignee_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (application_form_id => application_forms.id)
+#  fk_rails_...  (assignee_id => staff.id)
 #
 require "rails_helper"
 
@@ -32,6 +35,18 @@ RSpec.describe TimelineEvent do
         assessor_assigned: "assessor_assigned",
         reviewer_assigned: "reviewer_assigned"
       ).backed_by_column_of_type(:string)
+    end
+
+    context "with an assessor assigned event type" do
+      before { timeline_event.event_type = :assessor_assigned }
+
+      it { is_expected.to validate_presence_of(:assignee) }
+    end
+
+    context "with an reviewer assigned event type" do
+      before { timeline_event.event_type = :reviewer_assigned }
+
+      it { is_expected.to validate_presence_of(:assignee) }
     end
   end
 end


### PR DESCRIPTION
This changes the data model to allow assigning an application to an assessor or a reviewer, and recording such a change in the timeline event. For now we don't support the functionality on the frontend of assigning, but we're getting the database ready for that to be built.

[Trello Card](https://trello.com/c/HBJXiYiZ/803-assessor-application-form-relationships)