### PR TITLE
Add check qualifications page

### DIFF
--- a/app/controllers/assessor_interface/check_qualifications_controller.rb
+++ b/app/controllers/assessor_interface/check_qualifications_controller.rb
@@ -1,0 +1,11 @@
+module AssessorInterface
+  class CheckQualificationsController < BaseController
+    def show
+      @application_form =
+        ApplicationForm.includes(:qualifications).find(
+          params[:application_form_id]
+        )
+      @qualifications = @application_form.qualifications.ordered
+    end
+  end
+end

--- a/app/views/assessor_interface/check_qualifications/show.html.erb
+++ b/app/views/assessor_interface/check_qualifications/show.html.erb
@@ -1,0 +1,19 @@
+<% content_for :page_title, "Check qualifications" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+
+<h1 class="govuk-heading-xl">Check qualifications</h1>
+
+<%= render "shared/application_form/qualifications_summary",
+           application_form: @application_form,
+           qualifications: @qualifications,
+           changeable: false %>
+
+<%= render "shared/application_form/age_range_summary",
+           application_form: @application_form,
+           changeable: false %>
+
+<%= render "shared/application_form/subjects_summary",
+           application_form: @application_form,
+           changeable: false %>
+
+<%= govuk_button_link_to "Continue", [:assessor_interface, @application_form] %>

--- a/spec/support/page_objects/assessor_interface/check_qualifications.rb
+++ b/spec/support/page_objects/assessor_interface/check_qualifications.rb
@@ -1,0 +1,17 @@
+module PageObjects
+  module AssessorInterface
+    class QualificationCard < SitePrism::Section
+      element :heading, "h2"
+    end
+
+    class CheckQualifications < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/check_qualifications"
+
+      element :heading, "h1"
+      element :continue_button, ".govuk-button"
+      sections :qualification_cards,
+               QualificationCard,
+               ".govuk-summary-list__card"
+    end
+  end
+end

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe "Assessor check submitted details", type: :system do
+  before do
+    given_the_service_is_open
+    given_an_assessor_exists
+    given_there_is_an_application_form
+    given_i_am_authorized_as_an_assessor_user(assessor)
+  end
+
+  it "allows checking the qualifications" do
+    when_i_visit_the_check_qualifications_page
+    then_i_see_the_qualifications
+
+    when_i_click_continue
+    then_i_see_the_application_page
+  end
+
+  private
+
+  def given_an_assessor_exists
+    assessor
+  end
+
+  def given_there_is_an_application_form
+    application_form
+  end
+
+  def when_i_visit_the_check_qualifications_page
+    check_qualifications_page.load(application_id: application_form.id)
+  end
+
+  def then_i_see_the_qualifications
+    expect(check_qualifications_page.heading).to have_content(
+      "Check qualifications"
+    )
+    expect(
+      check_qualifications_page.qualification_cards.first.heading
+    ).to have_content("Your teaching qualification")
+  end
+
+  def when_i_click_continue
+    check_qualifications_page.continue_button.click
+  end
+
+  def then_i_see_the_application_page
+    expect(page).to have_content("Overview")
+  end
+
+  def assessor
+    @assessor ||= create(:staff, :confirmed)
+  end
+
+  def application_form
+    @application_form ||=
+      create(:application_form, :submitted, :with_completed_qualification)
+  end
+
+  def check_qualifications_page
+    @check_qualifications_page ||=
+      PageObjects::AssessorInterface::CheckQualifications.new
+  end
+end


### PR DESCRIPTION
This adds a new page which assessors will use to check the qualifications of the application. For now it just displays the qualifications and a button which takes the user back to the overview page.

Depends on #461, #460, and #458.

[Trello Card](https://trello.com/c/fqAMJgnC/837-check-qualifications)

## Screenshot

<img width="357" alt="Screenshot 2022-09-01 at 17 49 37" src="https://user-images.githubusercontent.com/510498/187969340-5e760749-8ba4-41f3-890b-b02c8306eef8.png">
