### PR TITLE
Rename URLs for application forms

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,9 +9,9 @@ Rails.application.routes.draw do
   end
 
   namespace :assessor_interface, path: "/assessor" do
-    root to: redirect("/assessor/application_forms")
+    root to: redirect("/assessor/applications")
 
-    resources :application_forms, only: %i[index show]
+    resources :application_forms, path: "/applications", only: %i[index show]
   end
 
   namespace :eligibility_interface, path: "/eligibility" do
@@ -75,9 +75,9 @@ Rails.application.routes.draw do
              }
 
   namespace :teacher_interface, path: "/teacher" do
-    root to: redirect("/teacher/application_form")
+    root to: redirect("/teacher/application")
 
-    resource :application_form, except: %i[destroy] do
+    resource :application_form, path: "/application", except: %i[destroy] do
       resource :personal_information,
                controller: :personal_information,
                only: %i[show] do

--- a/spec/components/application_form_search_result_component_spec.rb
+++ b/spec/components/application_form_search_result_component_spec.rb
@@ -18,9 +18,7 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
   describe "heading link" do
     subject(:href) { component.at_css("h2 > a")["href"] }
 
-    it do
-      is_expected.to eq("/assessor/application_forms/#{application_form.id}")
-    end
+    it { is_expected.to eq("/assessor/applications/#{application_form.id}") }
   end
 
   describe "description list" do

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -625,7 +625,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def then_i_see_the_new_application_page
-    expect(page).to have_current_path("/teacher/application_form/new")
+    expect(page).to have_current_path("/teacher/application/new")
     expect(page).to have_title(
       "In which country are you currently recognised as a teacher?"
     )
@@ -635,7 +635,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def then_i_see_the_active_application_page
-    expect(page).to have_current_path("/teacher/application_form")
+    expect(page).to have_current_path("/teacher/application")
     expect(page).to have_title("Apply for qualified teacher status (QTS)")
     expect(page).to have_content("Apply for qualified teacher status (QTS)")
 
@@ -935,7 +935,7 @@ RSpec.describe "Teacher application", type: :system do
   def then_i_see_the_submitted_application_page
     application_form = ApplicationForm.last
 
-    expect(page).to have_current_path("/teacher/application_form")
+    expect(page).to have_current_path("/teacher/application")
     expect(page).to have_title("Apply for qualified teacher status (QTS)")
     expect(page).to have_content("Apply for qualified teacher status (QTS)")
     expect(page).to have_content("Application complete")


### PR DESCRIPTION
This changes the URLs from `/application_forms` to `/applications` so we're not exposing internal model names to our users. We've decided to go with the name `ApplicationForm` rather than `Application` as the latter term is overused.