### PR TITLE
Add checks and failure reasons for personal information

### DIFF
--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -10,9 +10,11 @@
              application_form: @application_form,
              changeable: false %>
 
-  <%= render "shared/application_form/identity_document_summary",
-             application_form: @application_form,
-             changeable: false %>
+  <% if @application_form.has_alternative_name %>
+    <%= render "shared/application_form/identity_document_summary",
+               application_form: @application_form,
+               changeable: false %>
+  <% end %>
 <% when "qualifications" %>
   <%= render "shared/application_form/qualifications_summary",
              application_form: @application_form,

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -20,6 +20,18 @@ en:
           qualifications: Check qualifications
           work_history: Check work history
           professional_standing: Check professional standing
+        checks:
+          identification_document_present: a valid ID document is present
+          name_change_document_present: evidence of name change is present (if the name entered on the form is different to the name on their ID)
+          duplicate_application: up-front duplication check shows the applicant does not have another in-flight application
+          applicant_already_qts: applicant does not already hold QTS and induction exemption
+        failure_reasons:
+          identification_document_expired: The ID document has expired.
+          identification_document_illegible: The ID document is illegible.
+          identification_document_mismatch: The name on the online application form is different from the ID document, but no evidence of change of name was provided.
+          name_change_document_illegible: The evidence of change of name is illegible.
+          duplicate_application: There’s already another in-flight application for this applicant.
+          applicant_already_qts: The applicant already holds QTS and induction exemption.
     timeline_events:
       index:
         title:

--- a/spec/factories/assessment_sections.rb
+++ b/spec/factories/assessment_sections.rb
@@ -32,5 +32,13 @@ FactoryBot.define do
     trait :failed do
       passed { false }
     end
+
+    trait :personal_information do
+      key { "personal_information" }
+      checks { %w[identification_document_present] }
+      failure_reasons do
+        %w[identification_document_expired identification_document_illegible]
+      end
+    end
   end
 end

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -29,6 +29,38 @@ RSpec.describe AssessmentFactory do
         expect(sections.personal_information.count).to eq(1)
       end
 
+      it "has the right checks and failure reasons" do
+        section = sections.personal_information.first
+        expect(section.checks).to eq(
+          %w[
+            identification_document_present
+            duplicate_application
+            applicant_already_qts
+          ]
+        )
+        expect(section.failure_reasons).to eq(
+          %w[
+            identification_document_expired
+            identification_document_illegible
+            identification_document_mismatch
+            duplicate_application
+            applicant_already_qts
+          ]
+        )
+      end
+
+      context "with a name change document" do
+        before { application_form.update!(has_alternative_name: true) }
+
+        it "has the right checks and failure reasons" do
+          section = sections.personal_information.first
+          expect(section.checks).to include("name_change_document_present")
+          expect(section.failure_reasons).to include(
+            "name_change_document_illegible"
+          )
+        end
+      end
+
       it "creates a qualifications assessment" do
         expect(sections.qualifications.count).to eq(1)
       end

--- a/spec/support/page_objects/assessor_interface/application.rb
+++ b/spec/support/page_objects/assessor_interface/application.rb
@@ -18,6 +18,7 @@ module PageObjects
                    "ol.app-task-list > li > ul.app-task-list__items > li.app-task-list__item" do
             element :heading, "h2"
             element :link, "a"
+            element :status, "strong"
           end
         end
       end

--- a/spec/support/page_objects/assessor_interface/assessment_section.rb
+++ b/spec/support/page_objects/assessor_interface/assessment_section.rb
@@ -10,6 +10,9 @@ module PageObjects
         section :no_radio_item,
                 PageObjects::GovukRadioItem,
                 ".govuk-radios__item:nth-of-type(2)"
+        sections :failure_reason_checkbox_items,
+                 PageObjects::GovukCheckboxItem,
+                 ".govuk-checkboxes__item"
         element :continue_button, "button"
       end
     end

--- a/spec/support/page_objects/govuk_checkbox_item.rb
+++ b/spec/support/page_objects/govuk_checkbox_item.rb
@@ -1,8 +1,6 @@
 module PageObjects
-  module AssessorInterface
-    class GovukCheckboxItem < SitePrism::Section
-      element :label, "label"
-      element :checkbox, "input", visible: false
-    end
+  class GovukCheckboxItem < SitePrism::Section
+    element :label, "label"
+    element :checkbox, "input", visible: false
   end
 end

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -8,6 +8,32 @@ RSpec.describe "Assessor check submitted details", type: :system do
     given_i_am_authorized_as_an_assessor_user(assessor)
   end
 
+  it "allows passing the personal information" do
+    when_i_visit_the(
+      :check_personal_information_page,
+      application_id:,
+      assessment_id:
+    )
+    then_i_see_the_personal_information
+
+    when_i_choose_check_personal_information_yes
+    then_i_see_the(:application_page, application_id:)
+    and_i_see_check_personal_information_completed
+  end
+
+  it "allows failing the personal information" do
+    when_i_visit_the(
+      :check_personal_information_page,
+      application_id:,
+      assessment_id:
+    )
+    then_i_see_the_personal_information
+
+    when_i_choose_check_personal_information_no
+    then_i_see_the(:application_page, application_id:)
+    and_i_see_check_personal_information_action_required
+  end
+
   it "allows checking the qualifications" do
     when_i_visit_the(
       :check_qualifications_page,
@@ -40,18 +66,6 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the(:application_page, application_id:)
   end
 
-  it "allows checking the personal information" do
-    when_i_visit_the(
-      :check_personal_information_page,
-      application_id:,
-      assessment_id:
-    )
-    then_i_see_the_personal_information
-
-    when_i_click_check_personal_information_continue
-    then_i_see_the(:application_page, application_id:)
-  end
-
   private
 
   def given_an_assessor_exists
@@ -60,6 +74,47 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def given_there_is_an_application_form
     application_form
+  end
+
+  def then_i_see_the_personal_information
+    expect(
+      check_personal_information_page.personal_information.given_names.text
+    ).to eq(application_form.given_names)
+    expect(
+      check_personal_information_page.personal_information.family_name.text
+    ).to eq(application_form.family_name)
+  end
+
+  def when_i_choose_check_personal_information_yes
+    check_personal_information_page.form.yes_radio_item.input.click
+    check_personal_information_page.form.continue_button.click
+  end
+
+  def personal_information_task_item
+    application_page.task_list.tasks.first.items.find do |item|
+      item.link.text == "Check personal information"
+    end
+  end
+
+  def and_i_see_check_personal_information_completed
+    expect(personal_information_task_item.status).to have_content("COMPLETED")
+  end
+
+  def when_i_choose_check_personal_information_no
+    check_personal_information_page.form.no_radio_item.input.click
+    check_personal_information_page
+      .form
+      .failure_reason_checkbox_items
+      .first
+      .checkbox
+      .click
+    check_personal_information_page.form.continue_button.click
+  end
+
+  def and_i_see_check_personal_information_action_required
+    expect(personal_information_task_item.status).to have_content(
+      "ACTION REQUIRED"
+    )
   end
 
   def then_i_see_the_qualifications
@@ -86,15 +141,6 @@ RSpec.describe "Assessor check submitted details", type: :system do
     ).to eq(application_form.registration_number)
   end
 
-  def then_i_see_the_personal_information
-    expect(
-      check_personal_information_page.personal_information.given_names.text
-    ).to eq(application_form.given_names)
-    expect(
-      check_personal_information_page.personal_information.family_name.text
-    ).to eq(application_form.family_name)
-  end
-
   def when_i_click_check_qualifications_continue
     check_qualifications_page.form.continue_button.click
   end
@@ -105,10 +151,6 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def when_i_click_check_professional_standing_continue
     check_professional_standing_page.form.continue_button.click
-  end
-
-  def when_i_click_check_personal_information_continue
-    check_personal_information_page.form.continue_button.click
   end
 
   def assessor


### PR DESCRIPTION
This adds the checks and failure reasons an assessor needs to perform the assessment of the personal information section.

[Trello Card](https://trello.com/c/EQ9Wz3Sx/852-personal-information-outcome)

## Screenshot

![Screenshot 2022-09-12 at 10 25 43](https://user-images.githubusercontent.com/510498/189634438-e32e06c8-f75b-40c3-bf83-2f44be2514b4.png)
