### PR TITLE
Use page objects in remaining tests

### DIFF
--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -2,55 +2,59 @@
 
 <h1 class="govuk-heading-xl">Personas</h1>
 
-<h2 class="govuk-heading-l">Staff</h2>
+<section id="app-personas-staff">
+  <h2 class="govuk-heading-l">Staff</h2>
 
-<% if @staff.empty? %>
-  <p class="govuk-body">No staff personas.</p>
-<% else %>
-  <% @staff.find_each do |staff| %>
-    <h3 class="govuk-heading-m"><%= staff.email %></h3>
-    <%= govuk_button_to "Sign in as #{staff.email}", staff_sign_in_persona_path(staff) %>
+  <% if @staff.empty? %>
+    <p class="govuk-body">No staff personas.</p>
+  <% else %>
+    <% @staff.find_each do |staff| %>
+      <h3 class="govuk-heading-m"><%= staff.email %></h3>
+      <%= govuk_button_to "Sign in as #{staff.email}", staff_sign_in_persona_path(staff) %>
+    <% end %>
   <% end %>
-<% end %>
+</section>
 
-<h2 class="govuk-heading-l">Teachers</h2>
+<section id="app-personas-teachers">
+  <h2 class="govuk-heading-l">Teachers</h2>
 
-<% if @teacher_personas.empty? %>
-  <p class="govuk-body">No teacher personas.</p>
-<% else %>
-  <div class="app-teacher-personas">
-    <%= govuk_table do |table|
-      table.head do |head|
-        head.row do |row|
-          row.cell(header: true, text: "Country bucket")
-          row.cell(header: true, text: "Status check")
-          row.cell(header: true, text: "Sanction check")
-          row.cell(header: true, text: "Submitted?")
-          row.cell(header: true, text: "Actions")
+  <% if @teacher_personas.empty? %>
+    <p class="govuk-body">No teacher personas.</p>
+  <% else %>
+    <div class="app-teacher-personas">
+      <%= govuk_table do |table|
+        table.head do |head|
+          head.row do |row|
+            row.cell(header: true, text: "Country bucket")
+            row.cell(header: true, text: "Status check")
+            row.cell(header: true, text: "Sanction check")
+            row.cell(header: true, text: "Submitted?")
+            row.cell(header: true, text: "Actions")
+          end
         end
-      end
 
-      table.body do |body|
-        @teacher_personas.each do |persona|
-          body.row do |row|
-            row.cell do
-              bucket = region_bucket_for_teacher_persona(persona)
-              govuk_tag(text: bucket) if bucket
-            end
+        table.body do |body|
+          @teacher_personas.each do |persona|
+            body.row do |row|
+              row.cell do
+                bucket = region_bucket_for_teacher_persona(persona)
+                govuk_tag(text: bucket) if bucket
+              end
 
-            row.cell { persona_check_tag(persona[:status_check]) }
-            row.cell { persona_check_tag(persona[:sanction_check]) }
+              row.cell { persona_check_tag(persona[:status_check]) }
+              row.cell { persona_check_tag(persona[:sanction_check]) }
 
-            row.cell do
-              persona[:submitted] ? govuk_tag(text: "Yes", colour: "green") : govuk_tag(text: "No", colour: "red")
-            end
+              row.cell do
+                persona[:submitted] ? govuk_tag(text: "Yes", colour: "green") : govuk_tag(text: "No", colour: "red")
+              end
 
-            row.cell do
-              govuk_button_to "Sign in as #{persona[:teacher].email}", teacher_sign_in_persona_path(persona[:teacher])
+              row.cell do
+                govuk_button_to "Sign in as #{persona[:teacher].email}", teacher_sign_in_persona_path(persona[:teacher])
+              end
             end
           end
         end
-      end
-    end %>
-  </div>
-<% end %>
+      end %>
+    </div>
+  <% end %>
+</section>

--- a/spec/support/page_objects/eligiblity_interface/country.rb
+++ b/spec/support/page_objects/eligiblity_interface/country.rb
@@ -13,6 +13,11 @@ module PageObjects
         element :location_field, 'input[name="location_autocomplete"]'
         element :continue_button, "button"
       end
+
+      def submit(country:)
+        form.location_field.fill_in with: country
+        form.continue_button.click
+      end
     end
   end
 end

--- a/spec/support/page_objects/eligiblity_interface/question.rb
+++ b/spec/support/page_objects/eligiblity_interface/question.rb
@@ -1,4 +1,5 @@
-require "support/page_objects/govuk_error_summary"
+require_relative "../govuk_error_summary"
+require_relative "../govuk_radio_item"
 
 module PageObjects
   module EligibilityInterface

--- a/spec/support/page_objects/eligiblity_interface/question.rb
+++ b/spec/support/page_objects/eligiblity_interface/question.rb
@@ -17,6 +17,16 @@ module PageObjects
                 ".govuk-radios__item:nth-of-type(2)"
         element :continue_button, "button"
       end
+
+      def submit_yes
+        form.yes_radio_item.input.click
+        form.continue_button.click
+      end
+
+      def submit_no
+        form.no_radio_item.input.click
+        form.continue_button.click
+      end
     end
   end
 end

--- a/spec/support/page_objects/eligiblity_interface/region.rb
+++ b/spec/support/page_objects/eligiblity_interface/region.rb
@@ -1,4 +1,5 @@
-require "support/page_objects/govuk_error_summary"
+require_relative "../govuk_error_summary"
+require_relative "../govuk_radio_item"
 
 module PageObjects
   module EligibilityInterface

--- a/spec/support/page_objects/eligiblity_interface/region.rb
+++ b/spec/support/page_objects/eligiblity_interface/region.rb
@@ -16,6 +16,11 @@ module PageObjects
                  ".govuk-radios__item"
         element :continue_button, "button"
       end
+
+      def submit(region:)
+        form.radio_items.find { |e| e.text == region }.input.click
+        form.continue_button.click
+      end
     end
   end
 end

--- a/spec/support/page_objects/performance.rb
+++ b/spec/support/page_objects/performance.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  class Performance < SitePrism::Page
+    set_url "/performance{?since_launch*}"
+
+    section :live_service_usage, "main > div:nth-of-type(2)" do
+      elements :stats, "div > div"
+
+      element :table, "table"
+    end
+  end
+end

--- a/spec/support/page_objects/personas.rb
+++ b/spec/support/page_objects/personas.rb
@@ -1,0 +1,17 @@
+module PageObjects
+  class Personas < SitePrism::Page
+    set_url "/personas"
+
+    element :heading, "h1"
+
+    section :staff, "#app-personas-staff" do
+      element :heading, "h2"
+      elements :buttons, ".govuk-button"
+    end
+
+    section :teachers, "#app-personas-teachers" do
+      element :heading, "h2"
+      elements :buttons, ".govuk-button"
+    end
+  end
+end

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -210,25 +210,20 @@ RSpec.describe "Eligibility check", type: :system do
     @country_page ||= PageObjects::EligibilityInterface::Country.new
   end
 
-  def when_i_select_a_country(country)
-    country_page.form.location_field.fill_in with: country
-    country_page.form.continue_button.click
-  end
-
   def when_i_select_an_eligible_country
-    when_i_select_a_country "Scotland"
+    country_page.submit(country: "Scotland")
   end
 
   def when_i_select_an_ineligible_country
-    when_i_select_a_country "Spain"
+    country_page.submit(country: "Spain")
   end
 
   def when_i_select_a_legacy_country
-    when_i_select_a_country "France"
+    country_page.submit(country: "France")
   end
 
   def when_i_select_a_multiple_region_country
-    when_i_select_a_country "Italy"
+    country_page.submit(country: "Italy")
   end
 
   def when_i_dont_select_a_country
@@ -269,8 +264,7 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def when_i_select_a_region
-    region_page.form.radio_items.first.input.click
-    region_page.form.continue_button.click
+    region_page.submit(region: "Region")
   end
 
   def qualification_page
@@ -291,13 +285,11 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def when_i_have_a_qualification
-    qualification_page.form.yes_radio_item.input.click
-    qualification_page.form.continue_button.click
+    qualification_page.submit_yes
   end
 
   def when_i_dont_have_a_qualification
-    qualification_page.form.no_radio_item.input.click
-    qualification_page.form.continue_button.click
+    qualification_page.submit_no
   end
 
   def degree_page
@@ -316,13 +308,11 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def when_i_have_a_degree
-    degree_page.form.yes_radio_item.input.click
-    degree_page.form.continue_button.click
+    degree_page.submit_yes
   end
 
   def when_i_dont_have_a_degree
-    degree_page.form.no_radio_item.input.click
-    degree_page.form.continue_button.click
+    degree_page.submit_no
   end
 
   def teach_children_page
@@ -344,13 +334,11 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def when_i_can_teach_children
-    teach_children_page.form.yes_radio_item.input.click
-    teach_children_page.form.continue_button.click
+    teach_children_page.submit_yes
   end
 
   def when_i_cant_teach_children
-    teach_children_page.form.no_radio_item.input.click
-    teach_children_page.form.continue_button.click
+    teach_children_page.submit_no
   end
 
   def misconduct_page
@@ -371,13 +359,11 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def when_i_have_a_misconduct_record
-    misconduct_page.form.yes_radio_item.input.click
-    misconduct_page.form.continue_button.click
+    misconduct_page.submit_yes
   end
 
   def when_i_dont_have_a_misconduct_record
-    misconduct_page.form.no_radio_item.input.click
-    misconduct_page.form.continue_button.click
+    misconduct_page.submit_no
   end
 
   def eligible_page

--- a/spec/system/performance_spec.rb
+++ b/spec/system/performance_spec.rb
@@ -26,22 +26,38 @@ RSpec.describe "Performance", type: :system do
   end
 
   def when_i_visit_the_performance_page
-    visit performance_path
+    performance_page.load
   end
 
   def then_i_see_the_live_stats
-    expect(page).to have_content("36\nchecks over the last 7 days")
-    expect(page).to have_content("30 June\t1")
-    expect(page).to have_content("24 June\t7")
+    expect(performance_page.live_service_usage.stats.first).to have_content(
+      "36\nchecks over the last 7 days"
+    )
+    expect(performance_page.live_service_usage.table).to have_content(
+      "30 June\t1"
+    )
+    expect(performance_page.live_service_usage.table).to have_content(
+      "24 June\t7"
+    )
   end
 
   def when_i_visit_the_performance_page_since_launch
-    visit performance_path(since_launch: true)
+    performance_page.load(since_launch: true)
   end
 
   def then_i_see_the_live_stats_since_launch
-    expect(page).to have_content("45\nchecks since launch")
-    expect(page).to have_content("30 June\t1")
-    expect(page).to have_content("22 June\t9")
+    expect(performance_page.live_service_usage.stats.first).to have_content(
+      "45\nchecks since launch"
+    )
+    expect(performance_page.live_service_usage.table).to have_content(
+      "30 June\t1"
+    )
+    expect(performance_page.live_service_usage.table).to have_content(
+      "22 June\t9"
+    )
+  end
+
+  def performance_page
+    @performance_page ||= PageObjects::Performance.new
   end
 end

--- a/spec/system/personas_spec.rb
+++ b/spec/system/personas_spec.rb
@@ -57,22 +57,22 @@ RSpec.describe "Personas", type: :system do
   end
 
   def when_i_visit_the_personas_page
-    visit :personas
+    personas_page.load
   end
 
   def when_i_sign_in_as_a_staff_persona
-    click_button "Sign in as staff@example.com"
+    personas_page.staff.buttons.first.click
   end
 
   def when_i_sign_in_as_a_teacher_persona
-    click_button "Sign in as teacher@example.com"
+    personas_page.teachers.buttons.first.click
   end
 
   def then_i_see_the_personas_page
-    expect(page).to have_title("Personas")
-    expect(page).to have_content("Personas")
-    expect(page).to have_content("Staff")
-    expect(page).to have_content("Teachers")
+    expect(personas_page).to have_title("Personas")
+    expect(personas_page.heading).to have_content("Personas")
+    expect(personas_page.staff.heading).to have_content("Staff")
+    expect(personas_page.teachers.heading).to have_content("Teachers")
   end
 
   def then_i_see_the_case_management_page
@@ -91,16 +91,20 @@ RSpec.describe "Personas", type: :system do
   end
 
   def and_i_see_no_personas
-    expect(page).to have_content("No staff personas.")
-    expect(page).to have_content("No teacher personas.")
+    expect(personas_page.staff).to have_content("No staff personas.")
+    expect(personas_page.teachers).to have_content("No teacher personas.")
   end
 
   def and_i_see_some_personas
-    expect(page).to have_content("staff@example.com")
-    expect(page).to have_content("teacher@example.com")
+    expect(personas_page.staff).to have_content("staff@example.com")
+    expect(personas_page.teachers).to have_content("teacher@example.com")
   end
 
   def and_i_see_the_feature_disabled_message
-    expect(page).to have_content("Personas feature not active.")
+    expect(personas_page).to have_content("Personas feature not active.")
+  end
+
+  def personas_page
+    @personas_page ||= PageObjects::Personas.new
   end
 end

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -59,33 +59,27 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
   end
 
   def and_i_enter_a_country
-    country_page.form.location_field.fill_in with: "Canada"
-    country_page.form.continue_button.click
+    country_page.submit(country: "Canada")
   end
 
   def and_i_select_a_state
-    region_page.form.radio_items.find { |e| e.text == "Ontario" }.input.click
-    region_page.form.continue_button.click
+    region_page.submit(region: "Ontario")
   end
 
   def and_i_have_a_teaching_qualification
-    qualification_page.form.yes_radio_item.input.click
-    qualification_page.form.continue_button.click
+    qualification_page.submit_yes
   end
 
   def and_i_have_a_university_degree
-    degree_page.form.yes_radio_item.input.click
-    degree_page.form.continue_button.click
+    degree_page.submit_yes
   end
 
   def and_i_am_qualified_to_teach
-    teach_children_page.form.yes_radio_item.input.click
-    teach_children_page.form.continue_button.click
+    teach_children_page.submit_yes
   end
 
   def and_i_dont_have_sanctions
-    misconduct_page.form.no_radio_item.input.click
-    misconduct_page.form.continue_button.click
+    misconduct_page.submit_no
   end
 
   def then_i_should_be_eligible_to_apply

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -1,7 +1,19 @@
 # frozen_string_literal: true
+
 require "spec_helper"
 require "capybara/rspec"
 require "capybara/cuprite"
+require "site_prism"
+require "site_prism/all_there"
+
+require "support/page_objects/eligiblity_interface/country"
+require "support/page_objects/eligiblity_interface/degree"
+require "support/page_objects/eligiblity_interface/eligible"
+require "support/page_objects/eligiblity_interface/misconduct"
+require "support/page_objects/eligiblity_interface/qualification"
+require "support/page_objects/eligiblity_interface/region"
+require "support/page_objects/eligiblity_interface/start"
+require "support/page_objects/eligiblity_interface/teach_children"
 
 Capybara.javascript_driver = :cuprite
 Capybara.always_include_port = false
@@ -34,7 +46,7 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
   end
 
   def and_i_click_the_start_button
-    click_button("Start now")
+    start_page.start_button.click
   end
 
   def and_i_need_to_check_my_eligibility
@@ -47,42 +59,69 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
   end
 
   def and_i_enter_a_country
-    fill_in "eligibility-interface-country-form-location-field", with: "Canada"
-    continue
+    country_page.form.location_field.fill_in with: "Canada"
+    country_page.form.continue_button.click
   end
 
   def and_i_select_a_state
-    choose "Ontario", visible: false
-    continue
+    region_page.form.radio_items.find { |e| e.text == "Ontario" }.input.click
+    region_page.form.continue_button.click
   end
 
   def and_i_have_a_teaching_qualification
-    choose "Yes", visible: false
-    continue
+    qualification_page.form.yes_radio_item.input.click
+    qualification_page.form.continue_button.click
   end
 
   def and_i_have_a_university_degree
-    choose "Yes", visible: false
-    continue
+    degree_page.form.yes_radio_item.input.click
+    degree_page.form.continue_button.click
   end
 
   def and_i_am_qualified_to_teach
-    choose "Yes", visible: false
-    continue
+    teach_children_page.form.yes_radio_item.input.click
+    teach_children_page.form.continue_button.click
   end
 
   def and_i_dont_have_sanctions
-    choose "No", visible: false
-    continue
+    misconduct_page.form.no_radio_item.input.click
+    misconduct_page.form.continue_button.click
   end
 
   def then_i_should_be_eligible_to_apply
-    expect(page).to have_content("You’re eligible to apply")
+    expect(eligible_page).to have_content("You’re eligible to apply")
   end
 
-  private
+  def start_page
+    @start_page ||= PageObjects::EligibilityInterface::Start.new
+  end
 
-  def continue
-    click_button("Continue")
+  def country_page
+    @country_page ||= PageObjects::EligibilityInterface::Country.new
+  end
+
+  def region_page
+    @region_page ||= PageObjects::EligibilityInterface::Region.new
+  end
+
+  def qualification_page
+    @qualification_page ||= PageObjects::EligibilityInterface::Qualification.new
+  end
+
+  def degree_page
+    @degree_page ||= PageObjects::EligibilityInterface::Degree.new
+  end
+
+  def teach_children_page
+    @teach_children_page ||=
+      PageObjects::EligibilityInterface::TeachChildren.new
+  end
+
+  def misconduct_page
+    @misconduct_page ||= PageObjects::EligibilityInterface::Misconduct.new
+  end
+
+  def eligible_page
+    @eligible_page ||= PageObjects::EligibilityInterface::Eligible.new
   end
 end


### PR DESCRIPTION
This refactors the tests which aren't associate with a particular interface to use page objects, to improve the maintainability of the tests.

[Trello Card](https://trello.com/c/wrF7dS5p/845-pageobject-refactor-the-rest)