### PR TITLE
Make assessment tasks dynamic

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -17,12 +17,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
 
   def assessment_tasks
     {
-      submitted_details: %i[
-        personal_information
-        qualifications
-        work_history
-        professional_standing
-      ],
+      submitted_details: submitted_details_tasks,
       recommendation: %i[first_assessment second_assessment]
     }
   end
@@ -49,6 +44,16 @@ class AssessorInterface::ApplicationFormsShowViewObject
   private
 
   attr_reader :params
+
+  def submitted_details_tasks
+    %i[personal_information qualifications].tap do |tasks|
+      tasks << :work_history if application_form.needs_work_history?
+      if application_form.needs_written_statement? ||
+           application_form.needs_registration_number?
+        tasks << :professional_standing
+      end
+    end
+  end
 
   def url_helpers
     Rails.application.routes.url_helpers

--- a/spec/system/assessor_interface/view_application_form_spec.rb
+++ b/spec/system/assessor_interface/view_application_form_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe "Assessor view application form", type: :system do
     expect(page).to have_content("Check personal information")
     expect(page).to have_content("Check qualifications")
     expect(page).to have_content("Check work history")
-    expect(page).to have_content("Check professional standing")
     expect(page).to have_content("Your recommendation")
     expect(page).to have_content("First assessment")
     expect(page).to have_content("Second assessment")

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -36,20 +36,55 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
   end
 
   describe "#assessment_tasks" do
+    let(:application_form) { create(:application_form) }
+    let(:params) { { id: application_form.id } }
+
     subject(:assessment_tasks) { view_object.assessment_tasks }
 
-    it do
-      is_expected.to eq(
-        {
-          submitted_details: %i[
-            personal_information
-            qualifications
-            work_history
-            professional_standing
-          ],
-          recommendation: %i[first_assessment second_assessment]
-        }
-      )
+    describe "submitted details" do
+      subject(:submitted_details) { assessment_tasks.fetch(:submitted_details) }
+
+      context "with none checks" do
+        before do
+          application_form.update!(region: create(:region, :none_checks))
+        end
+
+        it do
+          is_expected.to eq(
+            %i[personal_information qualifications work_history]
+          )
+        end
+      end
+
+      context "with written checks" do
+        before do
+          application_form.update!(region: create(:region, :written_checks))
+        end
+
+        it do
+          is_expected.to eq(
+            %i[personal_information qualifications professional_standing]
+          )
+        end
+      end
+
+      context "with online checks" do
+        before do
+          application_form.update!(region: create(:region, :online_checks))
+        end
+
+        it do
+          is_expected.to eq(
+            %i[personal_information qualifications professional_standing]
+          )
+        end
+      end
+    end
+
+    describe "recommendation" do
+      subject(:recommendation) { assessment_tasks.fetch(:recommendation) }
+
+      it { is_expected.to eq(%i[first_assessment second_assessment]) }
     end
   end
 


### PR DESCRIPTION
This changes the tasks for an assessment of an application dynamic so that if an application form requires none checks then we'd expect the work history to be checked, and if there are written or online checks the professional standing has to be checked.

[Trello Card](https://trello.com/c/GuQOde4d/840-evidence-of-professional-recognition)