### PR TITLE
Ensure clearing country box resets filter

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -30,6 +30,7 @@ var loadCountryAutoComplete = () => {
     openregisterLocationPicker({
       selectElement: locationPicker,
       url: "/autocomplete_locations.json",
+      name: "location_autocomplete",
     });
   }
 };

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -5,7 +5,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
   include Pagy::Backend
 
   def initialize(params:)
-    @params = params
+    @params = remove_cleared_autocomplete_values(params)
   end
 
   def application_forms_pagy
@@ -71,6 +71,15 @@ class AssessorInterface::ApplicationFormsIndexViewObject
           filter.apply(scope:, params:)
         end
       end
+  end
+
+  def remove_cleared_autocomplete_values(params)
+    if params.include?(:location_autocomplete) &&
+         params[:location_autocomplete].blank?
+      params.except(:location)
+    else
+      params
+    end
   end
 
   attr_reader :params

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -129,6 +129,28 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
     end
 
     context "when the filter is set" do
+      let(:params) do
+        { location: "country:US", location_autocomplete: "United States" }
+      end
+
+      it do
+        is_expected.to include(
+          '<option selected="selected" value="country:US">United States</option>'
+        )
+      end
+    end
+
+    context "when the autocomplete input is cleared" do
+      let(:params) { { location: "country:US", location_autocomplete: "" } }
+
+      it do
+        is_expected.to include(
+          '<option value="country:US">United States</option>'
+        )
+      end
+    end
+
+    context "when the autocomplete input isn't being used" do
       let(:params) { { location: "country:US" } }
 
       it do


### PR DESCRIPTION
At the moment [there's a bug with the accessible autocomplete component](https://github.com/alphagov/accessible-autocomplete/issues/229) where clearing the box doesn't get recorded correctly and therefore the previously selected value continues to be sent to the server in the `POST` request.

To get around this, we need to include the original text in the form data and use that to determine whether someone is trying to clear the autocomplete component.

We also need to consider users who have JavaScript disabled and are therefore shown just the select box, and for that we allow the original `location` param to be used if the `location_autocomplete` param isn't present.