### PR TITLE
Improve selected failure reasons validation

### DIFF
--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -1,12 +1,8 @@
 module AssessorInterface
   class AssessmentSectionsController < BaseController
-    before_action :load_assessment_section
+    before_action :load_assessment_section_and_assessment
 
     def show
-      @assessment = @assessment_section.assessment
-      @application_form = @assessment.application_form
-      @qualifications = @application_form.qualifications.ordered
-      @work_histories = @application_form.work_histories.ordered
     end
 
     def update
@@ -22,7 +18,7 @@ module AssessorInterface
 
     private
 
-    def load_assessment_section
+    def load_assessment_section_and_assessment
       @assessment_section =
         AssessmentSection
           .includes(assessment: :application_form)
@@ -33,6 +29,11 @@ module AssessorInterface
             }
           )
           .find_by!(key: params[:key])
+
+      @assessment = @assessment_section.assessment
+      @application_form = @assessment.application_form
+      @qualifications = @application_form.qualifications.ordered
+      @work_histories = @application_form.work_histories.ordered
     end
 
     def assessment_section_params

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -47,10 +47,19 @@ class AssessmentSection < ApplicationRecord
   validates :selected_failure_reasons,
             presence: true,
             if: -> { passed == false }
-  before_validation -> { selected_failure_reasons&.compact_blank! }
+
+  before_validation :prepare_selected_failure_reasons
 
   def state
     return :not_started if passed.nil?
     passed ? :completed : :action_required
+  end
+
+  private
+
+  def prepare_selected_failure_reasons
+    return if selected_failure_reasons.nil?
+    selected_failure_reasons.compact_blank!
+    selected_failure_reasons.clear if passed
   end
 end

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -41,6 +41,14 @@ class AssessmentSection < ApplicationRecord
               in: keys.values
             }
 
+  validates :selected_failure_reasons,
+            absence: true,
+            if: -> { passed || passed.nil? }
+  validates :selected_failure_reasons,
+            presence: true,
+            if: -> { passed == false }
+  before_validation -> { selected_failure_reasons&.compact_blank! }
+
   def state
     return :not_started if passed.nil?
     passed ? :completed : :action_required

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -185,6 +185,10 @@ en:
           attributes:
             reviewer:
               same_as_assessor: can’t be assigned to the same person
+        assessment_section:
+          attributes:
+            selected_failure_reasons:
+              blank: Select the reasons for your recommendation.
 
   errors:
     messages:

--- a/spec/factories/assessment_sections.rb
+++ b/spec/factories/assessment_sections.rb
@@ -31,6 +31,7 @@ FactoryBot.define do
 
     trait :failed do
       passed { false }
+      selected_failure_reasons { %w[failure_reason] }
     end
 
     trait :personal_information do

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -44,16 +44,25 @@ RSpec.describe AssessmentSection, type: :model do
 
     it { is_expected.to validate_absence_of(:selected_failure_reasons) }
 
-    context "when passed" do
-      before { assessment_section.passed = true }
-
-      it { is_expected.to validate_absence_of(:selected_failure_reasons) }
-    end
-
     context "when not passed" do
       before { assessment_section.passed = false }
 
       it { is_expected.to validate_presence_of(:selected_failure_reasons) }
+    end
+  end
+
+  context "when passed" do
+    before do
+      assessment_section.update!(
+        key: :personal_information,
+        passed: false,
+        selected_failure_reasons: %w[failure_reason]
+      )
+    end
+
+    it "clears selected failure reasons" do
+      assessment_section.update!(passed: true)
+      expect(assessment_section.selected_failure_reasons).to be_empty
     end
   end
 

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe AssessmentSection, type: :model do
         professional_standing: "professional_standing"
       ).backed_by_column_of_type(:string)
     end
+
+    it { is_expected.to validate_absence_of(:selected_failure_reasons) }
+
+    context "when passed" do
+      before { assessment_section.passed = true }
+
+      it { is_expected.to validate_absence_of(:selected_failure_reasons) }
+    end
+
+    context "when not passed" do
+      before { assessment_section.passed = false }
+
+      it { is_expected.to validate_presence_of(:selected_failure_reasons) }
+    end
   end
 
   describe "#state" do

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -82,7 +82,12 @@ RSpec.describe Assessment, type: :model do
     end
 
     context "with a failed assessment" do
-      before { assessment_section.update!(passed: false) }
+      before do
+        assessment_section.update!(
+          passed: false,
+          selected_failure_reasons: %w[failure_reason]
+        )
+      end
       it { is_expected.to be true }
     end
   end


### PR DESCRIPTION
This adds validation to the assessment section model to ensure that selected failure reasons are present if passed is false.

Also, if the assessor passes the assessment, having previously failed it, we should clear the selected failure reasons.

[Trello Card](https://trello.com/c/aS7cIo9S/896-assessment-section-validation) &middot; [Trello Card](https://trello.com/c/TTpNAsSU/895-clear-failure-reasons-on-yes)