### PR TITLE
[806] Include reviewer in Filters::Assessor

### DIFF
--- a/app/lib/filters/assessor.rb
+++ b/app/lib/filters/assessor.rb
@@ -5,7 +5,9 @@ module Filters
     def apply
       return scope if assessor_ids.empty?
 
-      scope.where(assessor_id: assessor_ids)
+      scope.where(assessor_id: assessor_ids).or(
+        scope.where(reviewer_id: assessor_ids)
+      )
     end
 
     private

--- a/spec/lib/filters/assessor_spec.rb
+++ b/spec/lib/filters/assessor_spec.rb
@@ -10,15 +10,30 @@ module Filters
     subject { described_class.apply(scope:, params:) }
 
     context "the params include assessor_id" do
-      let(:params) { { assessor_ids: assessor_one.id } }
-      let(:scope) { ApplicationForm.all }
+      describe "filtering 'assigned to'" do
+        let(:params) { { assessor_ids: assessor_one.id } }
+        let(:scope) { ApplicationForm.all }
 
-      let!(:included) { create(:application_form, assessor: assessor_one) }
+        let!(:included) { create(:application_form, assessor: assessor_one) }
 
-      let!(:filtered) { create(:application_form, assessor: assessor_two) }
+        let!(:filtered) { create(:application_form, assessor: assessor_two) }
 
-      it "returns a filtered scope" do
-        expect(subject).to eq([included])
+        it "returns a filtered scope" do
+          expect(subject).to eq([included])
+        end
+      end
+
+      describe "filtering 'reviewer'" do
+        let(:params) { { assessor_ids: assessor_one.id } }
+        let(:scope) { ApplicationForm.all }
+
+        let!(:included) { create(:application_form, reviewer: assessor_one) }
+
+        let!(:filtered) { create(:application_form, reviewer: assessor_two) }
+
+        it "returns a filtered scope" do
+          expect(subject).to eq([included])
+        end
       end
     end
 


### PR DESCRIPTION
Assessors can be assigned as 'assessor' or 'reviewer' so include both in the filter.