### PR TITLE
Refactor eligibility tests to use page objects

### DIFF
--- a/app/views/eligibility_interface/misconduct/new.html.erb
+++ b/app/views/eligibility_interface/misconduct/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{'Error: ' if @misconduct_form.errors.any?}Is your employment record as a teacher free of sanctions?" %>
+<% content_for :page_title, "#{'Error: ' if @misconduct_form.errors.any?}Do you have any sanctions or restrictions on your employment record?" %>
 <% content_for :back_link_url, back_link_url(eligibility_interface_teach_children_path) %>
 
 <div class="govuk-grid-row">

--- a/spec/support/page_objects/eligiblity_interface/country.rb
+++ b/spec/support/page_objects/eligiblity_interface/country.rb
@@ -1,0 +1,18 @@
+require "support/page_objects/govuk_error_summary"
+
+module PageObjects
+  module EligibilityInterface
+    class Country < SitePrism::Page
+      set_url "/eligibility/countries"
+
+      element :heading, "h1"
+
+      section :error_summary, GovukErrorSummary, ".govuk-error-summary"
+
+      section :form, "form" do
+        element :location_field, 'input[name="location_autocomplete"]'
+        element :continue_button, "button"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/eligiblity_interface/degree.rb
+++ b/spec/support/page_objects/eligiblity_interface/degree.rb
@@ -1,0 +1,23 @@
+require "support/page_objects/govuk_error_summary"
+
+module PageObjects
+  module EligibilityInterface
+    class Degree < SitePrism::Page
+      set_url "/eligibility/degree"
+
+      element :heading, "h1"
+
+      section :error_summary, GovukErrorSummary, ".govuk-error-summary"
+
+      section :form, "form" do
+        section :yes_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(1)"
+        section :no_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(2)"
+        element :continue_button, "button"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/eligiblity_interface/degree.rb
+++ b/spec/support/page_objects/eligiblity_interface/degree.rb
@@ -1,23 +1,5 @@
-require "support/page_objects/govuk_error_summary"
+require_relative "question"
 
-module PageObjects
-  module EligibilityInterface
-    class Degree < SitePrism::Page
-      set_url "/eligibility/degree"
-
-      element :heading, "h1"
-
-      section :error_summary, GovukErrorSummary, ".govuk-error-summary"
-
-      section :form, "form" do
-        section :yes_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(1)"
-        section :no_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(2)"
-        element :continue_button, "button"
-      end
-    end
-  end
+class PageObjects::EligibilityInterface::Degree < PageObjects::EligibilityInterface::Question
+  set_url "/eligibility/degree"
 end

--- a/spec/support/page_objects/eligiblity_interface/eligible.rb
+++ b/spec/support/page_objects/eligiblity_interface/eligible.rb
@@ -1,0 +1,10 @@
+module PageObjects
+  module EligibilityInterface
+    class Eligible < SitePrism::Page
+      set_url "/eligibility/eligible"
+
+      element :heading, "h1"
+      element :apply_button, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/page_objects/eligiblity_interface/ineligible.rb
+++ b/spec/support/page_objects/eligiblity_interface/ineligible.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module EligibilityInterface
+    class Ineligible < SitePrism::Page
+      set_url "/eligibility/ineligible"
+
+      element :heading, "h1"
+      element :description, ".govuk-body", match: :first
+      element :reasons, ".govuk-list"
+    end
+  end
+end

--- a/spec/support/page_objects/eligiblity_interface/misconduct.rb
+++ b/spec/support/page_objects/eligiblity_interface/misconduct.rb
@@ -1,23 +1,5 @@
-require "support/page_objects/govuk_error_summary"
+require_relative "question"
 
-module PageObjects
-  module EligibilityInterface
-    class Misconduct < SitePrism::Page
-      set_url "/eligibility/misconduct"
-
-      element :heading, "h1"
-
-      section :error_summary, GovukErrorSummary, ".govuk-error-summary"
-
-      section :form, "form" do
-        section :yes_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(1)"
-        section :no_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(2)"
-        element :continue_button, "button"
-      end
-    end
-  end
+class PageObjects::EligibilityInterface::Misconduct < PageObjects::EligibilityInterface::Question
+  set_url "/eligibility/misconduct"
 end

--- a/spec/support/page_objects/eligiblity_interface/misconduct.rb
+++ b/spec/support/page_objects/eligiblity_interface/misconduct.rb
@@ -1,0 +1,23 @@
+require "support/page_objects/govuk_error_summary"
+
+module PageObjects
+  module EligibilityInterface
+    class Misconduct < SitePrism::Page
+      set_url "/eligibility/misconduct"
+
+      element :heading, "h1"
+
+      section :error_summary, GovukErrorSummary, ".govuk-error-summary"
+
+      section :form, "form" do
+        section :yes_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(1)"
+        section :no_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(2)"
+        element :continue_button, "button"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/eligiblity_interface/qualification.rb
+++ b/spec/support/page_objects/eligiblity_interface/qualification.rb
@@ -1,0 +1,23 @@
+require "support/page_objects/govuk_error_summary"
+
+module PageObjects
+  module EligibilityInterface
+    class Qualification < SitePrism::Page
+      set_url "/eligibility/qualifications"
+
+      element :heading, "h1"
+
+      section :error_summary, GovukErrorSummary, ".govuk-error-summary"
+
+      section :form, "form" do
+        section :yes_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(1)"
+        section :no_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(2)"
+        element :continue_button, "button"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/eligiblity_interface/qualification.rb
+++ b/spec/support/page_objects/eligiblity_interface/qualification.rb
@@ -1,23 +1,5 @@
-require "support/page_objects/govuk_error_summary"
+require_relative "question"
 
-module PageObjects
-  module EligibilityInterface
-    class Qualification < SitePrism::Page
-      set_url "/eligibility/qualifications"
-
-      element :heading, "h1"
-
-      section :error_summary, GovukErrorSummary, ".govuk-error-summary"
-
-      section :form, "form" do
-        section :yes_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(1)"
-        section :no_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(2)"
-        element :continue_button, "button"
-      end
-    end
-  end
+class PageObjects::EligibilityInterface::Qualification < PageObjects::EligibilityInterface::Question
+  set_url "/eligibility/qualification"
 end

--- a/spec/support/page_objects/eligiblity_interface/question.rb
+++ b/spec/support/page_objects/eligiblity_interface/question.rb
@@ -1,0 +1,21 @@
+require "support/page_objects/govuk_error_summary"
+
+module PageObjects
+  module EligibilityInterface
+    class Question < SitePrism::Page
+      element :heading, "h1"
+
+      section :error_summary, GovukErrorSummary, ".govuk-error-summary"
+
+      section :form, "form" do
+        section :yes_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(1)"
+        section :no_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(2)"
+        element :continue_button, "button"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/eligiblity_interface/region.rb
+++ b/spec/support/page_objects/eligiblity_interface/region.rb
@@ -1,0 +1,20 @@
+require "support/page_objects/govuk_error_summary"
+
+module PageObjects
+  module EligibilityInterface
+    class Region < SitePrism::Page
+      set_url "/eligibility/region"
+
+      element :heading, "h1"
+
+      section :error_summary, GovukErrorSummary, ".govuk-error-summary"
+
+      section :form, "form" do
+        sections :radio_items,
+                 PageObjects::GovukRadioItem,
+                 ".govuk-radios__item"
+        element :continue_button, "button"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/eligiblity_interface/start.rb
+++ b/spec/support/page_objects/eligiblity_interface/start.rb
@@ -4,6 +4,7 @@ module PageObjects
       set_url "/eligibility"
 
       element :heading, "h1"
+      element :description, ".govuk-body", match: :first
 
       element :start_button, "button"
 

--- a/spec/support/page_objects/eligiblity_interface/teach_children.rb
+++ b/spec/support/page_objects/eligiblity_interface/teach_children.rb
@@ -1,23 +1,5 @@
-require "support/page_objects/govuk_error_summary"
+require_relative "question"
 
-module PageObjects
-  module EligibilityInterface
-    class TeachChildren < SitePrism::Page
-      set_url "/eligibility/teach-children"
-
-      element :heading, "h1"
-
-      section :error_summary, GovukErrorSummary, ".govuk-error-summary"
-
-      section :form, "form" do
-        section :yes_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(1)"
-        section :no_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(2)"
-        element :continue_button, "button"
-      end
-    end
-  end
+class PageObjects::EligibilityInterface::TeachChildren < PageObjects::EligibilityInterface::Question
+  set_url "/eligibility/teach-children"
 end

--- a/spec/support/page_objects/eligiblity_interface/teach_children.rb
+++ b/spec/support/page_objects/eligiblity_interface/teach_children.rb
@@ -1,0 +1,23 @@
+require "support/page_objects/govuk_error_summary"
+
+module PageObjects
+  module EligibilityInterface
+    class TeachChildren < SitePrism::Page
+      set_url "/eligibility/teach-children"
+
+      element :heading, "h1"
+
+      section :error_summary, GovukErrorSummary, ".govuk-error-summary"
+
+      section :form, "form" do
+        section :yes_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(1)"
+        section :no_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(2)"
+        element :continue_button, "button"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/govuk_error_summary.rb
+++ b/spec/support/page_objects/govuk_error_summary.rb
@@ -1,0 +1,6 @@
+module PageObjects
+  class GovukErrorSummary < SitePrism::Section
+    element :title, ".govuk-error-summary__title"
+    element :body, ".govuk-error-summary__body"
+  end
+end

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_select_an_eligible_country
     then_i_see_the_qualifications_page
 
-    when_i_choose_yes
-    and_i_submit
+    when_i_have_a_qualification
     then_i_see_the_degree_page
 
     when_i_choose_yes
@@ -52,8 +51,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_select_an_eligible_country
     then_i_see_the_qualifications_page
 
-    when_i_choose_no
-    and_i_submit
+    when_i_dont_have_a_qualification
     then_i_see_the_degree_page
 
     when_i_choose_no
@@ -95,8 +93,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_try_to_go_to_the_degree_page
     then_i_see_the_qualifications_page
 
-    when_i_choose_yes
-    and_i_submit
+    when_i_have_a_qualification
     then_i_see_the_degree_page
 
     when_i_try_to_go_to_the_teach_children_page
@@ -258,12 +255,12 @@ RSpec.describe "Eligibility check", type: :system do
     )
   end
 
-  def when_i_try_to_go_to_the_region_page
-    region_page.load
-  end
-
   def region_page
     @region_page ||= PageObjects::EligibilityInterface::Region.new
+  end
+
+  def when_i_try_to_go_to_the_region_page
+    region_page.load
   end
 
   def then_i_see_the_region_page
@@ -278,6 +275,33 @@ RSpec.describe "Eligibility check", type: :system do
   def when_i_select_a_region
     region_page.form.radio_items.first.input.click
     region_page.form.continue_button.click
+  end
+
+  def qualification_page
+    @qualification_page ||= PageObjects::EligibilityInterface::Qualification.new
+  end
+
+  def when_i_try_to_go_to_the_qualification_page
+    qualification_page.load
+  end
+
+  def then_i_see_the_qualifications_page
+    expect(qualification_page).to have_title(
+      "Do you have a teacher training qualification?"
+    )
+    expect(qualification_page.heading).to have_content(
+      "Do you have a teacher training qualification?"
+    )
+  end
+
+  def when_i_have_a_qualification
+    qualification_page.form.yes_radio_item.input.click
+    qualification_page.form.continue_button.click
+  end
+
+  def when_i_dont_have_a_qualification
+    qualification_page.form.no_radio_item.input.click
+    qualification_page.form.continue_button.click
   end
 
   def and_i_submit
@@ -302,10 +326,6 @@ RSpec.describe "Eligibility check", type: :system do
 
   def when_i_try_to_go_to_the_degree_page
     visit "/eligibility/degree"
-  end
-
-  def when_i_try_to_go_to_the_qualifications_page
-    visit "/eligibility/qualifications"
   end
 
   def when_i_try_to_go_to_the_teach_children_page
@@ -391,13 +411,6 @@ RSpec.describe "Eligibility check", type: :system do
   def then_i_see_the_degree_page
     expect(page).to have_title("Do you have a university degree?")
     expect(page).to have_content("Do you have a university degree?")
-  end
-
-  def then_i_see_the_qualifications_page
-    expect(page).to have_title("Do you have a teacher training qualification?")
-    expect(page).to have_content(
-      "Do you have a teacher training qualification?"
-    )
   end
 
   def then_i_see_the_teach_children_page

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -140,8 +140,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_select_a_multiple_region_country
     then_i_see_the_region_page
 
-    when_i_choose_region
-    and_i_submit
+    when_i_select_a_region
     then_i_see_the_qualifications_page
   end
 
@@ -259,12 +258,30 @@ RSpec.describe "Eligibility check", type: :system do
     )
   end
 
-  def and_i_submit
-    click_button "Continue", visible: false
+  def when_i_try_to_go_to_the_region_page
+    region_page.load
   end
 
-  def when_i_choose_region
-    choose "Region", visible: false
+  def region_page
+    @region_page ||= PageObjects::EligibilityInterface::Region.new
+  end
+
+  def then_i_see_the_region_page
+    expect(region_page).to have_title(
+      "In which state/territory are you currently recognised as a teacher?"
+    )
+    expect(region_page.heading).to have_content(
+      "In which state/territory are you currently recognised as a teacher?"
+    )
+  end
+
+  def when_i_select_a_region
+    region_page.form.radio_items.first.input.click
+    region_page.form.continue_button.click
+  end
+
+  def and_i_submit
+    click_button "Continue", visible: false
   end
 
   def when_i_press_back
@@ -281,10 +298,6 @@ RSpec.describe "Eligibility check", type: :system do
 
   def when_i_try_to_go_to_the_ineligible_page
     visit "/eligibility/ineligible"
-  end
-
-  def when_i_try_to_go_to_the_region_page
-    visit "/eligibility/region"
   end
 
   def when_i_try_to_go_to_the_degree_page
@@ -306,15 +319,6 @@ RSpec.describe "Eligibility check", type: :system do
   def then_i_see_the_misconduct_page
     expect(page).to have_content(
       "Do you have any sanctions or restrictions on your employment record?"
-    )
-  end
-
-  def then_i_see_the_region_page
-    expect(page).to have_title(
-      "In which state/territory are you currently recognised as a teacher?"
-    )
-    expect(page).to have_content(
-      "In which state/territory are you currently recognised as a teacher?"
     )
   end
 

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -21,8 +21,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_have_a_qualification
     then_i_see_the_degree_page
 
-    when_i_choose_yes
-    and_i_submit
+    when_i_have_a_degree
     then_i_see_the_teach_children_page
 
     when_i_choose_yes
@@ -54,8 +53,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_dont_have_a_qualification
     then_i_see_the_degree_page
 
-    when_i_choose_no
-    and_i_submit
+    when_i_dont_have_a_degree
     then_i_see_the_teach_children_page
 
     when_i_choose_no
@@ -99,8 +97,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_try_to_go_to_the_teach_children_page
     then_i_see_the_degree_page
 
-    when_i_choose_yes
-    and_i_submit
+    when_i_have_a_degree
     then_i_see_the_teach_children_page
 
     when_i_try_to_go_to_the_misconduct_page
@@ -304,6 +301,31 @@ RSpec.describe "Eligibility check", type: :system do
     qualification_page.form.continue_button.click
   end
 
+  def degree_page
+    @degree_page ||= PageObjects::EligibilityInterface::Degree.new
+  end
+
+  def when_i_try_to_go_to_the_degree_page
+    degree_page.load
+  end
+
+  def then_i_see_the_degree_page
+    expect(degree_page).to have_title("Do you have a university degree?")
+    expect(degree_page.heading).to have_content(
+      "Do you have a university degree?"
+    )
+  end
+
+  def when_i_have_a_degree
+    degree_page.form.yes_radio_item.input.click
+    degree_page.form.continue_button.click
+  end
+
+  def when_i_dont_have_a_degree
+    degree_page.form.no_radio_item.input.click
+    degree_page.form.continue_button.click
+  end
+
   def and_i_submit
     click_button "Continue", visible: false
   end
@@ -322,10 +344,6 @@ RSpec.describe "Eligibility check", type: :system do
 
   def when_i_try_to_go_to_the_ineligible_page
     visit "/eligibility/ineligible"
-  end
-
-  def when_i_try_to_go_to_the_degree_page
-    visit "/eligibility/degree"
   end
 
   def when_i_try_to_go_to_the_teach_children_page
@@ -406,11 +424,6 @@ RSpec.describe "Eligibility check", type: :system do
     expect(page).to have_content(
       "Have you completed all requirements to work as a qualified teacher in"
     )
-  end
-
-  def then_i_see_the_degree_page
-    expect(page).to have_title("Do you have a university degree?")
-    expect(page).to have_content("Do you have a university degree?")
   end
 
   def then_i_see_the_teach_children_page

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -24,8 +24,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_have_a_degree
     then_i_see_the_teach_children_page
 
-    when_i_choose_yes
-    and_i_submit
+    when_i_can_teach_children
     then_i_see_the_misconduct_page
 
     when_i_choose_no
@@ -56,8 +55,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_dont_have_a_degree
     then_i_see_the_teach_children_page
 
-    when_i_choose_no
-    and_i_submit
+    when_i_cant_teach_children
     then_i_see_the_misconduct_page
 
     when_i_choose_yes
@@ -103,8 +101,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_try_to_go_to_the_misconduct_page
     then_i_see_the_teach_children_page
 
-    when_i_choose_yes
-    and_i_submit
+    when_i_can_teach_children
     then_i_see_the_misconduct_page
   end
 
@@ -326,6 +323,34 @@ RSpec.describe "Eligibility check", type: :system do
     degree_page.form.continue_button.click
   end
 
+  def teach_children_page
+    @teach_children_page ||=
+      PageObjects::EligibilityInterface::TeachChildren.new
+  end
+
+  def when_i_try_to_go_to_the_teach_children_page
+    teach_children_page.load
+  end
+
+  def then_i_see_the_teach_children_page
+    expect(teach_children_page).to have_title(
+      "Are you qualified to teach children who are aged somewhere between 5 and 16 years?"
+    )
+    expect(teach_children_page.heading).to have_content(
+      "Are you qualified to teach children who are aged somewhere between 5 and 16 years?"
+    )
+  end
+
+  def when_i_can_teach_children
+    teach_children_page.form.yes_radio_item.input.click
+    teach_children_page.form.continue_button.click
+  end
+
+  def when_i_cant_teach_children
+    teach_children_page.form.no_radio_item.input.click
+    teach_children_page.form.continue_button.click
+  end
+
   def and_i_submit
     click_button "Continue", visible: false
   end
@@ -344,10 +369,6 @@ RSpec.describe "Eligibility check", type: :system do
 
   def when_i_try_to_go_to_the_ineligible_page
     visit "/eligibility/ineligible"
-  end
-
-  def when_i_try_to_go_to_the_teach_children_page
-    visit "/eligibility/teach-children"
   end
 
   def when_i_try_to_go_to_the_misconduct_page
@@ -423,15 +444,6 @@ RSpec.describe "Eligibility check", type: :system do
     )
     expect(page).to have_content(
       "Have you completed all requirements to work as a qualified teacher in"
-    )
-  end
-
-  def then_i_see_the_teach_children_page
-    expect(page).to have_title(
-      "Are you qualified to teach children who are aged somewhere between 5 and 16 years?"
-    )
-    expect(page).to have_content(
-      "Are you qualified to teach children who are aged somewhere between 5 and 16 years?"
     )
   end
 

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -13,10 +13,9 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the_start_page
 
     when_i_press_start_now
-    then_i_see_the_countries_page
+    then_i_see_the_country_page
 
-    when_i_select_a_country
-    and_i_submit
+    when_i_select_an_eligible_country
     then_i_see_the_qualifications_page
 
     when_i_choose_yes
@@ -46,13 +45,11 @@ RSpec.describe "Eligibility check", type: :system do
 
     when_i_press_start_now
     when_i_select_an_ineligible_country
-    and_i_submit
     then_i_see_the_ineligible_page
     and_i_see_the_ineligible_country_text
 
     when_i_press_back
-    when_i_select_a_country
-    and_i_submit
+    when_i_select_an_eligible_country
     then_i_see_the_qualifications_page
 
     when_i_choose_no
@@ -87,13 +84,12 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the_start_page
 
     when_i_press_start_now
-    then_i_see_the_countries_page
+    then_i_see_the_country_page
 
     when_i_try_to_go_to_the_region_page
-    then_i_see_the_countries_page
+    then_i_see_the_country_page
 
-    when_i_select_a_country
-    and_i_submit
+    when_i_select_an_eligible_country
     then_i_see_the_qualifications_page
 
     when_i_try_to_go_to_the_degree_page
@@ -124,8 +120,7 @@ RSpec.describe "Eligibility check", type: :system do
     and_i_submit
     then_i_see_the_country_error_message
 
-    when_i_select_a_country_in_the_error_state
-    and_i_submit
+    when_i_select_an_eligible_country
     then_i_see_the_qualifications_page
   end
 
@@ -133,7 +128,6 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_visit_the_start_page
     when_i_press_start_now
     when_i_select_a_legacy_country
-    and_i_submit
     then_i_see_the_eligible_page
 
     when_i_press_start
@@ -143,8 +137,7 @@ RSpec.describe "Eligibility check", type: :system do
   it "handles countries with multiple regions" do
     when_i_visit_the_start_page
     when_i_press_start_now
-    when_i_select_a_country_with_multiple_regions
-    and_i_submit
+    when_i_select_a_multiple_region_country
     then_i_see_the_region_page
 
     when_i_choose_region
@@ -163,10 +156,9 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the_start_page
 
     when_i_press_start_now
-    then_i_see_the_countries_page
+    then_i_see_the_country_page
 
-    when_i_select_a_country
-    and_i_submit
+    when_i_select_an_eligible_country
     then_i_see_the_qualifications_page
   end
 
@@ -226,6 +218,47 @@ RSpec.describe "Eligibility check", type: :system do
     start_page.start_button.click
   end
 
+  def country_page
+    @country_page ||= PageObjects::EligibilityInterface::Country.new
+  end
+
+  def when_i_select_a_country(country)
+    country_page.form.location_field.fill_in with: country
+    country_page.form.continue_button.click
+  end
+
+  def when_i_select_an_eligible_country
+    when_i_select_a_country "Scotland"
+  end
+
+  def when_i_select_an_ineligible_country
+    when_i_select_a_country "Spain"
+  end
+
+  def when_i_select_a_legacy_country
+    when_i_select_a_country "France"
+  end
+
+  def when_i_select_a_multiple_region_country
+    when_i_select_a_country "Italy"
+  end
+
+  def then_i_see_the_country_page
+    expect(country_page).to have_title(
+      "In which country are you currently recognised as a teacher?"
+    )
+    expect(country_page.heading).to have_content(
+      "In which country are you currently recognised as a teacher?"
+    )
+  end
+
+  def then_i_see_the_country_error_message
+    expect(country_page).to have_error_summary
+    expect(country_page.error_summary.body).to have_content(
+      "Tell us where you’re currently recognised as a teacher"
+    )
+  end
+
   def and_i_submit
     click_button "Continue", visible: false
   end
@@ -240,28 +273,6 @@ RSpec.describe "Eligibility check", type: :system do
 
   def when_i_press_start
     click_link "Apply for QTS"
-  end
-
-  def when_i_select_a_country
-    fill_in "eligibility-interface-country-form-location-field",
-            with: "Scotland"
-  end
-
-  def when_i_select_a_country_in_the_error_state
-    fill_in "eligibility-interface-country-form-location-field-error",
-            with: "Scotland"
-  end
-
-  def when_i_select_an_ineligible_country
-    fill_in "eligibility-interface-country-form-location-field", with: "Spain"
-  end
-
-  def when_i_select_a_legacy_country
-    fill_in "eligibility-interface-country-form-location-field", with: "France"
-  end
-
-  def when_i_select_a_country_with_multiple_regions
-    fill_in "eligibility-interface-country-form-location-field", with: "Italy"
   end
 
   def when_i_try_to_go_to_the_eligible_page
@@ -298,27 +309,12 @@ RSpec.describe "Eligibility check", type: :system do
     )
   end
 
-  def then_i_see_the_countries_page
-    expect(page).to have_title(
-      "In which country are you currently recognised as a teacher?"
-    )
-    expect(page).to have_content(
-      "In which country are you currently recognised as a teacher?"
-    )
-  end
-
   def then_i_see_the_region_page
     expect(page).to have_title(
       "In which state/territory are you currently recognised as a teacher?"
     )
     expect(page).to have_content(
       "In which state/territory are you currently recognised as a teacher?"
-    )
-  end
-
-  def then_i_see_the_country_error_message
-    expect(page).to have_content(
-      "Tell us where you’re currently recognised as a teacher"
     )
   end
 

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -402,8 +402,8 @@ RSpec.describe "Eligibility check", type: :system do
     expect(page).to have_current_path("/MutualRecognition/")
   end
 
-  def when_i_press_back
-    click_link "Back"
+  def ineligible_page
+    @ineligible_page = PageObjects::EligibilityInterface::Ineligible.new
   end
 
   def when_i_try_to_go_to_the_ineligible_page
@@ -411,50 +411,51 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def then_i_see_the_ineligible_page
-    expect(page).to have_content(
+    expect(ineligible_page.heading).to have_content(
       "You’re not eligible to apply for qualified teacher status (QTS) in England"
     )
   end
 
   def and_i_see_the_ineligible_country_text
-    expect(page).to have_content(
+    expect(ineligible_page.heading).to have_content(
       "You’re not eligible to apply for qualified teacher status (QTS) in England"
     )
-    expect(page).to have_content(
+    expect(ineligible_page.body).to have_content(
       "Teachers applying from Spain are not currently eligible to use this service."
-    )
-    expect(page).to have_content(
-      "You can also learn more about teaching in England."
     )
   end
 
   def and_i_see_the_ineligible_completed_requirements_text
-    expect(page).to have_content(
+    expect(ineligible_page.reasons).to have_content(
       "You have not completed all requirements to work as a qualified teacher in Scotland."
     )
   end
 
   def and_i_see_the_ineligible_misconduct_text
-    expect(page).to have_content(
+    expect(ineligible_page.reasons).to have_content(
       "To teach in England, you must not have any findings of misconduct or restrictions on your practice."
     )
   end
 
   def and_i_see_the_ineligible_teach_children_text
-    expect(page).to have_content(
+    expect(ineligible_page.reasons).to have_content(
       "You are not qualified to teach children who are aged somewhere between 5 and 16 years."
     )
   end
 
   def and_i_see_the_ineligible_qualification_text
-    expect(page).to have_content(
+    expect(ineligible_page.reasons).to have_content(
       "You have not completed a formal teacher training course, for example, an undergraduate teaching " \
         "degree or postgraduate teacher training course."
     )
   end
 
   def and_i_see_the_ineligible_degree_text
-    expect(page).to have_content("You do not have a degree.")
+    expect(ineligible_page.reasons).to have_content("You do not have a degree.")
+  end
+
+  def when_i_press_back
+    click_link "Back"
   end
 
   def then_i_have_two_eligibility_checks

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_select_a_legacy_country
     then_i_see_the_eligible_page
 
-    when_i_press_start
+    when_i_press_apply
     then_i_see_the_legacy_service
   end
 
@@ -380,36 +380,40 @@ RSpec.describe "Eligibility check", type: :system do
     misconduct_page.form.continue_button.click
   end
 
-  def when_i_press_back
-    click_link "Back"
-  end
-
-  def when_i_press_start
-    click_link "Apply for QTS"
+  def eligible_page
+    @eligible_page = PageObjects::EligibilityInterface::Eligible.new
   end
 
   def when_i_try_to_go_to_the_eligible_page
-    visit "/eligibility/eligible"
+    eligible_page.load
+  end
+
+  def when_i_press_apply
+    eligible_page.apply_button.click
+  end
+
+  def then_i_see_the_eligible_page
+    expect(eligible_page).to have_content(
+      "You’re eligible to apply for qualified teacher status (QTS) in England"
+    )
+  end
+
+  def then_i_see_the_legacy_service
+    expect(page).to have_current_path("/MutualRecognition/")
+  end
+
+  def when_i_press_back
+    click_link "Back"
   end
 
   def when_i_try_to_go_to_the_ineligible_page
     visit "/eligibility/ineligible"
   end
 
-  def then_i_see_the_eligible_page
-    expect(page).to have_content(
-      "You’re eligible to apply for qualified teacher status (QTS) in England"
-    )
-  end
-
   def then_i_see_the_ineligible_page
     expect(page).to have_content(
       "You’re not eligible to apply for qualified teacher status (QTS) in England"
     )
-  end
-
-  def then_i_see_the_legacy_service
-    expect(page).to have_current_path("/MutualRecognition/")
   end
 
   def and_i_see_the_ineligible_country_text

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Eligibility check", type: :system do
@@ -281,14 +282,12 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def then_i_see_the_misconduct_page
-    expect(page).to have_current_path("/eligibility/misconduct")
     expect(page).to have_content(
       "Do you have any sanctions or restrictions on your employment record?"
     )
   end
 
   def then_i_see_the_countries_page
-    expect(page).to have_current_path("/eligibility/countries")
     expect(page).to have_title(
       "In which country are you currently recognised as a teacher?"
     )
@@ -298,7 +297,6 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def then_i_see_the_region_page
-    expect(page).to have_current_path("/eligibility/region")
     expect(page).to have_title(
       "In which state/territory are you currently recognised as a teacher?"
     )
@@ -314,14 +312,12 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def then_i_see_the_eligible_page
-    expect(page).to have_current_path("/eligibility/eligible")
     expect(page).to have_content(
       "You’re eligible to apply for qualified teacher status (QTS) in England"
     )
   end
 
   def then_i_see_the_ineligible_page
-    expect(page).to have_current_path("/eligibility/ineligible")
     expect(page).to have_content(
       "You’re not eligible to apply for qualified teacher status (QTS) in England"
     )
@@ -373,7 +369,6 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def then_i_see_the_completed_requirements_page
-    expect(page).to have_current_path("/eligibility/completed-requirements")
     expect(page).to have_title(
       "Have you completed all requirements to work as a qualified teacher in"
     )
@@ -383,13 +378,11 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def then_i_see_the_degree_page
-    expect(page).to have_current_path("/eligibility/degree")
     expect(page).to have_title("Do you have a university degree?")
     expect(page).to have_content("Do you have a university degree?")
   end
 
   def then_i_see_the_qualifications_page
-    expect(page).to have_current_path("/eligibility/qualifications")
     expect(page).to have_title("Do you have a teacher training qualification?")
     expect(page).to have_content(
       "Do you have a teacher training qualification?"
@@ -406,7 +399,6 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def then_i_see_the_teach_children_page
-    expect(page).to have_current_path("/eligibility/teach-children")
     expect(page).to have_title(
       "Are you qualified to teach children who are aged somewhere between 5 and 16 years?"
     )

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -27,8 +27,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_can_teach_children
     then_i_see_the_misconduct_page
 
-    when_i_choose_no
-    and_i_submit
+    when_i_dont_have_a_misconduct_record
     then_i_see_the_eligible_page
 
     when_i_visit_the_start_page
@@ -58,8 +57,7 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_cant_teach_children
     then_i_see_the_misconduct_page
 
-    when_i_choose_yes
-    and_i_submit
+    when_i_have_a_misconduct_record
     then_i_see_the_ineligible_page
     and_i_see_the_ineligible_degree_text
     and_i_see_the_ineligible_qualification_text
@@ -108,7 +106,7 @@ RSpec.describe "Eligibility check", type: :system do
   it "handles the country picker error" do
     when_i_visit_the_start_page
     when_i_press_start_now
-    and_i_submit
+    when_i_dont_select_a_country
     then_i_see_the_country_error_message
 
     when_i_select_an_eligible_country
@@ -233,6 +231,10 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_select_a_country "Italy"
   end
 
+  def when_i_dont_select_a_country
+    country_page.form.continue_button.click
+  end
+
   def then_i_see_the_country_page
     expect(country_page).to have_title(
       "In which country are you currently recognised as a teacher?"
@@ -351,8 +353,31 @@ RSpec.describe "Eligibility check", type: :system do
     teach_children_page.form.continue_button.click
   end
 
-  def and_i_submit
-    click_button "Continue", visible: false
+  def misconduct_page
+    @misconduct_page ||= PageObjects::EligibilityInterface::Misconduct.new
+  end
+
+  def when_i_try_to_go_to_the_misconduct_page
+    misconduct_page.load
+  end
+
+  def then_i_see_the_misconduct_page
+    expect(misconduct_page).to have_title(
+      "Do you have any sanctions or restrictions on your employment record?"
+    )
+    expect(misconduct_page.heading).to have_content(
+      "Do you have any sanctions or restrictions on your employment record?"
+    )
+  end
+
+  def when_i_have_a_misconduct_record
+    misconduct_page.form.yes_radio_item.input.click
+    misconduct_page.form.continue_button.click
+  end
+
+  def when_i_dont_have_a_misconduct_record
+    misconduct_page.form.no_radio_item.input.click
+    misconduct_page.form.continue_button.click
   end
 
   def when_i_press_back
@@ -369,16 +394,6 @@ RSpec.describe "Eligibility check", type: :system do
 
   def when_i_try_to_go_to_the_ineligible_page
     visit "/eligibility/ineligible"
-  end
-
-  def when_i_try_to_go_to_the_misconduct_page
-    visit "/eligibility/misconduct"
-  end
-
-  def then_i_see_the_misconduct_page
-    expect(page).to have_content(
-      "Do you have any sanctions or restrictions on your employment record?"
-    )
   end
 
   def then_i_see_the_eligible_page
@@ -436,15 +451,6 @@ RSpec.describe "Eligibility check", type: :system do
 
   def and_i_see_the_ineligible_degree_text
     expect(page).to have_content("You do not have a degree.")
-  end
-
-  def then_i_see_the_completed_requirements_page
-    expect(page).to have_title(
-      "Have you completed all requirements to work as a qualified teacher in"
-    )
-    expect(page).to have_content(
-      "Have you completed all requirements to work as a qualified teacher in"
-    )
   end
 
   def then_i_have_two_eligibility_checks


### PR DESCRIPTION
This improves the eligibility check tests to use page objects to improve the maintainability of the tests. Builds upon the #454.