### PR TITLE
[804] Application filter - name

### DIFF
--- a/app/controllers/assessor_interface/application_forms_controller.rb
+++ b/app/controllers/assessor_interface/application_forms_controller.rb
@@ -1,6 +1,9 @@
 class AssessorInterface::ApplicationFormsController < AssessorInterface::BaseController
   def index
-    @application_forms = ApplicationForm.all
+    @application_forms =
+      ::Filters::ALL.reduce(ApplicationForm.active) do |scope, filter|
+        filter.apply(scope:, params:)
+      end
   end
 
   def show

--- a/app/lib/filters.rb
+++ b/app/lib/filters.rb
@@ -1,0 +1,3 @@
+module Filters
+  ALL = [Name].freeze
+end

--- a/app/lib/filters/base.rb
+++ b/app/lib/filters/base.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Filters
+  class Base
+    include FilterPattern
+
+    def initialize(scope:, params:)
+      @scope = scope
+      @params = params
+    end
+
+    def apply
+      raise NotImplementedError("apply method must be implemented")
+    end
+
+    private
+
+    attr_reader :scope, :params
+  end
+end

--- a/app/lib/filters/name.rb
+++ b/app/lib/filters/name.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Filters
+  class Name < Base
+    def apply
+      return scope if name.blank?
+
+      scope.where("given_names ilike ?", "%#{name}%").or(
+        scope.where("family_name ilike ?", "%#{name}%")
+      )
+    end
+
+    private
+
+    def name
+      params[:name]
+    end
+  end
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -62,6 +62,8 @@ class ApplicationForm < ApplicationRecord
          declined: "declined"
        }
 
+  scope :active, -> { not_draft }
+
   def assign_reference
     return if reference.present?
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -26,6 +26,8 @@
 # Indexes
 #
 #  index_application_forms_on_assessor_id  (assessor_id)
+#  index_application_forms_on_family_name  (family_name)
+#  index_application_forms_on_given_names  (given_names)
 #  index_application_forms_on_reference    (reference) UNIQUE
 #  index_application_forms_on_region_id    (region_id)
 #  index_application_forms_on_reviewer_id  (reviewer_id)

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -10,6 +10,12 @@
   <div class="govuk-grid-column-full-from-desktop">
     <div class="govuk-grid-column-one-third app-application-forms__filters">
       <h2 class="govuk-heading-m">Filters</h2>
+      <%= form_with method: :get, class: "app-application-forms__filter-form" do |f| %>
+        <%= f.govuk_submit "Apply filters" do %>
+          <%= govuk_link_to "Clear selection"%>
+        <%- end -%>
+        <%= f.govuk_text_field :name, label: { text: "Applicant name" }, value: params[:name] %>
+      <%- end -%>
     </div>
 
     <div class="govuk-grid-column-two-thirds">

--- a/db/migrate/20220826045155_add_application_forms_index_for_names.rb
+++ b/db/migrate/20220826045155_add_application_forms_index_for_names.rb
@@ -1,0 +1,6 @@
+class AddApplicationFormsIndexForNames < ActiveRecord::Migration[7.0]
+  def change
+    add_index :application_forms, :given_names
+    add_index :application_forms, :family_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_25_130606) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_26_045155) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,6 +63,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_25_130606) do
     t.bigint "reviewer_id"
     t.string "state", default: "draft", null: false
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
+    t.index ["family_name"], name: "index_application_forms_on_family_name"
+    t.index ["given_names"], name: "index_application_forms_on_given_names"
     t.index ["reference"], name: "index_application_forms_on_reference", unique: true
     t.index ["region_id"], name: "index_application_forms_on_region_id"
     t.index ["reviewer_id"], name: "index_application_forms_on_reviewer_id"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -48,10 +48,6 @@ FactoryBot.define do
     association :teacher
     association :region, :national
 
-    trait :submitted do
-      state { "submitted" }
-    end
-
     trait :with_age_range do
       age_range_min { Faker::Number.between(from: 5, to: 11) }
       age_range_max { Faker::Number.between(from: age_range_min, to: 18) }

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -26,6 +26,8 @@
 # Indexes
 #
 #  index_application_forms_on_assessor_id  (assessor_id)
+#  index_application_forms_on_family_name  (family_name)
+#  index_application_forms_on_given_names  (given_names)
 #  index_application_forms_on_reference    (reference) UNIQUE
 #  index_application_forms_on_region_id    (region_id)
 #  index_application_forms_on_reviewer_id  (reviewer_id)

--- a/spec/lib/filters/name_spec.rb
+++ b/spec/lib/filters/name_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Filters
+  RSpec.describe Name do
+    subject { described_class.apply(scope:, params:) }
+
+    context "the params include :name" do
+      let(:params) { { name: "Dave" } }
+      let(:scope) { ApplicationForm.all }
+
+      context "first name match" do
+        let!(:included) do
+          create(
+            :application_form,
+            :with_personal_information,
+            given_names: "Dave"
+          )
+        end
+        let!(:filtered) do
+          create(
+            :application_form,
+            :with_personal_information,
+            given_names: "Maude",
+            family_name: "Ling"
+          )
+        end
+
+        it "returns a filtered scope" do
+          expect(subject).to eq([included])
+        end
+      end
+
+      context "first name partial match" do
+        let!(:included) do
+          create(
+            :application_form,
+            :with_personal_information,
+            given_names: "Cornishpasty Dave"
+          )
+        end
+        let!(:filtered) do
+          create(
+            :application_form,
+            :with_personal_information,
+            given_names: "Maude",
+            family_name: "Ling"
+          )
+        end
+
+        it "returns a filtered scope" do
+          expect(subject).to eq([included])
+        end
+      end
+
+      context "family name match" do
+        let!(:included) do
+          create(
+            :application_form,
+            :with_personal_information,
+            family_name: "Dave"
+          )
+        end
+        let!(:filtered) do
+          create(
+            :application_form,
+            :with_personal_information,
+            given_names: "Maude",
+            family_name: "Ling"
+          )
+        end
+
+        it "returns a filtered scope" do
+          expect(subject).to eq([included])
+        end
+      end
+
+      context "family name partial match" do
+        let!(:included) do
+          create(
+            :application_form,
+            :with_personal_information,
+            family_name: "Davethegangster"
+          )
+        end
+        let!(:filtered) do
+          create(
+            :application_form,
+            :with_personal_information,
+            given_names: "Maude",
+            family_name: "Ling"
+          )
+        end
+
+        it "returns a filtered scope" do
+          expect(subject).to eq([included])
+        end
+      end
+
+      context "match with different case" do
+        let(:params) { { name: "daVe" } }
+
+        let!(:included) do
+          create(
+            :application_form,
+            :with_personal_information,
+            family_name: "Dave"
+          )
+        end
+
+        it "returns a filtered scope" do
+          expect(subject).to eq([included])
+        end
+      end
+    end
+
+    context "the params don't include :name" do
+      let(:params) { {} }
+      let(:scope) { double }
+
+      it "returns the original scope" do
+        expect(subject).to eq(scope)
+      end
+    end
+  end
+end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -26,6 +26,8 @@
 # Indexes
 #
 #  index_application_forms_on_assessor_id  (assessor_id)
+#  index_application_forms_on_family_name  (family_name)
+#  index_application_forms_on_given_names  (given_names)
 #  index_application_forms_on_reference    (reference) UNIQUE
 #  index_application_forms_on_region_id    (region_id)
 #  index_application_forms_on_reviewer_id  (reviewer_id)

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -83,6 +83,36 @@ RSpec.describe ApplicationForm, type: :model do
     end
   end
 
+  describe "scopes" do
+    describe ".active" do
+      subject { described_class.active }
+
+      context "draft" do
+        let!(:application_form) { create(:application_form, :draft) }
+
+        it { is_expected.to be_empty }
+      end
+
+      context "submitted" do
+        let!(:application_form) { create(:application_form, :submitted) }
+
+        it { is_expected.to eq([application_form]) }
+      end
+
+      context "awarded" do
+        let!(:application_form) { create(:application_form, :awarded) }
+
+        it { is_expected.to eq([application_form]) }
+      end
+
+      context "declined" do
+        let!(:application_form) { create(:application_form, :declined) }
+
+        it { is_expected.to eq([application_form]) }
+      end
+    end
+  end
+
   it "attaches empty documents" do
     expect(application_form.identification_document).to_not be_nil
     expect(application_form.name_change_document).to_not be_nil

--- a/spec/system/assessor_interface/application_forms_spec.rb
+++ b/spec/system/assessor_interface/application_forms_spec.rb
@@ -36,6 +36,6 @@ RSpec.describe "Assessor application forms", type: :system do
 
   def application_forms
     @application_forms ||=
-      create_list(:application_form, 3, :with_personal_information)
+      create_list(:application_form, 3, :with_personal_information, :submitted)
   end
 end

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Filtering application forms", type: :system do
+  it "applies the filters" do
+    given_the_service_is_staff_http_basic_auth
+    given_there_are_application_forms
+
+    when_i_am_authorized_as_an_assessor_user
+    when_i_visit_the_applications_page
+
+    and_i_apply_the_name_filter
+    then_i_see_a_list_of_applications_filtered_by_name
+  end
+
+  private
+
+  def given_the_service_is_staff_http_basic_auth
+    FeatureFlag.activate(:staff_http_basic_auth)
+  end
+
+  def given_there_are_application_forms
+    application_forms
+  end
+
+  def when_i_visit_the_applications_page
+    visit assessor_interface_application_forms_path
+  end
+
+  def and_i_apply_the_name_filter
+    fill_in "Applicant name", with: "cher"
+    click_button "Apply filters"
+  end
+
+  def then_i_see_a_list_of_applications_filtered_by_name
+    expect(page).to have_content("Cher Bert")
+  end
+
+  def application_forms
+    @application_forms ||= [
+      create(
+        :application_form,
+        :submitted,
+        given_names: "Cher",
+        family_name: "Bert"
+      )
+    ]
+  end
+end


### PR DESCRIPTION
The assessor interface application form can be filtered by various parameters. This initial PR

* Establishes the patter for filter classes with `Filters::Name` and the `Filters::ALL`
* Adds the filter form to the UI
* Adds the 'Applicant name' filter
* Filters `draft` application forms from the assessor interface

<img width="1041" alt="Screenshot 2022-08-26 at 06 50 49" src="https://user-images.githubusercontent.com/5216/186834272-863e77ae-b545-43b2-9465-da22336e7609.png">

### Review

* should we use a gin index on names? I think it's the 'correct' one for wildcard search but names are shortish and it probably doesn't matter now. We don't have the extension installed so far as I can tell. I also considered concatenating the names in the DB. Given we'll not be holding more than 12 months of data so far as we know at the moment I don't expect the table size to ever get that big.
* `ApplicationForm.active` - I've added this which currently just excludes draft. I expect it'll exclude other things (e.g. awarded/declined over a certain age maybe) as we progress but I'm not sure `active` is quite right as a name. 