### PR TITLE
[806] Assessor filter

### DIFF
--- a/app/controllers/assessor_interface/application_forms_controller.rb
+++ b/app/controllers/assessor_interface/application_forms_controller.rb
@@ -1,5 +1,6 @@
 class AssessorInterface::ApplicationFormsController < AssessorInterface::BaseController
   def index
+    @assessors = Staff.all
     @application_forms =
       ::Filters::ALL.reduce(ApplicationForm.active) do |scope, filter|
         filter.apply(scope:, params:)

--- a/app/lib/filters.rb
+++ b/app/lib/filters.rb
@@ -1,3 +1,3 @@
 module Filters
-  ALL = [Name, Country].freeze
+  ALL = [Name, Assessor, Country].freeze
 end

--- a/app/lib/filters/assessor.rb
+++ b/app/lib/filters/assessor.rb
@@ -11,7 +11,7 @@ module Filters
     private
 
     def assessor_ids
-      Array(params[:assessor_ids])
+      Array(params[:assessor_ids]).reject(&:blank?)
     end
   end
 end

--- a/app/lib/filters/assessor.rb
+++ b/app/lib/filters/assessor.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Filters
+  class Assessor < Base
+    def apply
+      return scope if assessor_ids.empty?
+
+      scope.where(assessor_id: assessor_ids)
+    end
+
+    private
+
+    def assessor_ids
+      Array(params[:assessor_ids])
+    end
+  end
+end

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -14,13 +14,20 @@
         <%= f.govuk_submit "Apply filters" do %>
           <%= govuk_link_to "Clear selection"%>
         <%- end -%>
-
-        <%= f.govuk_text_field :name, label: { text: "Applicant name" }, value: params[:name] %>
-
+        
+        <%= f.govuk_check_boxes_fieldset :assessor_ids, legend: { text: "Assessor" } do %>
+          <%- @assessors.each do |assessor| -%>
+            <%= f.govuk_check_box :assessor_ids, assessor.id, label: { text: assessor.name }, checked: params[:assessor_ids]&.include?(assessor.id.to_s) %>
+          <%- end -%>
+        <%- end -%>
+        
         <%= f.govuk_select :location,
                            options_for_select(locations, params[:location]),
                            label: { text: "Country" },
                            options: { include_blank: true } %>
+                         
+
+        <%= f.govuk_text_field :name, label: { text: "Applicant name" }, value: params[:name] %>
       <%- end -%>
     </div>
 

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -14,6 +14,18 @@ namespace :example_data do
     Faker::Config.locale = "en-GB"
     Faker::UniqueGenerator.clear
 
+    [
+      { name: "Dave Assessor", email: "assessor-dave@example.com" },
+      { name: "Beryl Assessor", email: "assessor-beryl@example.com" }
+    ].each do |assessor|
+      FactoryBot.create(
+        :staff,
+        :confirmed,
+        name: assessor[:name],
+        email: assessor[:email]
+      )
+    end
+
     Country.all.each do |country|
       country.regions.each do |region|
         application_form_traits_for(region).each do |traits|

--- a/spec/factories/staff.rb
+++ b/spec/factories/staff.rb
@@ -44,7 +44,7 @@
 #
 FactoryBot.define do
   factory :staff do
-    email { "test@example.org" }
+    sequence(:email) { |n| "test#{n}@example.org" }
     password { "example" }
     name { Faker::Name.name }
 

--- a/spec/lib/filters/assessor_spec.rb
+++ b/spec/lib/filters/assessor_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Filters
+  RSpec.describe Assessor do
+    let(:assessor_one) { create(:staff) }
+    let(:assessor_two) { create(:staff) }
+
+    subject { described_class.apply(scope:, params:) }
+
+    context "the params include assessor_id" do
+      let(:params) { { assessor_ids: assessor_one.id } }
+      let(:scope) { ApplicationForm.all }
+
+      let!(:included) { create(:application_form, assessor: assessor_one) }
+
+      let!(:filtered) { create(:application_form, assessor: assessor_two) }
+
+      it "returns a filtered scope" do
+        expect(subject).to eq([included])
+      end
+    end
+
+    context "the params include multiple assessor_ids" do
+      let(:params) { { assessor_ids: [assessor_one.id, assessor_two.id] } }
+      let(:scope) { ApplicationForm.all }
+
+      let!(:included) do
+        [
+          create(:application_form, assessor: assessor_one),
+          create(:application_form, assessor: assessor_two)
+        ]
+      end
+
+      let!(:filterd) do
+        create(:application_form)
+        create(:application_form, assessor: create(:staff))
+      end
+
+      it "returns a filtered scope" do
+        expect(subject).to eq(included)
+      end
+    end
+
+    context "the params don't include :assessor_ids" do
+      let(:params) { {} }
+      let(:scope) { double }
+
+      it "returns the original scope" do
+        expect(subject).to eq(scope)
+      end
+    end
+  end
+end

--- a/spec/lib/filters/assessor_spec.rb
+++ b/spec/lib/filters/assessor_spec.rb
@@ -43,6 +43,15 @@ module Filters
       end
     end
 
+    context "the params include a blank string" do
+      let(:params) { { assessor_ids: [""] } }
+      let(:scope) { double }
+
+      it "returns the original scope" do
+        expect(subject).to eq(scope)
+      end
+    end
+
     context "the params don't include :assessor_ids" do
       let(:params) { {} }
       let(:scope) { double }

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -10,11 +10,17 @@ RSpec.describe "Filtering application forms", type: :system do
     when_i_am_authorized_as_an_assessor_user
     when_i_visit_the_applications_page
 
-    when_i_apply_the_name_filter
+    when_i_clear_the_filters
+    and_i_apply_the_name_filter
     then_i_see_a_list_of_applications_filtered_by_name
 
-    when_i_apply_the_country_filter
+    when_i_clear_the_filters
+    and_i_apply_the_country_filter
     then_i_see_a_list_of_applications_filtered_by_country
+
+    when_i_clear_the_filters
+    and_i_apply_the_assessor_filter
+    then_i_see_a_list_of_applications_filtered_by_assessor
   end
 
   private
@@ -31,8 +37,11 @@ RSpec.describe "Filtering application forms", type: :system do
     visit assessor_interface_application_forms_path
   end
 
-  def when_i_apply_the_name_filter
+  def when_i_clear_the_filters
     click_link "Clear selection"
+  end
+
+  def and_i_apply_the_name_filter
     fill_in "Applicant name", with: "cher"
     click_button "Apply filters"
   end
@@ -41,14 +50,22 @@ RSpec.describe "Filtering application forms", type: :system do
     expect(page).to have_content("Cher Bert")
   end
 
-  def when_i_apply_the_country_filter
-    click_link "Clear selection"
+  def and_i_apply_the_country_filter
     fill_in "Country", with: "France"
     click_button "Apply filters"
   end
 
   def then_i_see_a_list_of_applications_filtered_by_country
     expect(page).to have_content("Emma Dubois")
+  end
+
+  def and_i_apply_the_assessor_filter
+    check "Wag Staff", visible: false
+    click_button "Apply filters"
+  end
+
+  def then_i_see_a_list_of_applications_filtered_by_assessor
+    expect(page).to have_content("Arnold Drummond")
   end
 
   def application_forms
@@ -66,7 +83,18 @@ RSpec.describe "Filtering application forms", type: :system do
         region: create(:region, country: create(:country, code: "FR")),
         given_names: "Emma",
         family_name: "Dubois"
+      ),
+      create(
+        :application_form,
+        :submitted,
+        given_names: "Arnold",
+        family_name: "Drummond",
+        assessor: assessors.first
       )
     ]
+  end
+
+  def assessors
+    [create(:staff, name: "Wag Staff"), create(:staff, name: "Fal Staff")]
   end
 end


### PR DESCRIPTION
Add assessor filter to the application forms page.

There are some styling issues with the form labels vs the prototype and we need to think about how values are cleared from the form as that seems a bit buggy but we can address that separately.

<img width="1035" alt="Screenshot 2022-08-26 at 09 26 49" src="https://user-images.githubusercontent.com/5216/186858744-4f97d8b5-0a20-4331-98fb-7818d8844c78.png">

