### PR TITLE
Limit which recommendations are available

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -38,4 +38,12 @@ class Assessment < ApplicationRecord
   def sections_finished?
     sections.none? { |section| section.state == :not_started }
   end
+
+  def can_award?
+    sections.all? { |section| section.state == :completed }
+  end
+
+  def can_decline?
+    sections.any? { |section| section.state == :action_required }
+  end
 end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -46,4 +46,11 @@ class Assessment < ApplicationRecord
   def can_decline?
     sections.any? { |section| section.state == :action_required }
   end
+
+  def available_recommendations
+    [].tap do |recommendations|
+      recommendations << "award" if can_award?
+      recommendations << "decline" if can_decline?
+    end
+  end
 end

--- a/app/views/assessor_interface/assessments/edit.html.erb
+++ b/app/views/assessor_interface/assessments/edit.html.erb
@@ -5,7 +5,7 @@
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :recommendation,
-                                       %w[award decline],
+                                       @assessment.available_recommendations,
                                        :itself,
                                        legend: { size: "xl", tag: "h1" } %>
 

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -86,4 +86,67 @@ RSpec.describe Assessment, type: :model do
       it { is_expected.to be true }
     end
   end
+
+  describe "#can_award?" do
+    subject(:can_award?) { assessment.can_award? }
+
+    context "with an unknown assessment" do
+      before { create(:assessment_section, :personal_information, assessment:) }
+      it { is_expected.to be false }
+    end
+
+    context "with a passed assessment" do
+      before do
+        create(:assessment_section, :personal_information, :passed, assessment:)
+      end
+      it { is_expected.to be true }
+    end
+
+    context "with a failed assessment" do
+      before do
+        create(:assessment_section, :personal_information, :failed, assessment:)
+      end
+      it { is_expected.to be false }
+    end
+
+    context "with a mixture of assessments" do
+      before do
+        create(:assessment_section, :personal_information, :passed, assessment:)
+        create(:assessment_section, :qualifications, :failed, assessment:)
+      end
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#can_decline?" do
+    subject(:can_decline?) { assessment.can_decline? }
+
+    context "with an unfinished assessment" do
+      before { create(:assessment_section, :personal_information, assessment:) }
+
+      it { is_expected.to be false }
+    end
+
+    context "with a passed assessment" do
+      before do
+        create(:assessment_section, :personal_information, :passed, assessment:)
+      end
+      it { is_expected.to be false }
+    end
+
+    context "with a failed assessment" do
+      before do
+        create(:assessment_section, :personal_information, :failed, assessment:)
+      end
+      it { is_expected.to be true }
+    end
+
+    context "with a mixture of assessments" do
+      before do
+        create(:assessment_section, :personal_information, :passed, assessment:)
+        create(:assessment_section, :qualifications, :failed, assessment:)
+      end
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -149,4 +149,18 @@ RSpec.describe Assessment, type: :model do
       it { is_expected.to be true }
     end
   end
+
+  describe "#available_recommendations" do
+    subject(:available_recommendations) { assessment.available_recommendations }
+
+    context "with an award-able assessment" do
+      before { expect(assessment).to receive(:can_award?).and_return(true) }
+      it { is_expected.to include("award") }
+    end
+
+    context "with a decline-able assessment" do
+      before { expect(assessment).to receive(:can_decline?).and_return(true) }
+      it { is_expected.to include("decline") }
+    end
+  end
 end


### PR DESCRIPTION
We should only be able to award an assessment if all the sections are complete, or decline an assessment if any of the sections need an action. This commit changes the form to only show radio buttons for the recommendation which the user is allowed to choose, based on those rules.

I imagine when we add further information we'll refactor this code and move it in to a common `Recommendable` class (as per https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/adr/00009-assessments.md).

[Trello Card](https://trello.com/c/JDGVIIAD/894-hide-award-qts-on-the-recommendation-page)