### PR TITLE
Allowing awarding or declining an application

### DIFF
--- a/app/controllers/assessor_interface/complete_assessments_controller.rb
+++ b/app/controllers/assessor_interface/complete_assessments_controller.rb
@@ -1,0 +1,35 @@
+module AssessorInterface
+  class CompleteAssessmentsController < BaseController
+    def new
+      @complete_assessment_form =
+        CompleteAssessmentForm.new(application_form:, staff: current_staff)
+    end
+
+    def create
+      @complete_assessment_form =
+        CompleteAssessmentForm.new(
+          application_form:,
+          staff: current_staff,
+          new_state: complete_assessments_form_params[:new_state]
+        )
+
+      if @complete_assessment_form.save!
+        redirect_to [:assessor_interface, application_form]
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def application_form
+      @application_form ||= ApplicationForm.find(params[:application_form_id])
+    end
+
+    def complete_assessments_form_params
+      params.require(:assessor_interface_complete_assessment_form).permit(
+        :new_state
+      )
+    end
+  end
+end

--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -35,8 +35,9 @@ module TeacherInterface
 
     def update
       if application_form.can_submit?
-        SubmitApplicationForm.call(application_form:)
+        SubmitApplicationForm.call(application_form:, user: current_teacher)
       end
+
       redirect_to %i[teacher_interface application_form]
     end
 

--- a/app/forms/assessor_interface/complete_assessment_form.rb
+++ b/app/forms/assessor_interface/complete_assessment_form.rb
@@ -1,0 +1,17 @@
+class AssessorInterface::CompleteAssessmentForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  attr_accessor :application_form, :staff
+  attribute :new_state, :string
+
+  validates :application_form, :staff, :new_state, presence: true
+  validates :new_state, inclusion: %w[awarded declined]
+
+  def save!
+    return false unless valid?
+
+    ChangeApplicationFormState.call(application_form:, user: staff, new_state:)
+  end
+end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -8,6 +8,8 @@
 #  annotation          :string           default(""), not null
 #  creator_type        :string
 #  event_type          :string           not null
+#  new_state           :string           default(""), not null
+#  old_state           :string           default(""), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  application_form_id :bigint           not null
@@ -30,7 +32,8 @@ class TimelineEvent < ApplicationRecord
 
   enum event_type: {
          assessor_assigned: "assessor_assigned",
-         reviewer_assigned: "reviewer_assigned"
+         reviewer_assigned: "reviewer_assigned",
+         state_changed: "state_changed"
        }
   validates :event_type, inclusion: { in: event_types.values }
 
@@ -41,4 +44,7 @@ class TimelineEvent < ApplicationRecord
   validates :assignee,
             absence: true,
             unless: -> { assessor_assigned? || reviewer_assigned? }
+
+  validates :old_state, :new_state, presence: true, if: :state_changed?
+  validates :old_state, :new_state, absence: true, unless: :state_changed?
 end

--- a/app/services/change_application_form_state.rb
+++ b/app/services/change_application_form_state.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class ChangeApplicationFormState
+  include ServicePattern
+
+  def initialize(application_form:, user:, new_state:)
+    @application_form = application_form
+    @user = user
+    @new_state = new_state
+  end
+
+  def call
+    return if application_form.state == new_state
+
+    old_state = application_form.state
+
+    ActiveRecord::Base.transaction do
+      application_form.update!(state: new_state)
+
+      TimelineEvent.create!(
+        application_form:,
+        event_type: "state_changed",
+        creator: user,
+        new_state:,
+        old_state:
+      )
+    end
+  end
+
+  private
+
+  attr_reader :application_form, :user, :new_state
+end

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -1,8 +1,9 @@
 class SubmitApplicationForm
   include ServicePattern
 
-  def initialize(application_form:)
+  def initialize(application_form:, user:)
     @application_form = application_form
+    @user = user
   end
 
   def call
@@ -10,7 +11,12 @@ class SubmitApplicationForm
 
     application_form.subjects.compact_blank!
     application_form.submitted_at = Time.zone.now
-    application_form.submitted!
+
+    ChangeApplicationFormState.call(
+      application_form:,
+      user:,
+      new_state: "submitted"
+    )
 
     TeacherMailer
       .with(teacher: application_form.teacher)
@@ -20,5 +26,5 @@ class SubmitApplicationForm
 
   private
 
-  attr_reader :application_form
+  attr_reader :application_form, :user
 end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -10,11 +10,9 @@ class AssessorInterface::ApplicationFormsShowViewObject
   end
 
   def back_link_path
-    Rails
-      .application
-      .routes
-      .url_helpers
-      .assessor_interface_application_forms_path(params[:search]&.permit!)
+    url_helpers.assessor_interface_application_forms_path(
+      params[:search]&.permit!
+    )
   end
 
   def assessment_tasks
@@ -29,13 +27,25 @@ class AssessorInterface::ApplicationFormsShowViewObject
     }
   end
 
-  def assessment_task_path(_section, _item)
-    "#"
+  def assessment_task_path(section, _item)
+    if section == :recommendation
+      url_helpers.assessor_interface_application_form_complete_assessment_path(
+        application_form
+      )
+    else
+      "#"
+    end
   end
 
   def assessment_task_status(section, _item)
     return :in_progress if section == :submitted_details
     :not_started
+  end
+
+  private
+
+  def url_helpers
+    Rails.application.routes.url_helpers
   end
 
   attr_reader :params

--- a/app/views/assessor_interface/complete_assessments/new.html.erb
+++ b/app/views/assessor_interface/complete_assessments/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, t("helpers.legend.assessor_interface_complete_assessment_form.new_state") %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+
+<%= form_with model: @complete_assessment_form, url: [:assessor_interface, @application_form, :complete_assessment] do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_collection_radio_buttons :new_state,
+                                       %w[awarded declined],
+                                       :itself,
+                                       legend: { size: "xl", tag: "h1" } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -155,6 +155,8 @@
     - created_at
     - updated_at
     - assignee_id
+    - old_state
+    - new_state
   :uploads:
     - id
     - document_id

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -2,6 +2,8 @@ en:
   helpers:
     caption: {}
     hint:
+      assessor_interface_complete_assessment_form:
+        new_state: You've completed your review of this QTS application and marked all sections as complete to your satisfaction.
       qualification:
         add_another: You can use the next section to tell us about additional degrees if you want to.
       teacher:
@@ -15,6 +17,10 @@ en:
       work_history:
         add_another: You can use the next section to tell us about additional work history.
     label:
+      assessor_interface_complete_assessment_form:
+        new_state_options:
+          awarded: Award QTS
+          declined: Decline QTS
       qualification:
         add_another_options:
           true: "Yes"
@@ -37,6 +43,8 @@ en:
           true: "Yes"
           false: "No"
     legend:
+      assessor_interface_complete_assessment_form:
+        new_state: QTS review completed
       qualification:
         add_another: Add another qualification?
       teacher_interface_alternative_name_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,9 @@ Rails.application.routes.draw do
     resources :application_forms, path: "/applications", only: %i[index show] do
       get "assign-assessor", to: "assessor_assignments#new"
       post "assign-assessor", to: "assessor_assignments#create"
+
+      get "complete-assessment", to: "complete_assessments#new"
+      post "complete-assessment", to: "complete_assessments#create"
     end
   end
 

--- a/db/migrate/20220901121549_add_state_change_to_timeline_event.rb
+++ b/db/migrate/20220901121549_add_state_change_to_timeline_event.rb
@@ -1,0 +1,8 @@
+class AddStateChangeToTimelineEvent < ActiveRecord::Migration[7.0]
+  def change
+    change_table :timeline_events, bulk: true do |t|
+      t.string :old_state, null: false, default: ""
+      t.string :new_state, null: false, default: ""
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_30_121141) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_01_121549) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -213,6 +213,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_30_121141) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "assignee_id"
+    t.string "old_state", default: "", null: false
+    t.string "new_state", default: "", null: false
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
     t.index ["assignee_id"], name: "index_timeline_events_on_assignee_id"
   end

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -6,6 +6,8 @@
 #  annotation          :string           default(""), not null
 #  creator_type        :string
 #  event_type          :string           not null
+#  new_state           :string           default(""), not null
+#  old_state           :string           default(""), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  application_form_id :bigint           not null
@@ -25,9 +27,21 @@
 FactoryBot.define do
   factory :timeline_event do
     association :application_form
-    event_type { TimelineEvent.event_types.keys.sample }
 
-    # all our event types require this field for now
-    association :assignee, factory: :staff
+    trait :assessor_assigned do
+      event_type { "assessor_assigned" }
+      association :assignee, factory: :staff
+    end
+
+    trait :reviewer_assigned do
+      event_type { "reviewer_assigned" }
+      association :assignee, factory: :staff
+    end
+
+    trait :state_changed do
+      event_type { "state_changed" }
+      old_state { ApplicationForm.states.keys.sample }
+      new_state { ApplicationForm.states.keys.sample }
+    end
   end
 end

--- a/spec/forms/assessor_interface/complete_assessment_form_spec.rb
+++ b/spec/forms/assessor_interface/complete_assessment_form_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe AssessorInterface::CompleteAssessmentForm, type: :model do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:application_form) }
+    it { is_expected.to validate_presence_of(:staff) }
+    it { is_expected.to validate_presence_of(:new_state) }
+    it do
+      is_expected.to validate_inclusion_of(:new_state).in_array(
+        %w[awarded declined]
+      )
+    end
+  end
+
+  let(:application_form) { build(:application_form, :submitted) }
+  let(:staff) { create(:staff, :confirmed) }
+  let(:new_state) { "awarded" }
+
+  describe "#save!" do
+    let(:form) { described_class.new(application_form:, staff:, new_state:) }
+
+    before { form.save! }
+
+    it "saves the application form" do
+      expect(application_form.awarded?).to be true
+    end
+  end
+end

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -6,6 +6,8 @@
 #  annotation          :string           default(""), not null
 #  creator_type        :string
 #  event_type          :string           not null
+#  new_state           :string           default(""), not null
+#  old_state           :string           default(""), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  application_form_id :bigint           not null
@@ -25,15 +27,14 @@
 require "rails_helper"
 
 RSpec.describe TimelineEvent do
-  subject(:timeline_event) { create(:timeline_event) }
+  subject(:timeline_event) { build(:timeline_event) }
 
   describe "validations" do
-    it { is_expected.to be_valid }
-
     it do
       is_expected.to define_enum_for(:event_type).with_values(
         assessor_assigned: "assessor_assigned",
-        reviewer_assigned: "reviewer_assigned"
+        reviewer_assigned: "reviewer_assigned",
+        state_changed: "state_changed"
       ).backed_by_column_of_type(:string)
     end
 
@@ -41,12 +42,24 @@ RSpec.describe TimelineEvent do
       before { timeline_event.event_type = :assessor_assigned }
 
       it { is_expected.to validate_presence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
     end
 
     context "with an reviewer assigned event type" do
       before { timeline_event.event_type = :reviewer_assigned }
 
       it { is_expected.to validate_presence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+    end
+
+    context "with a state changed event type" do
+      before { timeline_event.event_type = :state_changed }
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_presence_of(:old_state) }
+      it { is_expected.to validate_presence_of(:new_state) }
     end
   end
 end

--- a/spec/services/change_application_form_state_spec.rb
+++ b/spec/services/change_application_form_state_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ChangeApplicationFormState do
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:user) { create(:staff) }
+  let(:new_state) { :awarded }
+
+  subject(:call) { described_class.call(application_form:, user:, new_state:) }
+
+  describe "application form status" do
+    subject(:state) { application_form.state }
+
+    it { is_expected.to eq("submitted") }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to eq("awarded") }
+    end
+  end
+
+  describe "record timeline event" do
+    subject(:timeline_event) { TimelineEvent.find_by(application_form:) }
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to_not be_nil }
+
+      it "sets the attributes correctly" do
+        expect(timeline_event.creator).to eq(user)
+        expect(timeline_event.old_state).to eq("submitted")
+        expect(timeline_event.new_state).to eq("awarded")
+      end
+    end
+  end
+end

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -4,8 +4,9 @@ RSpec.describe SubmitApplicationForm do
   let(:application_form) do
     create(:application_form, subjects: ["Maths", "", ""])
   end
+  let(:user) { create(:teacher) }
 
-  subject(:call) { described_class.call(application_form:) }
+  subject(:call) { described_class.call(application_form:, user:) }
 
   describe "application form submitted status" do
     subject(:submitted?) { application_form.submitted? }
@@ -40,6 +41,24 @@ RSpec.describe SubmitApplicationForm do
       before { travel_to(Date.new(2020, 1, 1)) { call } }
 
       it { is_expected.to eq(Date.new(2020, 1, 1)) }
+    end
+  end
+
+  describe "recording timeline event" do
+    subject(:timeline_event) { TimelineEvent.find_by(application_form:) }
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to_not be_nil }
+
+      it "sets the attributes correctly" do
+        expect(timeline_event.creator).to eq(user)
+        expect(timeline_event.old_state).to eq("draft")
+        expect(timeline_event.new_state).to eq("submitted")
+      end
     end
   end
 

--- a/spec/support/page_objects/assessor_interface/complete_assessment.rb
+++ b/spec/support/page_objects/assessor_interface/complete_assessment.rb
@@ -1,0 +1,12 @@
+require "support/page_objects/govuk_radio_item"
+
+module PageObjects
+  module AssessorInterface
+    class CompleteAssessment < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/complete-assessment"
+
+      element :heading, "h1"
+      sections :new_states, GovukRadioItem, ".govuk-radios__item"
+    end
+  end
+end

--- a/spec/support/page_objects/govuk_radio_item.rb
+++ b/spec/support/page_objects/govuk_radio_item.rb
@@ -1,0 +1,6 @@
+module PageObjects
+  class GovukRadioItem < SitePrism::Section
+    element :input, ".govuk-radios__input", visible: false
+    element :label, ".govuk-radios__label"
+  end
+end

--- a/spec/system/assessor_interface/assigning_assessor_spec.rb
+++ b/spec/system/assessor_interface/assigning_assessor_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "assgining an assessor", type: :system do
+RSpec.describe "Assigning an assessor", type: :system do
   it "assigns an assessor" do
     given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user(assessor)

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -9,7 +9,10 @@ RSpec.describe "Assessor completing assessment", type: :system do
     given_there_is_an_application_form
 
     when_i_visit_the_complete_assessment_page
-    and_i_select_award
+    then_i_see_the_complete_assessment_form
+
+    when_i_select_award_qts
+    and_i_click_continue
     then_the_application_form_is_awarded
   end
 
@@ -20,14 +23,23 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def when_i_visit_the_complete_assessment_page
-    visit assessor_interface_application_form_complete_assessment_path(
-            application_form
-          )
+    complete_assessment_page.load(application_id: application_form.id)
   end
 
-  def and_i_select_award
-    choose "Award QTS", visible: false
-    click_button "Continue"
+  def then_i_see_the_complete_assessment_form
+    expect(complete_assessment_page.heading).to have_content(
+      "QTS review completed"
+    )
+    expect(complete_assessment_page.new_states.first).to have_content(
+      "Award QTS"
+    )
+    expect(complete_assessment_page.new_states.second).to have_content(
+      "Decline QTS"
+    )
+  end
+
+  def when_i_select_award_qts
+    complete_assessment_page.new_states.first.input.choose
   end
 
   def then_the_application_form_is_awarded
@@ -41,5 +53,10 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
   def assessor
     @assessor ||= create(:staff, :confirmed)
+  end
+
+  def complete_assessment_page
+    @complete_assessment_page ||=
+      PageObjects::AssessorInterface::CompleteAssessment.new
   end
 end

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assessor completing assessment", type: :system do
+  it "completes an assessment" do
+    given_the_service_is_open
+    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_there_is_an_application_form
+
+    when_i_visit_the_complete_assessment_page
+    and_i_select_award
+    then_the_application_form_is_awarded
+  end
+
+  private
+
+  def given_there_is_an_application_form
+    application_form
+  end
+
+  def when_i_visit_the_complete_assessment_page
+    visit assessor_interface_application_form_complete_assessment_path(
+            application_form
+          )
+  end
+
+  def and_i_select_award
+    choose "Award QTS", visible: false
+    click_button "Continue"
+  end
+
+  def then_the_application_form_is_awarded
+    expect(page).to have_content("Status\tAWARDED")
+  end
+
+  def application_form
+    @application_form ||=
+      create(:application_form, :with_personal_information, :submitted)
+  end
+
+  def assessor
+    @assessor ||= create(:staff, :confirmed)
+  end
+end

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -58,10 +58,26 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       view_object.assessment_task_path(section, item)
     end
 
-    let(:section) { nil }
+    let(:application_form) { create(:application_form) }
+    let(:params) { { id: application_form.id } }
+
     let(:item) { nil }
 
-    it { is_expected.to eq("#") }
+    context "with submitted details section" do
+      let(:section) { :submitted_details }
+
+      it { is_expected.to eq("#") }
+    end
+
+    context "with recommendation section" do
+      let(:section) { :recommendation }
+
+      it do
+        is_expected.to eq(
+          "/assessor/applications/#{application_form.id}/complete-assessment"
+        )
+      end
+    end
   end
 
   describe "#assessment_task_status" do


### PR DESCRIPTION
This adds a new view allowing a staff user to award QTS or decline QTS to an application. For now there's nothing that prevents this from being awarded multiple times, and we don't have any functionality related to requesting further information.

[Trello Card](https://trello.com/c/VESzC5sP/835-qts-review-completed)

## Screenshots

<img width="714" alt="Screenshot 2022-09-01 at 15 18 06" src="https://user-images.githubusercontent.com/510498/187938379-186db09b-d656-48c6-a1a0-8dc646d3fa42.png">
<img width="341" alt="Screenshot 2022-09-01 at 15 18 30" src="https://user-images.githubusercontent.com/510498/187938426-e1d4300c-d7a2-4983-a39a-8648c2287fbd.png">
<img width="333" alt="Screenshot 2022-09-01 at 15 18 35" src="https://user-images.githubusercontent.com/510498/187938434-33100644-24d2-47f2-98a4-3e9be5a4dcf6.png">
