### PR TITLE
Add option for hiding change links to "Check your answers"

### DIFF
--- a/app/components/check_your_answers_summary/component.html.erb
+++ b/app/components/check_your_answers_summary/component.html.erb
@@ -19,11 +19,14 @@
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key"><%= row.fetch(:title) %></dt>
           <dd class="govuk-summary-list__value"><%= row.fetch(:value) %></dd>
-          <dd class="govuk-summary-list__actions">
-            <%= govuk_link_to(row.fetch(:href)) do %>
-              Change <span class="govuk-visually-hidden"><%= row.fetch(:title).downcase %></span>
-            <% end %>
-          </dd>
+
+          <% if (href = row[:href]).present? %>
+            <dd class="govuk-summary-list__actions">
+              <%= govuk_link_to(href) do %>
+                Change <span class="govuk-visually-hidden"><%= row.fetch(:title).downcase %></span>
+              <% end %>
+            </dd>
+          <% end %>
         </div>
       <% end %>
     </dl>

--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -1,11 +1,18 @@
 module CheckYourAnswersSummary
   class Component < ViewComponent::Base
-    def initialize(model:, title:, fields:, delete_link_to: nil)
+    def initialize(
+      model:,
+      title:,
+      fields:,
+      changeable: true,
+      delete_link_to: nil
+    )
       super
       @model = model
       @title = title
       @fields = fields
-      @delete_link_to = delete_link_to
+      @changeable = changeable
+      @delete_link_to = changeable ? delete_link_to : nil
     end
 
     attr_reader :title
@@ -16,7 +23,7 @@ module CheckYourAnswersSummary
 
     private
 
-    attr_reader :model, :fields
+    attr_reader :model, :fields, :changeable
 
     def fields_with_translations
       fields_as_array.flat_map do |field|
@@ -51,7 +58,7 @@ module CheckYourAnswersSummary
         key: field[:key],
         title: row_title_for(field),
         value: format_value(model.send(field[:key]), field),
-        href: field.fetch(:href)
+        href: changeable ? field.fetch(:href) : nil
       }
     end
 

--- a/app/views/shared/application_form/_age_range_summary.html.erb
+++ b/app/views/shared/application_form/_age_range_summary.html.erb
@@ -10,5 +10,6 @@
       title: "Maximum age",
       href: %i[age_range teacher_interface application_form]
     },
-  }
+  },
+  changeable:
 )) %>

--- a/app/views/shared/application_form/_identity_document_summary.html.erb
+++ b/app/views/shared/application_form/_identity_document_summary.html.erb
@@ -6,5 +6,6 @@
       title: "Identity documents",
       href: [:edit, :teacher_interface, :application_form, application_form.identification_document]
     },
-  }
+  },
+  changeable:
 )) %>

--- a/app/views/shared/application_form/_personal_information_summary.html.erb
+++ b/app/views/shared/application_form/_personal_information_summary.html.erb
@@ -24,5 +24,6 @@
     name_change_document: application_form.has_alternative_name? ? {
       href: [:edit, :teacher_interface, :application_form, application_form.name_change_document]
     } : nil,
-  }
+  },
+  changeable:
 )) %>

--- a/app/views/shared/application_form/_qualifications_summary.html.erb
+++ b/app/views/shared/application_form/_qualifications_summary.html.erb
@@ -41,6 +41,7 @@
         href: [:part_of_university_degree, :teacher_interface, :application_form, qualification]
       } : nil,
     },
+    changeable:,
     delete_link_to: qualification.can_delete? ? [:delete, :teacher_interface, :application_form, qualification] : nil,
   )) %>
 <% end %>

--- a/app/views/shared/application_form/_registration_number_summary.html.erb
+++ b/app/views/shared/application_form/_registration_number_summary.html.erb
@@ -5,5 +5,6 @@
     registration_number: {
       href: %i[registration_number teacher_interface application_form]
     },
-  }
+  },
+  changeable:
 )) %>

--- a/app/views/shared/application_form/_subjects_summary.html.erb
+++ b/app/views/shared/application_form/_subjects_summary.html.erb
@@ -5,5 +5,6 @@
     subjects: {
       href: %i[subjects teacher_interface application_form]
     },
-  }
+  },
+  changeable:
 )) %>

--- a/app/views/shared/application_form/_work_history_summary.html.erb
+++ b/app/views/shared/application_form/_work_history_summary.html.erb
@@ -6,7 +6,8 @@
       title: "Have you worked professionally as a teacher?",
       href: %i[has_work_history teacher_interface application_form work_histories]
     },
-  }
+  },
+  changeable:
 )) %>
 
 <% work_histories.each do |work_history| %>
@@ -44,6 +45,7 @@
         href: [:edit, :teacher_interface, :application_form, work_history]
       } : nil,
     },
+    changeable:,
     delete_link_to: [:delete, :teacher_interface, :application_form, work_history]
   )) %>
 <% end %>

--- a/app/views/shared/application_form/_written_statement_summary.html.erb
+++ b/app/views/shared/application_form/_written_statement_summary.html.erb
@@ -6,5 +6,6 @@
       title: "Written statement",
       href: [:edit, :teacher_interface, :application_form, application_form.written_statement_document]
     },
-  }
+  },
+  changeable:
 )) %>

--- a/app/views/teacher_interface/application_forms/edit.html.erb
+++ b/app/views/teacher_interface/application_forms/edit.html.erb
@@ -4,26 +4,26 @@
 <h1 class="govuk-heading-xl">Check your answers before submitting your application</h1>
 
 <h2 class="govuk-heading-m">About you</h2>
-<%= render "teacher_interface/personal_information/summary", application_form: @application_form %>
-<%= render "teacher_interface/identity_document/summary", application_form: @application_form %>
+<%= render "shared/application_form/personal_information_summary", application_form: @application_form, changeable: true %>
+<%= render "shared/application_form/identity_document_summary", application_form: @application_form, changeable: true %>
 
 <h2 class="govuk-heading-m">Who you can teach</h2>
-<%= render "teacher_interface/qualifications/summary", application_form: @application_form, qualifications: @application_form.qualifications.ordered %>
-<%= render "teacher_interface/age_range/summary", application_form: @application_form %>
-<%= render "teacher_interface/subjects/summary", application_form: @application_form %>
+<%= render "shared/application_form/qualifications_summary", application_form: @application_form, qualifications: @application_form.qualifications.ordered, changeable: true %>
+<%= render "shared/application_form/age_range_summary", application_form: @application_form, changeable: true %>
+<%= render "shared/application_form/subjects_summary", application_form: @application_form, changeable: true %>
 
 <% if @application_form.needs_work_history? %>
   <h2 class="govuk-heading-m">Your work history</h2>
-  <%= render "teacher_interface/work_histories/summary", application_form: @application_form, work_histories: @application_form.work_histories.ordered %>
+  <%= render "shared/application_form/work_history_summary", application_form: @application_form, work_histories: @application_form.work_histories.ordered, changeable: true %>
 <% end %>
 
 <% if @application_form.needs_written_statement? || @application_form.needs_registration_number? %>
   <h2 class="govuk-heading-m">Proof that you’re recognised as a teacher</h2>
   <% if @application_form.needs_registration_number? %>
-    <%= render "teacher_interface/registration_number/summary", application_form: @application_form %>
+    <%= render "shared/application_form/registration_number_summary", application_form: @application_form, changeable: true %>
   <% end %>
   <% if @application_form.needs_written_statement? %>
-    <%= render "teacher_interface/written_statement/summary", application_form: @application_form %>
+    <%= render "shared/application_form/written_statement_summary", application_form: @application_form, changeable: true %>
   <% end %>
 <% end %>
 

--- a/app/views/teacher_interface/personal_information/check.html.erb
+++ b/app/views/teacher_interface/personal_information/check.html.erb
@@ -4,6 +4,8 @@
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.about_you") %></span>
 <h1 class="govuk-heading-l">Check your answers</h1>
 
-<%= render "summary", application_form: @application_form %>
+<%= render "shared/application_form/personal_information_summary",
+           application_form: @application_form,
+           changeable: true %>
 
 <%= govuk_button_link_to "Continue", teacher_interface_application_form_path %>

--- a/app/views/teacher_interface/qualifications/check.html.erb
+++ b/app/views/teacher_interface/qualifications/check.html.erb
@@ -4,6 +4,9 @@
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 <h1 class="govuk-heading-l">Check your answers</h1>
 
-<%= render "summary", application_form: @application_form, qualifications: @qualifications %>
+<%= render "shared/application_form/qualifications_summary",
+           application_form: @application_form,
+           qualifications: @qualifications,
+           changeable: true %>
 
 <%= govuk_button_link_to "Continue", %i[add_another teacher_interface application_form qualifications] %>

--- a/app/views/teacher_interface/work_histories/check.html.erb
+++ b/app/views/teacher_interface/work_histories/check.html.erb
@@ -3,7 +3,10 @@
 
 <%= render "heading" %>
 
-<%= render "summary", application_form: @application_form, work_histories: @work_histories %>
+<%= render "shared/application_form/work_history_summary",
+           application_form: @application_form,
+           work_histories: @work_histories,
+           changeable: true %>
 
 <% if @application_form.has_work_history? %>
   <%= govuk_button_link_to "Continue", add_another_teacher_interface_application_form_work_histories_path %>

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -4,7 +4,9 @@ require "rails_helper"
 
 RSpec.describe CheckYourAnswersSummary::Component, type: :component do
   subject(:component) do
-    render_inline(described_class.new(model:, title:, fields:, delete_link_to:))
+    render_inline(
+      described_class.new(model:, title:, fields:, changeable:, delete_link_to:)
+    )
   end
 
   let(:model) do
@@ -65,13 +67,14 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
     }
   end
 
+  let(:changeable) { true }
   let(:delete_link_to) { nil }
 
   it "renders the title" do
     expect(component.css(".govuk-summary-list__card-title").text).to eq("Title")
   end
 
-  describe "with a delete link" do
+  context "with a delete link" do
     let(:delete_link_to) { "/delete" }
 
     it "renders a link" do
@@ -79,6 +82,16 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       expect(a.text.strip).to eq("Delete")
       expect(a.attribute("href").value).to eq("/delete")
     end
+  end
+
+  context "when changeable is false" do
+    let(:changeable) { false }
+
+    subject(:links) do
+      component.css(".govuk-summary-list__actions .govuk-link")
+    end
+
+    it { is_expected.to be_empty }
   end
 
   describe "string row" do


### PR DESCRIPTION
This adds a new option for the "Check your answers" component to hide the "Change" links, so this component can be used in both the teacher interface (where we do want the links) and in the assessor interface (where we don't want the links).

I've opened this PR as it applies to all the individual pages, which will be added in subsequent PRs.