### PR TITLE
Create section assessments model and factory

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -8,10 +8,21 @@ class AssessmentFactory
   end
 
   def call
-    Assessment.create!(application_form:)
+    sections = section_keys.map { |key| AssessmentSection.new(key:) }
+    Assessment.create!(application_form:, sections:)
   end
 
   private
 
   attr_reader :application_form
+
+  def section_keys
+    %i[personal_information qualifications].tap do |keys|
+      keys << :work_history if application_form.needs_work_history
+      if application_form.needs_written_statement ||
+           application_form.needs_registration_number
+        keys << :professional_standing
+      end
+    end
+  end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -52,6 +52,7 @@ class ApplicationForm < ApplicationRecord
   has_many :qualifications
   has_many :documents, as: :documentable
   has_many :timeline_events
+  has_one :assessment
 
   before_create :build_documents
 

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -32,6 +32,7 @@ class Assessment < ApplicationRecord
             }
 
   def finished?
-    award? || decline?
+    sections.none? { |section| section.state == :not_started } &&
+      (award? || decline?)
   end
 end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -19,6 +19,8 @@
 class Assessment < ApplicationRecord
   belongs_to :application_form
 
+  has_many :sections, class_name: "AssessmentSection"
+
   enum :recommendation,
        { unknown: "unknown", award: "award", decline: "decline" },
        default: :unknown

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -1,0 +1,43 @@
+# == Schema Information
+#
+# Table name: assessment_sections
+#
+#  id                       :bigint           not null, primary key
+#  checks                   :string           default([]), is an Array
+#  failure_reasons          :string           default([]), is an Array
+#  key                      :string           not null
+#  passed                   :boolean
+#  selected_failure_reasons :string           default([]), is an Array
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  assessment_id            :bigint           not null
+#
+# Indexes
+#
+#  index_assessment_sections_on_assessment_id          (assessment_id)
+#  index_assessment_sections_on_assessment_id_and_key  (assessment_id,key) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#
+class AssessmentSection < ApplicationRecord
+  belongs_to :assessment
+
+  enum :key,
+       {
+         personal_information: "personal_information",
+         qualifications: "qualifications",
+         work_history: "work_history",
+         professional_standing: "professional_standing"
+       }
+
+  validates :key,
+            presence: true,
+            uniqueness: {
+              scope: [:assessment]
+            },
+            inclusion: {
+              in: keys.values
+            }
+end

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -40,4 +40,9 @@ class AssessmentSection < ApplicationRecord
             inclusion: {
               in: keys.values
             }
+
+  def state
+    return :not_started if passed.nil?
+    passed ? :completed : :action_required
+  end
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -116,6 +116,16 @@
     - teaching_authority_other
     - teaching_authority_certificate
     - application_form_enabled
+  :assessment_sections:
+    - id
+    - assessment_id
+    - key
+    - passed
+    - checks
+    - failure_reasons
+    - selected_failure_reasons
+    - created_at
+    - updated_at
   :staff:
     - id
     - email

--- a/db/migrate/20220909100205_create_assessment_sections.rb
+++ b/db/migrate/20220909100205_create_assessment_sections.rb
@@ -1,0 +1,15 @@
+class CreateAssessmentSections < ActiveRecord::Migration[7.0]
+  def change
+    create_table :assessment_sections do |t|
+      t.references :assessment, null: false, foreign_key: true
+      t.string :key, null: false
+      t.boolean :passed
+      t.string :checks, array: true, default: []
+      t.string :failure_reasons, array: true, default: []
+      t.string :selected_failure_reasons, array: true, default: []
+      t.timestamps
+    end
+
+    add_index :assessment_sections, %i[assessment_id key], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_09_084614) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_09_100205) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,6 +74,19 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_09_084614) do
     t.index ["reviewer_id"], name: "index_application_forms_on_reviewer_id"
     t.index ["state"], name: "index_application_forms_on_state"
     t.index ["teacher_id"], name: "index_application_forms_on_teacher_id"
+  end
+
+  create_table "assessment_sections", force: :cascade do |t|
+    t.bigint "assessment_id", null: false
+    t.string "key", null: false
+    t.boolean "passed"
+    t.string "checks", default: [], array: true
+    t.string "failure_reasons", default: [], array: true
+    t.string "selected_failure_reasons", default: [], array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessment_id", "key"], name: "index_assessment_sections_on_assessment_id_and_key", unique: true
+    t.index ["assessment_id"], name: "index_assessment_sections_on_assessment_id"
   end
 
   create_table "assessments", force: :cascade do |t|
@@ -259,6 +272,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_09_084614) do
   add_foreign_key "application_forms", "staff", column: "assessor_id"
   add_foreign_key "application_forms", "staff", column: "reviewer_id"
   add_foreign_key "application_forms", "teachers"
+  add_foreign_key "assessment_sections", "assessments"
   add_foreign_key "assessments", "application_forms"
   add_foreign_key "eligibility_checks", "regions"
   add_foreign_key "qualifications", "application_forms"

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -30,7 +30,9 @@ namespace :example_data do
       country.regions.each do |region|
         application_form_traits_for(region).each do |traits|
           teacher = FactoryBot.create(:teacher, :confirmed)
-          FactoryBot.create(:application_form, *traits, teacher:, region:)
+          application_form =
+            FactoryBot.create(:application_form, *traits, teacher:, region:)
+          AssessmentFactory.call(application_form:)
         end
       end
     end

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -71,6 +71,12 @@ FactoryBot.define do
       submitted_at { Time.zone.now }
     end
 
+    trait :with_assessment do
+      after(:create) do |application_form, _evaluator|
+        create(:assessment, application_form:)
+      end
+    end
+
     trait :with_age_range do
       age_range_min { Faker::Number.between(from: 5, to: 11) }
       age_range_max { Faker::Number.between(from: age_range_min, to: 18) }

--- a/spec/factories/assessment_sections.rb
+++ b/spec/factories/assessment_sections.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: assessment_sections
+#
+#  id                       :bigint           not null, primary key
+#  checks                   :string           default([]), is an Array
+#  failure_reasons          :string           default([]), is an Array
+#  key                      :string           not null
+#  passed                   :boolean
+#  selected_failure_reasons :string           default([]), is an Array
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  assessment_id            :bigint           not null
+#
+# Indexes
+#
+#  index_assessment_sections_on_assessment_id          (assessment_id)
+#  index_assessment_sections_on_assessment_id_and_key  (assessment_id,key) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#
+FactoryBot.define do
+  factory :assessment_section do
+    association :assessment
+
+    trait :passed do
+      passed { true }
+    end
+
+    trait :failed do
+      passed { false }
+    end
+  end
+end

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -17,5 +17,45 @@ RSpec.describe AssessmentFactory do
       expect(assessment.unknown?).to be true
       expect(assessment.application_form).to eq(application_form)
     end
+
+    describe "sections" do
+      subject(:sections) { call.sections }
+
+      it "creates two assessments" do
+        expect(sections.count).to eq(2)
+      end
+
+      it "creates a personal information assessment" do
+        expect(sections.personal_information.count).to eq(1)
+      end
+
+      it "creates a qualifications assessment" do
+        expect(sections.qualifications.count).to eq(1)
+      end
+
+      context "with work history" do
+        before { application_form.needs_work_history = true }
+
+        it "creates a work history assessment" do
+          expect(sections.work_history.count).to eq(1)
+        end
+      end
+
+      context "with written statement" do
+        before { application_form.needs_written_statement = true }
+
+        it "creates a professional standing assessment" do
+          expect(sections.professional_standing.count).to eq(1)
+        end
+      end
+
+      context "with registration number" do
+        before { application_form.needs_registration_number = true }
+
+        it "creates a professional standing assessment" do
+          expect(sections.professional_standing.count).to eq(1)
+        end
+      end
+    end
   end
 end

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -42,4 +42,23 @@ RSpec.describe AssessmentSection, type: :model do
       ).backed_by_column_of_type(:string)
     end
   end
+
+  describe "#state" do
+    subject(:state) { assessment_section.state }
+
+    context "with a passed assessment" do
+      before { assessment_section.passed = true }
+      it { is_expected.to eq(:completed) }
+    end
+
+    context "with a failed assessment" do
+      before { assessment_section.passed = false }
+      it { is_expected.to eq(:action_required) }
+    end
+
+    context "with no assessment yet" do
+      before { assessment_section.passed = nil }
+      it { is_expected.to eq(:not_started) }
+    end
+  end
 end

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: assessment_sections
+#
+#  id                       :bigint           not null, primary key
+#  checks                   :string           default([]), is an Array
+#  failure_reasons          :string           default([]), is an Array
+#  key                      :string           not null
+#  passed                   :boolean
+#  selected_failure_reasons :string           default([]), is an Array
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  assessment_id            :bigint           not null
+#
+# Indexes
+#
+#  index_assessment_sections_on_assessment_id          (assessment_id)
+#  index_assessment_sections_on_assessment_id_and_key  (assessment_id,key) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#
+require "rails_helper"
+
+RSpec.describe AssessmentSection, type: :model do
+  subject(:assessment_section) { build(:assessment_section) }
+
+  describe "validations" do
+    it { is_expected.to belong_to(:assessment) }
+
+    it { is_expected.to validate_presence_of(:key) }
+
+    it do
+      is_expected.to define_enum_for(:key).with_values(
+        personal_information: "personal_information",
+        qualifications: "qualifications",
+        work_history: "work_history",
+        professional_standing: "professional_standing"
+      ).backed_by_column_of_type(:string)
+    end
+  end
+end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -58,5 +58,14 @@ RSpec.describe Assessment, type: :model do
       before { assessment.decline! }
       it { is_expected.to be true }
     end
+
+    context "with unfinished section assessments" do
+      before do
+        assessment.save!
+        assessment.sections.create!(key: :personal_information)
+      end
+
+      it { is_expected.to be false }
+    end
   end
 end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe Assessment, type: :model do
   subject(:assessment) { build(:assessment) }
 
   describe "validations" do
+    it { is_expected.to have_many(:sections) }
+
     it { is_expected.to validate_presence_of(:recommendation) }
 
     it do

--- a/spec/system/assessor_interface/assigning_assessor_spec.rb
+++ b/spec/system/assessor_interface/assigning_assessor_spec.rb
@@ -59,7 +59,12 @@ RSpec.describe "Assigning an assessor", type: :system do
 
   def application_form
     @application_form ||=
-      create(:application_form, :with_personal_information, :submitted)
+      create(
+        :application_form,
+        :with_personal_information,
+        :submitted,
+        :with_assessment
+      )
   end
 
   def assessor

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -107,11 +107,12 @@ RSpec.describe "Assessor check submitted details", type: :system do
     @application_form ||=
       create(
         :application_form,
-        :submitted,
         :with_completed_qualification,
         :with_work_history,
         :with_registration_number,
-        :with_personal_information
+        :with_personal_information,
+        :submitted,
+        :with_assessment
       )
   end
 

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -40,7 +40,12 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
   def application_form
     @application_form ||=
-      create(:application_form, :with_personal_information, :submitted)
+      create(
+        :application_form,
+        :with_personal_information,
+        :submitted,
+        :with_assessment
+      )
   end
 
   def application_id

--- a/spec/system/assessor_interface/view_application_form_spec.rb
+++ b/spec/system/assessor_interface/view_application_form_spec.rb
@@ -41,11 +41,7 @@ RSpec.describe "Assessor view application form", type: :system do
       application_page.task_list.tasks.first.items.map { |item| item.link.text }
 
     expect(first_section_links).to eq(
-      [
-        "Check personal information",
-        "Check qualifications",
-        "Check work history"
-      ]
+      ["Check personal information", "Check qualifications"]
     )
 
     second_section_links =
@@ -60,12 +56,29 @@ RSpec.describe "Assessor view application form", type: :system do
 
   def application_form
     @application_form ||=
-      create(
-        :application_form,
-        :submitted,
-        :with_work_history,
-        :with_personal_information
-      )
+      begin
+        application_form =
+          create(
+            :application_form,
+            :with_work_history,
+            :with_personal_information,
+            :submitted,
+            :with_assessment
+          )
+
+        create(
+          :assessment_section,
+          :personal_information,
+          assessment: application_form.assessment
+        )
+        create(
+          :assessment_section,
+          :qualifications,
+          assessment: application_form.assessment
+        )
+
+        application_form
+      end
   end
 
   def application_id

--- a/spec/system/assessor_interface/view_timeline_events_spec.rb
+++ b/spec/system/assessor_interface/view_timeline_events_spec.rb
@@ -46,7 +46,8 @@ RSpec.describe "Assessor view timeline events", type: :system do
   def application_form
     @application_form ||=
       begin
-        application_form = create(:application_form, :submitted)
+        application_form =
+          create(:application_form, :submitted, :with_assessment)
         create(:timeline_event, :assessor_assigned, application_form:)
         create(:timeline_event, :state_changed, application_form:)
         application_form

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -37,6 +37,9 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
 
   describe "#assessment_tasks" do
     let(:application_form) { create(:application_form) }
+    let(:assessment) { create(:assessment, application_form:) }
+    before { create(:assessment_section, :personal_information, assessment:) }
+
     let(:params) { { id: application_form.id } }
 
     subject(:assessment_tasks) { view_object.assessment_tasks }
@@ -45,33 +48,17 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       subject(:submitted_details) { assessment_tasks.fetch(:submitted_details) }
 
       context "with work history" do
-        before { application_form.update!(needs_work_history: true) }
+        before { create(:assessment_section, :work_history, assessment:) }
 
-        it do
-          is_expected.to eq(
-            %i[personal_information qualifications work_history]
-          )
-        end
+        it { is_expected.to eq(%i[personal_information work_history]) }
       end
 
-      context "with written statement" do
-        before { application_form.update!(needs_written_statement: true) }
-
-        it do
-          is_expected.to eq(
-            %i[personal_information qualifications professional_standing]
-          )
+      context "with professional standing statement" do
+        before do
+          create(:assessment_section, :professional_standing, assessment:)
         end
-      end
 
-      context "with registration number" do
-        before { application_form.update!(needs_registration_number: true) }
-
-        it do
-          is_expected.to eq(
-            %i[personal_information qualifications professional_standing]
-          )
-        end
+        it { is_expected.to eq(%i[personal_information professional_standing]) }
       end
     end
 
@@ -147,20 +134,26 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
   end
 
   describe "#assessment_task_status" do
+    let(:application_form) { create(:application_form) }
+    let(:assessment) { create(:assessment, application_form:) }
+    before { create(:assessment_section, :personal_information, assessment:) }
+
+    let(:params) { { id: application_form.id } }
+
     subject(:assessment_task_status) do
       view_object.assessment_task_status(section, item)
     end
 
-    let(:item) { nil }
-
     context "with submitted details section" do
       let(:section) { :submitted_details }
+      let(:item) { :personal_information }
 
-      it { is_expected.to eq(:in_progress) }
+      it { is_expected.to eq(:not_started) }
     end
 
     context "with recommendation section" do
       let(:section) { :recommendation }
+      let(:item) { nil }
 
       it { is_expected.to eq(:not_started) }
     end


### PR DESCRIPTION
Following on from https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/484 which starts to implement the decisions made, specifically the creation of an `SectionAssessment` model and updates the `AssessmentFactory` class.

Depends on #487.

[Trello Card](https://trello.com/c/R9PMJPmY/851-spike-assessment-sections-data-structure)