### PR TITLE
Add links to documents in check your answers

### DIFF
--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -63,7 +63,7 @@ module CheckYourAnswersSummary
         return value.strftime(format).strip
       end
 
-      return file_names_for(value, field[:translation]) if value.is_a?(Document)
+      return file_links_for(value, field[:translation]) if value.is_a?(Document)
 
       if value.is_a?(Array)
         return value.map { |v| format_value(v, field) }.join("<br />").html_safe
@@ -75,14 +75,15 @@ module CheckYourAnswersSummary
       value.to_s
     end
 
-    def file_names_for(document, translations)
+    def file_links_for(document, translations)
       scope =
         translations ? document.translated_uploads : document.original_uploads
       scope
         .order(:created_at)
-        .map { |upload| upload.attachment&.filename }
-        .compact
+        .select { |upload| upload.attachment.present? }
+        .map { |upload| link_to(upload.name, upload.url) }
         .join(", ")
+        .html_safe
     end
   end
 end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -26,6 +26,10 @@ class Upload < ApplicationRecord
     !translation?
   end
 
+  def name
+    attachment.filename.to_s
+  end
+
   def url
     Rails.application.routes.url_helpers.url_for(attachment)
   end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -25,4 +25,8 @@ class Upload < ApplicationRecord
   def original?
     !translation?
   end
+
+  def url
+    Rails.application.routes.url_helpers.url_for(attachment)
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,7 +65,8 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :sidekiq
 
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  routes.default_url_options = { host: "localhost", port: 3000 }
+
   config.action_mailer.delivery_method = :file
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -84,10 +84,11 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = {
+  routes.default_url_options = {
     host: HostingEnvironment.host,
     protocol: "https"
   }
+
   config.action_mailer.delivery_method = :notify
   config.action_mailer.notify_settings = {
     api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY")

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,6 +53,7 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :test
 
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+  routes.default_url_options = { host: "localhost", port: 3000 }
+
   config.action_mailer.delivery_method = :test
 end

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -232,7 +232,12 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
     end
 
     it "renders the value" do
-      expect(row.at_css(".govuk-summary-list__value").text).to eq("upload.pdf")
+      expect(row.at_css(".govuk-summary-list__value a").text).to eq(
+        "upload.pdf"
+      )
+      expect(row.at_css(".govuk-summary-list__value a")[:href]).to include(
+        "upload.pdf"
+      )
     end
 
     it "renders the change link" do
@@ -273,7 +278,10 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       end
 
       it "renders the value" do
-        expect(row.at_css(".govuk-summary-list__value").text).to eq(
+        expect(row.at_css(".govuk-summary-list__value a").text).to eq(
+          "upload.pdf"
+        )
+        expect(row.at_css(".govuk-summary-list__value a")[:href]).to include(
           "upload.pdf"
         )
       end
@@ -296,7 +304,10 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       end
 
       it "renders the value" do
-        expect(row.at_css(".govuk-summary-list__value").text).to eq(
+        expect(row.at_css(".govuk-summary-list__value a").text).to eq(
+          "translation_upload.pdf"
+        )
+        expect(row.at_css(".govuk-summary-list__value a")[:href]).to include(
           "translation_upload.pdf"
         )
       end

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe Upload, type: :model do
     end
   end
 
+  describe "#name" do
+    subject(:name) { upload.name }
+
+    it { is_expected.to eq("upload.pdf") }
+  end
+
   describe "#url" do
     subject(:url) { upload.url }
 

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -37,4 +37,15 @@ RSpec.describe Upload, type: :model do
       it { is_expected.to be(false) }
     end
   end
+
+  describe "#url" do
+    subject(:url) { upload.url }
+
+    it do
+      is_expected.to include(
+        "http://localhost:3000/rails/active_storage/blobs/redirect/"
+      )
+    end
+    it { is_expected.to include("upload.pdf") }
+  end
 end


### PR DESCRIPTION
When rendering a check your answers summary component, when displaying a document with a list of uploads we want to include a link to the upload so teachers can see what they uploaded and assessors can see the documents. 

I've opened this PR as it applies to all the individual pages, which will be added in subsequent PRs.