### PR TITLE
Add text that shows if there are no results

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -8,10 +8,11 @@ class AssessorInterface::ApplicationFormsIndexViewObject
   end
 
   def application_forms
-    ::Filters::State.apply(
-      scope: application_forms_without_state_filter,
-      params:
-    ).order(created_at: :desc)
+    @application_forms ||=
+      ::Filters::State.apply(
+        scope: application_forms_without_state_filter,
+        params:
+      ).order(created_at: :desc)
   end
 
   def assessor_filter_options

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -39,11 +39,17 @@
     </div>
 
     <div class="govuk-grid-column-two-thirds">
-      <ul class="app-search-results">
-        <%- @view_object.application_forms.each do |application_form| -%>
-          <%= render(ApplicationFormSearchResultComponent.new(application_form)) %>
-        <%- end -%>
-      </ul>
+      <% if @view_object.application_forms.any? %>
+        <ul class="app-search-results">
+          <%- @view_object.application_forms.each do |application_form| -%>
+            <%= render(ApplicationFormSearchResultComponent.new(application_form)) %>
+          <%- end -%>
+        </ul>
+      <% else %>
+        <h2 class="govuk-heading-m">
+          No applications found. Use the filters on the left to try again or refine your search.
+        </h2>
+      <% end %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This adds a piece of text for if there are no search results when looking for applications.

[Trello Card](https://trello.com/c/Yf6mb6RQ/824-no-results-content-for-applicationform-index)

## Screenshot

<img width="621" alt="Screenshot 2022-08-26 at 15 03 18" src="https://user-images.githubusercontent.com/510498/186921972-e232ab71-1d81-4679-ba4e-31d39fa82351.png">
