### PR TITLE
Store application form section rules on model

### DIFF
--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -3,16 +3,13 @@ module TeacherInterface
     before_action :load_application_form, except: %i[new create]
 
     def new
-      @application_form = ApplicationForm.new
       @country_region_form = CountryRegionForm.new
     end
 
     def create
-      @application_form = ApplicationForm.new(teacher: current_teacher)
-
       @country_region_form =
         CountryRegionForm.new(
-          country_region_form_params.merge(application_form:)
+          country_region_form_params.merge(teacher: current_teacher)
         )
 
       if @country_region_form.needs_region?

--- a/app/controllers/teachers/registrations_controller.rb
+++ b/app/controllers/teachers/registrations_controller.rb
@@ -37,7 +37,7 @@ class Teachers::RegistrationsController < Devise::RegistrationsController
 
   def create_application_form
     if valid_eligibility_check? && teacher_requires_application_form?
-      ApplicationForm.create!(
+      ApplicationFormFactory.call(
         teacher: resource,
         region: eligibility_check.region
       )

--- a/app/forms/teacher_interface/country_region_form.rb
+++ b/app/forms/teacher_interface/country_region_form.rb
@@ -2,12 +2,11 @@ class TeacherInterface::CountryRegionForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attr_accessor :application_form
-
+  attr_accessor :teacher
   attribute :location, :string
   attribute :region_id, :integer
 
-  validates :application_form, presence: true
+  validates :teacher, presence: true
   validates :location, presence: true
   validates :region_id, presence: true, if: -> { location.present? }
 
@@ -27,8 +26,7 @@ class TeacherInterface::CountryRegionForm
   def save
     return false unless valid?
 
-    application_form.region_id = region_id
-    application_form.save!
+    ApplicationFormFactory.call(teacher:, region: Region.find(region_id))
   end
 
   private

--- a/app/lib/application_form_factory.rb
+++ b/app/lib/application_form_factory.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class ApplicationFormFactory
+  include ServicePattern
+
+  def initialize(teacher:, region:)
+    @teacher = teacher
+    @region = region
+  end
+
+  def call
+    ApplicationForm.create!(
+      teacher:,
+      region:,
+      needs_work_history:,
+      needs_written_statement:,
+      needs_registration_number:
+    )
+  end
+
+  private
+
+  attr_reader :teacher, :region
+
+  def needs_work_history
+    region.status_check_none? || region.sanction_check_none?
+  end
+
+  def needs_written_statement
+    region.status_check_written? || region.sanction_check_written?
+  end
+
+  def needs_registration_number
+    region.status_check_online? || region.sanction_check_online?
+  end
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -92,13 +92,13 @@ class ApplicationForm < ApplicationRecord
         hash = {}
         hash.merge!(about_you: %i[personal_information identity_document])
         hash.merge!(qualifications: %i[qualifications age_range subjects])
-        hash.merge!(work_history: %i[work_history]) if needs_work_history?
+        hash.merge!(work_history: %i[work_history]) if needs_work_history
 
-        if needs_written_statement? || needs_registration_number?
+        if needs_written_statement || needs_registration_number
           hash.merge!(
             proof_of_recognition: [
-              needs_registration_number? ? :registration_number : nil,
-              needs_written_statement? ? :written_statement : nil
+              needs_registration_number ? :registration_number : nil,
+              needs_written_statement ? :written_statement : nil
             ].compact
           )
         end
@@ -154,18 +154,6 @@ class ApplicationForm < ApplicationRecord
     rescue NoMethodError
       url_helpers.send("#{key}_teacher_interface_application_form_path")
     end
-  end
-
-  def needs_work_history?
-    region.status_check_none? || region.sanction_check_none?
-  end
-
-  def needs_registration_number?
-    region.status_check_online? || region.sanction_check_online?
-  end
-
-  def needs_written_statement?
-    region.status_check_written? || region.sanction_check_written?
   end
 
   def teaching_qualification

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -2,27 +2,30 @@
 #
 # Table name: application_forms
 #
-#  id                      :bigint           not null, primary key
-#  age_range_max           :integer
-#  age_range_min           :integer
-#  alternative_family_name :text             default(""), not null
-#  alternative_given_names :text             default(""), not null
-#  date_of_birth           :date
-#  family_name             :text             default(""), not null
-#  given_names             :text             default(""), not null
-#  has_alternative_name    :boolean
-#  has_work_history        :boolean
-#  reference               :string(31)       not null
-#  registration_number     :text
-#  state                   :string           default("draft"), not null
-#  subjects                :text             default([]), not null, is an Array
-#  submitted_at            :datetime
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  assessor_id             :bigint
-#  region_id               :bigint           not null
-#  reviewer_id             :bigint
-#  teacher_id              :bigint           not null
+#  id                        :bigint           not null, primary key
+#  age_range_max             :integer
+#  age_range_min             :integer
+#  alternative_family_name   :text             default(""), not null
+#  alternative_given_names   :text             default(""), not null
+#  date_of_birth             :date
+#  family_name               :text             default(""), not null
+#  given_names               :text             default(""), not null
+#  has_alternative_name      :boolean
+#  has_work_history          :boolean
+#  needs_registration_number :boolean          not null
+#  needs_work_history        :boolean          not null
+#  needs_written_statement   :boolean          not null
+#  reference                 :string(31)       not null
+#  registration_number       :text
+#  state                     :string           default("draft"), not null
+#  subjects                  :text             default([]), not null, is an Array
+#  submitted_at              :datetime
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  assessor_id               :bigint
+#  region_id                 :bigint           not null
+#  reviewer_id               :bigint
+#  teacher_id                :bigint           not null
 #
 # Indexes
 #

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -47,9 +47,9 @@ class AssessorInterface::ApplicationFormsShowViewObject
 
   def submitted_details_tasks
     %i[personal_information qualifications].tap do |tasks|
-      tasks << :work_history if application_form.needs_work_history?
-      if application_form.needs_written_statement? ||
-           application_form.needs_registration_number?
+      tasks << :work_history if application_form.needs_work_history
+      if application_form.needs_written_statement ||
+           application_form.needs_registration_number
         tasks << :professional_standing
       end
     end

--- a/app/views/teacher_interface/application_forms/edit.html.erb
+++ b/app/views/teacher_interface/application_forms/edit.html.erb
@@ -12,17 +12,17 @@
 <%= render "shared/application_form/age_range_summary", application_form: @application_form, changeable: true %>
 <%= render "shared/application_form/subjects_summary", application_form: @application_form, changeable: true %>
 
-<% if @application_form.needs_work_history? %>
+<% if @application_form.needs_work_history %>
   <h2 class="govuk-heading-m">Your work history</h2>
   <%= render "shared/application_form/work_history_summary", application_form: @application_form, work_histories: @application_form.work_histories.ordered, changeable: true %>
 <% end %>
 
-<% if @application_form.needs_written_statement? || @application_form.needs_registration_number? %>
+<% if @application_form.needs_written_statement || @application_form.needs_registration_number %>
   <h2 class="govuk-heading-m">Proof that you’re recognised as a teacher</h2>
-  <% if @application_form.needs_registration_number? %>
+  <% if @application_form.needs_registration_number %>
     <%= render "shared/application_form/registration_number_summary", application_form: @application_form, changeable: true %>
   <% end %>
-  <% if @application_form.needs_written_statement? %>
+  <% if @application_form.needs_written_statement %>
     <%= render "shared/application_form/written_statement_summary", application_form: @application_form, changeable: true %>
   <% end %>
 <% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -43,6 +43,9 @@
     - assessor_id
     - reviewer_id
     - submitted_at
+    - needs_work_history
+    - needs_written_statement
+    - needs_registration_number
   :countries:
     - id
     - code

--- a/db/migrate/20220908064656_add_rules_to_application_forms.rb
+++ b/db/migrate/20220908064656_add_rules_to_application_forms.rb
@@ -1,0 +1,28 @@
+class AddRulesToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    change_table :application_forms, bulk: true do |t|
+      t.boolean :needs_work_history
+      t.boolean :needs_written_statement
+      t.boolean :needs_registration_number
+    end
+
+    ApplicationForm
+      .includes(:region)
+      .each do |application_form|
+        region = application_form.region
+
+        application_form.update!(
+          needs_work_history:
+            region.status_check_none? || region.sanction_check_none?,
+          needs_written_statement:
+            region.status_check_online? || region.sanction_check_online?,
+          needs_registration_number:
+            region.status_check_written? || region.sanction_check_written?
+        )
+      end
+
+    change_column_null :application_forms, :needs_work_history, false
+    change_column_null :application_forms, :needs_written_statement, false
+    change_column_null :application_forms, :needs_registration_number, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_01_121549) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_08_064656) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,6 +63,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_01_121549) do
     t.bigint "reviewer_id"
     t.string "state", default: "draft", null: false
     t.datetime "submitted_at"
+    t.boolean "needs_work_history", null: false
+    t.boolean "needs_written_statement", null: false
+    t.boolean "needs_registration_number", null: false
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["family_name"], name: "index_application_forms_on_family_name"
     t.index ["given_names"], name: "index_application_forms_on_given_names"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -2,27 +2,30 @@
 #
 # Table name: application_forms
 #
-#  id                      :bigint           not null, primary key
-#  age_range_max           :integer
-#  age_range_min           :integer
-#  alternative_family_name :text             default(""), not null
-#  alternative_given_names :text             default(""), not null
-#  date_of_birth           :date
-#  family_name             :text             default(""), not null
-#  given_names             :text             default(""), not null
-#  has_alternative_name    :boolean
-#  has_work_history        :boolean
-#  reference               :string(31)       not null
-#  registration_number     :text
-#  state                   :string           default("draft"), not null
-#  subjects                :text             default([]), not null, is an Array
-#  submitted_at            :datetime
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
-#  assessor_id             :bigint
-#  region_id               :bigint           not null
-#  reviewer_id             :bigint
-#  teacher_id              :bigint           not null
+#  id                        :bigint           not null, primary key
+#  age_range_max             :integer
+#  age_range_min             :integer
+#  alternative_family_name   :text             default(""), not null
+#  alternative_given_names   :text             default(""), not null
+#  date_of_birth             :date
+#  family_name               :text             default(""), not null
+#  given_names               :text             default(""), not null
+#  has_alternative_name      :boolean
+#  has_work_history          :boolean
+#  needs_registration_number :boolean          not null
+#  needs_work_history        :boolean          not null
+#  needs_written_statement   :boolean          not null
+#  reference                 :string(31)       not null
+#  registration_number       :text
+#  state                     :string           default("draft"), not null
+#  subjects                  :text             default([]), not null, is an Array
+#  submitted_at              :datetime
+#  created_at                :datetime         not null
+#  updated_at                :datetime         not null
+#  assessor_id               :bigint
+#  region_id                 :bigint           not null
+#  reviewer_id               :bigint
+#  teacher_id                :bigint           not null
 #
 # Indexes
 #
@@ -48,6 +51,10 @@ FactoryBot.define do
     state { "draft" }
     association :teacher
     association :region, :national
+
+    needs_work_history { false }
+    needs_written_statement { false }
+    needs_registration_number { false }
 
     trait :submitted do
       state { "submitted" }
@@ -92,6 +99,7 @@ FactoryBot.define do
     end
 
     trait :with_registration_number do
+      needs_registration_number { true }
       registration_number do
         Faker::Number.unique.leading_zero_number(digits: 8)
       end
@@ -104,6 +112,7 @@ FactoryBot.define do
     end
 
     trait :with_work_history do
+      needs_work_history { true }
       has_work_history { true }
 
       after(:create) do |application_form, _evaluator|
@@ -112,6 +121,7 @@ FactoryBot.define do
     end
 
     trait :with_written_statement do
+      needs_written_statement { true }
       after(:build) do |application_form, _evaluator|
         build(:upload, document: application_form.written_statement_document)
       end

--- a/spec/forms/teacher_interface/country_region_form_spec.rb
+++ b/spec/forms/teacher_interface/country_region_form_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe TeacherInterface::CountryRegionForm, type: :model do
   describe "validations" do
-    it { is_expected.to validate_presence_of(:application_form) }
+    it { is_expected.to validate_presence_of(:teacher) }
     it { is_expected.to validate_presence_of(:location) }
 
     context "with a location" do
@@ -69,20 +69,20 @@ RSpec.describe TeacherInterface::CountryRegionForm, type: :model do
   end
 
   describe "#save" do
-    let(:application_form) { build(:application_form) }
+    let(:teacher) { create(:teacher) }
     let(:region) { create(:region, :national) }
 
     let(:form) do
       described_class.new(
-        application_form:,
+        teacher:,
         location: "country:#{region.country.code}",
         region_id: region.id
       )
     end
 
-    before { form.save }
-
-    it "saves the application form" do
+    it "creates an application form" do
+      application_form = form.save
+      expect(application_form.teacher).to eq(teacher)
       expect(application_form.region).to eq(region)
     end
   end

--- a/spec/lib/application_form_factory_spec.rb
+++ b/spec/lib/application_form_factory_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationFormFactory do
+  let(:teacher) { create(:teacher) }
+  let(:region) { nil }
+
+  describe "#call" do
+    subject(:call) { described_class.call(teacher:, region:) }
+
+    context "with a none checks region" do
+      let(:region) { create(:region, :none_checks) }
+
+      it "creates an application form" do
+        expect { call }.to change(ApplicationForm, :count).by(1)
+      end
+
+      it "sets the rules" do
+        application_form = call
+        expect(application_form.needs_work_history).to be true
+        expect(application_form.needs_written_statement).to be false
+        expect(application_form.needs_registration_number).to be false
+      end
+    end
+
+    context "with a written checks region" do
+      let(:region) { create(:region, :written_checks) }
+
+      it "creates an application form" do
+        expect { call }.to change(ApplicationForm, :count).by(1)
+      end
+
+      it "sets the rules" do
+        application_form = call
+        expect(application_form.needs_work_history).to be false
+        expect(application_form.needs_written_statement).to be true
+        expect(application_form.needs_registration_number).to be false
+      end
+    end
+
+    context "with an online checks region" do
+      let(:region) { create(:region, :online_checks) }
+
+      it "creates an application form" do
+        expect { call }.to change(ApplicationForm, :count).by(1)
+      end
+
+      it "sets the rules" do
+        application_form = call
+        expect(application_form.needs_work_history).to be false
+        expect(application_form.needs_written_statement).to be false
+        expect(application_form.needs_registration_number).to be true
+      end
+    end
+  end
+end

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -164,8 +164,8 @@ RSpec.describe ApplicationForm, type: :model do
   describe "#tasks" do
     subject(:tasks) { application_form.tasks }
 
-    context "with no checks" do
-      before { application_form.region = create(:region, :none_checks) }
+    context "with needs work history" do
+      before { application_form.needs_work_history = true }
 
       it do
         is_expected.to eq(
@@ -178,8 +178,8 @@ RSpec.describe ApplicationForm, type: :model do
       end
     end
 
-    context "with written checks" do
-      before { application_form.region = create(:region, :written_checks) }
+    context "with needs written statement" do
+      before { application_form.needs_written_statement = true }
 
       it do
         is_expected.to eq(
@@ -192,8 +192,8 @@ RSpec.describe ApplicationForm, type: :model do
       end
     end
 
-    context "with online checks" do
-      before { application_form.region = create(:region, :online_checks) }
+    context "with needs registration number" do
+      before { application_form.needs_registration_number = true }
 
       it do
         is_expected.to eq(
@@ -221,16 +221,36 @@ RSpec.describe ApplicationForm, type: :model do
             qualifications: :not_started,
             age_range: :not_started,
             subjects: :not_started
-          },
-          work_history: {
-            work_history: :not_started
           }
         }
       )
     end
 
-    context "with written checks" do
-      before { application_form.region = create(:region, :written_checks) }
+    context "with work history" do
+      before { application_form.needs_work_history = true }
+
+      it do
+        is_expected.to eq(
+          {
+            about_you: {
+              personal_information: :not_started,
+              identity_document: :not_started
+            },
+            qualifications: {
+              qualifications: :not_started,
+              age_range: :not_started,
+              subjects: :not_started
+            },
+            work_history: {
+              work_history: :not_started
+            }
+          }
+        )
+      end
+    end
+
+    context "with written statement" do
+      before { application_form.needs_written_statement = true }
 
       it do
         is_expected.to eq(
@@ -252,8 +272,8 @@ RSpec.describe ApplicationForm, type: :model do
       end
     end
 
-    context "with online checks" do
-      before { application_form.region = create(:region, :online_checks) }
+    context "with registration number" do
+      before { application_form.needs_registration_number = true }
 
       it do
         is_expected.to eq(
@@ -425,6 +445,8 @@ RSpec.describe ApplicationForm, type: :model do
     end
 
     describe "work history section" do
+      before { application_form.needs_work_history = true }
+
       subject(:work_history_status) { task_statuses[:work_history] }
 
       describe "work history item" do
@@ -466,7 +488,7 @@ RSpec.describe ApplicationForm, type: :model do
       end
 
       describe "written statement item" do
-        before { application_form.region = create(:region, :written_checks) }
+        before { application_form.needs_written_statement = true }
 
         subject(:written_statement_status) do
           proof_of_recognition_status[:written_statement]
@@ -489,7 +511,7 @@ RSpec.describe ApplicationForm, type: :model do
       end
 
       describe "registration number item" do
-        before { application_form.region = create(:region, :online_checks) }
+        before { application_form.needs_registration_number = true }
 
         subject(:registration_number_status) do
           proof_of_recognition_status[:registration_number]
@@ -520,69 +542,5 @@ RSpec.describe ApplicationForm, type: :model do
     subject(:can_submit?) { application_form.can_submit? }
 
     it { is_expected.to eq(false) }
-  end
-
-  describe "#needs_work_history?" do
-    subject(:needs_work_history?) { application_form.needs_work_history? }
-
-    context "with none checks" do
-      it { is_expected.to be true }
-    end
-
-    context "with written checks" do
-      before { application_form.region = create(:region, :written_checks) }
-
-      it { is_expected.to be false }
-    end
-
-    context "with online checks" do
-      before { application_form.region = create(:region, :online_checks) }
-
-      it { is_expected.to be false }
-    end
-  end
-
-  describe "#needs_registration_number?" do
-    subject(:needs_registration_number?) do
-      application_form.needs_registration_number?
-    end
-
-    context "with none checks" do
-      it { is_expected.to be false }
-    end
-
-    context "with written checks" do
-      before { application_form.region = create(:region, :written_checks) }
-
-      it { is_expected.to be false }
-    end
-
-    context "with online checks" do
-      before { application_form.region = create(:region, :online_checks) }
-
-      it { is_expected.to be true }
-    end
-  end
-
-  describe "#needs_written_statement?" do
-    subject(:needs_written_statement?) do
-      application_form.needs_written_statement?
-    end
-
-    context "with none checks" do
-      it { is_expected.to be false }
-    end
-
-    context "with written checks" do
-      before { application_form.region = create(:region, :written_checks) }
-
-      it { is_expected.to be true }
-    end
-
-    context "with online checks" do
-      before { application_form.region = create(:region, :online_checks) }
-
-      it { is_expected.to be false }
-    end
   end
 end

--- a/spec/system/assessor_interface/view_application_form_spec.rb
+++ b/spec/system/assessor_interface/view_application_form_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe "Assessor view application form", type: :system do
 
   def application_form
     @application_form ||=
-      create(:application_form, :submitted, :with_personal_information)
+      create(
+        :application_form,
+        :submitted,
+        :with_work_history,
+        :with_personal_information
+      )
   end
 end

--- a/spec/system/personas_spec.rb
+++ b/spec/system/personas_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Personas", type: :system do
 
   def then_i_see_the_application_form_page
     expect(page).to have_content("Application incomplete")
-    expect(page).to have_content("You have completed 0 of 3 sections.")
+    expect(page).to have_content("You have completed 0 of 2 sections.")
   end
 
   def then_i_see_the_start_page

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -44,10 +44,8 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
     describe "submitted details" do
       subject(:submitted_details) { assessment_tasks.fetch(:submitted_details) }
 
-      context "with none checks" do
-        before do
-          application_form.update!(region: create(:region, :none_checks))
-        end
+      context "with work history" do
+        before { application_form.update!(needs_work_history: true) }
 
         it do
           is_expected.to eq(
@@ -56,10 +54,8 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
         end
       end
 
-      context "with written checks" do
-        before do
-          application_form.update!(region: create(:region, :written_checks))
-        end
+      context "with written statement" do
+        before { application_form.update!(needs_written_statement: true) }
 
         it do
           is_expected.to eq(
@@ -68,10 +64,8 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
         end
       end
 
-      context "with online checks" do
-        before do
-          application_form.update!(region: create(:region, :online_checks))
-        end
+      context "with registration number" do
+        before { application_form.update!(needs_registration_number: true) }
 
         it do
           is_expected.to eq(


### PR DESCRIPTION
Rather than dynamically fetching the rules from the region each time, we should store them on the application form ensuring that if the rules for a region were to change while an application form is being filled out or assessed, the required sections wouldn't change half way through.

[Trello Card](https://trello.com/c/R9PMJPmY/851-spike-assessment-sections-data-structure)