### PR TITLE
Add filtering on application form status

### DIFF
--- a/app/lib/filters/state.rb
+++ b/app/lib/filters/state.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Filters::State < Filters::Base
+  def apply
+    return scope if states.empty?
+
+    scope.where(state: states)
+  end
+
+  private
+
+  def states
+    Array(params[:states]).reject(&:blank?)
+  end
+end

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -27,6 +27,12 @@
                            options: { include_blank: true } %>
 
         <%= f.govuk_text_field :name, label: { text: "Applicant name" }, value: @view_object.name_filter_value %>
+
+        <%= f.govuk_check_boxes_fieldset :states, legend: { text: "Status of application" } do %>
+          <%- @view_object.state_filter_options.each do |option| -%>
+            <%= f.govuk_check_box :states, option.id, label: { text: option.label }, checked: @view_object.state_filter_checked?(option) %>
+          <%- end -%>
+        <%- end -%>
       <%- end -%>
     </div>
 

--- a/spec/lib/filters/assessor_spec.rb
+++ b/spec/lib/filters/assessor_spec.rb
@@ -2,78 +2,76 @@
 
 require "rails_helper"
 
-module Filters
-  RSpec.describe Assessor do
-    let(:assessor_one) { create(:staff) }
-    let(:assessor_two) { create(:staff) }
+RSpec.describe Filters::Assessor do
+  let(:assessor_one) { create(:staff) }
+  let(:assessor_two) { create(:staff) }
 
-    subject { described_class.apply(scope:, params:) }
+  subject { described_class.apply(scope:, params:) }
 
-    context "the params include assessor_id" do
-      describe "filtering 'assigned to'" do
-        let(:params) { { assessor_ids: assessor_one.id } }
-        let(:scope) { ApplicationForm.all }
-
-        let!(:included) { create(:application_form, assessor: assessor_one) }
-
-        let!(:filtered) { create(:application_form, assessor: assessor_two) }
-
-        it "returns a filtered scope" do
-          expect(subject).to eq([included])
-        end
-      end
-
-      describe "filtering 'reviewer'" do
-        let(:params) { { assessor_ids: assessor_one.id } }
-        let(:scope) { ApplicationForm.all }
-
-        let!(:included) { create(:application_form, reviewer: assessor_one) }
-
-        let!(:filtered) { create(:application_form, reviewer: assessor_two) }
-
-        it "returns a filtered scope" do
-          expect(subject).to eq([included])
-        end
-      end
-    end
-
-    context "the params include multiple assessor_ids" do
-      let(:params) { { assessor_ids: [assessor_one.id, assessor_two.id] } }
+  context "the params include assessor_id" do
+    describe "filtering 'assigned to'" do
+      let(:params) { { assessor_ids: assessor_one.id } }
       let(:scope) { ApplicationForm.all }
 
-      let!(:included) do
-        [
-          create(:application_form, assessor: assessor_one),
-          create(:application_form, assessor: assessor_two)
-        ]
-      end
+      let!(:included) { create(:application_form, assessor: assessor_one) }
 
-      let!(:filterd) do
-        create(:application_form)
-        create(:application_form, assessor: create(:staff))
-      end
+      let!(:filtered) { create(:application_form, assessor: assessor_two) }
 
       it "returns a filtered scope" do
-        expect(subject).to eq(included)
+        expect(subject).to eq([included])
       end
     end
 
-    context "the params include a blank string" do
-      let(:params) { { assessor_ids: [""] } }
-      let(:scope) { double }
+    describe "filtering 'reviewer'" do
+      let(:params) { { assessor_ids: assessor_one.id } }
+      let(:scope) { ApplicationForm.all }
 
-      it "returns the original scope" do
-        expect(subject).to eq(scope)
+      let!(:included) { create(:application_form, reviewer: assessor_one) }
+
+      let!(:filtered) { create(:application_form, reviewer: assessor_two) }
+
+      it "returns a filtered scope" do
+        expect(subject).to eq([included])
       end
     end
+  end
 
-    context "the params don't include :assessor_ids" do
-      let(:params) { {} }
-      let(:scope) { double }
+  context "the params include multiple assessor_ids" do
+    let(:params) { { assessor_ids: [assessor_one.id, assessor_two.id] } }
+    let(:scope) { ApplicationForm.all }
 
-      it "returns the original scope" do
-        expect(subject).to eq(scope)
-      end
+    let!(:included) do
+      [
+        create(:application_form, assessor: assessor_one),
+        create(:application_form, assessor: assessor_two)
+      ]
+    end
+
+    let!(:filtered) do
+      create(:application_form)
+      create(:application_form, assessor: create(:staff))
+    end
+
+    it "returns a filtered scope" do
+      expect(subject).to eq(included)
+    end
+  end
+
+  context "the params include a blank string" do
+    let(:params) { { assessor_ids: [""] } }
+    let(:scope) { double }
+
+    it "returns the original scope" do
+      expect(subject).to eq(scope)
+    end
+  end
+
+  context "the params don't include :assessor_ids" do
+    let(:params) { {} }
+    let(:scope) { double }
+
+    it "returns the original scope" do
+      expect(subject).to eq(scope)
     end
   end
 end

--- a/spec/lib/filters/name_spec.rb
+++ b/spec/lib/filters/name_spec.rb
@@ -2,126 +2,124 @@
 
 require "rails_helper"
 
-module Filters
-  RSpec.describe Name do
-    subject { described_class.apply(scope:, params:) }
+RSpec.describe Filters::Name do
+  subject { described_class.apply(scope:, params:) }
 
-    context "the params include :name" do
-      let(:params) { { name: "Dave" } }
-      let(:scope) { ApplicationForm.all }
+  context "the params include :name" do
+    let(:params) { { name: "Dave" } }
+    let(:scope) { ApplicationForm.all }
 
-      context "first name match" do
-        let!(:included) do
-          create(
-            :application_form,
-            :with_personal_information,
-            given_names: "Dave"
-          )
-        end
-        let!(:filtered) do
-          create(
-            :application_form,
-            :with_personal_information,
-            given_names: "Maude",
-            family_name: "Ling"
-          )
-        end
-
-        it "returns a filtered scope" do
-          expect(subject).to eq([included])
-        end
+    context "first name match" do
+      let!(:included) do
+        create(
+          :application_form,
+          :with_personal_information,
+          given_names: "Dave"
+        )
+      end
+      let!(:filtered) do
+        create(
+          :application_form,
+          :with_personal_information,
+          given_names: "Maude",
+          family_name: "Ling"
+        )
       end
 
-      context "first name partial match" do
-        let!(:included) do
-          create(
-            :application_form,
-            :with_personal_information,
-            given_names: "Cornishpasty Dave"
-          )
-        end
-        let!(:filtered) do
-          create(
-            :application_form,
-            :with_personal_information,
-            given_names: "Maude",
-            family_name: "Ling"
-          )
-        end
-
-        it "returns a filtered scope" do
-          expect(subject).to eq([included])
-        end
-      end
-
-      context "family name match" do
-        let!(:included) do
-          create(
-            :application_form,
-            :with_personal_information,
-            family_name: "Dave"
-          )
-        end
-        let!(:filtered) do
-          create(
-            :application_form,
-            :with_personal_information,
-            given_names: "Maude",
-            family_name: "Ling"
-          )
-        end
-
-        it "returns a filtered scope" do
-          expect(subject).to eq([included])
-        end
-      end
-
-      context "family name partial match" do
-        let!(:included) do
-          create(
-            :application_form,
-            :with_personal_information,
-            family_name: "Davethegangster"
-          )
-        end
-        let!(:filtered) do
-          create(
-            :application_form,
-            :with_personal_information,
-            given_names: "Maude",
-            family_name: "Ling"
-          )
-        end
-
-        it "returns a filtered scope" do
-          expect(subject).to eq([included])
-        end
-      end
-
-      context "match with different case" do
-        let(:params) { { name: "daVe" } }
-
-        let!(:included) do
-          create(
-            :application_form,
-            :with_personal_information,
-            family_name: "Dave"
-          )
-        end
-
-        it "returns a filtered scope" do
-          expect(subject).to eq([included])
-        end
+      it "returns a filtered scope" do
+        expect(subject).to eq([included])
       end
     end
 
-    context "the params don't include :name" do
-      let(:params) { {} }
-      let(:scope) { double }
-
-      it "returns the original scope" do
-        expect(subject).to eq(scope)
+    context "first name partial match" do
+      let!(:included) do
+        create(
+          :application_form,
+          :with_personal_information,
+          given_names: "Cornishpasty Dave"
+        )
       end
+      let!(:filtered) do
+        create(
+          :application_form,
+          :with_personal_information,
+          given_names: "Maude",
+          family_name: "Ling"
+        )
+      end
+
+      it "returns a filtered scope" do
+        expect(subject).to eq([included])
+      end
+    end
+
+    context "family name match" do
+      let!(:included) do
+        create(
+          :application_form,
+          :with_personal_information,
+          family_name: "Dave"
+        )
+      end
+      let!(:filtered) do
+        create(
+          :application_form,
+          :with_personal_information,
+          given_names: "Maude",
+          family_name: "Ling"
+        )
+      end
+
+      it "returns a filtered scope" do
+        expect(subject).to eq([included])
+      end
+    end
+
+    context "family name partial match" do
+      let!(:included) do
+        create(
+          :application_form,
+          :with_personal_information,
+          family_name: "Davethegangster"
+        )
+      end
+      let!(:filtered) do
+        create(
+          :application_form,
+          :with_personal_information,
+          given_names: "Maude",
+          family_name: "Ling"
+        )
+      end
+
+      it "returns a filtered scope" do
+        expect(subject).to eq([included])
+      end
+    end
+
+    context "match with different case" do
+      let(:params) { { name: "daVe" } }
+
+      let!(:included) do
+        create(
+          :application_form,
+          :with_personal_information,
+          family_name: "Dave"
+        )
+      end
+
+      it "returns a filtered scope" do
+        expect(subject).to eq([included])
+      end
+    end
+  end
+
+  context "the params don't include :name" do
+    let(:params) { {} }
+    let(:scope) { double }
+
+    it "returns the original scope" do
+      expect(subject).to eq(scope)
     end
   end
 end

--- a/spec/lib/filters/state_spec.rb
+++ b/spec/lib/filters/state_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Filters::State do
+  subject { described_class.apply(scope:, params:) }
+
+  context "with states param and a single state" do
+    let(:params) { { states: :draft } }
+    let(:scope) { ApplicationForm.all }
+
+    let!(:included) { create(:application_form, :draft) }
+
+    let!(:filtered) { create(:application_form, :submitted) }
+
+    it "returns a filtered scope" do
+      expect(subject).to eq([included])
+    end
+  end
+
+  context "wth states param and multiple states" do
+    let(:params) { { states: %w[draft submitted] } }
+    let(:scope) { ApplicationForm.all }
+
+    let!(:included) do
+      [create(:application_form, :draft), create(:application_form, :submitted)]
+    end
+
+    let!(:filtered) do
+      create(:application_form, :awarded)
+      create(:application_form, :declined)
+    end
+
+    it "returns a filtered scope" do
+      expect(subject).to eq(included)
+    end
+  end
+
+  context "with states param and a blank string" do
+    let(:params) { { states: [""] } }
+    let(:scope) { double }
+
+    it "returns the original scope" do
+      expect(subject).to eq(scope)
+    end
+  end
+
+  context "without states param" do
+    let(:params) { {} }
+    let(:scope) { double }
+
+    it "returns the original scope" do
+      expect(subject).to eq(scope)
+    end
+  end
+end

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe "Filtering application forms", type: :system do
     when_i_clear_the_filters
     and_i_apply_the_assessor_filter
     then_i_see_a_list_of_applications_filtered_by_assessor
+
+    when_i_clear_the_filters
+    and_i_apply_the_state_filter
+    then_i_see_a_list_of_applications_filtered_by_state
   end
 
   private
@@ -68,6 +72,15 @@ RSpec.describe "Filtering application forms", type: :system do
     expect(page).to have_content("Arnold Drummond")
   end
 
+  def and_i_apply_the_state_filter
+    check "Awarded (1)", visible: false
+    click_button "Apply filters"
+  end
+
+  def then_i_see_a_list_of_applications_filtered_by_state
+    expect(page).to have_content("John Smith")
+  end
+
   def application_forms
     @application_forms ||= [
       create(
@@ -90,6 +103,12 @@ RSpec.describe "Filtering application forms", type: :system do
         given_names: "Arnold",
         family_name: "Drummond",
         assessor: assessors.first
+      ),
+      create(
+        :application_form,
+        :awarded,
+        given_names: "John",
+        family_name: "Smith"
       )
     ]
   end


### PR DESCRIPTION
This adds the ability for a user to filter the application forms on the state, where the checkboxes include a count of each application form so users can see how many application forms there are in each state.

Depends on #432 

[Trello Card](https://trello.com/c/u97RpiY5/807-application-filter-status)

## Screenshot

<img width="344" alt="Screenshot 2022-08-26 at 14 02 21" src="https://user-images.githubusercontent.com/510498/186909456-f6637af4-6153-4f96-8665-e77638956429.png">

