### PR TITLE
Add names to staff users

### DIFF
--- a/app/controllers/staff/invitations_controller.rb
+++ b/app/controllers/staff/invitations_controller.rb
@@ -3,34 +3,14 @@ class Staff::InvitationsController < Devise::InvitationsController
 
   layout "two_thirds"
 
+  before_action :configure_permitted_parameters
   protect_from_forgery prepend: true
 
-  # GET /resource/invitation/new
-  # def new
-  #   super
-  # end
-
-  # POST /resource/invitation
-  # def create
-  #   super
-  # end
-
-  # GET /resource/invitation/accept?invitation_token=abcdef
-  # def edit
-  #   super
-  # end
-
-  # PUT /resource/invitation
-  # def update
-  #   super
-  # end
-
-  # GET /resource/invitation/remove?invitation_token=abcdef
-  # def destroy
-  #   super
-  # end
-
   protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:invite, keys: [:name])
+  end
 
   def invite_resource(&block)
     if current_inviter.is_a?(AnonymousSupportUser)

--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -33,13 +33,13 @@ module ApplicationFormHelper
       ],
       [
         I18n.t("application_form.summary.assessor"),
-        application_form.assessor&.email ||
+        application_form.assessor&.name ||
           I18n.t("application_form.summary.unassigned"),
         [{ href: "#" }]
       ],
       [
         I18n.t("application_form.summary.reviewer"),
-        application_form.reviewer&.email ||
+        application_form.reviewer&.name ||
           I18n.t("application_form.summary.unassigned"),
         [{ href: "#" }]
       ],

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -53,6 +53,8 @@ class Staff < ApplicationRecord
          :lockable,
          :invitable
 
+  validates :name, presence: true
+
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later
   end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -21,6 +21,7 @@
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string
 #  locked_at              :datetime
+#  name                   :text             default(""), not null
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string

--- a/app/views/staff/invitations/new.html.erb
+++ b/app/views/staff/invitations/new.html.erb
@@ -7,5 +7,7 @@
     <%= f.govuk_text_field field, label: { text: field.to_s.humanize } %>
   <% end -%>
 
+  <%= f.govuk_text_field :name %>
+
   <%= f.govuk_submit t("devise.invitations.new.submit_button") %>
 <% end %>

--- a/app/views/support_interface/staff/index.html.erb
+++ b/app/views/support_interface/staff/index.html.erb
@@ -7,17 +7,22 @@
 </p>
 
 <% @staff.find_each do |staff| %>
-  <h2 class="govuk-heading-m"><%= staff.email %></h2>
+  <h2 class="govuk-heading-m"><%= staff.name %></h2>
 
   <%= govuk_summary_list do |summary_list|
     summary_list.row do |row|
-      row.key { 'Created at' }
+      row.key { "Email address" }
+      row.value { staff.email }
+    end
+
+    summary_list.row do |row|
+      row.key { "Created at" }
       row.value { staff.created_at.to_s }
     end
 
     if staff.created_by_invite?
       summary_list.row do |row|
-        row.key { 'Invitation status' }
+        row.key { "Invitation status" }
 
         row.value do
           if staff.invitation_accepted?
@@ -29,13 +34,13 @@
       end
 
       summary_list.row do |row|
-        row.key { 'Invited at' }
+        row.key { "Invited at" }
         row.value { staff.invitation_sent_at.to_s }
       end
     end
 
     summary_list.row do |row|
-      row.key { 'Last signed in at' }
+      row.key { "Last signed in at" }
       row.value { staff.last_sign_in_at.to_s }
     end
   end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -130,6 +130,7 @@
     - invited_by_type
     - invited_by_id
     - invitations_count
+    - name
   :teachers:
     - id
     - email

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -29,6 +29,7 @@
     - unconfirmed_email
     - current_sign_in_ip
     - last_sign_in_ip
+    - name
   :teachers:
     - email
     - unconfirmed_email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,7 +78,7 @@ en:
       assessor: Assigned to
       reviewer: Reviewer
       reference: Reference
-      unassigned: Unassigned
+      unassigned: Not assigned
       status: Status
       notes: Notes
     overview:

--- a/db/migrate/20220825124404_add_name_to_staff.rb
+++ b/db/migrate/20220825124404_add_name_to_staff.rb
@@ -1,0 +1,5 @@
+class AddNameToStaff < ActiveRecord::Migration[7.0]
+  def change
+    add_column :staff, :name, :text, null: false, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_25_110557) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_25_124404) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -175,6 +175,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_110557) do
     t.string "invited_by_type"
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
+    t.text "name", default: "", null: false
     t.index ["confirmation_token"], name: "index_staff_on_confirmation_token", unique: true
     t.index ["email"], name: "index_staff_on_email", unique: true
     t.index ["invitation_token"], name: "index_staff_on_invitation_token", unique: true

--- a/spec/factories/staff.rb
+++ b/spec/factories/staff.rb
@@ -46,6 +46,7 @@ FactoryBot.define do
   factory :staff do
     email { "test@example.org" }
     password { "example" }
+    name { Faker::Name.name }
 
     trait :confirmed do
       confirmed_at { Time.zone.now }

--- a/spec/factories/staff.rb
+++ b/spec/factories/staff.rb
@@ -21,6 +21,7 @@
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string
 #  locked_at              :datetime
+#  name                   :text             default(""), not null
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe ApplicationFormHelper do
               text: "Assigned to"
             },
             value: {
-              text: "Unassigned"
+              text: "Not assigned"
             },
             actions: [{ href: "#" }]
           },
@@ -96,7 +96,7 @@ RSpec.describe ApplicationFormHelper do
               text: "Reviewer"
             },
             value: {
-              text: "Unassigned"
+              text: "Not assigned"
             },
             actions: [{ href: "#" }]
           },

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -56,5 +56,7 @@ RSpec.describe Staff, type: :model do
     end
 
     it { is_expected.to validate_presence_of(:password).allow_nil }
+
+    it { is_expected.to validate_presence_of(:name) }
   end
 end

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -21,6 +21,7 @@
 #  last_sign_in_at        :datetime
 #  last_sign_in_ip        :string
 #  locked_at              :datetime
+#  name                   :text             default(""), not null
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string

--- a/spec/system/support_interface/staff_spec.rb
+++ b/spec/system/support_interface/staff_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Staff support", type: :system do
     then_i_see_the_staff_invitation_form
 
     when_i_fill_email_address
+    and_i_fill_name
     and_i_send_invitation
     then_i_see_an_invitation_email
     then_i_see_the_staff_index
@@ -79,6 +80,10 @@ RSpec.describe "Staff support", type: :system do
   def then_i_see_the_accepted_staff_user
     expect(page).to have_content("test@example.com")
     expect(page).to have_content("ACCEPTED")
+  end
+
+  def and_i_fill_name
+    fill_in "staff-name-field", with: "Name"
   end
 
   def and_i_fill_password


### PR DESCRIPTION
We want to show the name of staff users instead of their email address, so we need to add this field to the staff model.

[Trello Card](https://trello.com/c/Q9y1PGyw/822-add-names-to-staff-users)