### PR TITLE
Add check professional standing page

### DIFF
--- a/app/controllers/assessor_interface/check_professional_standings_controller.rb
+++ b/app/controllers/assessor_interface/check_professional_standings_controller.rb
@@ -1,0 +1,7 @@
+module AssessorInterface
+  class CheckProfessionalStandingsController < BaseController
+    def show
+      @application_form = ApplicationForm.find(params[:application_form_id])
+    end
+  end
+end

--- a/app/views/assessor_interface/check_professional_standings/show.html.erb
+++ b/app/views/assessor_interface/check_professional_standings/show.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, "Check professional standing" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+
+<h1 class="govuk-heading-xl">Check professional standing</h1>
+
+<% if @application_form.registration_number.present? %>
+  <%= render "shared/application_form/registration_number_summary",
+             application_form: @application_form,
+             changeable: false %>
+<% end %>
+
+<% if @application_form.written_statement_document.uploaded? %>
+  <%= render "shared/application_form/written_statement_summary",
+             application_form: @application_form,
+             changeable: false %>
+<% end %>
+
+<%= govuk_button_link_to "Continue", [:assessor_interface, @application_form] %>

--- a/spec/support/page_objects/assessor_interface/check_professional_standing.rb
+++ b/spec/support/page_objects/assessor_interface/check_professional_standing.rb
@@ -1,0 +1,17 @@
+module PageObjects
+  module AssessorInterface
+    class ProfessionalStandingCard < SitePrism::Section
+      element :heading, "h2"
+    end
+
+    class CheckProfessionalStanding < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/check_professional_standing"
+
+      element :heading, "h1"
+      element :continue_button, ".govuk-button"
+      sections :professional_standing_cards,
+               ProfessionalStandingCard,
+               ".govuk-summary-list__card"
+    end
+  end
+end

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -24,6 +24,14 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_application_page
   end
 
+  it "allows checking the professional standing" do
+    when_i_visit_the_check_professional_standing_page
+    then_i_see_the_professional_standing
+
+    when_i_click_continue
+    then_i_see_the_application_page
+  end
+
   private
 
   def given_an_assessor_exists
@@ -40,6 +48,10 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def when_i_visit_the_check_work_history_page
     check_work_history_page.load(application_id: application_form.id)
+  end
+
+  def when_i_visit_the_check_professional_standing_page
+    check_professional_standing_page.load(application_id: application_form.id)
   end
 
   def then_i_see_the_qualifications
@@ -63,6 +75,15 @@ RSpec.describe "Assessor check submitted details", type: :system do
     ).to have_content("Your current or most recent role")
   end
 
+  def then_i_see_the_professional_standing
+    expect(check_professional_standing_page.heading).to have_content(
+      "Check professional standing"
+    )
+    expect(
+      check_professional_standing_page.professional_standing_cards.first.heading
+    ).to have_content("Enter your registration number")
+  end
+
   def when_i_click_continue
     check_qualifications_page.continue_button.click
   end
@@ -81,7 +102,8 @@ RSpec.describe "Assessor check submitted details", type: :system do
         :application_form,
         :submitted,
         :with_completed_qualification,
-        :with_work_history
+        :with_work_history,
+        :with_registration_number
       )
   end
 
@@ -93,5 +115,10 @@ RSpec.describe "Assessor check submitted details", type: :system do
   def check_work_history_page
     @check_work_history_page ||=
       PageObjects::AssessorInterface::CheckWorkHistory.new
+  end
+
+  def check_professional_standing_page
+    @check_professional_standing_page ||=
+      PageObjects::AssessorInterface::CheckProfessionalStanding.new
   end
 end


### PR DESCRIPTION
This adds a new page which assessors will use to check the professional standing of the application. For now it just displays the professional standing and a button which takes the user back to the overview page.

Depends on https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/461, https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/460, and https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/458.

[Trello Card](https://trello.com/c/Y8bSmI6Z/839-check-professional-standing)