### PR TITLE
Add links to check submitted details

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -27,13 +27,17 @@ class AssessorInterface::ApplicationFormsShowViewObject
     }
   end
 
-  def assessment_task_path(section, _item)
-    if section == :recommendation
+  def assessment_task_path(section, item)
+    case section
+    when :submitted_details
+      url_helpers.send(
+        "assessor_interface_application_form_check_#{item}_path",
+        application_form
+      )
+    when :recommendation
       url_helpers.assessor_interface_application_form_complete_assessment_path(
         application_form
       )
-    else
-      "#"
     end
   end
 
@@ -44,9 +48,9 @@ class AssessorInterface::ApplicationFormsShowViewObject
 
   private
 
+  attr_reader :params
+
   def url_helpers
     Rails.application.routes.url_helpers
   end
-
-  attr_reader :params
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,12 @@ Rails.application.routes.draw do
     resources :application_forms, path: "/applications", only: %i[index show] do
       get "assign-assessor", to: "assessor_assignments#new"
       post "assign-assessor", to: "assessor_assignments#create"
-
       get "complete-assessment", to: "complete_assessments#new"
       post "complete-assessment", to: "complete_assessments#create"
+      resource :check_personal_information, only: :show
+      resource :check_qualifications, only: :show
+      resource :check_work_history, only: :show
+      resource :check_professional_standing, only: :show
     end
   end
 

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -61,16 +61,53 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
     let(:application_form) { create(:application_form) }
     let(:params) { { id: application_form.id } }
 
-    let(:item) { nil }
-
     context "with submitted details section" do
       let(:section) { :submitted_details }
 
-      it { is_expected.to eq("#") }
+      context "with personal information item" do
+        let(:item) { :personal_information }
+
+        it do
+          is_expected.to eq(
+            "/assessor/applications/#{application_form.id}/check_personal_information"
+          )
+        end
+      end
+
+      context "with qualifications item" do
+        let(:item) { :qualifications }
+
+        it do
+          is_expected.to eq(
+            "/assessor/applications/#{application_form.id}/check_qualifications"
+          )
+        end
+      end
+
+      context "with work history item" do
+        let(:item) { :work_history }
+
+        it do
+          is_expected.to eq(
+            "/assessor/applications/#{application_form.id}/check_work_history"
+          )
+        end
+      end
+
+      context "with professional standing item" do
+        let(:item) { :professional_standing }
+
+        it do
+          is_expected.to eq(
+            "/assessor/applications/#{application_form.id}/check_professional_standing"
+          )
+        end
+      end
     end
 
     context "with recommendation section" do
       let(:section) { :recommendation }
+      let(:item) { nil }
 
       it do
         is_expected.to eq(


### PR DESCRIPTION
This adds the necessary links to the items in the "Check submitted details" section of the assessor interface application form assessment page.

I've opened this PR as it applies to all the individual pages, which will be added in subsequent PRs.