### PR TITLE
[823] ApplicationForm.status -> .state

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -14,7 +14,7 @@
 #  has_work_history        :boolean
 #  reference               :string(31)       not null
 #  registration_number     :text
-#  status                  :string           default("active"), not null
+#  state                   :string           default("draft"), not null
 #  subjects                :text             default([]), not null, is an Array
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
@@ -29,7 +29,7 @@
 #  index_application_forms_on_reference    (reference) UNIQUE
 #  index_application_forms_on_region_id    (region_id)
 #  index_application_forms_on_reviewer_id  (reviewer_id)
-#  index_application_forms_on_status       (status)
+#  index_application_forms_on_state        (state)
 #  index_application_forms_on_teacher_id   (teacher_id)
 #
 # Foreign Keys
@@ -55,7 +55,12 @@ class ApplicationForm < ApplicationRecord
   belongs_to :reviewer, class_name: "Staff", optional: true
   validate :assessor_and_reviewer_must_be_different
 
-  enum status: { active: "active", submitted: "submitted" }
+  enum state: {
+         draft: "draft",
+         submitted: "submitted",
+         awarded: "awarded",
+         declined: "declined"
+       }
 
   def assign_reference
     return if reference.present?

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -24,7 +24,7 @@
   :application_forms:
     - id
     - reference
-    - status
+    - state
     - teacher_id
     - created_at
     - updated_at

--- a/db/migrate/20220825130606_change_application_form_status_to_state.rb
+++ b/db/migrate/20220825130606_change_application_form_status_to_state.rb
@@ -1,0 +1,9 @@
+class ChangeApplicationFormStatusToState < ActiveRecord::Migration[7.0]
+  def change
+    change_table :application_forms, bulk: true do |t|
+      t.string :state, null: false, default: "draft"
+      t.remove :status, type: :string, null: false, default: "active"
+      t.index :state
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_25_124404) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_25_130606) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,7 +44,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_124404) do
 
   create_table "application_forms", force: :cascade do |t|
     t.string "reference", limit: 31, null: false
-    t.string "status", default: "active", null: false
     t.bigint "teacher_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -62,11 +61,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_124404) do
     t.text "subjects", default: [], null: false, array: true
     t.bigint "assessor_id"
     t.bigint "reviewer_id"
+    t.string "state", default: "draft", null: false
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["reference"], name: "index_application_forms_on_reference", unique: true
     t.index ["region_id"], name: "index_application_forms_on_region_id"
     t.index ["reviewer_id"], name: "index_application_forms_on_reviewer_id"
-    t.index ["status"], name: "index_application_forms_on_status"
+    t.index ["state"], name: "index_application_forms_on_state"
     t.index ["teacher_id"], name: "index_application_forms_on_teacher_id"
   end
 

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -14,7 +14,7 @@
 #  has_work_history        :boolean
 #  reference               :string(31)       not null
 #  registration_number     :text
-#  status                  :string           default("active"), not null
+#  state                   :string           default("draft"), not null
 #  subjects                :text             default([]), not null, is an Array
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
@@ -29,7 +29,7 @@
 #  index_application_forms_on_reference    (reference) UNIQUE
 #  index_application_forms_on_region_id    (region_id)
 #  index_application_forms_on_reviewer_id  (reviewer_id)
-#  index_application_forms_on_status       (status)
+#  index_application_forms_on_state        (state)
 #  index_application_forms_on_teacher_id   (teacher_id)
 #
 # Foreign Keys
@@ -42,12 +42,12 @@
 FactoryBot.define do
   factory :application_form do
     sequence(:reference) { |n| n.to_s.rjust(7, "0") }
-    status { "active" }
+    state { "draft" }
     association :teacher
     association :region, :national
 
     trait :submitted do
-      status { "submitted" }
+      state { "submitted" }
     end
 
     trait :with_age_range do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -14,7 +14,7 @@
 #  has_work_history        :boolean
 #  reference               :string(31)       not null
 #  registration_number     :text
-#  status                  :string           default("active"), not null
+#  state                   :string           default("draft"), not null
 #  subjects                :text             default([]), not null, is an Array
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
@@ -29,7 +29,7 @@
 #  index_application_forms_on_reference    (reference) UNIQUE
 #  index_application_forms_on_region_id    (region_id)
 #  index_application_forms_on_reviewer_id  (reviewer_id)
-#  index_application_forms_on_status       (status)
+#  index_application_forms_on_state        (state)
 #  index_application_forms_on_teacher_id   (teacher_id)
 #
 # Foreign Keys
@@ -63,9 +63,11 @@ RSpec.describe ApplicationForm, type: :model do
     end
 
     it do
-      is_expected.to define_enum_for(:status).with_values(
-        active: "active",
-        submitted: "submitted"
+      is_expected.to define_enum_for(:state).with_values(
+        draft: "draft",
+        submitted: "submitted",
+        awarded: "awarded",
+        declined: "declined"
       ).backed_by_column_of_type(:string)
     end
 


### PR DESCRIPTION
* Add a state column with a default of 'draft' (should we set this using default on the enum instead? 🤷 )
* Drop the status column
* Changes states to draft, submitted, awarded, declined

This is the beginnings of what will ultimately become a more complex state machine. The default state is changed to `draft` as `active` probably more accurately describes a grouping of most of the other states so we can use that as a scope that covers everything except `draft` (and maybe `declined` or `expired` etc)
