### PR TITLE
Add Check Personal Information Page

### DIFF
--- a/app/controllers/assessor_interface/check_personal_informations_controller.rb
+++ b/app/controllers/assessor_interface/check_personal_informations_controller.rb
@@ -1,0 +1,7 @@
+module AssessorInterface
+  class CheckPersonalInformationsController < BaseController
+    def show
+      @application_form = ApplicationForm.find(params[:application_form_id])
+    end
+  end
+end

--- a/app/views/assessor_interface/check_personal_informations/show.html.erb
+++ b/app/views/assessor_interface/check_personal_informations/show.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, "Check personal information" %>
+
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+
+<h1 class="govuk-heading-xl">Check personal information</h1>
+
+<%= render "shared/application_form/personal_information_summary", 
+    application_form: @application_form,
+    changeable: false %>
+
+<%= govuk_button_link_to "Continue", [:assessor_interface, @application_form] %>

--- a/spec/support/page_objects/assessor_interface/check_personal_informations.rb
+++ b/spec/support/page_objects/assessor_interface/check_personal_informations.rb
@@ -1,0 +1,17 @@
+module PageObjects
+  module AssessorInterface
+    class CheckPersonalInformationCard < SitePrism::Section
+      element :heading, "h2"
+    end
+
+    class CheckPersonalInformation < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/check_personal_information"
+
+      element :heading, "h1"
+      element :continue_button, ".govuk-button"
+      sections :personal_informations_cards,
+               CheckPersonalInformationCard,
+               ".govuk-summary-list__card"
+    end
+  end
+end

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_application_page
   end
 
+  it "allows checking the personal information" do
+    when_i_visit_the_check_personal_information_page
+    then_i_see_the_personal_informations
+
+    when_i_click_continue
+    then_i_see_the_application_page
+  end
+
   private
 
   def given_an_assessor_exists
@@ -40,6 +48,10 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def given_there_is_an_application_form
     application_form
+  end
+
+  def when_i_visit_the_check_personal_information_page
+    check_personal_information_page.load(application_id: application_form.id)
   end
 
   def when_i_visit_the_check_qualifications_page
@@ -52,6 +64,12 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def when_i_visit_the_check_professional_standing_page
     check_professional_standing_page.load(application_id: application_form.id)
+  end
+
+  def then_i_see_the_personal_informations
+    expect(check_personal_information_page.heading).to have_content(
+      "Check personal information"
+    )
   end
 
   def then_i_see_the_qualifications
@@ -103,8 +121,14 @@ RSpec.describe "Assessor check submitted details", type: :system do
         :submitted,
         :with_completed_qualification,
         :with_work_history,
-        :with_registration_number
+        :with_registration_number,
+        :with_personal_information
       )
+  end
+
+  def check_personal_information_page
+    @check_personal_information_page ||=
+      PageObjects::AssessorInterface::CheckPersonalInformation.new
   end
 
   def check_qualifications_page


### PR DESCRIPTION
This adds a new page which assessors will use to check the personal of the application. For now it just displays the personal information and a button which takes the user back to the overview page.