### PR TITLE
Improve navigation of assessor interface

### DIFF
--- a/app/components/application_form_search_result/component.rb
+++ b/app/components/application_form_search_result/component.rb
@@ -1,8 +1,9 @@
 module ApplicationFormSearchResult
   class Component < ViewComponent::Base
-    def initialize(application_form)
+    def initialize(application_form:, search_params:)
       super
       @application_form = application_form
+      @search_params = search_params
     end
 
     def full_name
@@ -10,7 +11,10 @@ module ApplicationFormSearchResult
     end
 
     def href
-      assessor_interface_application_form_path(application_form)
+      assessor_interface_application_form_path(
+        application_form,
+        search: search_params
+      )
     end
 
     def summary_rows
@@ -24,7 +28,7 @@ module ApplicationFormSearchResult
 
     private
 
-    attr_reader :application_form
+    attr_reader :application_form, :search_params
 
     delegate :application_form_full_name, to: :helpers
     delegate :application_form_summary_rows, to: :helpers

--- a/app/controllers/assessor_interface/application_forms_controller.rb
+++ b/app/controllers/assessor_interface/application_forms_controller.rb
@@ -5,7 +5,7 @@ module AssessorInterface
     end
 
     def show
-      @application_form = ApplicationForm.find(params[:id])
+      @view_object = ApplicationFormsShowViewObject.new(params:)
     end
   end
 end

--- a/app/controllers/assessor_interface/base_controller.rb
+++ b/app/controllers/assessor_interface/base_controller.rb
@@ -1,9 +1,5 @@
-module AssessorInterface
-  class BaseController < ApplicationController
-    before_action :authenticate_staff!
+class AssessorInterface::BaseController < ApplicationController
+  include AssessorCurrentNamespace
 
-    def current_namespace
-      "assessor"
-    end
-  end
+  before_action :authenticate_staff!
 end

--- a/app/controllers/concerns/assessor_current_namespace.rb
+++ b/app/controllers/concerns/assessor_current_namespace.rb
@@ -1,0 +1,5 @@
+module AssessorCurrentNamespace
+  def current_namespace
+    "assessor"
+  end
+end

--- a/app/controllers/concerns/eligibility_current_namespace.rb
+++ b/app/controllers/concerns/eligibility_current_namespace.rb
@@ -1,0 +1,5 @@
+module EligibilityCurrentNamespace
+  def current_namespace
+    "eligibility"
+  end
+end

--- a/app/controllers/concerns/staff_current_namespace.rb
+++ b/app/controllers/concerns/staff_current_namespace.rb
@@ -1,5 +1,0 @@
-module StaffCurrentNamespace
-  def current_namespace
-    "staff"
-  end
-end

--- a/app/controllers/concerns/support_current_namespace.rb
+++ b/app/controllers/concerns/support_current_namespace.rb
@@ -1,0 +1,5 @@
+module SupportCurrentNamespace
+  def current_namespace
+    "support"
+  end
+end

--- a/app/controllers/eligibility_interface/base_controller.rb
+++ b/app/controllers/eligibility_interface/base_controller.rb
@@ -1,5 +1,7 @@
 module EligibilityInterface
   class BaseController < ApplicationController
+    include EligibilityCurrentNamespace
+
     before_action :load_region
     after_action :save_eligibility_check_id
 
@@ -20,10 +22,6 @@ module EligibilityInterface
 
     def save_eligibility_check_id
       session[:eligibility_check_id] = eligibility_check.id
-    end
-
-    def current_namespace
-      "eligibility"
     end
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,6 @@
 class ErrorsController < ApplicationController
+  include EligibilityCurrentNamespace
+
   skip_before_action :verify_authenticity_token
 
   def not_found
@@ -15,9 +17,5 @@ class ErrorsController < ApplicationController
 
   def internal_server_error
     render "internal_server_error", status: :internal_server_error
-  end
-
-  def current_namespace
-    "errors"
   end
 end

--- a/app/controllers/performance_controller.rb
+++ b/app/controllers/performance_controller.rb
@@ -1,4 +1,6 @@
 class PerformanceController < ApplicationController
+  include EligibilityCurrentNamespace
+
   def index
     from = 1.week.ago.beginning_of_day
     @since_text = "over the last 7 days"
@@ -18,9 +20,5 @@ class PerformanceController < ApplicationController
       stats.live_service_usage
     @time_to_complete_data = stats.time_to_complete
     @usage_by_country_count, @usage_by_country_data = stats.usage_by_country
-  end
-
-  def current_namespace
-    "performance"
   end
 end

--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -1,4 +1,6 @@
 class PersonasController < ApplicationController
+  include EligibilityCurrentNamespace
+
   before_action :ensure_feature_active
   before_action :load_teacher_personas
 
@@ -17,10 +19,6 @@ class PersonasController < ApplicationController
   end
 
   protected
-
-  def current_namespace
-    "personas"
-  end
 
   def after_sign_in_path_for(resource)
     case resource

--- a/app/controllers/staff/confirmations_controller.rb
+++ b/app/controllers/staff/confirmations_controller.rb
@@ -1,5 +1,5 @@
 class Staff::ConfirmationsController < Devise::ConfirmationsController
-  include StaffCurrentNamespace
+  include AssessorCurrentNamespace
 
   layout "two_thirds"
 

--- a/app/controllers/staff/invitations_controller.rb
+++ b/app/controllers/staff/invitations_controller.rb
@@ -1,5 +1,5 @@
 class Staff::InvitationsController < Devise::InvitationsController
-  include StaffCurrentNamespace
+  include AssessorCurrentNamespace
 
   layout "two_thirds"
 

--- a/app/controllers/staff/passwords_controller.rb
+++ b/app/controllers/staff/passwords_controller.rb
@@ -1,5 +1,5 @@
 class Staff::PasswordsController < Devise::PasswordsController
-  include StaffCurrentNamespace
+  include AssessorCurrentNamespace
 
   layout "two_thirds"
 

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -1,5 +1,5 @@
 class Staff::SessionsController < Devise::SessionsController
-  include StaffCurrentNamespace
+  include AssessorCurrentNamespace
 
   layout "two_thirds"
 

--- a/app/controllers/staff/unlocks_controller.rb
+++ b/app/controllers/staff/unlocks_controller.rb
@@ -1,5 +1,5 @@
 class Staff::UnlocksController < Devise::UnlocksController
-  include StaffCurrentNamespace
+  include AssessorCurrentNamespace
 
   layout "two_thirds"
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,7 +1,5 @@
 class StaticController < ApplicationController
-  layout "two_thirds"
+  include EligibilityCurrentNamespace
 
-  def current_namespace
-    "static"
-  end
+  layout "two_thirds"
 end

--- a/app/controllers/support_interface/base_controller.rb
+++ b/app/controllers/support_interface/base_controller.rb
@@ -1,9 +1,5 @@
-module SupportInterface
-  class BaseController < ApplicationController
-    before_action :authenticate_staff!
+class SupportInterface::BaseController < ApplicationController
+  include SupportCurrentNamespace
 
-    def current_namespace
-      "support"
-    end
-  end
+  before_action :authenticate_staff!
 end

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -51,6 +51,17 @@ class AssessorInterface::ApplicationFormsIndexViewObject
     params[:states]&.include?(option.id) || false
   end
 
+  def search_params
+    params.permit(
+      :assessor_ids,
+      :location,
+      :location_autocomplete,
+      :name,
+      :states,
+      :page
+    )
+  end
+
   private
 
   def application_forms_with_pagy

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AssessorInterface::ApplicationFormsShowViewObject
+  def initialize(params:)
+    @params = params
+  end
+
+  def application_form
+    @application_form ||= ApplicationForm.find(params[:id])
+  end
+
+  def back_link_path
+    Rails
+      .application
+      .routes
+      .url_helpers
+      .assessor_interface_application_forms_path(params[:search]&.permit!)
+  end
+
+  attr_reader :params
+end

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -42,7 +42,7 @@
       <% if @view_object.application_forms_records.any? %>
         <ul class="app-search-results">
           <%- @view_object.application_forms_records.each do |application_form| -%>
-            <%= render(ApplicationFormSearchResult::Component.new(application_form)) %>
+            <%= render(ApplicationFormSearchResult::Component.new(application_form:, search_params: @view_object.search_params)) %>
           <%- end -%>
         </ul>
 

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, "Application" %>
+<% content_for :back_link_url, assessor_interface_application_forms_path(params[:search]&.permit!) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full-from-desktop">

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Application" %>
-<% content_for :back_link_url, assessor_interface_application_forms_path(params[:search]&.permit!) %>
+<% content_for :back_link_url, @view_object.back_link_path %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full-from-desktop">
@@ -10,7 +10,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full-from-desktop">
     <div class="govuk-body">
-      <%= render(ApplicationFormOverview::Component.new(@application_form)) %>
+      <%= render(ApplicationFormOverview::Component.new(@view_object.application_form)) %>
     </div>
   </div>
 </div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -12,7 +12,7 @@
     <p class="govuk-body">
       If the web address is correct or you selected a link or button and you
       need to speak to someone about this problem, contact the <%=
-      t('service.name') %> team: <a class="govuk-link" href="mailto:<%=
+      t(current_namespace, scope: %i[service name]) %> team: <a class="govuk-link" href="mailto:<%=
       t('service.email') %>"><%= t('service.email') %></a>.
     </p>
   </div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -7,9 +7,8 @@
     <p class="govuk-body">Try again later.</p>
 
     <p class="govuk-body">
-      If you continue to see this error contact the <%= t('service.name')
-      %> team: <a class="govuk-link" href="mailto:<%= t('service.email') %>"><%=
-      t('service.email') %></a>.
+      If you continue to see this error contact the <%= t(current_namespace, scope: %i[service name]) %>
+      team: <a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.
     </p>
   </div>
 </div>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -28,46 +28,7 @@
 
     <%= govuk_skip_link %>
 
-    <%= govuk_header(homepage_url: "https://www.gov.uk", service_name: t(current_namespace, scope: %i[service name]), classes: "app-header--#{HostingEnvironment.name}") do |header| %>
-      <% case try(:current_namespace) %>
-      <% when "support" %>
-        <% header.navigation_item(
-          text: "Features",
-          href: support_interface_features_path,
-          active: current_page?(support_interface_features_path)
-        ) %>
-        <% header.navigation_item(
-          text: "Countries",
-          href: support_interface_countries_path,
-          active: request.path.start_with?("/support/countries") || request.path.start_with?("/support/regions")
-        ) %>
-        <% header.navigation_item(
-          text: "Staff",
-          href: support_interface_staff_index_path,
-          active: request.path.start_with?("/support/staff")
-        ) %>
-        <% header.navigation_item(
-          text: "Sidekiq",
-          href: support_interface_sidekiq_web_path
-        ) %>
-        <% header.navigation_item(
-          text: "Assessor case management",
-          href: assessor_interface_root_path
-        ) %>
-      <% when "teacher" %>
-        <% if current_teacher %>
-          <% header.navigation_item(text: "Sign out", href: destroy_teacher_session_path) %>
-        <% end %>
-      <% when "assessor" %>
-        <% header.navigation_item(
-          text: "Support console",
-          href: support_interface_root_path
-        ) %>
-        <% if current_staff %>
-          <% header.navigation_item(text: "Sign out", href: destroy_staff_session_path) %>
-        <% end %>
-      <% end %>
-    <% end %>
+    <%= render partial: "shared/header" %>
 
     <div class="govuk-width-container">
       <div class="govuk-phase-banner">

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta charset="utf-8">
-    <title><%= [yield(:page_title).presence, t('service.name')].compact.join(' - ') %></title>
+    <title><%= [yield(:page_title).presence, t(current_namespace, scope: %i[service name])].compact.join(' - ') %></title>
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -28,7 +28,7 @@
 
     <%= govuk_skip_link %>
 
-    <%= govuk_header(homepage_url: "https://www.gov.uk", service_name: t('service.name'), classes: "app-header--#{HostingEnvironment.name}") do |header| %>
+    <%= govuk_header(homepage_url: "https://www.gov.uk", service_name: t(current_namespace, scope: %i[service name]), classes: "app-header--#{HostingEnvironment.name}") do |header| %>
       <% case try(:current_namespace) %>
       <% when "support" %>
         <% header.navigation_item(

--- a/app/views/performance/index.html.erb
+++ b/app/views/performance/index.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl">
       <span class="govuk-caption-xl">
-        <%= t('service.name') %>
+        <%= t(current_namespace, scope: %i[service name]) %>
       </span>
       Performance dashboard
     </h1>
@@ -64,7 +64,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">Visit this service</h2>
     <p class="govuk-heading-m">
-      <%= govuk_link_to t('service.name'), eligibility_interface_start_path %>
+      <%= govuk_link_to t(current_namespace, scope: %i[service name]), eligibility_interface_start_path %>
     </p>
 
     <h2 class="govuk-body govuk-!-font-size-16 govuk-!-margin-0">Ministerial department:</h2>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,41 @@
+<%= govuk_header(
+      homepage_url: "https://www.gov.uk",
+      service_name: t(current_namespace, scope: %i[service name]),
+      service_url: "/#{current_namespace}",
+      classes: "app-header--#{HostingEnvironment.name}"
+    ) do |header| %>
+  <% case current_namespace %>
+  <% when "assessor" %>
+    <% header.navigation_item(
+         text: "Search",
+         href: assessor_interface_application_forms_path,
+         active: current_page?(assessor_interface_application_forms_path)
+       ) %>
+    <% header.navigation_item(text: "Support console", href: support_interface_root_path) %>
+    <% if current_staff %>
+      <% header.navigation_item(text: "Sign out", href: destroy_staff_session_path) %>
+    <% end %>
+  <% when "support" %>
+    <% header.navigation_item(
+         text: "Features",
+         href: support_interface_features_path,
+         active: current_page?(support_interface_features_path)
+       ) %>
+    <% header.navigation_item(
+         text: "Countries",
+         href: support_interface_countries_path,
+         active: request.path.start_with?("/support/countries") || request.path.start_with?("/support/regions")
+       ) %>
+    <% header.navigation_item(
+         text: "Staff",
+         href: support_interface_staff_index_path,
+         active: request.path.start_with?("/support/staff")
+       ) %>
+    <% header.navigation_item(text: "Sidekiq", href: support_interface_sidekiq_web_path) %>
+    <% header.navigation_item(text: "Assessor case management", href: assessor_interface_root_path) %>
+  <% when "teacher" %>
+    <% if current_teacher %>
+      <% header.navigation_item(text: "Sign out", href: destroy_teacher_session_path) %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/static/accessibility.md
+++ b/app/views/static/accessibility.md
@@ -1,8 +1,8 @@
 <% content_for :page_title, 'Accessibility statement' %>
 
-# Accessibility statement for <%= t('service.name') %>
+# Accessibility statement for <%= t(current_namespace, scope: %i[service name]) %>
 
-This page only contains information about the <%= t('service.name') %>
+This page only contains information about the <%= t(current_namespace, scope: %i[service name]) %>
 service, available at: <a href="<%= t('service.url') %>" class="govuk-link
 govuk-link--no-visited-state"> <%= t('service.url') %> </a>
 

--- a/app/views/static/cookies.md
+++ b/app/views/static/cookies.md
@@ -5,13 +5,13 @@
 Cookies are small files saved on your phone, tablet or computer when you visit
 a website.
 
-We use cookies to make the <%= t('service.name') %> service work and
+We use cookies to make the <%= t(current_namespace, scope: %i[service name]) %> service work and
 collect information about how you use our service.
 
 ## Essential cookies
 
 Essential cookies keep your information secure while you use the <%=
-t('service.name') %> service. We do not need to ask permission to use them.
+t(current_namespace, scope: %i[service name]) %> service. We do not need to ask permission to use them.
 
 <table class="govuk-table">
   <caption class="govuk-visually-hidden">Essential cookies</caption>

--- a/app/views/static/privacy.md
+++ b/app/views/static/privacy.md
@@ -4,7 +4,7 @@
 
 ## Who we are
 
-The <%= t('service.name') %> service is run by the [Teaching Regulation Agency
+The <%= t(current_namespace, scope: %i[service name]) %> service is run by the [Teaching Regulation Agency
 (TRA)](https://www.gov.uk/government/organisations/teaching-regulation-agency/about),
 an executive agency of the Department for Education (DfE).
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,12 @@ en:
     warning: Warning
 
   service:
-    name: Apply for qualified teacher status (QTS) in England
+    name:
+      assessor: Manage applications for qualified teacher services (QTS)
+      eligibility: Apply for qualified teacher status (QTS) in England
+      support: Support for qualified teacher services (QTS)
+      teacher: Apply for qualified teacher status (QTS) in England
+
     email: qts.enquiries@education.gov.uk
     url: https://apply-for-qts-in-england.education.gov.uk
     phase_banner_text: This is a new service – <a href="https://docs.google.com/forms/d/1OpMhXJ1blJu2qFqW7VWwKnfjIoU-5SmOLXdgI0Z_kZg/viewform?edit_requested=true">your feedback will help us to improve it</a>.

--- a/spec/components/application_form_search_result_component_spec.rb
+++ b/spec/components/application_form_search_result_component_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe ApplicationFormSearchResult::Component, type: :component do
-  subject(:component) { render_inline(described_class.new(application_form)) }
+  subject(:component) do
+    render_inline(described_class.new(application_form:, search_params:))
+  end
 
   let(:application_form) do
     create(
@@ -13,6 +15,8 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
       family_name: "Family"
     )
   end
+
+  let(:search_params) { {} }
 
   describe "heading text" do
     subject(:text) { component.at_css("h2").text.strip }
@@ -24,6 +28,16 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
     subject(:href) { component.at_css("h2 > a")["href"] }
 
     it { is_expected.to eq("/assessor/applications/#{application_form.id}") }
+
+    context "with search params" do
+      let(:search_params) { { states: %w[awarded] } }
+
+      it do
+        is_expected.to eq(
+          "/assessor/applications/#{application_form.id}?search%5Bstates%5D%5B%5D=awarded"
+        )
+      end
+    end
   end
 
   describe "description list" do

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe ApplicationFormHelper do
             },
             value: {
               text:
-                "<strong class=\"govuk-tag govuk-tag--grey app-search-result__item__tag\" id=\"application-form-#{application_form.id}-status\">Draft</strong>\n"
+                "<strong class=\"govuk-tag govuk-tag--grey app-search-result__item__tag\" id=\"application-form-#{application_form.id}-status\">New</strong>\n"
             },
             actions: []
           },

--- a/spec/system/assessor_interface/view_application_form_spec.rb
+++ b/spec/system/assessor_interface/view_application_form_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe "Assessor view application form", type: :system do
     when_i_am_authorized_as_an_assessor_user
     when_i_visit_the_application_page
     then_i_see_the_application
+
+    when_i_click_back_link
+    then_i_see_the_application_forms
   end
 
   private
@@ -24,11 +27,19 @@ RSpec.describe "Assessor view application form", type: :system do
     visit assessor_interface_application_form_path(application_form)
   end
 
+  def when_i_click_back_link
+    click_link "Back"
+  end
+
   def then_i_see_the_application
     expect(page).to have_content(
       "#{application_form.given_names} #{application_form.family_name}"
     )
     expect(page).to have_content(application_form.reference)
+  end
+
+  def then_i_see_the_application_forms
+    expect(page).to have_content("Applications")
   end
 
   def application_form

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
-  subject(:view_object) { described_class.new(params:) }
+  subject(:view_object) do
+    described_class.new(params: ActionController::Parameters.new(params))
+  end
 
   let(:params) { {} }
 
@@ -218,6 +220,44 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
       let(:params) { { states: %w[draft submitted] } }
 
       it { is_expected.to be true }
+    end
+  end
+
+  describe "#search_params" do
+    subject(:search_params) { view_object.search_params }
+
+    it { is_expected.to be_empty }
+
+    context "with permitted params" do
+      let(:params) do
+        %w[
+          assessor_ids
+          location
+          location_autocomplete
+          name
+          states
+          page
+        ].each_with_object({}) { |p, memo| memo[p] = p }
+      end
+
+      it do
+        is_expected.to eq(
+          {
+            "assessor_ids" => "assessor_ids",
+            "location" => "location",
+            "location_autocomplete" => "location_autocomplete",
+            "name" => "name",
+            "states" => "states",
+            "page" => "page"
+          }
+        )
+      end
+    end
+
+    context "with unpermitted params" do
+      let(:params) { { unpermitted: "unpermitted" } }
+
+      it { is_expected.to be_empty }
     end
   end
 end

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
+  subject(:view_object) do
+    described_class.new(params: ActionController::Parameters.new(params))
+  end
+
+  let(:params) { {} }
+
+  describe "#application_form" do
+    subject(:application_form) { view_object.application_form }
+
+    it "raise an error" do
+      expect { application_form }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    context "with an application form" do
+      let(:params) { { id: create(:application_form).id } }
+
+      it { is_expected.to_not be_nil }
+    end
+  end
+
+  describe "#back_link_path" do
+    subject(:back_link_path) { view_object.back_link_path }
+
+    it { is_expected.to eq("/assessor/applications") }
+
+    context "with search params" do
+      let(:params) { { search: { states: %w[awarded] } } }
+
+      it { is_expected.to eq("/assessor/applications?states%5B%5D=awarded") }
+    end
+  end
+end


### PR DESCRIPTION
This improves the navigation of the assessor interface by adding navigation items to the header and a back link to the application show page. The back link will retain the search filters from the application forms index page.

[Trello Card](https://trello.com/c/53Sh08CF/833-missing-links)

## Screenshots

![Screenshot 2022-08-31 at 12 53 10](https://user-images.githubusercontent.com/510498/187674403-48839681-4192-4c9c-bafe-fb07aa4ada1d.png)

![Screenshot 2022-08-31 at 12 53 13](https://user-images.githubusercontent.com/510498/187674408-684165a2-4dc0-447d-94db-3ca592a89069.png)
