### PR TITLE
Generate upload URLs which expire

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include ActiveStorage::SetCurrent
   include DfE::Analytics::Requests
 
   default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -31,6 +31,6 @@ class Upload < ApplicationRecord
   end
 
   def url
-    Rails.application.routes.url_helpers.url_for(attachment)
+    attachment.url(expires_in: 5.minutes)
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,8 +66,7 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :sidekiq
 
-  routes.default_url_options = { host: "localhost", port: 3000 }
-
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
   config.action_mailer.delivery_method = :file
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,6 +35,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
+  config.active_storage.draw_routes = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -85,11 +85,10 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  routes.default_url_options = {
+  config.action_mailer.default_url_options = {
     host: HostingEnvironment.host,
     protocol: "https"
   }
-
   config.action_mailer.delivery_method = :notify
   config.action_mailer.notify_settings = {
     api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY")

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,6 +39,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :microsoft
+  config.active_storage.draw_routes = false
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,7 +54,6 @@ Rails.application.configure do
 
   config.active_job.queue_adapter = :test
 
-  routes.default_url_options = { host: "localhost", port: 3000 }
-
+  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
   config.action_mailer.delivery_method = :test
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,6 +35,7 @@ Rails.application.configure do
 
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
+  config.active_storage.draw_routes = true
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -48,9 +48,7 @@ RSpec.describe Upload, type: :model do
     subject(:url) { upload.url }
 
     it do
-      is_expected.to include(
-        "http://localhost:3000/rails/active_storage/blobs/redirect/"
-      )
+      is_expected.to include("http://localhost:3000/rails/active_storage/disk/")
     end
     it { is_expected.to include("upload.pdf") }
   end

--- a/spec/support/active_storage.rb
+++ b/spec/support/active_storage.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before do
+    ActiveStorage::Current.url_options = { host: "localhost", port: 3000 }
+  end
+end


### PR DESCRIPTION
This changes how we generate URLs to uploads to make sure they expire, meaning if the URL is shared it will only last for 5 minutes.

These URLs are still public, so we might want to consider putting it behind authentication, but that will slow down the requests as rather than taking the user directly to Azure, we'll have to handle the request ourselves first. We can discuss this and add that improvement in a separate PR.