### PR TITLE
[809] Status component

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,7 @@ Style/BlockDelimiters:
 Style/MethodCalledOnDoEndBlock:
   Exclude:
     - app/models/feature_flag.rb
+
+Layout/LineLength:
+  Exclude:
+    - spec/helpers/application_form_helper_spec.rb

--- a/app/components/application_form_status_tag/component.html.erb
+++ b/app/components/application_form_status_tag/component.html.erb
@@ -1,1 +1,1 @@
-<%= govuk_tag(text:, colour:, html_attributes: { id: }, classes: %w[app-task-list__tag]) %>
+<%= govuk_tag(text:, colour:, html_attributes: { id: }, classes: ["#{class_context}__tag"]) %>

--- a/app/components/application_form_status_tag/component.rb
+++ b/app/components/application_form_status_tag/component.rb
@@ -1,9 +1,12 @@
 module ApplicationFormStatusTag
   class Component < ViewComponent::Base
-    def initialize(key:, status:)
+    attr_reader :class_context
+
+    def initialize(key:, status:, class_context:)
       super
       @key = key
-      @status = status
+      @status = status.to_sym
+      @class_context = class_context
     end
 
     def id
@@ -11,10 +14,22 @@ module ApplicationFormStatusTag
     end
 
     def text
+      return "New" if @status.to_s == "submitted"
+
       @status.to_s.humanize
     end
 
-    COLOURS = { not_started: "grey", in_progress: "blue" }.freeze
+    COLOURS = {
+      not_started: "grey",
+      in_progress: "blue",
+      initial_assessment: "blue",
+      request_further_information: "yellow",
+      received_further_information: "purple",
+      awarded: "green",
+      declined: "red",
+      draft: "grey",
+      submitted: "grey"
+    }.freeze
 
     def colour
       COLOURS[@status]

--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -54,9 +54,10 @@ module ApplicationFormHelper
       [
         I18n.t("application_form.summary.status"),
         render(
-          GovukComponent::TagComponent.new(
-            text: "Not implemented",
-            colour: "blue"
+          ApplicationFormStatusTag::Component.new(
+            key: "application-form-#{application_form.id}",
+            status: application_form.state,
+            class_context: "app-search-result__item"
           )
         )
       ],

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -40,7 +40,8 @@
 
               <%= render(ApplicationFormStatusTag::Component.new(
                 key: item,
-                status: @application_form.task_statuses.dig(section, item)
+                status: @application_form.task_statuses.dig(section, item),
+                class_context: "app-task-list"
               )) %>
             </li>
           <% end %>

--- a/spec/components/application_form_status_tag_component_spec.rb
+++ b/spec/components/application_form_status_tag_component_spec.rb
@@ -3,15 +3,24 @@
 require "rails_helper"
 
 RSpec.describe ApplicationFormStatusTag::Component, type: :component do
-  subject(:component) { render_inline(described_class.new(key:, status:)) }
+  subject(:component) do
+    render_inline(described_class.new(key:, status:, class_context:))
+  end
 
   let(:key) { "key" }
   let(:status) { :status }
+  let(:class_context) { "app-task-list" }
 
   describe "text" do
     subject(:text) { component.text.strip }
 
     it { is_expected.to eq("Status") }
+
+    context "submitted" do
+      let(:status) { :submitted }
+
+      it { is_expected.to eq("New") }
+    end
   end
 
   describe "id" do
@@ -39,6 +48,48 @@ RSpec.describe ApplicationFormStatusTag::Component, type: :component do
       let(:status) { :completed }
 
       it { is_expected.to eq("govuk-tag app-task-list__tag") }
+    end
+
+    context "with an 'initial_assessment' status" do
+      let(:status) { :initial_assessment }
+
+      it { is_expected.to eq("govuk-tag govuk-tag--blue app-task-list__tag") }
+    end
+
+    context "with an 'request_further_information' status" do
+      let(:status) { :request_further_information }
+
+      it { is_expected.to eq("govuk-tag govuk-tag--yellow app-task-list__tag") }
+    end
+
+    context "with an 'received_further_information' status" do
+      let(:status) { :received_further_information }
+
+      it { is_expected.to eq("govuk-tag govuk-tag--purple app-task-list__tag") }
+    end
+
+    context "with an 'awarded' status" do
+      let(:status) { :awarded }
+
+      it { is_expected.to eq("govuk-tag govuk-tag--green app-task-list__tag") }
+    end
+
+    context "with an 'declined' status" do
+      let(:status) { :declined }
+
+      it { is_expected.to eq("govuk-tag govuk-tag--red app-task-list__tag") }
+    end
+
+    context "with an 'draft' status" do
+      let(:status) { :draft }
+
+      it { is_expected.to eq("govuk-tag govuk-tag--grey app-task-list__tag") }
+    end
+
+    context "with an 'submitted' status" do
+      let(:status) { :submitted }
+
+      it { is_expected.to eq("govuk-tag govuk-tag--grey app-task-list__tag") }
     end
   end
 end

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe ApplicationFormHelper do
             },
             value: {
               text:
-                "<strong class=\"govuk-tag govuk-tag--blue\">Not implemented</strong>"
+                "<strong class=\"govuk-tag govuk-tag--grey app-search-result__item__tag\" id=\"application-form-#{application_form.id}-status\">Draft</strong>\n"
             },
             actions: []
           },


### PR DESCRIPTION
* Update to the `ApplicationFormStatusTag` component to support more states for use in the assessor interface.
* Add `class_context` to support reuse

<img width="967" alt="Screenshot 2022-08-30 at 14 02 23" src="https://user-images.githubusercontent.com/5216/187443558-db0b5ce8-5fe3-44d5-b1a4-1da4df773bb9.png">

I've added some states that we don't have yet based on the prototype. We can refine these as we implement them.
