### PR TITLE
Order application forms by submitted at

### DIFF
--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -24,8 +24,8 @@ module ApplicationFormHelper
       ],
       [I18n.t("application_form.summary.region"), application_form.region.name],
       [
-        I18n.t("application_form.summary.created_at"),
-        application_form.created_at.strftime("%e %B %Y")
+        I18n.t("application_form.summary.submitted_at"),
+        application_form.submitted_at.strftime("%e %B %Y")
       ],
       [
         I18n.t("application_form.summary.days_remaining_sla"),

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -58,6 +58,8 @@ class ApplicationForm < ApplicationRecord
   belongs_to :reviewer, class_name: "Staff", optional: true
   validate :assessor_and_reviewer_must_be_different
 
+  validates :submitted_at, presence: true, unless: :draft?
+
   enum state: {
          draft: "draft",
          submitted: "submitted",

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -16,6 +16,7 @@
 #  registration_number     :text
 #  state                   :string           default("draft"), not null
 #  subjects                :text             default([]), not null, is an Array
+#  submitted_at            :datetime
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  assessor_id             :bigint

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -9,6 +9,7 @@ class SubmitApplicationForm
     return if application_form.submitted?
 
     application_form.subjects.compact_blank!
+    application_form.submitted_at = Time.zone.now
     application_form.submitted!
 
     TeacherMailer

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -59,7 +59,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
         ::Filters::State.apply(
           scope: application_forms_without_state_filter,
           params:
-        ).order(created_at: :desc)
+        ).order(:submitted_at)
       )
   end
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -42,6 +42,7 @@
     - subjects
     - assessor_id
     - reviewer_id
+    - submitted_at
   :countries:
     - id
     - code

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,7 +73,7 @@ en:
       name: Name
       country: Country trained in
       region: State/territory trained in
-      created_at: Created on
+      submitted_at: Created on
       days_remaining_sla: Days remaining in SLA
       assessor: Assigned to
       reviewer: Reviewer

--- a/db/migrate/20220830121141_add_submitted_at_to_application_forms.rb
+++ b/db/migrate/20220830121141_add_submitted_at_to_application_forms.rb
@@ -1,0 +1,5 @@
+class AddSubmittedAtToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_forms, :submitted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_26_045155) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_30_121141) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_26_045155) do
     t.bigint "assessor_id"
     t.bigint "reviewer_id"
     t.string "state", default: "draft", null: false
+    t.datetime "submitted_at"
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["family_name"], name: "index_application_forms_on_family_name"
     t.index ["given_names"], name: "index_application_forms_on_given_names"

--- a/spec/components/application_form_overview_component_spec.rb
+++ b/spec/components/application_form_overview_component_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ApplicationFormOverview::Component, type: :component do
   subject(:component) { render_inline(described_class.new(application_form)) }
 
-  let(:application_form) { create(:application_form) }
+  let(:application_form) { create(:application_form, :submitted) }
 
   describe "heading" do
     subject(:text) { component.at_css("h2").text.strip }

--- a/spec/components/application_form_search_result_component_spec.rb
+++ b/spec/components/application_form_search_result_component_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
   subject(:component) { render_inline(described_class.new(application_form)) }
 
   let(:application_form) do
-    create(:application_form, given_names: "Given", family_name: "Family")
+    create(
+      :application_form,
+      :submitted,
+      given_names: "Given",
+      family_name: "Family"
+    )
   end
 
   describe "heading text" do

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -49,6 +49,11 @@ FactoryBot.define do
     association :teacher
     association :region, :national
 
+    trait :submitted do
+      state { "submitted" }
+      submitted_at { Time.zone.now }
+    end
+
     trait :with_age_range do
       age_range_min { Faker::Number.between(from: 5, to: 11) }
       age_range_max { Faker::Number.between(from: age_range_min, to: 18) }

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -16,6 +16,7 @@
 #  registration_number     :text
 #  state                   :string           default("draft"), not null
 #  subjects                :text             default([]), not null, is an Array
+#  submitted_at            :datetime
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  assessor_id             :bigint

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -54,6 +54,16 @@ FactoryBot.define do
       submitted_at { Time.zone.now }
     end
 
+    trait :awarded do
+      state { "awarded" }
+      submitted_at { Time.zone.now }
+    end
+
+    trait :declined do
+      state { "declined" }
+      submitted_at { Time.zone.now }
+    end
+
     trait :with_age_range do
       age_range_min { Faker::Number.between(from: 5, to: 11) }
       age_range_max { Faker::Number.between(from: age_range_min, to: 18) }

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -10,9 +10,10 @@ RSpec.describe ApplicationFormHelper do
   let(:application_form) do
     create(
       :application_form,
+      :submitted,
       region:,
       reference: "0000001",
-      created_at: Date.new(2020, 1, 1),
+      submitted_at: Date.new(2020, 1, 1),
       given_names: "Given",
       family_name: "Family"
     )

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -84,6 +84,18 @@ RSpec.describe ApplicationForm, type: :model do
 
       it { is_expected.to_not be_valid }
     end
+
+    context "when submitted" do
+      before { application_form.state = "submitted" }
+
+      it { is_expected.to_not be_valid }
+
+      context "with submitted_at" do
+        before { application_form.submitted_at = Time.zone.now }
+
+        it { is_expected.to be_valid }
+      end
+    end
   end
 
   describe "scopes" do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -16,6 +16,7 @@
 #  registration_number     :text
 #  state                   :string           default("draft"), not null
 #  subjects                :text             default([]), not null, is an Array
+#  submitted_at            :datetime
 #  created_at              :datetime         not null
 #  updated_at              :datetime         not null
 #  assessor_id             :bigint

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -31,6 +31,18 @@ RSpec.describe SubmitApplicationForm do
     end
   end
 
+  describe "setting submitted at date" do
+    subject(:submitted_at) { application_form.submitted_at }
+
+    it { is_expected.to be_nil }
+
+    context "when calling the service" do
+      before { travel_to(Date.new(2020, 1, 1)) { call } }
+
+      it { is_expected.to eq(Date.new(2020, 1, 1)) }
+    end
+  end
+
   describe "sending application received email" do
     it "queues an email job" do
       expect { call }.to have_enqueued_mail(

--- a/spec/system/assessor_interface/listing_application_forms_spec.rb
+++ b/spec/system/assessor_interface/listing_application_forms_spec.rb
@@ -69,6 +69,6 @@ RSpec.describe "Assessor listing application forms", type: :system do
         25,
         :with_personal_information,
         :submitted
-      ).sort_by(&:created_at).reverse
+      ).sort_by(&:submitted_at)
   end
 end

--- a/spec/system/assessor_interface/view_application_form_spec.rb
+++ b/spec/system/assessor_interface/view_application_form_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "Assessor view application form", type: :system do
   end
 
   def application_form
-    @application_form ||= create(:application_form, :with_personal_information)
+    @application_form ||=
+      create(:application_form, :submitted, :with_personal_information)
   end
 end


### PR DESCRIPTION
This adds a new field to application forms for setting the submitted at date, which is recorded when an application form is submitted, and then used to order the application forms index page.

[Trello Card](https://trello.com/c/0m946a62/827-order-applicationforms-by-submittedat)