### PR TITLE
Remove Devise flash messages

### DIFF
--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -27,4 +27,8 @@ class Staff::SessionsController < Devise::SessionsController
   def after_sign_out_path_for(_resource)
     new_staff_session_path
   end
+
+  def set_flash_message(*)
+    # Intentionally left blank
+  end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/login.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/login.rb
@@ -3,10 +3,6 @@ module PageObjects
     class Login < SitePrism::Page
       set_url "/staff/sign_in"
 
-      element :signed_out_message,
-              ".govuk-notification-banner__heading",
-              text: "Signed out successfully."
-
       section :form, "form" do
         element :email_field, "#staff-email-field"
         element :password_field, "#staff-password-field"

--- a/spec/system/assessor_interface/authentication_spec.rb
+++ b/spec/system/assessor_interface/authentication_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "Assessor authentication", type: :system do
 
     when_i_click_sign_out
     then_i_see_the(:login_page)
-    and_i_see_the_signed_out_message
   end
 
   private
@@ -30,9 +29,5 @@ RSpec.describe "Assessor authentication", type: :system do
 
   def when_i_click_sign_out
     applications_page.header.sign_out_link.click
-  end
-
-  def and_i_see_the_signed_out_message
-    expect(login_page.signed_out_message).to be_visible
   end
 end


### PR DESCRIPTION
When signing in or signing out we don't want to see the built in Devise flash messages as they're not part of our designs.

[Trello Card](https://trello.com/c/Ev2tnck3/885-remove-devise-flash-messages)