### PR TITLE
Add ability to filter on submitted at date

### DIFF
--- a/app/forms/assessor_interface/filter_form.rb
+++ b/app/forms/assessor_interface/filter_form.rb
@@ -2,5 +2,10 @@ class AssessorInterface::FilterForm
   include ActiveModel::Model
   include ActiveRecord::AttributeAssignment
 
-  attr_accessor :assessor_ids, :location, :name, :states
+  attr_accessor :assessor_ids,
+                :location,
+                :name,
+                :states,
+                :submitted_at_before,
+                :submitted_at_after
 end

--- a/app/forms/assessor_interface/filter_form.rb
+++ b/app/forms/assessor_interface/filter_form.rb
@@ -1,0 +1,6 @@
+class AssessorInterface::FilterForm
+  include ActiveModel::Model
+  include ActiveRecord::AttributeAssignment
+
+  attr_accessor :assessor_ids, :location, :name, :states
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -23,6 +23,10 @@ var loadCountryAutoComplete = () => {
     document.getElementById(
       "qualification-institution-country-code-field-error"
     ) ??
+    document.getElementById("assessor-interface-filter-form-location-field") ??
+    document.getElementById(
+      "assessor-interface-filter-form-location-field-error"
+    ) ??
     document.getElementById("location-field") ??
     document.getElementById("location-field-error");
 

--- a/app/lib/filters/submitted_at.rb
+++ b/app/lib/filters/submitted_at.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Filters
+  class SubmittedAt < Base
+    def apply
+      new_scope = scope
+
+      if submitted_at_after.present?
+        new_scope =
+          new_scope.where("DATE(submitted_at) >= ?", submitted_at_after)
+      end
+
+      if submitted_at_before.present?
+        new_scope =
+          new_scope.where("DATE(submitted_at) <= ?", submitted_at_before)
+      end
+
+      new_scope
+    end
+
+    private
+
+    def submitted_at_after
+      Date.new(
+        params["submitted_at_after(1i)"].to_i,
+        params["submitted_at_after(2i)"].to_i,
+        params["submitted_at_after(3i)"].to_i
+      )
+    rescue Date::Error
+      nil
+    end
+
+    def submitted_at_before
+      Date.new(
+        params["submitted_at_before(1i)"].to_i,
+        params["submitted_at_before(2i)"].to_i,
+        params["submitted_at_before(3i)"].to_i
+      )
+    rescue Date::Error
+      nil
+    end
+  end
+end

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -70,7 +70,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
         ::Filters::State.apply(
           scope: application_forms_without_state_filter,
           params:
-        ).order(:submitted_at)
+        ).order(submitted_at: :desc)
       )
   end
 

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -50,6 +50,8 @@ class AssessorInterface::ApplicationFormsIndexViewObject
       assessor_interface_filter_form: [
         :location,
         :name,
+        :submitted_at_before,
+        :submitted_at_after,
         { assessor_ids: [], states: [] }
       ]
     )
@@ -74,10 +76,15 @@ class AssessorInterface::ApplicationFormsIndexViewObject
   def application_forms_without_state_filter
     @application_forms_without_state_filter ||=
       begin
-        filters = [::Filters::Name, ::Filters::Assessor, ::Filters::Country]
-        filters.reduce(ApplicationForm.active) do |scope, filter|
-          filter.apply(scope:, params: filter_params)
-        end
+        filters = [
+          ::Filters::Assessor,
+          ::Filters::Country,
+          ::Filters::Name,
+          ::Filters::SubmittedAt
+        ]
+        filters.reduce(
+          ApplicationForm.includes(region: :country).active
+        ) { |scope, filter| filter.apply(scope:, params: filter_params) }
       end
   end
 

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -23,6 +23,11 @@
 
     <%= f.govuk_text_field :name, label: { text: "Applicant name", size: "s" } %>
 
+    <%= f.govuk_fieldset legend: { text: "Created date", size: "s" } do %>
+      <%= f.govuk_date_field :submitted_at_after, legend: { text: "Start date", size: "s" } %>
+      <%= f.govuk_date_field :submitted_at_before, legend: { text: "End date", size: "s" } %>
+    <% end %>
+
     <%= f.govuk_check_boxes_fieldset :states, legend: { text: "Status of application", size: "s" }, small: true do %>
       <%- @view_object.state_filter_options.each do |option| -%>
         <%= f.govuk_check_box :states, option.id, label: { text: option.label }, checked: @view_object.filter_form.states&.include?(option.id) %>

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -5,14 +5,14 @@
 <div class="govuk-grid-column-one-third app-application-forms__filters">
   <h2 class="govuk-heading-m">Filters</h2>
 
-  <%= form_with method: :get, class: "app-application-forms__filter-form" do |f| %>
+  <%= form_with model: @view_object.filter_form, method: :get, url: assessor_interface_application_forms_path, class: "app-application-forms__filter-form" do |f| %>
     <%= f.govuk_submit "Apply filters" do %>
       <%= govuk_link_to "Clear selection"%>
     <%- end -%>
 
     <%= f.govuk_check_boxes_fieldset :assessor_ids, legend: { text: "Assessor name", size: "s" }, small: true do %>
       <%- @view_object.assessor_filter_options.each do |option| -%>
-        <%= f.govuk_check_box :assessor_ids, option.id, label: { text: option.name }, checked: @view_object.assessor_filter_checked?(option) %>
+        <%= f.govuk_check_box :assessor_ids, option.id, label: { text: option.name }, checked: @view_object.filter_form.assessor_ids&.include?(option.id.to_s) %>
       <%- end -%>
     <%- end -%>
 
@@ -21,13 +21,11 @@
                        label: { text: "Country trained in", size: "s" },
                        options: { include_blank: true } %>
 
-    <%= f.govuk_text_field :name,
-                           label: { text: "Applicant name", size: "s" },
-                           value: @view_object.name_filter_value %>
+    <%= f.govuk_text_field :name, label: { text: "Applicant name", size: "s" } %>
 
     <%= f.govuk_check_boxes_fieldset :states, legend: { text: "Status of application", size: "s" }, small: true do %>
       <%- @view_object.state_filter_options.each do |option| -%>
-        <%= f.govuk_check_box :states, option.id, label: { text: option.label }, checked: @view_object.state_filter_checked?(option) %>
+        <%= f.govuk_check_box :states, option.id, label: { text: option.label }, checked: @view_object.filter_form.states&.include?(option.id) %>
       <%- end -%>
     <%- end -%>
   <%- end -%>
@@ -37,7 +35,7 @@
   <% if @view_object.application_forms_records.any? %>
     <ul class="app-search-results">
       <%- @view_object.application_forms_records.each do |application_form| -%>
-        <%= render(ApplicationFormSearchResult::Component.new(application_form:, search_params: @view_object.search_params)) %>
+        <%= render(ApplicationFormSearchResult::Component.new(application_form:, search_params: @view_object.permitted_params)) %>
       <%- end -%>
     </ul>
 

--- a/spec/lib/filters/submitted_at_spec.rb
+++ b/spec/lib/filters/submitted_at_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Filters::SubmittedAt do
+  subject { described_class.apply(scope:, params:) }
+
+  context "with both submitted_at params " do
+    let(:params) do
+      {
+        "submitted_at_after(1i)" => "2020",
+        "submitted_at_after(2i)" => "01",
+        "submitted_at_after(3i)" => "01",
+        "submitted_at_before(1i)" => "2020",
+        "submitted_at_before(2i)" => "01",
+        "submitted_at_before(3i)" => "31"
+      }
+    end
+    let(:scope) { ApplicationForm.all }
+
+    let!(:included) do
+      create(:application_form, submitted_at: Date.new(2020, 1, 10))
+    end
+
+    let!(:filtered) do
+      create(:application_form, :submitted, submitted_at: Date.new(2019, 1, 1))
+      create(:application_form, :submitted, submitted_at: Date.new(2021, 1, 1))
+    end
+
+    it { is_expected.to eq([included]) }
+  end
+
+  context "with submitted_at before param" do
+    let(:params) do
+      {
+        "submitted_at_before(1i)" => "2020",
+        "submitted_at_before(2i)" => "01",
+        "submitted_at_before(3i)" => "01"
+      }
+    end
+    let(:scope) { ApplicationForm.all }
+
+    let!(:included) do
+      create(:application_form, submitted_at: Date.new(2020, 1, 1))
+    end
+
+    let!(:filtered) do
+      create(:application_form, :submitted, submitted_at: Date.new(2020, 1, 2))
+    end
+
+    it { is_expected.to eq([included]) }
+  end
+
+  context "with submitted_at after param" do
+    let(:params) do
+      {
+        "submitted_at_after(1i)" => "2020",
+        "submitted_at_after(2i)" => "01",
+        "submitted_at_after(3i)" => "02"
+      }
+    end
+    let(:scope) { ApplicationForm.all }
+
+    let!(:included) do
+      create(:application_form, submitted_at: Date.new(2020, 1, 2))
+    end
+
+    let!(:filtered) do
+      create(:application_form, :submitted, submitted_at: Date.new(2020, 1, 1))
+    end
+
+    it { is_expected.to eq([included]) }
+  end
+
+  context "without submitted_at params" do
+    let(:params) { {} }
+    let(:scope) { double }
+
+    it { is_expected.to eq(scope) }
+  end
+end

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -11,16 +11,20 @@ RSpec.describe "Assessor filtering application forms", type: :system do
     when_i_visit_the_applications_page
 
     when_i_clear_the_filters
-    and_i_apply_the_name_filter
-    then_i_see_a_list_of_applications_filtered_by_name
+    and_i_apply_the_assessor_filter
+    then_i_see_a_list_of_applications_filtered_by_assessor
 
     when_i_clear_the_filters
     and_i_apply_the_country_filter
     then_i_see_a_list_of_applications_filtered_by_country
 
     when_i_clear_the_filters
-    and_i_apply_the_assessor_filter
-    then_i_see_a_list_of_applications_filtered_by_assessor
+    and_i_apply_the_name_filter
+    then_i_see_a_list_of_applications_filtered_by_name
+
+    when_i_clear_the_filters
+    and_i_apply_the_submitted_at_filter
+    then_i_see_a_list_of_applications_filtered_by_submitted_at
 
     when_i_clear_the_filters
     and_i_apply_the_state_filter
@@ -45,13 +49,13 @@ RSpec.describe "Assessor filtering application forms", type: :system do
     click_link "Clear selection"
   end
 
-  def and_i_apply_the_name_filter
-    fill_in "Applicant name", with: "cher"
+  def and_i_apply_the_assessor_filter
+    check "Wag Staff", visible: false
     click_button "Apply filters"
   end
 
-  def then_i_see_a_list_of_applications_filtered_by_name
-    expect(page).to have_content("Cher Bert")
+  def then_i_see_a_list_of_applications_filtered_by_assessor
+    expect(page).to have_content("Arnold Drummond")
   end
 
   def and_i_apply_the_country_filter
@@ -63,13 +67,25 @@ RSpec.describe "Assessor filtering application forms", type: :system do
     expect(page).to have_content("Emma Dubois")
   end
 
-  def and_i_apply_the_assessor_filter
-    check "Wag Staff", visible: false
+  def and_i_apply_the_name_filter
+    fill_in "Applicant name", with: "cher"
     click_button "Apply filters"
   end
 
-  def then_i_see_a_list_of_applications_filtered_by_assessor
-    expect(page).to have_content("Arnold Drummond")
+  def then_i_see_a_list_of_applications_filtered_by_name
+    expect(page).to have_content("Cher Bert")
+  end
+
+  def and_i_apply_the_submitted_at_filter
+    fill_in "assessor_interface_filter_form_submitted_at_before_1i",
+            with: "2020"
+    fill_in "assessor_interface_filter_form_submitted_at_before_2i", with: "1"
+    fill_in "assessor_interface_filter_form_submitted_at_before_3i", with: "1"
+    click_button "Apply filters"
+  end
+
+  def then_i_see_a_list_of_applications_filtered_by_submitted_at
+    expect(page).to have_content("John Smith")
   end
 
   def and_i_apply_the_state_filter
@@ -108,7 +124,8 @@ RSpec.describe "Assessor filtering application forms", type: :system do
         :application_form,
         :awarded,
         given_names: "John",
-        family_name: "Smith"
+        family_name: "Smith",
+        submitted_at: Date.new(2020, 1, 1)
       )
     ]
   end

--- a/spec/system/assessor_interface/listing_application_forms_spec.rb
+++ b/spec/system/assessor_interface/listing_application_forms_spec.rb
@@ -69,6 +69,6 @@ RSpec.describe "Assessor listing application forms", type: :system do
         25,
         :with_personal_information,
         :submitted
-      ).sort_by(&:submitted_at)
+      ).sort_by(&:submitted_at).reverse
   end
 end

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -75,10 +75,18 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
 
     context "with multiple application forms" do
       let(:application_form_1) do
-        create(:application_form, :submitted, created_at: Date.new(2020, 1, 1))
+        create(
+          :application_form,
+          :submitted,
+          submitted_at: Date.new(2020, 1, 1)
+        )
       end
       let(:application_form_2) do
-        create(:application_form, :submitted, created_at: Date.new(2020, 1, 2))
+        create(
+          :application_form,
+          :submitted,
+          submitted_at: Date.new(2020, 1, 2)
+        )
       end
 
       it { is_expected.to eq([application_form_2, application_form_1]) }

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -113,22 +113,6 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
     end
   end
 
-  describe "#assessor_filter_checked?" do
-    subject(:assessor_filter_checked?) do
-      view_object.assessor_filter_checked?(option)
-    end
-
-    let(:option) { OpenStruct.new(id: 1) }
-
-    it { is_expected.to be false }
-
-    context "when the filter is set" do
-      let(:params) { { assessor_ids: %w[1] } }
-
-      it { is_expected.to be true }
-    end
-  end
-
   describe "#country_filter_options" do
     subject(:country_filter_options) { view_object.country_filter_options }
 
@@ -140,7 +124,12 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
 
     context "when the filter is set" do
       let(:params) do
-        { location: "country:US", location_autocomplete: "United States" }
+        {
+          assessor_interface_filter_form: {
+            location: "country:US"
+          },
+          location_autocomplete: "United States"
+        }
       end
 
       it do
@@ -151,7 +140,14 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
     end
 
     context "when the autocomplete input is cleared" do
-      let(:params) { { location: "country:US", location_autocomplete: "" } }
+      let(:params) do
+        {
+          assessor_interface_filter_form: {
+            location: "country:US"
+          },
+          location_autocomplete: ""
+        }
+      end
 
       it do
         is_expected.to include(
@@ -161,25 +157,15 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
     end
 
     context "when the autocomplete input isn't being used" do
-      let(:params) { { location: "country:US" } }
+      let(:params) do
+        { assessor_interface_filter_form: { location: "country:US" } }
+      end
 
       it do
         is_expected.to include(
           '<option selected="selected" value="country:US">United States</option>'
         )
       end
-    end
-  end
-
-  describe "#name_filter_value" do
-    subject(:name_filter_value) { view_object.name_filter_value }
-
-    it { is_expected.to be_nil }
-
-    context "when the filter is set" do
-      let(:params) { { name: "abc" } }
-
-      it { is_expected.to eq("abc") }
     end
   end
 
@@ -215,47 +201,35 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
     end
   end
 
-  describe "#state_filter_checked?" do
-    subject(:state_filter_checked?) do
-      view_object.state_filter_checked?(option)
-    end
-
-    let(:option) { OpenStruct.new(id: "draft") }
-
-    it { is_expected.to be false }
-
-    context "when the filter is set" do
-      let(:params) { { states: %w[draft submitted] } }
-
-      it { is_expected.to be true }
-    end
-  end
-
-  describe "#search_params" do
-    subject(:search_params) { view_object.search_params }
+  describe "#permitted_params" do
+    subject(:permitted_params) { view_object.permitted_params }
 
     it { is_expected.to be_empty }
 
     context "with permitted params" do
       let(:params) do
-        %w[
-          assessor_ids
-          location
-          location_autocomplete
-          name
-          states
-          page
-        ].each_with_object({}) { |p, memo| memo[p] = p }
+        {
+          assessor_interface_filter_form: {
+            assessor_ids: ["assessor_id"],
+            location: "location",
+            name: "name",
+            states: ["state"]
+          },
+          location_autocomplete: "location_autocomplete",
+          page: "page"
+        }
       end
 
       it do
         is_expected.to eq(
           {
-            "assessor_ids" => "assessor_ids",
-            "location" => "location",
+            "assessor_interface_filter_form" => {
+              "assessor_ids" => ["assessor_id"],
+              "location" => "location",
+              "name" => "name",
+              "states" => ["state"]
+            },
             "location_autocomplete" => "location_autocomplete",
-            "name" => "name",
-            "states" => "states",
             "page" => "page"
           }
         )

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
     context "with form params" do
       let(:params) { { search: { states: %w[awarded] } } }
 
-      it { is_expected.to eq("/assessor/applications?states%5D%5B%5D=awarded") }
+      it { is_expected.to eq("/assessor/applications?states%5B%5D=awarded") }
     end
   end
 

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
 
     it { is_expected.to eq("/assessor/applications") }
 
-    context "with search params" do
+    context "with form params" do
       let(:params) { { search: { states: %w[awarded] } } }
 
-      it { is_expected.to eq("/assessor/applications?states%5B%5D=awarded") }
+      it { is_expected.to eq("/assessor/applications?states%5D%5B%5D=awarded") }
     end
   end
 


### PR DESCRIPTION
This adds a new filter on the application form index page to allow users to choose to show only application forms within a submitted at range.

[Trello Card](https://trello.com/c/ws5wJvoI/857-submission-date-filter)

## Screenshots

<img width="359" alt="Screenshot 2022-09-05 at 21 26 09" src="https://user-images.githubusercontent.com/510498/188566747-3c9f57d9-80e9-464f-a3f1-b4c5cc3d24ba.png">
