### PR TITLE
Fix order of submitted details tasks

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -17,10 +17,17 @@ class AssessorInterface::ApplicationFormsShowViewObject
   end
 
   def assessment_tasks
-    {
-      submitted_details: assessment.sections.map(&:key).map(&:to_sym),
-      recommendation: %i[initial_assessment]
-    }
+    assessment_section_keys = assessment.sections.map(&:key).map(&:to_sym)
+
+    submitted_details =
+      %i[
+        personal_information
+        qualifications
+        work_history
+        professional_standing
+      ].select { |key| assessment_section_keys.include?(key) }
+
+    { submitted_details:, recommendation: %i[initial_assessment] }
   end
 
   def assessment_task_path(section, item)

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -40,7 +40,10 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
 
     let(:application_form) { create(:application_form) }
     let(:assessment) { create(:assessment, application_form:) }
-    before { create(:assessment_section, :personal_information, assessment:) }
+    before do
+      create(:assessment_section, :personal_information, assessment:)
+      create(:assessment_section, :qualifications, assessment:)
+    end
 
     let(:params) { { id: application_form.id } }
 
@@ -50,7 +53,11 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       context "with work history" do
         before { create(:assessment_section, :work_history, assessment:) }
 
-        it { is_expected.to eq(%i[personal_information work_history]) }
+        it do
+          is_expected.to eq(
+            %i[personal_information qualifications work_history]
+          )
+        end
       end
 
       context "with professional standing statement" do
@@ -59,8 +66,8 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
         end
 
         it do
-          is_expected.to match_array(
-            %i[personal_information professional_standing]
+          is_expected.to eq(
+            %i[personal_information qualifications professional_standing]
           )
         end
       end


### PR DESCRIPTION
This ensures that they always show in a fixed order regardless of the database records.

[Trello Card](https://trello.com/c/iyeNjpw4/886-order-check-submitted-details-section)