### PR TITLE
Fix missing smoke test method

### DIFF
--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -54,7 +54,7 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
     # not. We can remove this conditional when the feature is released
     if page.has_content?("Have you used the service before?")
       choose "No, I need to check my eligibility", visible: false
-      continue
+      click_button "Continue"
     end
   end
 


### PR DESCRIPTION
This method was removed in 5843662aa36645546670de54b7205461ec4fb093 without a suitable replacement, so the smoke test were failing in the dev/test environments.