### PR TITLE
[832] Assign reviewer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem "sentry-rails"
 gem "sentry-ruby"
 gem "sidekiq"
 gem "sitemap_generator"
-gem "site_prism"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby] # Windows
 
 gem "dfe-analytics", git: "https://github.com/DFE-Digital/dfe-analytics"
@@ -61,4 +60,5 @@ group :test do
   gem "rspec"
   gem "rspec-rails", "~> 6.0.0.rc1"
   gem "shoulda-matchers", "~> 5.1"
+  gem "site_prism"
 end

--- a/app/controllers/assessor_interface/reviewer_assignments_controller.rb
+++ b/app/controllers/assessor_interface/reviewer_assignments_controller.rb
@@ -1,0 +1,38 @@
+module AssessorInterface
+  class ReviewerAssignmentsController < BaseController
+    def new
+      @reviewer_assignment_form =
+        ReviewerAssignmentForm.new(
+          reviewer_id: application_form.reviewer_id,
+          application_form:
+        )
+    end
+
+    def create
+      @reviewer_assignment_form =
+        ReviewerAssignmentForm.new(
+          reviewer_id: reviewer_params[:reviewer_id],
+          application_form:,
+          assigning_user_id: current_staff.id
+        )
+
+      if @reviewer_assignment_form.save!
+        redirect_to assessor_interface_application_form_path(application_form)
+      else
+        render :new
+      end
+    end
+
+    private
+
+    def application_form
+      @application_form ||= ApplicationForm.find(params[:application_form_id])
+    end
+
+    def reviewer_params
+      params.require(:assessor_interface_reviewer_assignment_form).permit(
+        :reviewer_id
+      )
+    end
+  end
+end

--- a/app/forms/assessor_interface/reviewer_assignment_form.rb
+++ b/app/forms/assessor_interface/reviewer_assignment_form.rb
@@ -1,0 +1,30 @@
+class AssessorInterface::ReviewerAssignmentForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  attr_accessor :application_form
+  attribute :reviewer_id, :string
+  attribute :assigning_user_id, :string
+
+  validates :application_form, :reviewer_id, :assigning_user_id, presence: true
+
+  def save!
+    return false unless valid?
+
+    application_form.reviewer_id = reviewer_id
+    application_form.save!
+    create_timeline_event!
+  end
+
+  private
+
+  def create_timeline_event!
+    TimelineEvent.create!(
+      application_form:,
+      event_type: "reviewer_assigned",
+      creator_id: assigning_user_id,
+      assignee_id: reviewer_id
+    )
+  end
+end

--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -48,7 +48,14 @@ module ApplicationFormHelper
         I18n.t("application_form.summary.reviewer"),
         application_form.reviewer&.name ||
           I18n.t("application_form.summary.unassigned"),
-        [{ href: "#" }]
+        [
+          {
+            href:
+              assessor_interface_application_form_assign_reviewer_path(
+                application_form
+              )
+          }
+        ]
       ],
       (
         if include_reference

--- a/app/views/assessor_interface/reviewer_assignments/new.html.erb
+++ b/app/views/assessor_interface/reviewer_assignments/new.html.erb
@@ -1,0 +1,18 @@
+<h1 class="govuk-heading-l">
+  Select a reviewer
+</h1>
+
+<%= form_for @reviewer_assignment_form, url: assessor_interface_application_form_assign_reviewer_path(@application_form) do |form| %>
+    <%= form.govuk_error_summary %>
+
+    <%= form.govuk_collection_radio_buttons :reviewer_id,
+      Staff.all,
+      :id,
+      :name,
+      legend: nil
+    %>
+    <%= form.govuk_submit "Continue" do %>
+      <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
+    <%- end -%>
+<%- end -%>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,8 +14,11 @@ Rails.application.routes.draw do
     resources :application_forms, path: "/applications", only: %i[index show] do
       get "assign-assessor", to: "assessor_assignments#new"
       post "assign-assessor", to: "assessor_assignments#create"
+      get "assign-reviewer", to: "reviewer_assignments#new"
+      post "assign-reviewer", to: "reviewer_assignments#create"
       get "complete-assessment", to: "complete_assessments#new"
       post "complete-assessment", to: "complete_assessments#create"
+
       resource :check_personal_information, only: :show
       resource :check_qualifications, only: :show
       resource :check_work_history, only: :show

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -106,7 +106,14 @@ RSpec.describe ApplicationFormHelper do
             value: {
               text: "Not assigned"
             },
-            actions: [{ href: "#" }]
+            actions: [
+              {
+                href:
+                  assessor_interface_application_form_assign_reviewer_path(
+                    application_form
+                  )
+              }
+            ]
           },
           {
             key: {

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,8 @@ require "rspec/rails"
 require "capybara/cuprite"
 require "dfe/analytics/testing"
 require "view_component/test_helpers"
+require "site_prism"
+require "site_prism/all_there"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -77,4 +79,4 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }

--- a/spec/support/page_objects/assessor_interface/assign_reviewer.rb
+++ b/spec/support/page_objects/assessor_interface/assign_reviewer.rb
@@ -1,0 +1,13 @@
+require "support/page_objects/govuk_radio_item"
+
+module PageObjects
+  module AssessorInterface
+    class AssignReviewer < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/assign-reviewer"
+
+      element :heading, "h1"
+      sections :reviewers, PageObjects::GovukRadioItem, ".govuk-radios__item"
+      element :continue_button, "button"
+    end
+  end
+end

--- a/spec/system/assessor_interface/assigning_assessor_spec.rb
+++ b/spec/system/assessor_interface/assigning_assessor_spec.rb
@@ -14,6 +14,17 @@ RSpec.describe "Assigning an assessor", type: :system do
     then_the_assessor_is_assigned_to_the_application_form
   end
 
+  it "assigns a reviewer" do
+    given_the_service_is_open
+    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_there_is_an_application_form
+    given_an_assessor_exists
+
+    when_i_visit_the_assign_reviewer_page
+    and_i_select_a_reviewer
+    then_the_assessor_is_assigned_as_reviewer_to_the_application_form
+  end
+
   private
 
   def given_there_is_an_application_form
@@ -39,6 +50,19 @@ RSpec.describe "Assigning an assessor", type: :system do
     expect(page).to have_content("Assigned to\t#{assessor.name}")
   end
 
+  def when_i_visit_the_assign_reviewer_page
+    assign_reviewer_page.load(application_id: application_form.id)
+  end
+
+  def and_i_select_a_reviewer
+    assign_reviewer_page.reviewers.first.input.click
+    assign_reviewer_page.continue_button.click
+  end
+
+  def then_the_assessor_is_assigned_as_reviewer_to_the_application_form
+    expect(page).to have_content("Reviewer\t#{assessor.name}")
+  end
+
   def application_form
     @application_form ||=
       create(:application_form, :with_personal_information, :submitted)
@@ -46,5 +70,9 @@ RSpec.describe "Assigning an assessor", type: :system do
 
   def assessor
     @assessor ||= create(:staff, :confirmed)
+  end
+
+  def assign_reviewer_page
+    @assign_reviewer_page ||= PageObjects::AssessorInterface::AssignReviewer.new
   end
 end


### PR DESCRIPTION
Add functionality to all an assessor user to attach a reviewer to an application.

This is very similar to the assign_assessor functionality already in place. I did consider trying to extract some common functionality from that but the additional structural complexity didn't seem worth it with the individual bits being so simple as it. Happy to revisit that approach though.

<img width="1044" alt="Screenshot 2022-09-01 at 16 30 08" src="https://user-images.githubusercontent.com/5216/187954004-fb7f9bb0-ada9-4f03-87ec-a79509b3ae36.png">

