### PR TITLE
Teacher interface refactor

### DIFF
--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -1,6 +1,15 @@
 module PageHelpers
-  def application_page
-    @application_page ||= PageObjects::AssessorInterface::Application.new
+  def then_i_see_the(page, **args)
+    expect(send(page.to_sym)).to be_displayed(**args)
+  end
+
+  def when_i_visit_the(page, **args)
+    send(page.to_sym).load(**args)
+  end
+
+  def assessor_application_page
+    @assessor_application_page ||=
+      PageObjects::AssessorInterface::Application.new
   end
 
   def applications_page
@@ -93,11 +102,119 @@ module PageHelpers
     @timeline_page ||= PageObjects::AssessorInterface::Timeline.new
   end
 
-  def then_i_see_the(page, **args)
-    expect(send(page.to_sym)).to be_displayed(**args)
+  def teacher_sign_in_page
+    @teacher_sign_in_page = PageObjects::TeacherInterface::SignIn.new
   end
 
-  def when_i_visit_the(page, **args)
-    send(page.to_sym).load(**args)
+  def teacher_sign_up_page
+    @teacher_sign_up_page = PageObjects::TeacherInterface::SignUp.new
+  end
+
+  def document_form_page
+    @document_form_page = PageObjects::TeacherInterface::DocumentForm.new
+  end
+
+  def check_uploaded_files_page
+    @check_uploaded_files_page =
+      PageObjects::TeacherInterface::CheckUploadedFiles.new
+  end
+
+  def check_email_page
+    @check_email_page = PageObjects::TeacherInterface::CheckYourEmail.new
+  end
+
+  def new_application_form_page
+    @new_application_form_page =
+      PageObjects::TeacherInterface::NewApplicationForm.new
+  end
+
+  def signed_out_page
+    @signed_out_page = PageObjects::TeacherInterface::SignedOut.new
+  end
+
+  def teacher_application_page
+    @teacher_application_page = PageObjects::TeacherInterface::Application.new
+  end
+
+  def new_teacher_form_page
+    @new_teacher_form_page =
+      PageObjects::TeacherInterface::NewApplicationForm.new
+  end
+
+  def subjects_form_page
+    @subjects_form_page = PageObjects::TeacherInterface::SubjectsForm.new
+  end
+
+  def work_history_form_page
+    @work_history_form_page = PageObjects::TeacherInterface::WorkHistoryForm.new
+  end
+
+  def delete_confirmation_page
+    @delete_confirmation_page =
+      PageObjects::TeacherInterface::DeleteConfirmationForm.new
+  end
+
+  def written_statement_page
+    @written_statement_page =
+      PageObjects::TeacherInterface::WrittenStatement.new
+  end
+
+  def personal_information_summary_page
+    @personal_information_summary_page =
+      PageObjects::TeacherInterface::PersonalInformationSummary.new
+  end
+
+  def qualification_summary_page
+    @qualification_summary_page =
+      PageObjects::TeacherInterface::QualificationSummary.new
+  end
+
+  def qualifications_form_page
+    @qualifications_form_page =
+      PageObjects::TeacherInterface::QualificationsForm.new
+  end
+
+  def name_and_date_of_birth_page
+    @name_and_date_of_birth_page =
+      PageObjects::TeacherInterface::NameAndDateOfBirth.new
+  end
+
+  def check_your_answers_page
+    @check_your_answers_page =
+      PageObjects::TeacherInterface::CheckYourAnswers.new
+  end
+
+  def work_history_summary_page
+    @work_history_summary_page =
+      PageObjects::TeacherInterface::WorkHistorySummary.new
+  end
+
+  def upload_document_page
+    @upload_document_page =
+      PageObjects::TeacherInterface::UploadDocumentForm.new
+  end
+
+  def submitted_application_page
+    @submitted_application_page =
+      PageObjects::TeacherInterface::SubmittedApplication.new
+  end
+
+  def check_your_uploads_page
+    @check_your_uploads_page =
+      PageObjects::TeacherInterface::CheckYourUploads.new
+  end
+
+  def alternative_name_page
+    @alternative_name_page =
+      PageObjects::TeacherInterface::AlternativeNameForm.new
+  end
+
+  def age_range_form
+    @age_range_page = PageObjects::TeacherInterface::AgeRangeForm.new
+  end
+
+  def registration_number_form
+    @registration_number_form =
+      PageObjects::TeacherInterface::RegistrationNumberForm.new
   end
 end

--- a/spec/support/page_objects/teacher_interface/age_range_form.rb
+++ b/spec/support/page_objects/teacher_interface/age_range_form.rb
@@ -1,0 +1,8 @@
+module PageObjects
+  module TeacherInterface
+    class AgeRangeForm < SitePrism::Page
+      element :heading, "h1"
+      element :grid, ".govuk-grid-row"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/alternative_name_form.rb
+++ b/spec/support/page_objects/teacher_interface/alternative_name_form.rb
@@ -1,0 +1,8 @@
+module PageObjects
+  module TeacherInterface
+    class AlternativeNameForm < SitePrism::Page
+      element :heading, "h1"
+      element :grid, ".govuk-grid-row"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/application.rb
+++ b/spec/support/page_objects/teacher_interface/application.rb
@@ -1,0 +1,37 @@
+module PageObjects
+  module TeacherInterface
+    class TaskListItem < SitePrism::Section
+      element :link, "a"
+      element :status, ".govuk-tag"
+    end
+
+    class TaskListSection < SitePrism::Section
+      element :heading, "h2"
+      sections :task_list_items, TaskListItem, ".app-task-list__item"
+    end
+
+    class Application < SitePrism::Page
+      set_url "/teacher/application"
+
+      element :heading, "h1"
+      element :content_title, "app-task-list_section"
+      element :app_task_list, ".app-task-list"
+
+      element :check_answers, ".govuk-button:nth-of-type(1)"
+      element :save_and_sign_out, ".govuk-button:nth-of-type(2)"
+
+      sections :task_list_sections, TaskListSection, ".app-task-list>li"
+
+      def find_item(link_text)
+        task_list_sections
+          .flat_map(&:task_list_items)
+          .map(&:link)
+          .find { |link| link.text == link_text }
+      end
+
+      def click_item(link_text)
+        find_item(link_text).click
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/check_uploaded_files.rb
+++ b/spec/support/page_objects/teacher_interface/check_uploaded_files.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module TeacherInterface
+    class CheckUploadedFiles < SitePrism::Page
+      set_url "/teacher/application/documents/{application_id}/edit"
+
+      element :heading, "h1"
+      element :files, ".govuk-grid-row .govuk-grid-column-two-thirds"
+      element :continue_button, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/check_your_answers.rb
+++ b/spec/support/page_objects/teacher_interface/check_your_answers.rb
@@ -1,0 +1,12 @@
+module PageObjects
+  module TeacherInterface
+    class CheckYourAnswers < SitePrism::Page
+      element :heading, "h1"
+      element :content_title, "app-task-list_section"
+      element :heading_1, ".govuk-heading-m:nth-of-type(1)"
+      element :heading_2, ".govuk-heading-m:nth-of-type(2)"
+      element :heading_3, ".govuk-heading-m:nth-of-type(3)"
+      element :content, ".govuk-summary-list__card:nth-of-type(4)"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/check_your_email.rb
+++ b/spec/support/page_objects/teacher_interface/check_your_email.rb
@@ -1,0 +1,12 @@
+module PageObjects
+  module TeacherInterface
+    class CheckYourEmail < SitePrism::Page
+      set_url "/teacher/check_email?{?email}"
+
+      element :heading, "h1"
+      element :email_heading, "gov-uk-heading-xl"
+      element :email_field, "govuk-input"
+      element :continue_button, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/check_your_uploads.rb
+++ b/spec/support/page_objects/teacher_interface/check_your_uploads.rb
@@ -1,0 +1,8 @@
+module PageObjects
+  module TeacherInterface
+    class CheckYourUploads < SitePrism::Page
+      element :heading, "h1"
+      element :summary_list_row, ".govuk-summary-list__row"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/delete_confirmation_form.rb
+++ b/spec/support/page_objects/teacher_interface/delete_confirmation_form.rb
@@ -1,0 +1,8 @@
+module PageObjects
+  module TeacherInterface
+    class DeleteConfirmationForm < SitePrism::Page
+      element :heading, "h1"
+      element :delete_button, ".govuk-button:"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/document_form.rb
+++ b/spec/support/page_objects/teacher_interface/document_form.rb
@@ -1,0 +1,8 @@
+module PageObjects
+  module TeacherInterface
+    class DocumentForm < SitePrism::Page
+      element :heading, "h1"
+      element :continue_button, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/name_and_date_of_birth.rb
+++ b/spec/support/page_objects/teacher_interface/name_and_date_of_birth.rb
@@ -1,0 +1,8 @@
+module PageObjects
+  module TeacherInterface
+    class NameAndDateOfBirth < SitePrism::Page
+      element :heading, "h1"
+      element :grid, ".govuk-grid-row"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/new_application_form.rb
+++ b/spec/support/page_objects/teacher_interface/new_application_form.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module TeacherInterface
+    class NewApplicationForm < SitePrism::Page
+      set_url "/teacher/sign_up"
+
+      element :heading, ".govuk-label"
+      element :email_field, "govuk-input"
+      element :continue_button, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/personal_information_summary.rb
+++ b/spec/support/page_objects/teacher_interface/personal_information_summary.rb
@@ -1,0 +1,10 @@
+module PageObjects
+  module TeacherInterface
+    class PersonalInformationSummary < SitePrism::Page
+      set_url "/teacher/application/personal_information/check"
+
+      element :heading, "h1"
+      element :summary_card, ".govuk-summary-list"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/qualification_summary.rb
+++ b/spec/support/page_objects/teacher_interface/qualification_summary.rb
@@ -1,0 +1,8 @@
+module PageObjects
+  module TeacherInterface
+    class QualificationSummary < SitePrism::Page
+      element :heading, "h1"
+      element :summary_card, ".govuk-summary-list__card:nth-of-type(1)"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/qualifications_form.rb
+++ b/spec/support/page_objects/teacher_interface/qualifications_form.rb
@@ -1,0 +1,8 @@
+module PageObjects
+  module TeacherInterface
+    class QualificationsForm < SitePrism::Page
+      element :heading, "h1"
+      element :body, ".govuk-body-l"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/registration_number_form.rb
+++ b/spec/support/page_objects/teacher_interface/registration_number_form.rb
@@ -1,0 +1,8 @@
+module PageObjects
+  module TeacherInterface
+    class RegistrationNumberForm < SitePrism::Page
+      element :heading, "h1"
+      element :input_number, ".govuk-input"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/sign_in.rb
+++ b/spec/support/page_objects/teacher_interface/sign_in.rb
@@ -1,0 +1,13 @@
+module PageObjects
+  module TeacherInterface
+    class SignIn < SitePrism::Page
+      set_url "/teacher/sign_in/"
+
+      element :heading, "h1"
+      element :radio_heading, "govuk-fieldset__legend govuk-fieldset__legend--m"
+      element :continue_button, ".govuk-button"
+      element :radio_button, "govuk-radios__input"
+      element :email_input, "govuk-input"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/sign_up.rb
+++ b/spec/support/page_objects/teacher_interface/sign_up.rb
@@ -1,0 +1,12 @@
+module PageObjects
+  module TeacherInterface
+    class SignUp < SitePrism::Page
+      set_url "/teacher/sign_up/"
+
+      element :heading, "h1"
+      element :email_heading, ".govuk-heading-xl"
+      element :hint, "#teacher-email-hint"
+      element :continue_button, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/signed_out.rb
+++ b/spec/support/page_objects/teacher_interface/signed_out.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module TeacherInterface
+    class SignedOut < SitePrism::Page
+      set_url "/teacher/signed_out"
+
+      element :body_content, ".govuk-main-wrapper"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/subjects_form.rb
+++ b/spec/support/page_objects/teacher_interface/subjects_form.rb
@@ -1,0 +1,10 @@
+module PageObjects
+  module TeacherInterface
+    class SubjectsForm < SitePrism::Page
+      element :heading, "h1"
+      element :input_subject, ".govuk-input"
+      element :continue_button, ".govuk-button:nth-of-type(1)"
+      element :save_and_come_back, ".govuk-button:nth-of-type(1)"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/submitted_application_form.rb
+++ b/spec/support/page_objects/teacher_interface/submitted_application_form.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module TeacherInterface
+    class SubmittedApplication < SitePrism::Page
+      element :heading_1, ".govuk-heading-xl"
+      element :heading_2, ".govuk-panel__title"
+      element :reference, ".govuk-panel__body"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/upload_document_form.rb
+++ b/spec/support/page_objects/teacher_interface/upload_document_form.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module TeacherInterface
+    class UploadDocumentForm < SitePrism::Page
+      element :heading, "h1"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/work_history_form.rb
+++ b/spec/support/page_objects/teacher_interface/work_history_form.rb
@@ -1,0 +1,8 @@
+module PageObjects
+  module TeacherInterface
+    class WorkHistoryForm < SitePrism::Page
+      element :heading, "h1"
+      element :grid, ".govuk-grid-row"
+    end
+  end
+end

--- a/spec/support/page_objects/teacher_interface/work_history_summary.rb
+++ b/spec/support/page_objects/teacher_interface/work_history_summary.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module TeacherInterface
+    class WorkHistorySummary < SitePrism::Page
+      element :heading, "h1"
+      element :summary_card_1, ".govuk-summary-list__card:nth-of-type(1)"
+      element :summary_card_2, ".govuk-summary-list__card:nth-of-type(2)"
+    end
+  end
+end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -126,12 +126,18 @@ module SystemHelpers
   end
 
   def then_i_see_the_sign_in_form
-    expect(page).to have_title(
+    expect(teacher_sign_in_page).to have_title(
       "Apply for qualified teacher status (QTS) in England"
     )
-    expect(page).to have_content("Have you used the service before?")
-    expect(page).to have_content("Yes, sign in and continue application")
-    expect(page).to have_content("No, I need to check my eligibility")
+    expect(teacher_sign_in_page).to have_content(
+      "Have you used the service before?"
+    )
+    expect(teacher_sign_in_page).to have_content(
+      "Yes, sign in and continue application"
+    )
+    expect(teacher_sign_in_page).to have_content(
+      "No, I need to check my eligibility"
+    )
   end
 
   def and_i_sign_up

--- a/spec/system/assessor_interface/assigning_assessor_spec.rb
+++ b/spec/system/assessor_interface/assigning_assessor_spec.rb
@@ -41,7 +41,9 @@ RSpec.describe "Assigning an assessor", type: :system do
   end
 
   def then_the_assessor_is_assigned_to_the_application_form
-    expect(application_page.overview.assessor_name.text).to eq(assessor.name)
+    expect(assessor_application_page.overview.assessor_name.text).to eq(
+      assessor.name
+    )
   end
 
   def when_i_visit_the_assign_reviewer_page
@@ -54,7 +56,9 @@ RSpec.describe "Assigning an assessor", type: :system do
   end
 
   def then_the_assessor_is_assigned_as_reviewer_to_the_application_form
-    expect(application_page.overview.reviewer_name.text).to eq(assessor.name)
+    expect(assessor_application_page.overview.reviewer_name.text).to eq(
+      assessor.name
+    )
   end
 
   def application_form

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_personal_information
 
     when_i_choose_check_personal_information_yes
-    then_i_see_the(:application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_check_personal_information_completed
   end
 
@@ -30,7 +30,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_personal_information
 
     when_i_choose_check_personal_information_no
-    then_i_see_the(:application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_check_personal_information_action_required
   end
 
@@ -43,7 +43,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_qualifications
 
     when_i_choose_check_qualifications_yes
-    then_i_see_the(:application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_check_qualifications_completed
   end
 
@@ -56,7 +56,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_qualifications
 
     when_i_choose_check_qualifications_no
-    then_i_see_the(:application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_check_qualifications_action_required
   end
 
@@ -65,7 +65,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_work_history
 
     when_i_choose_check_work_history_yes
-    then_i_see_the(:application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_check_work_history_completed
   end
 
@@ -74,7 +74,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_work_history
 
     when_i_choose_check_work_history_no
-    then_i_see_the(:application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_check_work_history_action_required
   end
 
@@ -87,7 +87,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_professional_standing
 
     when_i_choose_check_professional_standing_yes
-    then_i_see_the(:application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_check_professional_standing_completed
   end
 
@@ -100,7 +100,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_professional_standing
 
     when_i_choose_check_professional_standing_no
-    then_i_see_the(:application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_check_professional_standing_action_required
   end
 
@@ -128,10 +128,16 @@ RSpec.describe "Assessor check submitted details", type: :system do
     check_personal_information_page.form.continue_button.click
   end
 
+  def personal_information_task_item
+    assessor_application_page.task_list.tasks.first.items.find do |item|
+      item.link.text == "Check personal information"
+    end
+  end
+
   def and_i_see_check_personal_information_completed
-    expect(application_page.personal_information_task.status.text).to eq(
-      "COMPLETED"
-    )
+    expect(
+      assessor_application_page.personal_information_task.status.text
+    ).to eq("COMPLETED")
   end
 
   def when_i_choose_check_personal_information_no
@@ -146,9 +152,9 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def and_i_see_check_personal_information_action_required
-    expect(application_page.personal_information_task.status.text).to eq(
-      "ACTION REQUIRED"
-    )
+    expect(
+      assessor_application_page.personal_information_task.status.text
+    ).to eq("ACTION REQUIRED")
   end
 
   def then_i_see_the_qualifications
@@ -176,11 +182,13 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def and_i_see_check_qualifications_completed
-    expect(application_page.qualifications_task.status.text).to eq("COMPLETED")
+    expect(assessor_application_page.qualifications_task.status.text).to eq(
+      "COMPLETED"
+    )
   end
 
   def and_i_see_check_qualifications_action_required
-    expect(application_page.qualifications_task.status.text).to eq(
+    expect(assessor_application_page.qualifications_task.status.text).to eq(
       "ACTION REQUIRED"
     )
   end
@@ -198,7 +206,9 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def and_i_see_check_work_history_completed
-    expect(application_page.work_history_task.status.text).to eq("COMPLETED")
+    expect(assessor_application_page.work_history_task.status.text).to eq(
+      "COMPLETED"
+    )
   end
 
   def when_i_choose_check_work_history_no
@@ -213,7 +223,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def and_i_see_check_work_history_action_required
-    expect(application_page.work_history_task.status.text).to eq(
+    expect(assessor_application_page.work_history_task.status.text).to eq(
       "ACTION REQUIRED"
     )
   end
@@ -233,9 +243,9 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def and_i_see_check_professional_standing_completed
-    expect(application_page.professional_standing_task.status.text).to eq(
-      "COMPLETED"
-    )
+    expect(
+      assessor_application_page.professional_standing_task.status.text
+    ).to eq("COMPLETED")
   end
 
   def when_i_choose_check_professional_standing_no
@@ -250,9 +260,9 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def and_i_see_check_professional_standing_action_required
-    expect(application_page.professional_standing_task.status.text).to eq(
-      "ACTION REQUIRED"
-    )
+    expect(
+      assessor_application_page.professional_standing_task.status.text
+    ).to eq("ACTION REQUIRED")
   end
 
   def assessor

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def then_the_application_form_is_awarded
-    expect(application_page.overview.status.text).to eq("AWARDED")
+    expect(assessor_application_page.overview.status.text).to eq("AWARDED")
   end
 
   def application_form

--- a/spec/system/assessor_interface/view_application_form_spec.rb
+++ b/spec/system/assessor_interface/view_application_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Assessor view application form", type: :system do
     given_there_is_an_application_form
 
     when_i_am_authorized_as_an_assessor_user
-    when_i_visit_the(:application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_id:)
     then_i_see_the_application
     and_i_see_the_assessment_tasks
 
@@ -25,27 +25,29 @@ RSpec.describe "Assessor view application form", type: :system do
   end
 
   def when_i_click_back_link
-    application_page.back_link.click
+    assessor_application_page.back_link.click
   end
 
   def then_i_see_the_application
-    expect(application_page.overview.name.text).to eq(
+    expect(assessor_application_page.overview.name.text).to eq(
       "#{application_form.given_names} #{application_form.family_name}"
     )
   end
 
   def and_i_see_the_assessment_tasks
-    expect(application_page.task_list.tasks.count).to eq(2)
+    expect(assessor_application_page.task_list.tasks.count).to eq(2)
 
     first_section_links =
-      application_page.task_list.tasks.first.items.map { |item| item.name.text }
+      assessor_application_page.task_list.tasks.first.items.map do |item|
+        item.name.text
+      end
 
     expect(first_section_links).to eq(
       ["Check personal information", "Check qualifications"]
     )
 
     second_section_links =
-      application_page.task_list.tasks.second.items.map do |item|
+      assessor_application_page.task_list.tasks.second.items.map do |item|
         item.name.text
       end
 

--- a/spec/system/assessor_interface/view_timeline_events_spec.rb
+++ b/spec/system/assessor_interface/view_timeline_events_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Assessor view timeline events", type: :system do
   end
 
   it "displays the timeline events" do
-    when_i_visit_the(:application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_id:)
     and_i_click_view_timeline
     then_i_see_the_timeline
   end
@@ -25,7 +25,7 @@ RSpec.describe "Assessor view timeline events", type: :system do
   end
 
   def and_i_click_view_timeline
-    application_page.overview.click_link(
+    assessor_application_page.overview.click_link(
       "View timeline of this applications actions"
     )
   end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_click_apply_for_qts
     and_i_sign_up
-    then_i_see_the_active_application_page
+    then_i_see_the_teacher_application_page
     and_i_see_the_work_history_is_not_started
 
     when_i_click_personal_information
@@ -122,7 +122,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_click_apply_for_qts
     and_i_sign_up
-    then_i_see_the_active_application_page
+    then_i_see_the_teacher_application_page
     and_i_see_the_registration_number_is_not_started
 
     when_i_click_personal_information
@@ -225,7 +225,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_click_apply_for_qts
     and_i_sign_up
-    then_i_see_the_active_application_page
+    then_i_see_the_teacher_application_page
     and_i_see_the_written_statement_is_not_started
 
     when_i_click_personal_information
@@ -331,7 +331,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_click_apply_for_qts
     and_i_sign_up
-    then_i_see_the_active_application_page
+    then_i_see_the_teacher_application_page
     and_i_see_the_work_history_is_not_started
 
     when_i_click_work_history
@@ -358,7 +358,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_click_apply_for_qts
     and_i_sign_up
-    then_i_see_the_active_application_page
+    then_i_see_the_teacher_application_page
     and_i_see_the_work_history_is_not_started
 
     when_i_click_qualifications
@@ -425,7 +425,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_click_apply_for_qts
     and_i_sign_up
-    then_i_see_the_active_application_page
+    then_i_see_the_teacher_application_page
     and_i_see_the_work_history_is_not_started
 
     when_i_click_subjects
@@ -446,7 +446,7 @@ RSpec.describe "Teacher application", type: :system do
 
     when_i_click_apply_for_qts
     and_i_sign_up
-    then_i_see_the_active_application_page
+    then_i_see_the_teacher_application_page
     and_i_see_the_work_history_is_not_started
 
     when_i_click_personal_information
@@ -464,13 +464,13 @@ RSpec.describe "Teacher application", type: :system do
   it "allows starting an application form without a session" do
     when_i_visit_the_sign_up_page
     and_i_sign_up
-    then_i_see_the_new_application_page
+    then_i_see_the_new_teacher_application_page
   end
 
   private
 
   def when_i_click_apply_for_qts
-    click_link "Apply for QTS"
+    eligible_page.apply_button.click
   end
 
   def when_i_click_start_now
@@ -478,7 +478,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_check_your_answers
-    click_link "Check your answers"
+    teacher_application_page.check_answers.click
   end
 
   def when_i_click_submit
@@ -494,7 +494,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_personal_information
-    click_link "Enter your personal information"
+    teacher_application_page.click_item("Enter your personal information")
   end
 
   def when_i_fill_in_the_name_and_date_of_birth_form
@@ -533,7 +533,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_qualifications
-    click_link "Add your teaching qualifications"
+    teacher_application_page.click_item("Add your teaching qualifications")
   end
 
   def when_i_fill_in_qualifications
@@ -568,7 +568,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_subjects
-    click_link "Enter the subjects you can teach"
+    teacher_application_page.click_item("Enter the subjects you can teach")
   end
 
   def and_i_click_add_another_subject
@@ -580,7 +580,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_work_history
-    click_link "Add your work history"
+    teacher_application_page.click_item("Add your work history")
   end
 
   def when_i_fill_in_has_work_history
@@ -599,7 +599,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_registration_number
-    click_link "Enter your registration number"
+    teacher_application_page.click_item("Enter your registration number")
   end
 
   def when_i_fill_in_registration_number
@@ -608,7 +608,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_written_statement
-    click_link "Upload your written statement"
+    teacher_application_page.click_item("Upload your written statement")
   end
 
   def when_i_click_delete
@@ -621,57 +621,78 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_visit_the_sign_up_page
-    visit new_teacher_registration_path
+    new_teacher_form_page.load
   end
 
-  def then_i_see_the_new_application_page
-    expect(page).to have_current_path("/teacher/application/new")
-    expect(page).to have_title(
-      "In which country are you currently recognised as a teacher?"
+  def then_i_see_the_new_teacher_application_page
+    expect(new_teacher_form_page).to have_current_path(
+      "/teacher/application/new"
     )
-    expect(page).to have_content(
+    expect(new_teacher_form_page.heading.text).to eq(
       "In which country are you currently recognised as a teacher?"
     )
   end
 
-  def then_i_see_the_active_application_page
-    expect(page).to have_current_path("/teacher/application")
-    expect(page).to have_title("Apply for qualified teacher status (QTS)")
-    expect(page).to have_content("Apply for qualified teacher status (QTS)")
+  def then_i_see_the_teacher_application_page
+    expect(teacher_application_page).to have_current_path(
+      "/teacher/application"
+    )
+    expect(teacher_application_page.heading.text).to eq(
+      "Apply for qualified teacher status (QTS)"
+    )
 
-    expect(page).to have_content("About you")
-    expect(page).to have_content("Enter your personal information\nNOT STARTED")
-    expect(page).to have_content("Upload your identity document\nNOT STARTED")
+    expect(teacher_application_page).to have_content("About you")
+    expect(teacher_application_page).to have_content(
+      "Enter your personal information\nNOT STARTED"
+    )
+    expect(teacher_application_page).to have_content(
+      "Upload your identity document\nNOT STARTED"
+    )
 
-    expect(page).to have_content("Your qualifications")
-    expect(page).to have_content(
+    expect(teacher_application_page).to have_content("Your qualifications")
+    expect(teacher_application_page).to have_content(
       "Enter the age range you can teach\nNOT STARTED"
     )
 
-    expect(page).to have_content("Check your answers")
+    expect(teacher_application_page).to have_content("Check your answers")
   end
 
   def and_i_see_the_work_history_is_not_started
-    expect(page).to have_content("Your work history")
-    expect(page).to have_content("Add your work history\nNOT STARTED")
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Your work history"
+    )
+
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Add your work history\nNOT STARTED"
+    )
   end
 
   def and_i_see_the_written_statement_is_not_started
-    expect(page).to have_content("Proof that you’re recognised as a teacher")
-    expect(page).to have_content("Upload your written statement\nNOT STARTED")
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Proof that you’re recognised as a teacher"
+    )
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Upload your written statement\nNOT STARTED"
+    )
   end
 
   def and_i_see_the_registration_number_is_not_started
-    expect(page).to have_content("Proof that you’re recognised as a teacher")
-    expect(page).to have_content("Enter your registration number\nNOT STARTED")
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Proof that you’re recognised as a teacher"
+    )
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Enter your registration number\nNOT STARTED"
+    )
   end
 
   def then_i_see_the_name_and_date_of_birth_form
-    expect(page).to have_title("About you")
-    expect(page).to have_content("Personal information")
-    expect(page).to have_content("Given names")
-    expect(page).to have_content("Family name")
-    expect(page).to have_content("Date of birth")
+    expect(name_and_date_of_birth_page).to have_title("About you")
+    expect(name_and_date_of_birth_page.heading.text).to eq(
+      "Personal information"
+    )
+    expect(name_and_date_of_birth_page.grid).to have_content("Given names")
+    expect(name_and_date_of_birth_page.grid).to have_content("Family name")
+    expect(name_and_date_of_birth_page.grid).to have_content("Date of birth")
   end
 
   def and_i_receive_an_application_email
@@ -685,266 +706,391 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def then_i_see_the_alternative_name_form
-    expect(page).to have_title("About you")
-    expect(page).to have_content(
+    expect(alternative_name_page).to have_title("About you")
+    expect(alternative_name_page.heading.text).to eq(
       "Does your name appear differently on your ID documents or qualifications?"
     )
-    expect(page).to have_content(
+    expect(alternative_name_page.grid).to have_content(
       "Yes – I’ll upload another document to prove this"
     )
-    expect(page).to have_content("No")
+    expect(alternative_name_page.grid).to have_content("No")
   end
 
   def then_i_see_the_upload_name_change_form
-    expect(page).to have_title("Upload a document")
-    expect(page).to have_content("Upload proof of your change of name")
+    expect(upload_document_page).to have_title("Upload a document")
+    expect(upload_document_page.heading.text).to eq(
+      "Upload proof of your change of name"
+    )
   end
 
   def then_i_see_the_upload_identification_form
-    expect(page).to have_title("Upload a document")
-    expect(page).to have_content("Upload a valid identification document")
+    expect(check_your_uploads_page).to have_title("Upload a document")
+    expect(check_your_uploads_page.heading.text).to eq(
+      "Upload a valid identification document"
+    )
   end
 
   def then_i_see_the_check_your_identification_uploads
-    expect(page).to have_title("Check your uploaded files")
-    expect(page).to have_content(
+    expect(check_your_uploads_page).to have_title("Check your uploaded files")
+    expect(check_your_uploads_page.heading.text).to eq(
       "Check your uploaded files – identity document"
     )
-    expect(page).to have_content("File 1\tupload.pdf\tDelete")
+    expect(check_your_uploads_page.summary_list_row).to have_content(
+      "File 1\tupload.pdf\tDelete"
+    )
   end
 
   def then_i_see_the_check_your_name_change_uploads
-    expect(page).to have_title("Check your uploaded files")
-    expect(page).to have_content(
+    expect(check_your_uploads_page).to have_title("Check your uploaded files")
+    expect(check_your_uploads_page.heading.text).to eq(
       "Check your uploaded files – name change document"
     )
-    expect(page).to have_content("File 1\tupload.pdf\tDelete")
+    expect(check_your_uploads_page.summary_list_row).to have_content(
+      "File 1\tupload.pdf\tDelete"
+    )
   end
 
   def then_i_see_the_check_your_certificate_uploads
-    expect(page).to have_title("Check your uploaded files")
-    expect(page).to have_content(
+    expect(check_your_uploads_page).to have_title("Check your uploaded files")
+    expect(check_your_uploads_page.heading.text).to eq(
       "Check your uploaded files – certificate document"
     )
-    expect(page).to have_content("File 1\tupload.pdf\tDelete")
+    expect(check_your_uploads_page.summary_list_row).to have_content(
+      "File 1\tupload.pdf\tDelete"
+    )
   end
 
   def then_i_see_the_check_your_transcript_uploads
-    expect(page).to have_title("Check your uploaded files")
-    expect(page).to have_content(
+    expect(check_your_uploads_page).to have_title("Check your uploaded files")
+    expect(check_your_uploads_page.heading.text).to eq(
       "Check your uploaded files – transcript document"
     )
-    expect(page).to have_content("File 1\tupload.pdf\tDelete")
+    expect(check_your_uploads_page.summary_list_row).to have_content(
+      "File 1\tupload.pdf\tDelete"
+    )
   end
 
   def then_i_see_the_check_your_written_statement_uploads
-    expect(page).to have_title("Check your uploaded files")
-    expect(page).to have_content(
+    expect(check_your_uploads_page).to have_title("Check your uploaded files")
+    expect(check_your_uploads_page.heading.text).to eq(
       "Check your uploaded files – written statement document"
     )
-    expect(page).to have_content("File 1\tupload.pdf\tDelete")
+    expect(check_your_uploads_page.summary_list_row).to have_content(
+      "File 1\tupload.pdf\tDelete"
+    )
   end
 
   def then_i_see_the_qualifications_form
-    expect(page).to have_title("Your qualifications")
-    expect(page).to have_content("Your teaching qualification")
-    expect(page).to have_content(
+    expect(qualifications_form_page).to have_title("Your qualifications")
+    expect(qualifications_form_page.heading.text).to eq(
+      "Your teaching qualification"
+    )
+    expect(qualifications_form_page.body).to have_content(
       "This is the qualification that led to you being recognised as a teacher."
     )
   end
 
   def then_i_see_the_degree_qualifications_form
-    expect(page).to have_title("Your qualifications")
-    expect(page).to have_content("Your university degree")
-    expect(page).to have_content(
+    expect(qualifications_form_page).to have_title("Your qualifications")
+    expect(qualifications_form_page.heading.text).to eq(
+      "Your university degree"
+    )
+    expect(qualifications_form_page.body).to have_content(
       "Tell us about your university degree qualification."
     )
   end
 
   def then_i_see_the_upload_certificate_form
-    expect(page).to have_title("Upload a document")
-    expect(page).to have_content("Upload your certificate for Name")
+    expect(upload_document_page).to have_title("Upload a document")
+    expect(upload_document_page.heading.text).to eq(
+      "Upload your certificate for Name"
+    )
   end
 
   def then_i_see_the_upload_degree_certificate_form
-    expect(page).to have_title("Upload a document")
-    expect(page).to have_content("Upload your certificate for Name")
+    expect(upload_document_page).to have_title("Upload a document")
+    expect(upload_document_page.heading.text).to eq(
+      "Upload your certificate for Name"
+    )
   end
 
   def then_i_see_the_upload_transcript_form
-    expect(page).to have_title("Upload a document")
-    expect(page).to have_content("Upload your transcript for Name")
+    expect(upload_document_page).to have_title("Upload a document")
+    expect(upload_document_page.heading.text).to eq(
+      "Upload your transcript for Name"
+    )
   end
 
   def then_i_see_the_upload_degree_transcript_form
-    expect(page).to have_title("Upload a document")
-    expect(page).to have_content("Upload your transcript for Name")
+    expect(upload_document_page).to have_title("Upload a document")
+    expect(upload_document_page.heading.text).to eq(
+      "Upload your transcript for Name"
+    )
   end
 
   def then_i_see_the_age_range_form
-    expect(page).to have_title("Enter the age range you can teach")
-    expect(page).to have_content("What age range are you qualified to teach?")
-    expect(page).to have_content("From")
-    expect(page).to have_content("To")
+    expect(age_range_form).to have_title("Enter the age range you can teach")
+    expect(age_range_form.heading.text).to eq(
+      "What age range are you qualified to teach?"
+    )
+    expect(age_range_form.grid).to have_content("From")
+    expect(age_range_form.grid).to have_content("To")
   end
 
   def then_i_see_the_subjects_form
-    expect(page).to have_title("Enter the subjects you can teach")
-    expect(page).to have_content("What subjects are you qualified to teach?")
+    expect(subjects_form_page).to have_title("Enter the subjects you can teach")
+    expect(subjects_form_page.heading.text).to eq(
+      "What subjects are you qualified to teach?"
+    )
   end
 
   def then_i_see_the_two_subjects_form
-    expect(page).to have_title("Enter the subjects you can teach")
-    expect(page).to have_content("What subjects are you qualified to teach?")
-    expect(page).to have_content("Subject")
-    expect(page).to have_content("Remove")
+    expect(subjects_form_page).to have_title("Enter the subjects you can teach")
+    expect(subjects_form_page.heading.text).to eq(
+      "What subjects are you qualified to teach?"
+    )
+    expect(subjects_form_page).to have_content("Subject")
+    expect(subjects_form_page).to have_content("Remove")
   end
 
   def then_i_see_the_has_work_history_form
-    expect(page).to have_title("Your work history")
-    expect(page).to have_content("Have you worked professionally as a teacher?")
-    expect(page).to have_content("Yes")
-    expect(page).to have_content("No")
+    expect(work_history_form_page).to have_title("Your work history")
+    expect(work_history_form_page.heading.text).to eq(
+      "Have you worked professionally as a teacher?"
+    )
+    expect(work_history_form_page.grid).to have_content("Yes")
+    expect(work_history_form_page.grid).to have_content("No")
   end
 
   def then_i_see_the_work_history_form
-    expect(page).to have_title("Your work history")
-    expect(page).to have_content("Your work history in education")
-    expect(page).to have_content("Your current or most recent role")
+    expect(work_history_form_page).to have_title("Your work history")
+    expect(work_history_form_page).to have_content(
+      "Your work history in education"
+    )
+    expect(work_history_form_page).to have_content(
+      "Your current or most recent role"
+    )
   end
 
   def then_i_see_the_registration_number_form
-    expect(page).to have_title("Enter your registration number")
-    expect(page).to have_content("What is your registration number?")
+    expect(registration_number_form).to have_title(
+      "Enter your registration number"
+    )
+    expect(registration_number_form.heading.text).to eq(
+      "What is your registration number?"
+    )
   end
 
   def then_i_see_the_upload_written_statement_form
-    expect(page).to have_title("Upload a document")
-    expect(page).to have_content("Upload your written statement")
+    expect(upload_document_page).to have_title("Upload a document")
+    expect(upload_document_page.heading.text).to eq(
+      "Upload your written statement"
+    )
   end
 
   def then_i_see_the_personal_information_summary
-    expect(page).to have_content("Check your answers")
-    expect(page).to have_content("Given names\tName")
-    expect(page).to have_content("Family name\tName")
-    expect(page).to have_content("Date of birth\t1 January 2000")
-    expect(page).to have_content(
+    expect(personal_information_summary_page).to have_content(
+      "Check your answers"
+    )
+    expect(personal_information_summary_page).to have_content(
+      "Given names\tName"
+    )
+    expect(personal_information_summary_page).to have_content(
+      "Family name\tName"
+    )
+    expect(personal_information_summary_page).to have_content(
+      "Date of birth\t1 January 2000"
+    )
+    expect(personal_information_summary_page).to have_content(
       "Name appears differently on your ID documents or qualifications?\tYes"
     )
-    expect(page).to have_content("Alternative given names\tName")
-    expect(page).to have_content("Alternative family name\tName")
-    expect(page).to have_content("Name change document")
+    expect(personal_information_summary_page).to have_content(
+      "Alternative given names\tName"
+    )
+    expect(personal_information_summary_page).to have_content(
+      "Alternative family name\tName"
+    )
+    expect(personal_information_summary_page).to have_content(
+      "Name change document"
+    )
   end
 
   def then_i_see_the_personal_information_summary_without_name_change
-    expect(page).to have_content("Check your answers")
-    expect(page).to have_content("Given names\tName")
-    expect(page).to have_content("Family name\tName")
-    expect(page).to have_content("Date of birth\t1 January 2000")
-    expect(page).to have_content(
+    expect(personal_information_summary_page.heading.text).to eq(
+      "Check your answers"
+    )
+    expect(personal_information_summary_page.summary_card).to have_content(
+      "Given names\tName"
+    )
+    expect(personal_information_summary_page.summary_card).to have_content(
+      "Family name\tName"
+    )
+    expect(personal_information_summary_page.summary_card).to have_content(
+      "Date of birth\t1 January 2000"
+    )
+    expect(personal_information_summary_page.summary_card).to have_content(
       "Name appears differently on your ID documents or qualifications?\tNo"
     )
   end
 
   def then_i_see_completed_personal_information_section
-    expect(page).to have_content("Enter your personal information\nCOMPLETED")
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Enter your personal information\nCOMPLETED"
+    )
   end
 
   def then_i_see_completed_identity_document_section
-    expect(page).to have_content("Upload your identity document\nCOMPLETED")
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Upload your identity document\nCOMPLETED"
+    )
   end
 
   def then_i_see_the_qualifications_summary
-    expect(page).to have_content("Check your answers")
-    expect(page).to have_content("Qualification title\tTitle")
-    expect(page).to have_content("Name of institution\tName")
-    expect(page).to have_content("Country of institution\tFrance")
+    expect(qualification_summary_page.heading.text).to eq("Check your answers")
+    expect(qualification_summary_page.summary_card).to have_content(
+      "Qualification title\tTitle"
+    )
+    expect(qualification_summary_page.summary_card).to have_content(
+      "Name of institution\tName"
+    )
+    expect(qualification_summary_page.summary_card).to have_content(
+      "Country of institution\tFrance"
+    )
   end
 
   def then_i_see_completed_qualifications_section
-    expect(page).to have_content("Add your teaching qualifications\nCOMPLETED")
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Add your teaching qualifications\nCOMPLETED"
+    )
   end
 
   def then_i_see_completed_age_range_section
-    expect(page).to have_content("Enter the age range you can teach\nCOMPLETED")
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Enter the age range you can teach\nCOMPLETED"
+    )
   end
 
   def then_i_see_completed_subjects_section
-    expect(page).to have_content("Enter the subjects you can teach\nCOMPLETED")
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Enter the subjects you can teach\nCOMPLETED"
+    )
   end
 
   def then_i_see_the_work_history_summary
-    expect(page).to have_content("Your work history in education")
-    expect(page).to have_content(
+    expect(work_history_summary_page.heading.text).to eq(
+      "Your work history in education"
+    )
+    expect(work_history_summary_page.summary_card_1).to have_content(
       "Have you worked professionally as a teacher?\tYes"
     )
-    expect(page).to have_content("Your current or most recent role")
-    expect(page).to have_content("School name\tSchool name")
-    expect(page).to have_content("City of institution\tCity")
-    expect(page).to have_content("Country of institution\tFrance")
-    expect(page).to have_content("Your job role\tJob")
-    expect(page).to have_content("Contact email address\ttest@example.com")
-    expect(page).to have_content("Role start date\tJanuary 2000")
+    expect(work_history_summary_page.summary_card_2).to have_content(
+      "Your current or most recent role"
+    )
+    expect(work_history_summary_page.summary_card_2).to have_content(
+      "School name\tSchool name"
+    )
+    expect(work_history_summary_page.summary_card_2).to have_content(
+      "City of institution\tCity"
+    )
+    expect(work_history_summary_page.summary_card_2).to have_content(
+      "Country of institution\tFrance"
+    )
+    expect(work_history_summary_page.summary_card_2).to have_content(
+      "Your job role\tJob"
+    )
+    expect(work_history_summary_page.summary_card_2).to have_content(
+      "Contact email address\ttest@example.com"
+    )
+    expect(work_history_summary_page.summary_card_2).to have_content(
+      "Role start date\tJanuary 2000"
+    )
   end
 
   def then_i_see_the_empty_work_history_summary
-    expect(page).to have_content("Your work history in education")
-    expect(page).to have_content(
+    expect(work_history_summary_page.heading.text).to eq(
+      "Your work history in education"
+    )
+    expect(work_history_summary_page.summary_card_1).to have_content(
       "Have you worked professionally as a teacher?\tYes"
     )
   end
 
   def then_i_see_completed_work_history_section
-    expect(page).to have_content("Add your work history\nCOMPLETED")
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Add your work history\nCOMPLETED"
+    )
   end
 
   def then_i_see_completed_registration_number_section
-    expect(page).to have_content("Enter your registration number\nCOMPLETED")
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Enter your registration number\nCOMPLETED"
+    )
   end
 
   def then_i_see_completed_written_statement_section
-    expect(page).to have_content("Upload your written statement\nCOMPLETED")
+    expect(teacher_application_page.app_task_list).to have_content(
+      "Upload your written statement\nCOMPLETED"
+    )
   end
 
   def then_i_see_the_check_your_answers_page
-    expect(page).to have_title("Check your answers")
-    expect(page).to have_content(
+    expect(check_your_answers_page).to have_title("Check your answers")
+    expect(check_your_answers_page.heading.text).to eq(
       "Check your answers before submitting your application"
     )
-    expect(page).to have_content("About you")
-    expect(page).to have_content("Who you can teach")
-    expect(page).to have_content("Minimum age\t7")
-    expect(page).to have_content("Maximum age\t11")
-    expect(page).to have_content("Subjects\tSubject")
-    expect(page).to have_content("Your teaching qualification")
+    expect(check_your_answers_page.heading_1.text).to have_content("About you")
+    expect(check_your_answers_page.heading_2.text).to have_content(
+      "Who you can teach"
+    )
+    expect(check_your_answers_page.content).to have_content("Minimum age\t7")
+    expect(check_your_answers_page.content).to have_content("Maximum age\t11")
+    expect(check_your_answers_page).to have_content("Subjects\tSubject")
+    expect(check_your_answers_page).to have_content(
+      "Your teaching qualification"
+    )
   end
 
   def and_i_see_check_your_work_history
-    expect(page).to have_content("Your work history")
+    expect(check_your_answers_page).to have_content("Your work history")
   end
 
   def and_i_see_check_proof_of_recognition
-    expect(page).to have_content("Proof that you’re recognised as a teacher")
+    expect(check_your_answers_page.heading_3.text).to have_content(
+      "Proof that you’re recognised as a teacher"
+    )
   end
 
   def and_i_see_check_registration_number
-    expect(page).to have_content("Registration number")
-    expect(page).to have_content("Registration number\tABC")
+    expect(check_your_answers_page).to have_content("Registration number")
   end
 
   def then_i_see_the_submitted_application_page
     application_form = ApplicationForm.last
 
-    expect(page).to have_current_path("/teacher/application")
-    expect(page).to have_title("Apply for qualified teacher status (QTS)")
-    expect(page).to have_content("Apply for qualified teacher status (QTS)")
-    expect(page).to have_content("Application complete")
-    expect(page).to have_content("Your reference number")
-    expect(page).to have_content(application_form.reference)
+    expect(submitted_application_page).to have_current_path(
+      "/teacher/application"
+    )
+    expect(submitted_application_page).to have_title(
+      "Apply for qualified teacher status (QTS)"
+    )
+    expect(submitted_application_page.heading_1.text).to have_content(
+      "Apply for qualified teacher status (QTS)"
+    )
+    expect(submitted_application_page.heading_2.text).to have_content(
+      "Application complete"
+    )
+    expect(submitted_application_page.reference).to have_content(
+      "Your reference number"
+    )
+    expect(submitted_application_page.reference).to have_content(
+      application_form.reference
+    )
   end
 
   def then_i_see_delete_confirmation_form
-    expect(page).to have_title("Delete")
-    expect(page).to have_content("Are you sure you want to delete")
+    expect(delete_confirmation_page).to have_title("Delete")
+    expect(delete_confirmation_page.heading).to have_content(
+      "Are you sure you want to delete"
+    )
   end
 end

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -156,11 +156,11 @@ RSpec.describe "Teacher authentication", type: :system do
   end
 
   def when_i_visit_the_sign_up_page
-    visit new_teacher_registration_path
+    when_i_visit_the(:teacher_sign_up_page)
   end
 
   def when_i_visit_the_sign_in_page
-    visit new_teacher_session_path
+    teacher_sign_in_page.load
   end
 
   def when_i_visit_the_magic_link_email
@@ -189,26 +189,28 @@ RSpec.describe "Teacher authentication", type: :system do
   end
 
   def then_i_see_the_sign_up_form
-    expect(page).to have_title("Your email address")
-    expect(page).to have_content("Your email address")
-    expect(page).to have_content(
+    expect(teacher_sign_up_page.heading.text).to eq("Your email address")
+    expect(teacher_sign_up_page.email_heading).to have_content(
+      "Your email address"
+    )
+    expect(teacher_sign_up_page.hint).to have_content(
       "We’ll use this to send you a link to continue with your QTS application."
     )
   end
 
   def then_i_see_the_check_your_email_page
-    expect(page).to have_title("Check your email")
-    expect(page).to have_content("Check your email")
+    expect(check_email_page).to have_title("Check your email")
+    expect(check_email_page.heading.text).to eq("Check your email")
   end
 
   def then_i_see_successful_confirmation
-    expect(page).to have_content(
+    expect(new_application_form_page.heading.text).to eq(
       "In which country are you currently recognised as a teacher?"
     )
   end
 
   def then_i_see_the_new_application_form
-    expect(page).to have_content(
+    expect(new_application_form_page.heading.text).to eq(
       "In which country are you currently recognised as a teacher?"
     )
   end
@@ -218,10 +220,10 @@ RSpec.describe "Teacher authentication", type: :system do
   end
 
   def then_i_see_the_signed_out_page
-    expect(page).to have_content(
+    expect(signed_out_page.body_content).to have_content(
       "We’ve signed you out of the Apply for qualified teacher status (QTS) service."
     )
-    expect(page).to have_content(
+    expect(signed_out_page.body_content).to have_content(
       "We’ve saved the information you’ve added to your application so far."
     )
   end
@@ -245,7 +247,7 @@ RSpec.describe "Teacher authentication", type: :system do
   end
 
   def and_i_see_already_confirmed_message
-    expect(page).to have_content(
+    expect(teacher_sign_up_page).to have_content(
       "Your email address is already confirmed, please sign in."
     )
   end

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -57,28 +57,36 @@ RSpec.describe "Teacher documents", type: :system do
   end
 
   def then_i_see_document_form
-    expect(page).to have_title("Upload a document")
-    expect(page).to have_content("Upload your written statement")
+    expect(document_form_page).to have_title("Upload a document")
+    expect(document_form_page.heading.text).to eq(
+      "Upload your written statement"
+    )
   end
 
   def then_i_see_the_next_page_document_form
-    expect(page).to have_title("Upload a document")
-    expect(page).to have_content(
+    expect(document_form_page).to have_title("Upload a document")
+    expect(document_form_page.heading.text).to eq(
       "Upload the next page of your written statement document"
     )
   end
 
   def then_i_see_the_check_your_uploaded_files_page
-    expect(page).to have_title("Check your uploaded files")
-    expect(page).to have_content(
+    expect(check_uploaded_files_page).to have_title("Check your uploaded files")
+    expect(check_uploaded_files_page.heading.text).to eq(
       "Check your uploaded files – written statement document"
     )
-    expect(page).to have_content("File 1\tupload.pdf\tDelete")
-    expect(page).to have_content("File 2\tupload.pdf\tDelete")
+    expect(check_uploaded_files_page.files).to have_content(
+      "File 1\tupload.pdf\tDelete"
+    )
+    expect(check_uploaded_files_page.files).to have_content(
+      "File 2\tupload.pdf\tDelete"
+    )
   end
 
   def then_i_see_the_check_your_uploaded_files_page_with_three_files
     then_i_see_the_check_your_uploaded_files_page
-    expect(page).to have_content("File 3\tupload.pdf\tDelete")
+    expect(check_uploaded_files_page.files).to have_content(
+      "File 3\tupload.pdf\tDelete"
+    )
   end
 end

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -58,7 +58,11 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           create(:assessment_section, :professional_standing, assessment:)
         end
 
-        it { is_expected.to eq(%i[personal_information professional_standing]) }
+        it do
+          is_expected.to match_array(
+            %i[personal_information professional_standing]
+          )
+        end
       end
     end
 


### PR DESCRIPTION
refactor teacher interface rspecs to use pageobjects

Where granular access of elements was more tricky, I opted for a simpler refactor. 
Some PageObjects are almost identical to others, but i opted to keep them separate where I thought future changes to the pages likely could need distinct objects.