### PR TITLE
Add check work history page

### DIFF
--- a/app/controllers/assessor_interface/check_work_histories_controller.rb
+++ b/app/controllers/assessor_interface/check_work_histories_controller.rb
@@ -1,0 +1,11 @@
+module AssessorInterface
+  class CheckWorkHistoriesController < BaseController
+    def show
+      @application_form =
+        ApplicationForm.includes(:work_histories).find(
+          params[:application_form_id]
+        )
+      @work_histories = @application_form.work_histories.ordered
+    end
+  end
+end

--- a/app/views/assessor_interface/check_work_histories/show.html.erb
+++ b/app/views/assessor_interface/check_work_histories/show.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, "Check work history" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+
+<h1 class="govuk-heading-xl">Check work history</h1>
+
+<%= render "shared/application_form/work_history_summary",
+           application_form: @application_form,
+           work_histories: @work_histories,
+           changeable: false %>
+
+<%= govuk_button_link_to "Continue", [:assessor_interface, @application_form] %>

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -105,6 +105,10 @@ FactoryBot.define do
 
     trait :with_work_history do
       has_work_history { true }
+
+      after(:create) do |application_form, _evaluator|
+        application_form.work_histories << build(:work_history, :completed)
+      end
     end
 
     trait :with_written_statement do

--- a/spec/support/page_objects/assessor_interface/check_work_history.rb
+++ b/spec/support/page_objects/assessor_interface/check_work_history.rb
@@ -1,0 +1,15 @@
+module PageObjects
+  module AssessorInterface
+    class WorkHistoryCard < SitePrism::Section
+      element :heading, "h2"
+    end
+
+    class CheckWorkHistory < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/check_work_history"
+
+      element :heading, "h1"
+      element :continue_button, ".govuk-button"
+      sections :work_history_cards, WorkHistoryCard, ".govuk-summary-list__card"
+    end
+  end
+end

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_application_page
   end
 
+  it "allows checking the work history" do
+    when_i_visit_the_check_work_history_page
+    then_i_see_the_work_history
+
+    when_i_click_continue
+    then_i_see_the_application_page
+  end
+
   private
 
   def given_an_assessor_exists
@@ -30,6 +38,10 @@ RSpec.describe "Assessor check submitted details", type: :system do
     check_qualifications_page.load(application_id: application_form.id)
   end
 
+  def when_i_visit_the_check_work_history_page
+    check_work_history_page.load(application_id: application_form.id)
+  end
+
   def then_i_see_the_qualifications
     expect(check_qualifications_page.heading).to have_content(
       "Check qualifications"
@@ -37,6 +49,18 @@ RSpec.describe "Assessor check submitted details", type: :system do
     expect(
       check_qualifications_page.qualification_cards.first.heading
     ).to have_content("Your teaching qualification")
+  end
+
+  def then_i_see_the_work_history
+    expect(check_work_history_page.heading).to have_content(
+      "Check work history"
+    )
+    expect(
+      check_work_history_page.work_history_cards.first.heading
+    ).to have_content("Add your work history")
+    expect(
+      check_work_history_page.work_history_cards.second.heading
+    ).to have_content("Your current or most recent role")
   end
 
   def when_i_click_continue
@@ -53,11 +77,21 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def application_form
     @application_form ||=
-      create(:application_form, :submitted, :with_completed_qualification)
+      create(
+        :application_form,
+        :submitted,
+        :with_completed_qualification,
+        :with_work_history
+      )
   end
 
   def check_qualifications_page
     @check_qualifications_page ||=
       PageObjects::AssessorInterface::CheckQualifications.new
+  end
+
+  def check_work_history_page
+    @check_work_history_page ||=
+      PageObjects::AssessorInterface::CheckWorkHistory.new
   end
 end


### PR DESCRIPTION
This adds a new page which assessors will use to check the work history of the application. For now it just displays the work history and a button which takes the user back to the overview page.

Depends on #461, #460, and #458.

[Trello Card](https://trello.com/c/s4cLoZir/838-check-work-history)