### PR TITLE
Add ApplicationFormsIndexViewObject

### DIFF
--- a/app/controllers/assessor_interface/application_forms_controller.rb
+++ b/app/controllers/assessor_interface/application_forms_controller.rb
@@ -1,13 +1,11 @@
-class AssessorInterface::ApplicationFormsController < AssessorInterface::BaseController
-  def index
-    @assessors = Staff.all
-    @application_forms =
-      ::Filters::ALL.reduce(ApplicationForm.active) do |scope, filter|
-        filter.apply(scope:, params:)
-      end
-  end
+module AssessorInterface
+  class ApplicationFormsController < BaseController
+    def index
+      @view_object = ApplicationFormsIndexViewObject.new(params:)
+    end
 
-  def show
-    @application_form = ApplicationForm.find(params[:id])
+    def show
+      @application_form = ApplicationForm.find(params[:id])
+    end
   end
 end

--- a/app/lib/filters.rb
+++ b/app/lib/filters.rb
@@ -1,3 +1,0 @@
-module Filters
-  ALL = [Name, Assessor, Country].freeze
-end

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class AssessorInterface::ApplicationFormsIndexViewObject
+  include ActionView::Helpers::FormOptionsHelper
+
+  def initialize(params:)
+    @params = params
+  end
+
+  def application_forms
+    ALL_FILTERS.reduce(ApplicationForm.active) do |scope, filter|
+      filter.apply(scope:, params:)
+    end
+  end
+
+  def assessor_filter_options
+    Staff.all
+  end
+
+  def assessor_filter_checked?(option)
+    params[:assessor_ids]&.include?(option.id.to_s) || false
+  end
+
+  def country_filter_options
+    options_for_select(
+      Country::LOCATION_AUTOCOMPLETE_CANONICAL_LIST,
+      params[:location]
+    )
+  end
+
+  def name_filter_value
+    params[:name]
+  end
+
+  private
+
+  ALL_FILTERS = [
+    ::Filters::Name,
+    ::Filters::Assessor,
+    ::Filters::Country
+  ].freeze
+
+  attr_reader :params
+end

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -14,26 +14,25 @@
         <%= f.govuk_submit "Apply filters" do %>
           <%= govuk_link_to "Clear selection"%>
         <%- end -%>
-        
+
         <%= f.govuk_check_boxes_fieldset :assessor_ids, legend: { text: "Assessor" } do %>
-          <%- @assessors.each do |assessor| -%>
-            <%= f.govuk_check_box :assessor_ids, assessor.id, label: { text: assessor.name }, checked: params[:assessor_ids]&.include?(assessor.id.to_s) %>
+          <%- @view_object.assessor_filter_options.each do |option| -%>
+            <%= f.govuk_check_box :assessor_ids, option.id, label: { text: option.name }, checked: @view_object.assessor_filter_checked?(option) %>
           <%- end -%>
         <%- end -%>
-        
+
         <%= f.govuk_select :location,
-                           options_for_select(locations, params[:location]),
+                           @view_object.country_filter_options,
                            label: { text: "Country" },
                            options: { include_blank: true } %>
-                         
 
-        <%= f.govuk_text_field :name, label: { text: "Applicant name" }, value: params[:name] %>
+        <%= f.govuk_text_field :name, label: { text: "Applicant name" }, value: @view_object.name_filter_value %>
       <%- end -%>
     </div>
 
     <div class="govuk-grid-column-two-thirds">
       <ul class="app-search-results">
-        <%- @application_forms.each do |application_form| -%>
+        <%- @view_object.application_forms.each do |application_form| -%>
           <%= render(ApplicationFormSearchResultComponent.new(application_form)) %>
         <%- end -%>
       </ul>

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
+  subject(:view_object) { described_class.new(params:) }
+
+  let(:params) { {} }
+
+  describe "#application_forms" do
+    subject(:application_forms) { view_object.application_forms }
+
+    it { is_expected.to be_empty }
+
+    context "with an active application form" do
+      let!(:application_form) { create(:application_form, :submitted) }
+
+      it { is_expected.to include(application_form) }
+
+      it "filters on the name" do
+        expect_any_instance_of(Filters::Name).to receive(:apply).and_return(
+          ApplicationForm.none
+        )
+        expect(application_forms).to be_empty
+      end
+
+      it "filters on the assessor" do
+        expect_any_instance_of(Filters::Assessor).to receive(:apply).and_return(
+          ApplicationForm.none
+        )
+        expect(application_forms).to be_empty
+      end
+
+      it "filters on the country" do
+        expect_any_instance_of(Filters::Country).to receive(:apply).and_return(
+          ApplicationForm.none
+        )
+        expect(application_forms).to be_empty
+      end
+    end
+  end
+
+  describe "#assessor_filter_options" do
+    subject(:assessor_filter_options) { view_object.assessor_filter_options }
+
+    it { is_expected.to be_empty }
+
+    context "with a staff user" do
+      let(:staff) { create(:staff) }
+
+      it { is_expected.to include(staff) }
+    end
+  end
+
+  describe "#assessor_filter_checked?" do
+    subject(:assessor_filter_checked?) do
+      view_object.assessor_filter_checked?(option)
+    end
+
+    let(:option) { OpenStruct.new(id: 1) }
+
+    it { is_expected.to be false }
+
+    context "when the filter is set" do
+      let(:params) { { assessor_ids: %w[1] } }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "#country_filter_options" do
+    subject(:country_filter_options) { view_object.country_filter_options }
+
+    it do
+      is_expected.to include(
+        '<option value="country:US">United States</option>'
+      )
+    end
+
+    context "when the filter is set" do
+      let(:params) { { location: "country:US" } }
+
+      it do
+        is_expected.to include(
+          '<option selected="selected" value="country:US">United States</option>'
+        )
+      end
+    end
+  end
+
+  describe "#name_filter_value" do
+    subject(:name_filter_value) { view_object.name_filter_value }
+
+    it { is_expected.to be_nil }
+
+    context "when the filter is set" do
+      let(:params) { { name: "abc" } }
+
+      it { is_expected.to eq("abc") }
+    end
+  end
+end


### PR DESCRIPTION
This is a view object which represents the application forms index view and managed all the business logic associated with that view.

I was considering moving the filters to be classes within the `ApplicationFormsIndexViewObject` as they deal with the `params` in the same way, but I decided against it in the end as that's not strictly required for this refactor, but it might be something to consider in the future.