### PR TITLE
Add a task for generating countries CSV file

### DIFF
--- a/lib/tasks/analytics.rake
+++ b/lib/tasks/analytics.rake
@@ -1,0 +1,11 @@
+require "csv"
+
+namespace :analytics do
+  desc "Generate a countries CSV file for analytics dashboards."
+  task generate_countries_csv: :environment do
+    CSV.open("countries.csv", "wb") do |csv|
+      csv << %w[code name]
+      Country::CODES.each { |code| csv << [code, CountryName.from_code(code)] }
+    end
+  end
+end


### PR DESCRIPTION
This file is used in our analytics dashboards to map country codes (which are sent to BigQuery) with a more human-readable country name. I've create a Rake task in case we need to keep this file up to date in the future.