### PR TITLE
Localise application form status

### DIFF
--- a/app/components/application_form_status_tag/component.rb
+++ b/app/components/application_form_status_tag/component.rb
@@ -14,9 +14,7 @@ module ApplicationFormStatusTag
     end
 
     def text
-      return "New" if @status.to_s == "submitted"
-
-      @status.to_s.humanize
+      I18n.t("application_form.status.#{@status}")
     end
 
     COLOURS = {

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -36,10 +36,8 @@ class AssessorInterface::ApplicationFormsIndexViewObject
     states = %w[submitted awarded declined]
 
     states.map do |state|
-      OpenStruct.new(
-        id: state,
-        label: "#{state.humanize} (#{counts.fetch(state, 0)})"
-      )
+      text = I18n.t("application_form.status.#{state}")
+      OpenStruct.new(id: state, label: "#{text} (#{counts.fetch(state, 0)})")
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,17 @@ en:
       title: Your email address
 
   application_form:
+    status:
+      not_started: Not started
+      in_progress: In progress
+      initial_assessment: Initial assessment
+      request_further_information: Request further information
+      received_further_information: Received further information
+      awarded: Awarded
+      declined: Declined
+      draft: Draft
+      submitted: Not started
+      completed: Completed
     tasks:
       sections:
         about_you: About you

--- a/spec/components/application_form_status_tag_component_spec.rb
+++ b/spec/components/application_form_status_tag_component_spec.rb
@@ -8,18 +8,18 @@ RSpec.describe ApplicationFormStatusTag::Component, type: :component do
   end
 
   let(:key) { "key" }
-  let(:status) { :status }
+  let(:status) { :awarded }
   let(:class_context) { "app-task-list" }
 
   describe "text" do
     subject(:text) { component.text.strip }
 
-    it { is_expected.to eq("Status") }
+    it { is_expected.to eq("Awarded") }
 
     context "submitted" do
       let(:status) { :submitted }
 
-      it { is_expected.to eq("New") }
+      it { is_expected.to eq("Not started") }
     end
   end
 

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe ApplicationFormHelper do
             },
             value: {
               text:
-                "<strong class=\"govuk-tag govuk-tag--grey app-search-result__item__tag\" id=\"application-form-#{application_form.id}-status\">New</strong>\n"
+                "<strong class=\"govuk-tag govuk-tag--grey app-search-result__item__tag\" id=\"application-form-#{application_form.id}-status\">Not started</strong>\n"
             },
             actions: []
           },

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
     it do
       is_expected.to eq(
         [
-          OpenStruct.new(id: "submitted", label: "Submitted (0)"),
+          OpenStruct.new(id: "submitted", label: "Not started (0)"),
           OpenStruct.new(id: "awarded", label: "Awarded (0)"),
           OpenStruct.new(id: "declined", label: "Declined (0)")
         ]
@@ -192,7 +192,7 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
       it do
         is_expected.to eq(
           [
-            OpenStruct.new(id: "submitted", label: "Submitted (2)"),
+            OpenStruct.new(id: "submitted", label: "Not started (2)"),
             OpenStruct.new(id: "awarded", label: "Awarded (3)"),
             OpenStruct.new(id: "declined", label: "Declined (4)")
           ]


### PR DESCRIPTION
We've also renamed the "New" status to "Not started" as requeste by the designers.

[Trello Card](https://trello.com/c/3C0mnBhh/858-new-not-started)