### PR TITLE
Show identity documents when checking personal info

### DIFF
--- a/app/views/assessor_interface/check_personal_informations/show.html.erb
+++ b/app/views/assessor_interface/check_personal_informations/show.html.erb
@@ -4,8 +4,12 @@
 
 <h1 class="govuk-heading-xl">Check personal information</h1>
 
-<%= render "shared/application_form/personal_information_summary", 
-    application_form: @application_form,
-    changeable: false %>
+<%= render "shared/application_form/personal_information_summary",
+           application_form: @application_form,
+           changeable: false %>
+
+<%= render "shared/application_form/identity_document_summary",
+           application_form: @application_form,
+           changeable: false %>
 
 <%= govuk_button_link_to "Continue", [:assessor_interface, @application_form] %>


### PR DESCRIPTION
When viewing the "Check personal information" page we want to show the identity documents, if there are any, as this is asked as part of the personal information set of questions.