### PR TITLE
[843] Page object refactor for the assessor interface specs

### DIFF
--- a/app/components/application_form_overview/component.html.erb
+++ b/app/components/application_form_overview/component.html.erb
@@ -1,2 +1,4 @@
-<h2 class="govuk-heading-l"><%= title %></h2>
-<%= render(GovukComponent::SummaryListComponent.new(rows: summary_rows)) %>
+<section id="app-application-overview">
+  <h2 class="govuk-heading-l"><%= title %></h2>
+  <%= render(GovukComponent::SummaryListComponent.new(rows: summary_rows)) %>
+</section>

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -10,29 +10,41 @@
       <%= govuk_link_to "Clear selection"%>
     <%- end -%>
 
-    <%= f.govuk_check_boxes_fieldset :assessor_ids, legend: { text: "Assessor name", size: "s" }, small: true do %>
-      <%- @view_object.assessor_filter_options.each do |option| -%>
-        <%= f.govuk_check_box :assessor_ids, option.id, label: { text: option.name }, checked: @view_object.filter_form.assessor_ids&.include?(option.id.to_s) %>
+    <section id="app-applications-filters-assessor">
+      <%= f.govuk_check_boxes_fieldset :assessor_ids, legend: { text: "Assessor name", size: "s" }, small: true do %>
+        <%- @view_object.assessor_filter_options.each do |option| -%>
+          <%= f.govuk_check_box :assessor_ids, option.id, label: { text: option.name }, checked: @view_object.filter_form.assessor_ids&.include?(option.id.to_s) %>
+        <%- end -%>
       <%- end -%>
-    <%- end -%>
+    </section>
 
-    <%= f.govuk_select :location,
-                       @view_object.country_filter_options,
-                       label: { text: "Country trained in", size: "s" },
-                       options: { include_blank: true } %>
 
-    <%= f.govuk_text_field :name, label: { text: "Applicant name", size: "s" } %>
+    <section id="app-applications-filters-country">
+      <%= f.govuk_select :location,
+                         @view_object.country_filter_options,
+                         label: { text: "Country trained in", size: "s" },
+                         options: { include_blank: true } %>
+    </section>
 
-    <%= f.govuk_fieldset legend: { text: "Created date", size: "s" } do %>
-      <%= f.govuk_date_field :submitted_at_after, legend: { text: "Start date", size: "s" } %>
-      <%= f.govuk_date_field :submitted_at_before, legend: { text: "End date", size: "s" } %>
-    <% end %>
+    <section id="app-applications-filters-name">
+      <%= f.govuk_text_field :name, label: { text: "Applicant name", size: "s" } %>
+    </section>
 
-    <%= f.govuk_check_boxes_fieldset :states, legend: { text: "Status of application", size: "s" }, small: true do %>
-      <%- @view_object.state_filter_options.each do |option| -%>
-        <%= f.govuk_check_box :states, option.id, label: { text: option.label }, checked: @view_object.filter_form.states&.include?(option.id) %>
+    <section id="app-applications-filters-submitted-at">
+      <%= f.govuk_fieldset legend: { text: "Created date", size: "s" } do %>
+        <%= f.govuk_date_field :submitted_at_after, legend: { text: "Start date", size: "s" } %>
+        <%= f.govuk_date_field :submitted_at_before, legend: { text: "End date", size: "s" } %>
+      <% end %>
+    </section>
+
+    <section id="app-applications-filters-state">
+      <%= f.govuk_check_boxes_fieldset :states, legend: { text: "Status of application", size: "s" }, small: true do %>
+        <%- @view_object.state_filter_options.each do |option| -%>
+          <%= f.govuk_check_box :states, option.id, label: { text: option.label }, checked: @view_object.filter_form.states&.include?(option.id) %>
+        <%- end -%>
       <%- end -%>
-    <%- end -%>
+    </section>
+
   <%- end -%>
 </div>
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,10 +10,10 @@ require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 require "capybara/cuprite"
 require "dfe/analytics/testing"
-require "view_component/test_helpers"
+require "support/page_helpers"
 require "site_prism"
 require "site_prism/all_there"
-
+require "view_component/test_helpers"
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end
@@ -70,6 +70,7 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.before(:each, type: :system) { driven_by(:cuprite) }
   config.include ViewComponent::TestHelpers, type: :component
+  config.include PageHelpers, type: :system
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -1,6 +1,7 @@
 require "support/page_objects/govuk_radio_item"
 require "support/page_objects/govuk_checkbox_item"
 require "support/page_objects/page_header"
+require "support/page_objects/govuk_error_summary"
 
 module PageHelpers
   def application_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -1,0 +1,42 @@
+require "support/page_objects/govuk_radio_item"
+require "support/page_objects/govuk_checkbox_item"
+require "support/page_objects/page_header"
+
+module PageHelpers
+  def application_page
+    @application_page ||= PageObjects::AssessorInterface::Application.new
+  end
+
+  def applications_page
+    @applications_page ||= PageObjects::AssessorInterface::Applications.new
+  end
+
+  def assign_assessor_page
+    @assign_assessor_page ||= PageObjects::AssessorInterface::AssignAssessor.new
+  end
+
+  def assign_reviewer_page
+    @assign_reviewer_page ||= PageObjects::AssessorInterface::AssignReviewer.new
+  end
+
+  def check_qualifications_page
+    @check_qualifications_page ||=
+      PageObjects::AssessorInterface::CheckQualifications.new
+  end
+
+  def login_page
+    @login_page ||= PageObjects::AssessorInterface::Login.new
+  end
+
+  def timeline_page
+    @timeline_page ||= PageObjects::AssessorInterface::Timeline.new
+  end
+
+  def then_i_see_the(page, **args)
+    expect(send(page.to_sym)).to be_displayed(**args)
+  end
+
+  def when_i_visit_the(page, **args)
+    send(page.to_sym).load(**args)
+  end
+end

--- a/spec/support/page_objects/assessor_interface/application.rb
+++ b/spec/support/page_objects/assessor_interface/application.rb
@@ -3,7 +3,24 @@ module PageObjects
     class Application < SitePrism::Page
       set_url "/assessor/applications/{application_id}"
 
-      element :summary_list, "dl"
+      element :back_link, "a", text: "Back"
+
+      section :overview, "#app-application-overview" do
+        element :name, "div:nth-of-type(1) > dd:nth-of-type(1)"
+        element :assessor_name, "div:nth-of-type(6) > dd:nth-of-type(1)"
+        element :reviewer_name, "div:nth-of-type(7) > dd:nth-of-type(1)"
+        element :status, "div:nth-of-type(9) > dd:nth-of-type(1)"
+      end
+
+      section :task_list, "ol.app-task-list" do
+        sections :tasks, "ol.app-task-list > li" do
+          sections :items,
+                   "ol.app-task-list > li > ul.app-task-list__items > li.app-task-list__item" do
+            element :heading, "h2"
+            element :link, "a"
+          end
+        end
+      end
     end
   end
 end

--- a/spec/support/page_objects/assessor_interface/applications.rb
+++ b/spec/support/page_objects/assessor_interface/applications.rb
@@ -1,0 +1,52 @@
+module PageObjects
+  module AssessorInterface
+    class Applications < SitePrism::Page
+      set_url "/assessor/applications"
+
+      section :header, PageHeader, "header"
+
+      section :assessor_filter, "#app-applications-filters-assessor" do
+        sections :assessors, GovukCheckboxItem, ".govuk-checkboxes__item"
+      end
+
+      section :country_filter, "#app-applications-filters-country" do
+        element :country, "input"
+      end
+
+      section :name_filter, "#app-applications-filters-name" do
+        element :name, "input"
+      end
+
+      section :submitted_at_filter, "#app-applications-filters-submitted-at" do
+        element :start_day,
+                "#assessor_interface_filter_form_submitted_at_after_3i"
+        element :start_month,
+                "#assessor_interface_filter_form_submitted_at_after_2i"
+        element :start_year,
+                "#assessor_interface_filter_form_submitted_at_after_1i"
+        element :end_day,
+                "#assessor_interface_filter_form_submitted_at_before_3i"
+        element :end_month,
+                "#assessor_interface_filter_form_submitted_at_before_2i"
+        element :end_year,
+                "#assessor_interface_filter_form_submitted_at_before_1i"
+      end
+
+      section :state_filter, "#app-applications-filters-state" do
+        sections :states, GovukCheckboxItem, ".govuk-checkboxes__item"
+      end
+
+      sections :search_results, ".app-search-results__item" do
+        element :name, "h2"
+      end
+
+      element :clear_filters, "div.govuk-button-group a.govuk-link"
+      element :apply_filters, "div.govuk-button-group button"
+
+      section :pagination, "nav.govuk-pagination" do
+        element :next, "a", text: "Next"
+        element :previous, "a", text: "Previous"
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/assessor_interface/assign_assessor.rb
+++ b/spec/support/page_objects/assessor_interface/assign_assessor.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module AssessorInterface
+    class AssignAssessor < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/assign-assessor"
+
+      element :heading, "h1"
+      sections :assessors, PageObjects::GovukRadioItem, ".govuk-radios__item"
+      element :continue_button, "button"
+    end
+  end
+end

--- a/spec/support/page_objects/assessor_interface/assign_reviewer.rb
+++ b/spec/support/page_objects/assessor_interface/assign_reviewer.rb
@@ -1,5 +1,3 @@
-require "support/page_objects/govuk_radio_item"
-
 module PageObjects
   module AssessorInterface
     class AssignReviewer < SitePrism::Page

--- a/spec/support/page_objects/assessor_interface/check_personal_information.rb
+++ b/spec/support/page_objects/assessor_interface/check_personal_information.rb
@@ -2,6 +2,10 @@ module PageObjects
   module AssessorInterface
     class CheckPersonalInformationCard < SitePrism::Section
       element :heading, "h2"
+      element :given_names,
+              "dl.govuk-summary-list > div:nth-of-type(1) > dd:nth-of-type(1)"
+      element :family_name,
+              "dl.govuk-summary-list > div:nth-of-type(2) > dd:nth-of-type(1)"
     end
 
     class CheckPersonalInformation < SitePrism::Page
@@ -9,9 +13,13 @@ module PageObjects
 
       element :heading, "h1"
       element :continue_button, ".govuk-button"
-      sections :personal_informations_cards,
+      sections :personal_information_cards,
                CheckPersonalInformationCard,
                ".govuk-summary-list__card"
+
+      def personal_information
+        personal_information_cards&.first
+      end
     end
   end
 end

--- a/spec/support/page_objects/assessor_interface/check_professional_standing.rb
+++ b/spec/support/page_objects/assessor_interface/check_professional_standing.rb
@@ -2,6 +2,8 @@ module PageObjects
   module AssessorInterface
     class ProfessionalStandingCard < SitePrism::Section
       element :heading, "h2"
+      element :reference_number,
+              "dl.govuk-summary-list > div:nth-of-type(1) > dd:nth-of-type(1)"
     end
 
     class CheckProfessionalStanding < SitePrism::Page
@@ -12,6 +14,10 @@ module PageObjects
       sections :professional_standing_cards,
                ProfessionalStandingCard,
                ".govuk-summary-list__card"
+
+      def proof_of_recognition
+        professional_standing_cards&.first
+      end
     end
   end
 end

--- a/spec/support/page_objects/assessor_interface/check_qualifications.rb
+++ b/spec/support/page_objects/assessor_interface/check_qualifications.rb
@@ -2,6 +2,8 @@ module PageObjects
   module AssessorInterface
     class QualificationCard < SitePrism::Section
       element :heading, "h2"
+      element :title,
+              "dl.govuk-summary-list > div:nth-of-type(1) > dd:nth-of-type(1)"
     end
 
     class CheckQualifications < SitePrism::Page
@@ -12,6 +14,10 @@ module PageObjects
       sections :qualification_cards,
                QualificationCard,
                ".govuk-summary-list__card"
+
+      def teaching_qualification
+        qualification_cards&.first
+      end
     end
   end
 end

--- a/spec/support/page_objects/assessor_interface/check_work_history.rb
+++ b/spec/support/page_objects/assessor_interface/check_work_history.rb
@@ -2,6 +2,8 @@ module PageObjects
   module AssessorInterface
     class WorkHistoryCard < SitePrism::Section
       element :heading, "h2"
+      element :school_name,
+              "dl.govuk-summary-list > div:nth-of-type(1) > dd:nth-of-type(1)"
     end
 
     class CheckWorkHistory < SitePrism::Page
@@ -10,6 +12,10 @@ module PageObjects
       element :heading, "h1"
       element :continue_button, ".govuk-button"
       sections :work_history_cards, WorkHistoryCard, ".govuk-summary-list__card"
+
+      def most_recent_role
+        work_history_cards&.second
+      end
     end
   end
 end

--- a/spec/support/page_objects/assessor_interface/complete_assessment.rb
+++ b/spec/support/page_objects/assessor_interface/complete_assessment.rb
@@ -1,5 +1,3 @@
-require "support/page_objects/govuk_radio_item"
-
 module PageObjects
   module AssessorInterface
     class CompleteAssessment < SitePrism::Page

--- a/spec/support/page_objects/assessor_interface/complete_assessment.rb
+++ b/spec/support/page_objects/assessor_interface/complete_assessment.rb
@@ -7,6 +7,14 @@ module PageObjects
 
       element :heading, "h1"
       sections :new_states, GovukRadioItem, ".govuk-radios__item"
+
+      def award_qts
+        new_states.find { |radio_item| radio_item.label.text == "Award QTS" }
+      end
+
+      def decline_qts
+        new_states.find { |radio_item| radio_item.label.text == "Decline QTS" }
+      end
     end
   end
 end

--- a/spec/support/page_objects/assessor_interface/login.rb
+++ b/spec/support/page_objects/assessor_interface/login.rb
@@ -1,0 +1,23 @@
+module PageObjects
+  module AssessorInterface
+    class Login < SitePrism::Page
+      set_url "/staff/sign_in"
+
+      element :signed_out_message,
+              ".govuk-notification-banner__heading",
+              text: "Signed out successfully."
+
+      section :form, "form" do
+        element :email_field, "#staff-email-field"
+        element :password_field, "#staff-password-field"
+        element :continue_button, "button"
+      end
+
+      def submit(email:, password:)
+        form.email_field.fill_in with: email
+        form.password_field.fill_in with: password
+        form.continue_button.click
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/eligiblity_interface/country.rb
+++ b/spec/support/page_objects/eligiblity_interface/country.rb
@@ -1,5 +1,3 @@
-require "support/page_objects/govuk_error_summary"
-
 module PageObjects
   module EligibilityInterface
     class Country < SitePrism::Page

--- a/spec/support/page_objects/eligiblity_interface/question.rb
+++ b/spec/support/page_objects/eligiblity_interface/question.rb
@@ -1,6 +1,3 @@
-require_relative "../govuk_error_summary"
-require_relative "../govuk_radio_item"
-
 module PageObjects
   module EligibilityInterface
     class Question < SitePrism::Page

--- a/spec/support/page_objects/eligiblity_interface/region.rb
+++ b/spec/support/page_objects/eligiblity_interface/region.rb
@@ -1,6 +1,3 @@
-require_relative "../govuk_error_summary"
-require_relative "../govuk_radio_item"
-
 module PageObjects
   module EligibilityInterface
     class Region < SitePrism::Page

--- a/spec/support/page_objects/govuk_checkbox_item.rb
+++ b/spec/support/page_objects/govuk_checkbox_item.rb
@@ -1,0 +1,8 @@
+module PageObjects
+  module AssessorInterface
+    class GovukCheckboxItem < SitePrism::Section
+      element :label, "label"
+      element :checkbox, "input", visible: false
+    end
+  end
+end

--- a/spec/support/page_objects/page_header.rb
+++ b/spec/support/page_objects/page_header.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  class PageHeader < SitePrism::Section
+    element :search_link, "a.govuk-header__link", text: "Search"
+    element :sign_out_link, "a.govuk-header__link", text: "Sign out"
+    element :support_console_link,
+            "a.govuk-header__link",
+            text: "Support console"
+  end
+end

--- a/spec/system/assessor_interface/assigning_assessor_spec.rb
+++ b/spec/system/assessor_interface/assigning_assessor_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Assigning an assessor", type: :system do
     given_there_is_an_application_form
     given_an_assessor_exists
 
-    when_i_visit_the_assign_assessor_page
+    when_i_visit_the(:assign_assessor_page, application_id: application_form.id)
     and_i_select_an_assessor
     then_the_assessor_is_assigned_to_the_application_form
   end
@@ -20,7 +20,7 @@ RSpec.describe "Assigning an assessor", type: :system do
     given_there_is_an_application_form
     given_an_assessor_exists
 
-    when_i_visit_the_assign_reviewer_page
+    when_i_visit_the(:assign_reviewer_page, application_id: application_form.id)
     and_i_select_a_reviewer
     then_the_assessor_is_assigned_as_reviewer_to_the_application_form
   end
@@ -35,19 +35,13 @@ RSpec.describe "Assigning an assessor", type: :system do
     assessor
   end
 
-  def when_i_visit_the_assign_assessor_page
-    visit assessor_interface_application_form_assign_assessor_path(
-            application_form
-          )
-  end
-
   def and_i_select_an_assessor
-    choose assessor.name, visible: false
-    click_button "Continue"
+    assign_assessor_page.assessors.first.input.click
+    assign_assessor_page.continue_button.click
   end
 
   def then_the_assessor_is_assigned_to_the_application_form
-    expect(page).to have_content("Assigned to\t#{assessor.name}")
+    expect(application_page.overview.assessor_name.text).to eq(assessor.name)
   end
 
   def when_i_visit_the_assign_reviewer_page
@@ -60,7 +54,7 @@ RSpec.describe "Assigning an assessor", type: :system do
   end
 
   def then_the_assessor_is_assigned_as_reviewer_to_the_application_form
-    expect(page).to have_content("Reviewer\t#{assessor.name}")
+    expect(application_page.overview.reviewer_name.text).to eq(assessor.name)
   end
 
   def application_form

--- a/spec/system/assessor_interface/assigning_assessor_spec.rb
+++ b/spec/system/assessor_interface/assigning_assessor_spec.rb
@@ -71,8 +71,4 @@ RSpec.describe "Assigning an assessor", type: :system do
   def assessor
     @assessor ||= create(:staff, :confirmed)
   end
-
-  def assign_reviewer_page
-    @assign_reviewer_page ||= PageObjects::AssessorInterface::AssignReviewer.new
-  end
 end

--- a/spec/system/assessor_interface/authentication_spec.rb
+++ b/spec/system/assessor_interface/authentication_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe "Assessor authentication", type: :system do
     given_the_service_is_open
     given_staff_exist
 
-    when_i_visit_the_assessor_page
-    then_i_see_the_sign_in_form
+    when_i_visit_the(:applications_page)
+    then_i_see_the(:login_page)
 
-    when_i_fill_in_the_sign_in_form
-    and_i_click_continue
+    when_i_login
+    then_i_see_the(:applications_page)
 
     when_i_click_sign_out
-    then_i_see_the_sign_in_form
+    then_i_see_the(:login_page)
     and_i_see_the_signed_out_message
   end
 
@@ -24,25 +24,15 @@ RSpec.describe "Assessor authentication", type: :system do
     create(:staff, :confirmed, email: "staff@example.com", password: "password")
   end
 
-  def when_i_visit_the_assessor_page
-    visit assessor_interface_root_path
-  end
-
-  def when_i_fill_in_the_sign_in_form
-    fill_in "staff-email-field", with: "staff@example.com"
-    fill_in "staff-password-field", with: "password"
+  def when_i_login
+    login_page.submit(email: "staff@example.com", password: "password")
   end
 
   def when_i_click_sign_out
-    click_link "Sign out"
-  end
-
-  def then_i_see_the_sign_in_form
-    expect(page).to have_content("Email")
-    expect(page).to have_content("Password")
+    applications_page.header.sign_out_link.click
   end
 
   def and_i_see_the_signed_out_message
-    expect(page).to have_content("Signed out successfully.")
+    expect(login_page.signed_out_message).to be_visible
   end
 end

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -9,35 +9,35 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   it "allows checking the qualifications" do
-    when_i_visit_the_check_qualifications_page
+    when_i_visit_the(:check_qualifications_page, application_id:)
     then_i_see_the_qualifications
 
-    when_i_click_continue
-    then_i_see_the_application_page
+    when_i_click_check_qualifications_continue
+    then_i_see_the(:application_page, application_id:)
   end
 
   it "allows checking the work history" do
-    when_i_visit_the_check_work_history_page
+    when_i_visit_the(:check_work_history_page, application_id:)
     then_i_see_the_work_history
 
-    when_i_click_continue
-    then_i_see_the_application_page
+    when_i_click_check_work_history_continue
+    then_i_see_the(:application_page, application_id:)
   end
 
   it "allows checking the professional standing" do
-    when_i_visit_the_check_professional_standing_page
+    when_i_visit_the(:check_professional_standing_page, application_id:)
     then_i_see_the_professional_standing
 
-    when_i_click_continue
-    then_i_see_the_application_page
+    when_i_click_check_professional_standing_continue
+    then_i_see_the(:application_page, application_id:)
   end
 
   it "allows checking the personal information" do
-    when_i_visit_the_check_personal_information_page
-    then_i_see_the_personal_informations
+    when_i_visit_the(:check_personal_information_page, application_id:)
+    then_i_see_the_personal_information
 
-    when_i_click_continue
-    then_i_see_the_application_page
+    when_i_click_check_personal_information_continue
+    then_i_see_the(:application_page, application_id:)
   end
 
   private
@@ -50,64 +50,53 @@ RSpec.describe "Assessor check submitted details", type: :system do
     application_form
   end
 
-  def when_i_visit_the_check_personal_information_page
-    check_personal_information_page.load(application_id: application_form.id)
-  end
-
-  def when_i_visit_the_check_qualifications_page
-    check_qualifications_page.load(application_id: application_form.id)
-  end
-
-  def when_i_visit_the_check_work_history_page
-    check_work_history_page.load(application_id: application_form.id)
-  end
-
-  def when_i_visit_the_check_professional_standing_page
-    check_professional_standing_page.load(application_id: application_form.id)
-  end
-
-  def then_i_see_the_personal_informations
-    expect(check_personal_information_page.heading).to have_content(
-      "Check personal information"
-    )
-  end
-
   def then_i_see_the_qualifications
-    expect(check_qualifications_page.heading).to have_content(
-      "Check qualifications"
+    teaching_qualification =
+      application_form.qualifications.find(&:is_teaching_qualification?)
+    expect(check_qualifications_page.teaching_qualification.title.text).to eq(
+      teaching_qualification.title
     )
-    expect(
-      check_qualifications_page.qualification_cards.first.heading
-    ).to have_content("Your teaching qualification")
   end
 
   def then_i_see_the_work_history
-    expect(check_work_history_page.heading).to have_content(
-      "Check work history"
+    most_recent_role = application_form.work_histories.first
+    expect(check_work_history_page.most_recent_role.school_name.text).to eq(
+      most_recent_role.school_name
     )
-    expect(
-      check_work_history_page.work_history_cards.first.heading
-    ).to have_content("Add your work history")
-    expect(
-      check_work_history_page.work_history_cards.second.heading
-    ).to have_content("Your current or most recent role")
   end
 
   def then_i_see_the_professional_standing
-    expect(check_professional_standing_page.heading).to have_content(
-      "Check professional standing"
-    )
     expect(
-      check_professional_standing_page.professional_standing_cards.first.heading
-    ).to have_content("Enter your registration number")
+      check_professional_standing_page
+        .proof_of_recognition
+        .reference_number
+        .text
+    ).to eq(application_form.registration_number)
   end
 
-  def when_i_click_continue
+  def then_i_see_the_personal_information
+    expect(
+      check_personal_information_page.personal_information.given_names.text
+    ).to eq(application_form.given_names)
+    expect(
+      check_personal_information_page.personal_information.family_name.text
+    ).to eq(application_form.family_name)
+  end
+
+  def when_i_click_check_qualifications_continue
     check_qualifications_page.continue_button.click
   end
 
-  def then_i_see_the_application_page
-    expect(page).to have_content("Overview")
+  def when_i_click_check_work_history_continue
+    check_work_history_page.continue_button.click
+  end
+
+  def when_i_click_check_professional_standing_continue
+    check_professional_standing_page.continue_button.click
+  end
+
+  def when_i_click_check_personal_information_continue
+    check_personal_information_page.continue_button.click
   end
 
   def assessor
@@ -124,6 +113,10 @@ RSpec.describe "Assessor check submitted details", type: :system do
         :with_registration_number,
         :with_personal_information
       )
+  end
+
+  def application_id
+    application_form.id
   end
 
   def check_personal_information_page

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
     given_i_am_authorized_as_an_assessor_user(assessor)
     given_there_is_an_application_form
 
-    when_i_visit_the_complete_assessment_page
-    then_i_see_the_complete_assessment_form
+    when_i_visit_the(:complete_assessment_page, application_id:)
 
     when_i_select_award_qts
     and_i_click_continue
@@ -27,28 +26,25 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def then_i_see_the_complete_assessment_form
-    expect(complete_assessment_page.heading).to have_content(
-      "QTS review completed"
-    )
-    expect(complete_assessment_page.new_states.first).to have_content(
-      "Award QTS"
-    )
-    expect(complete_assessment_page.new_states.second).to have_content(
-      "Decline QTS"
-    )
+    expect(complete_assessment_page.award_qts).to be_visible
+    expect(complete_assessment_page.decline_qts).to be_visible
   end
 
   def when_i_select_award_qts
-    complete_assessment_page.new_states.first.input.choose
+    complete_assessment_page.award_qts.input.choose
   end
 
   def then_the_application_form_is_awarded
-    expect(page).to have_content("Status\tAWARDED")
+    expect(application_page.overview.status.text).to eq("AWARDED")
   end
 
   def application_form
     @application_form ||=
       create(:application_form, :with_personal_information, :submitted)
+  end
+
+  def application_id
+    application_form.id
   end
 
   def assessor

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Assessor filtering application forms", type: :system do
     given_there_are_application_forms
 
     when_i_am_authorized_as_an_assessor_user
-    when_i_visit_the_applications_page
+    when_i_visit_the(:applications_page)
 
     when_i_clear_the_filters
     and_i_apply_the_assessor_filter
@@ -46,55 +46,67 @@ RSpec.describe "Assessor filtering application forms", type: :system do
   end
 
   def when_i_clear_the_filters
-    click_link "Clear selection"
+    applications_page.clear_filters.click
   end
 
   def and_i_apply_the_assessor_filter
-    check "Wag Staff", visible: false
-    click_button "Apply filters"
+    applications_page.assessor_filter.assessors.first.checkbox.click
+    applications_page.apply_filters.click
   end
 
   def then_i_see_a_list_of_applications_filtered_by_assessor
-    expect(page).to have_content("Arnold Drummond")
+    expect(applications_page.search_results.count).to eq(1)
+    expect(applications_page.search_results.first.name.text).to eq(
+      "Arnold Drummond"
+    )
   end
 
   def and_i_apply_the_country_filter
-    fill_in "Country", with: "France"
-    click_button "Apply filters"
+    applications_page.country_filter.country.set("France")
+    applications_page.apply_filters.click
   end
 
   def then_i_see_a_list_of_applications_filtered_by_country
-    expect(page).to have_content("Emma Dubois")
+    expect(applications_page.search_results.count).to eq(1)
+    expect(applications_page.search_results.first.name.text).to eq(
+      "Emma Dubois"
+    )
   end
 
   def and_i_apply_the_name_filter
-    fill_in "Applicant name", with: "cher"
-    click_button "Apply filters"
+    applications_page.name_filter.name.set("cher")
+    applications_page.apply_filters.click
   end
 
   def then_i_see_a_list_of_applications_filtered_by_name
-    expect(page).to have_content("Cher Bert")
+    expect(applications_page.search_results.count).to eq(1)
+    expect(applications_page.search_results.first.name.text).to eq("Cher Bert")
   end
 
   def and_i_apply_the_submitted_at_filter
-    fill_in "assessor_interface_filter_form_submitted_at_before_1i",
-            with: "2020"
-    fill_in "assessor_interface_filter_form_submitted_at_before_2i", with: "1"
-    fill_in "assessor_interface_filter_form_submitted_at_before_3i", with: "1"
-    click_button "Apply filters"
+    applications_page.submitted_at_filter.start_day.set(1)
+    applications_page.submitted_at_filter.start_month.set(1)
+    applications_page.submitted_at_filter.start_year.set(2020)
+    applications_page.apply_filters.click
   end
 
   def then_i_see_a_list_of_applications_filtered_by_submitted_at
-    expect(page).to have_content("John Smith")
+    expect(applications_page.search_results.count).to eq(1)
+    expect(applications_page.search_results.first.name.text).to eq("John Smith")
   end
 
   def and_i_apply_the_state_filter
-    check "Awarded (1)", visible: false
-    click_button "Apply filters"
+    awarded_state =
+      applications_page.state_filter.states.find do |state|
+        state.label.text == "Awarded (1)"
+      end
+    awarded_state.checkbox.click
+    applications_page.apply_filters.click
   end
 
   def then_i_see_a_list_of_applications_filtered_by_state
-    expect(page).to have_content("John Smith")
+    expect(applications_page.search_results.count).to eq(1)
+    expect(applications_page.search_results.first.name.text).to eq("John Smith")
   end
 
   def application_forms
@@ -104,21 +116,24 @@ RSpec.describe "Assessor filtering application forms", type: :system do
         :submitted,
         region: create(:region, country: create(:country, code: "US")),
         given_names: "Cher",
-        family_name: "Bert"
+        family_name: "Bert",
+        submitted_at: Date.new(2019, 12, 1)
       ),
       create(
         :application_form,
         :submitted,
         region: create(:region, country: create(:country, code: "FR")),
         given_names: "Emma",
-        family_name: "Dubois"
+        family_name: "Dubois",
+        submitted_at: Date.new(2019, 12, 1)
       ),
       create(
         :application_form,
         :submitted,
         given_names: "Arnold",
         family_name: "Drummond",
-        assessor: assessors.first
+        assessor: assessors.first,
+        submitted_at: Date.new(2019, 12, 1)
       ),
       create(
         :application_form,

--- a/spec/system/assessor_interface/listing_application_forms_spec.rb
+++ b/spec/system/assessor_interface/listing_application_forms_spec.rb
@@ -11,12 +11,12 @@ RSpec.describe "Assessor listing application forms", type: :system do
   end
 
   it "displays a list of applications" do
-    when_i_visit_the_applications_page
+    when_i_visit_the(:applications_page)
     then_i_see_a_list_of_applications
   end
 
   it "paginates the results" do
-    when_i_visit_the_applications_page
+    when_i_visit_the(:applications_page)
     then_i_see_the_pagination_controls
 
     when_i_click_on_next
@@ -33,33 +33,34 @@ RSpec.describe "Assessor listing application forms", type: :system do
     application_forms
   end
 
-  def when_i_visit_the_applications_page
-    visit assessor_interface_application_forms_path
-  end
-
   def when_i_click_on_next
-    click_link "Next"
+    applications_page.pagination.next.click
   end
 
   def then_i_see_a_list_of_applications
-    application_forms[0..19].each do |application_form|
-      expect(page).to have_content(
+    page_one_names =
+      application_forms[0..19].map do |application_form|
         "#{application_form.given_names} #{application_form.family_name}"
-      )
-    end
+      end
+
+    expect(page_one_names).to eq(visible_names)
   end
 
   def then_i_see_the_pagination_controls
-    expect(page).to have_content("1")
-    expect(page).to have_content("Next")
+    expect(applications_page.pagination).to be_visible
   end
 
   def then_i_see_the_next_page_of_applications
-    application_forms[20..24].each do |application_form|
-      expect(page).to have_content(
+    page_two_names =
+      application_forms[20..24].map do |application_form|
         "#{application_form.given_names} #{application_form.family_name}"
-      )
-    end
+      end
+
+    expect(page_two_names).to eq(visible_names)
+  end
+
+  def visible_names
+    applications_page.search_results.map { |result| result.name.text }
   end
 
   def application_forms

--- a/spec/system/assessor_interface/view_application_form_spec.rb
+++ b/spec/system/assessor_interface/view_application_form_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe "Assessor view application form", type: :system do
     given_there_is_an_application_form
 
     when_i_am_authorized_as_an_assessor_user
-    when_i_visit_the_application_page
+    when_i_visit_the(:application_page, application_id:)
     then_i_see_the_application
     and_i_see_the_assessment_tasks
 
     when_i_click_back_link
-    then_i_see_the_application_forms
+    then_i_see_the(:applications_page)
   end
 
   private
@@ -24,33 +24,38 @@ RSpec.describe "Assessor view application form", type: :system do
     application_form
   end
 
-  def when_i_visit_the_application_page
-    visit assessor_interface_application_form_path(application_form)
-  end
-
   def when_i_click_back_link
-    click_link "Back"
+    application_page.back_link.click
   end
 
   def then_i_see_the_application
-    expect(page).to have_content(
+    expect(application_page.overview.name.text).to eq(
       "#{application_form.given_names} #{application_form.family_name}"
     )
-    expect(page).to have_content(application_form.reference)
   end
 
   def and_i_see_the_assessment_tasks
-    expect(page).to have_content("Check submitted details")
-    expect(page).to have_content("Check personal information")
-    expect(page).to have_content("Check qualifications")
-    expect(page).to have_content("Check work history")
-    expect(page).to have_content("Your recommendation")
-    expect(page).to have_content("First assessment")
-    expect(page).to have_content("Second assessment")
-  end
+    expect(application_page.task_list.tasks.count).to eq(2)
 
-  def then_i_see_the_application_forms
-    expect(page).to have_content("Applications")
+    first_section_links =
+      application_page.task_list.tasks.first.items.map { |item| item.link.text }
+
+    expect(first_section_links).to eq(
+      [
+        "Check personal information",
+        "Check qualifications",
+        "Check work history"
+      ]
+    )
+
+    second_section_links =
+      application_page.task_list.tasks.second.items.map do |item|
+        item.link.text
+      end
+
+    expect(second_section_links).to eq(
+      ["First assessment", "Second assessment"]
+    )
   end
 
   def application_form
@@ -61,5 +66,9 @@ RSpec.describe "Assessor view application form", type: :system do
         :with_work_history,
         :with_personal_information
       )
+  end
+
+  def application_id
+    application_form.id
   end
 end

--- a/spec/system/assessor_interface/view_timeline_events_spec.rb
+++ b/spec/system/assessor_interface/view_timeline_events_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Assessor view timeline events", type: :system do
   end
 
   it "displays the timeline events" do
-    when_i_visit_the_application_page
+    when_i_visit_the(:application_page, application_id:)
     and_i_click_view_timeline
     then_i_see_the_timeline
   end
@@ -24,12 +24,8 @@ RSpec.describe "Assessor view timeline events", type: :system do
     application_form
   end
 
-  def when_i_visit_the_application_page
-    application_page.load(application_id: application_form.id)
-  end
-
   def and_i_click_view_timeline
-    application_page.summary_list.click_link(
+    application_page.overview.click_link(
       "View timeline of this applications actions"
     )
   end
@@ -57,15 +53,11 @@ RSpec.describe "Assessor view timeline events", type: :system do
       end
   end
 
+  def application_id
+    application_form.id
+  end
+
   def assessor
     @assessor ||= create(:staff, :confirmed)
-  end
-
-  def application_page
-    @application_page ||= PageObjects::AssessorInterface::Application.new
-  end
-
-  def timeline_page
-    @timeline_page ||= PageObjects::AssessorInterface::Timeline.new
   end
 end


### PR DESCRIPTION
* Update the assessor interface system specs to use page objects
* Add PageHelpers module to centralise the creation of page objects.

I've not updated any other specs to use the PageHelpers module. I'll do that in a separate PR if this approach is merged.