### PR TITLE
[890] Completing an assessment section generates a timeline event

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -1,0 +1,18 @@
+<div class="moj-timeline__item">
+  <div class="moj-timeline__header">
+    <h2 class="moj-timeline__title"><%= t("components.timeline_entry.title.#{timeline_event.event_type}") %></h2>
+    <p class="moj-timeline__byline">by <%= timeline_event.creator.try(:name).presence || timeline_event.creator.email %></p>
+  </div>
+
+  <p class="moj-timeline__date">
+  <time datetime="<%= timeline_event.created_at.iso8601 %>">
+    <%= timeline_event.created_at.strftime("%e %B %Y at %l:%M %P") %>
+  </time>
+  </p>
+
+  <div class="moj-timeline__description">
+    <p>
+      <%= t("components.timeline_entry.description.#{timeline_event.event_type}", **description_vars).html_safe %>
+    </p>
+  </div>
+</div>

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -1,0 +1,58 @@
+module TimelineEntry
+  class Component < ViewComponent::Base
+    def initialize(timeline_event:)
+      super
+      @timeline_event = timeline_event
+    end
+
+    attr_reader :timeline_event
+
+    def description_vars
+      send("#{timeline_event.event_type}_vars")
+    end
+
+    private
+
+    def state_changed_vars
+      {
+        old_state:
+          render(
+            ApplicationFormStatusTag::Component.new(
+              key: timeline_event.id,
+              status: timeline_event.old_state,
+              class_context: "timeline-event"
+            )
+          ),
+        new_state:
+          render(
+            ApplicationFormStatusTag::Component.new(
+              key: timeline_event.id,
+              status: timeline_event.new_state,
+              class_context: "timeline-event"
+            )
+          )
+      }
+    end
+
+    def assessor_assigned_vars
+      { assignee_name: timeline_event.assignee.name }
+    end
+
+    alias_method :reviewer_assigned_vars, :assessor_assigned_vars
+
+    def assessment_section_recorded_vars
+      section = timeline_event.eventable
+      {
+        section_name: section.key.titleize,
+        section_state:
+          render(
+            ApplicationFormStatusTag::Component.new(
+              key: timeline_event.id,
+              status: section.state,
+              class_context: "timeline-event"
+            )
+          )
+      }
+    end
+  end
+end

--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -6,7 +6,7 @@ module AssessorInterface
     def update
       if UpdateAssessmentSection.call(
            assessment_section:,
-           user: current_user,
+           user: current_staff,
            params: assessment_section_params
          )
         redirect_to [

--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -1,15 +1,17 @@
 module AssessorInterface
   class AssessmentSectionsController < BaseController
-    before_action :load_assessment_section_and_assessment
-
     def show
     end
 
     def update
-      if @assessment_section.update(assessment_section_params)
+      if UpdateAssessmentSection.call(
+           assessment_section:,
+           user: current_user,
+           params: assessment_section_params
+         )
         redirect_to [
                       :assessor_interface,
-                      @assessment_section.assessment.application_form
+                      assessment_section.assessment.application_form
                     ]
       else
         render :show, status: :unprocessable_entity
@@ -18,8 +20,8 @@ module AssessorInterface
 
     private
 
-    def load_assessment_section_and_assessment
-      @assessment_section =
+    def assessment_section
+      @assessment_section ||=
         AssessmentSection
           .includes(assessment: :application_form)
           .where(
@@ -29,11 +31,22 @@ module AssessorInterface
             }
           )
           .find_by!(key: params[:key])
+    end
 
-      @assessment = @assessment_section.assessment
-      @application_form = @assessment.application_form
-      @qualifications = @application_form.qualifications.ordered
-      @work_histories = @application_form.work_histories.ordered
+    def assessment
+      @assessment ||= @assessment_section.assessment
+    end
+
+    def application_form
+      @application_form ||= assessment.application_form
+    end
+
+    def qualifications
+      @qualifications ||= application_form.qualifications.ordered
+    end
+
+    def work_histories
+      @work_histories = application_form.work_histories.ordered
     end
 
     def assessment_section_params

--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -1,17 +1,21 @@
+# frozen_string_literal: true
+
 module AssessorInterface
   class AssessmentSectionsController < BaseController
     def show
+      assessment_section_view_object
     end
 
     def update
       if UpdateAssessmentSection.call(
-           assessment_section:,
+           assessment_section:
+             assessment_section_view_object.assessment_section,
            user: current_staff,
            params: assessment_section_params
          )
         redirect_to [
                       :assessor_interface,
-                      assessment_section.assessment.application_form
+                      assessment_section_view_object.application_form
                     ]
       else
         render :show, status: :unprocessable_entity
@@ -20,33 +24,9 @@ module AssessorInterface
 
     private
 
-    def assessment_section
-      @assessment_section ||=
-        AssessmentSection
-          .includes(assessment: :application_form)
-          .where(
-            assessment_id: params[:assessment_id],
-            assessment: {
-              application_form_id: params[:application_form_id]
-            }
-          )
-          .find_by!(key: params[:key])
-    end
-
-    def assessment
-      @assessment ||= @assessment_section.assessment
-    end
-
-    def application_form
-      @application_form ||= assessment.application_form
-    end
-
-    def qualifications
-      @qualifications ||= application_form.qualifications.ordered
-    end
-
-    def work_histories
-      @work_histories = application_form.work_histories.ordered
+    def assessment_section_view_object
+      @assessment_section_view_object ||=
+        AssessmentSectionViewObject.new(params:)
     end
 
     def assessment_section_params

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -33,7 +33,8 @@ class TimelineEvent < ApplicationRecord
   enum event_type: {
          assessor_assigned: "assessor_assigned",
          reviewer_assigned: "reviewer_assigned",
-         state_changed: "state_changed"
+         state_changed: "state_changed",
+         assessment_section_recorded: "assessment_section_recorded"
        }
   validates :event_type, inclusion: { in: event_types.values }
 

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -8,6 +8,7 @@
 #  annotation          :string           default(""), not null
 #  creator_type        :string
 #  event_type          :string           not null
+#  eventable_type      :string
 #  new_state           :string           default(""), not null
 #  old_state           :string           default(""), not null
 #  created_at          :datetime         not null
@@ -15,11 +16,13 @@
 #  application_form_id :bigint           not null
 #  assignee_id         :bigint
 #  creator_id          :integer
+#  eventable_id        :bigint
 #
 # Indexes
 #
 #  index_timeline_events_on_application_form_id  (application_form_id)
 #  index_timeline_events_on_assignee_id          (assignee_id)
+#  index_timeline_events_on_eventable            (eventable_type,eventable_id)
 #
 # Foreign Keys
 #
@@ -29,6 +32,7 @@
 class TimelineEvent < ApplicationRecord
   belongs_to :application_form
   belongs_to :creator, polymorphic: true
+  belongs_to :eventable, polymorphic: true
 
   enum event_type: {
          assessor_assigned: "assessor_assigned",

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -32,7 +32,7 @@
 class TimelineEvent < ApplicationRecord
   belongs_to :application_form
   belongs_to :creator, polymorphic: true
-  belongs_to :eventable, polymorphic: true
+  belongs_to :eventable, polymorphic: true, optional: true
 
   enum event_type: {
          assessor_assigned: "assessor_assigned",

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class UpdateAssessmentSection
+  include ServicePattern
+
+  def initialize(assessment_section:, params:)
+    @assessment_section = assessment_section
+    @params = params
+  end
+
+  def call
+    assessment_section.update(params)
+  end
+
+  private
+
+  attr_reader :assessment_section, :params
+end

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -21,7 +21,7 @@ class UpdateAssessmentSection
   def create_timeline_event
     TimelineEvent.create!(
       creator: user,
-      event_type: :assessment_section_completed,
+      event_type: :assessment_section_recorded,
       eventable: assessment_section,
       application_form:
     )

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -3,16 +3,31 @@
 class UpdateAssessmentSection
   include ServicePattern
 
-  def initialize(assessment_section:, params:)
+  def initialize(assessment_section:, user:, params:)
     @assessment_section = assessment_section
     @params = params
+    @user = user
   end
 
   def call
-    assessment_section.update(params)
+    create_timeline_event if (result = assessment_section.update(params))
+    result
   end
 
   private
 
-  attr_reader :assessment_section, :params
+  attr_reader :assessment_section, :user, :params
+
+  def create_timeline_event
+    TimelineEvent.create!(
+      creator: user,
+      event_type: :assessment_section_completed,
+      eventable: assessment_section,
+      application_form:
+    )
+  end
+
+  def application_form
+    assessment_section.assessment.application_form
+  end
 end

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module AssessorInterface
+  class AssessmentSectionViewObject
+    def initialize(params:)
+      @params = params
+    end
+
+    def assessment_section
+      @assessment_section ||=
+        AssessmentSection
+          .includes(assessment: :application_form)
+          .where(
+            assessment_id: params[:assessment_id],
+            assessment: {
+              application_form_id: params[:application_form_id]
+            }
+          )
+          .find_by!(key: params[:key])
+    end
+
+    delegate :assessment, to: :assessment_section
+    delegate :application_form, to: :assessment
+    delegate :registration_number, to: :application_form
+    delegate :checks, to: :assessment_section
+
+    def qualifications
+      application_form.qualifications.ordered
+    end
+
+    def work_histories
+      application_form.work_histories.ordered
+    end
+
+    def show_registration_number_summary
+      registration_number.present?
+    end
+
+    def show_written_statement_summary
+      application_form.written_statement_document.uploaded?
+    end
+
+    private
+
+    attr_reader :params
+  end
+end

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -1,65 +1,68 @@
-<% content_for :page_title, t(".title.#{@assessment_section.key}") %>
+<% content_for :page_title, t(".title.#{@assessment_section_view_object.assessment_section.key}") %>
 
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@assessment_section_view_object.application_form) %>
 
-<h1 class="govuk-heading-xl"><%= t(".title.#{@assessment_section.key}") %></h1>
+<h1 class="govuk-heading-xl"><%= t(".title.#{@assessment_section_view_object.assessment_section.key}") %></h1>
 
-<% case @assessment_section.key %>
+<% case @assessment_section_view_object.assessment_section.key %>
 <% when "personal_information" %>
   <%= render "shared/application_form/personal_information_summary",
-             application_form: @application_form,
+             application_form: @assessment_section_view_object.application_form,
              changeable: false %>
 
   <%= render "shared/application_form/identity_document_summary",
-             application_form: @application_form,
+             application_form: @assessment_section_view_object.application_form,
              changeable: false %>
 <% when "qualifications" %>
   <%= render "shared/application_form/age_range_summary",
-             application_form: @application_form,
+             application_form: @assessment_section_view_object.application_form,
              changeable: false %>
 
   <%= render "shared/application_form/subjects_summary",
-             application_form: @application_form,
+             application_form: @assessment_section_view_object.application_form,
              changeable: false %>
 
   <%= render "shared/application_form/qualifications_summary",
-             application_form: @application_form,
-             qualifications: @qualifications,
+             application_form: @assessment_section_view_object.application_form,
+             qualifications: @assessment_section_view_object.qualifications,
              changeable: false %>
 <% when "work_history" %>
   <%= render "shared/application_form/work_history_summary",
-             application_form: @application_form,
-             work_histories: @work_histories,
+             application_form: @assessment_section_view_object.application_form,
+             work_histories: @assessment_section_view_object.work_histories,
              changeable: false %>
 <% when "professional_standing" %>
-  <% if @application_form.registration_number.present? %>
+  <% if @assessment_section_view_object.show_registration_number_summary %>
     <%= render "shared/application_form/registration_number_summary",
-               application_form: @application_form,
-               changeable: false %>
+      application_form: @assessment_section_view_object.application_form,
+      changeable: false %>
   <% end %>
 
-  <% if @application_form.written_statement_document.uploaded? %>
+  <% if @assessment_section_view_object.show_written_statement_summary %>
     <%= render "shared/application_form/written_statement_summary",
-               application_form: @application_form,
+               application_form: @assessment_section_view_object.application_form,
                changeable: false %>
   <% end %>
 <% end %>
 
 <h2 class="govuk-heading-s">Check:</h2>
 <ul class="govuk-list govuk-list--bullet">
-  <% @assessment_section.checks.each do |check| %>
+  <% @assessment_section_view_object.checks.each do |check| %>
     <li><%= t(".checks.#{check}") %></li>
   <% end %>
 </ul>
 
-<%= form_with model: @assessment_section, url: assessor_interface_application_form_assessment_assessment_section_path(@application_form, @assessment, @assessment_section.key) do |f| %>
+<%= form_with model: @assessment_section_view_object.assessment_section, 
+  url: assessor_interface_application_form_assessment_assessment_section_path(
+    @assessment_section_view_object.application_form, @assessment_section_view_object.assessment, @assessment_section_view_object.assessment_section.key
+  ) do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "Has the applicant completed this section to your satisfaction?", size: "s" } do %>
     <%= f.govuk_radio_button :passed, true, label: { text: "Yes" }, link_errors: true %>
     <%= f.govuk_radio_button :passed, false, label: { text: "No" } do %>
       <%= f.govuk_collection_check_boxes :selected_failure_reasons,
-                                         @assessment_section.failure_reasons.map { |id| OpenStruct.new(id:, label: t(".failure_reasons.#{id}")) },
+                                         @assessment_section_view_object.assessment_section.failure_reasons.map { |id| OpenStruct.new(id:, label: t(".failure_reasons.#{id}")) },
                                          :id,
                                          :label,
                                          legend: { size: "s" } %>
@@ -67,6 +70,6 @@
   <% end %>
 
   <%= f.govuk_submit prevent_double_click: false do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
+    <%= govuk_link_to "Cancel", [:assessor_interface, @assessment_section_view_object.application_form] %>
   <% end %>
 <% end %>

--- a/app/views/assessor_interface/timeline_events/index.html.erb
+++ b/app/views/assessor_interface/timeline_events/index.html.erb
@@ -5,24 +5,6 @@
 
 <div class="moj-timeline">
   <% @timeline_events.each do |timeline_event| %>
-    <div class="moj-timeline__item">
-      <div class="moj-timeline__header">
-        <h2 class="moj-timeline__title"><%= t(".title.#{timeline_event.event_type}") %></h2>
-        <p class="moj-timeline__byline">by <%= timeline_event.creator.try(:name).presence || timeline_event.creator.email %></p>
-      </div>
-
-      <p class="moj-timeline__date">
-        <time datetime="<%= timeline_event.created_at.iso8601 %>">
-          <%= timeline_event.created_at.strftime("%e %B %Y at %l:%M %P") %>
-        </time>
-      </p>
-
-      <div class="moj-timeline__description">
-        <p><%= t(".description.#{timeline_event.event_type}",
-                 old_state: timeline_event.old_state,
-                 new_state: timeline_event.new_state,
-                 assignee_name: timeline_event.assignee&.name) %></p>
-      </div>
-    </div>
+    <%= render(TimelineEntry::Component.new(timeline_event:))%>
   <% end %>
 </div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -176,6 +176,8 @@
     - assignee_id
     - old_state
     - new_state
+    - eventable_type
+    - eventable_id
   :uploads:
     - id
     - document_id

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -70,13 +70,15 @@ en:
           age_ranges_subjects: We were not provided with sufficient evidence to confirm qualification to teach the age ranges and subjects entered on the online application form.
           qualified_to_teach: We were not provided with sufficient evidence to confirm qualification to teach at state or government schools.
           full_professional_status: Recognition level as a teacher does not match the required level, or has outstanding additional conditions.
-    timeline_events:
-      index:
-        title:
-          assessor_assigned: Assessor assigned
-          reviewer_assigned: Reviewer assigned
-          state_changed: Status changed
-        description:
-          assessor_assigned: "%{assignee_name} is assigned as the assessor."
-          reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
-          state_changed: Status changed from %{old_state} to %{new_state}.
+  components:
+    timeline_entry:
+      title:
+        assessor_assigned: Assessor assigned
+        reviewer_assigned: Reviewer assigned
+        state_changed: Status changed
+        assessment_section_completed: Section completed
+      description:
+        assessor_assigned: "%{assignee_name} is assigned as the assessor."
+        reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
+        state_changed: Status changed from %{old_state} to %{new_state}
+        assessment_section_recorded: "%{section_name}: %{section_state}"

--- a/db/migrate/20220914121554_add_eventable_fields_to_timeline_event.rb
+++ b/db/migrate/20220914121554_add_eventable_fields_to_timeline_event.rb
@@ -1,0 +1,7 @@
+class AddEventableFieldsToTimelineEvent < ActiveRecord::Migration[7.0]
+  def change
+    change_table :timeline_events, bulk: true do |t|
+      t.references :eventable, polymorphic: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_09_100205) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_14_121554) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -239,8 +239,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_09_100205) do
     t.bigint "assignee_id"
     t.string "old_state", default: "", null: false
     t.string "new_state", default: "", null: false
+    t.string "eventable_type"
+    t.bigint "eventable_id"
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
     t.index ["assignee_id"], name: "index_timeline_events_on_assignee_id"
+    t.index ["eventable_type", "eventable_id"], name: "index_timeline_events_on_eventable"
   end
 
   create_table "uploads", force: :cascade do |t|

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TimelineEntry::Component, type: :component do
+  subject(:component) { render_inline(described_class.new(timeline_event:)) }
+  let(:creator) { timeline_event.creator }
+
+  context "assessor assigned" do
+    let(:timeline_event) { create(:timeline_event, :assessor_assigned) }
+    let(:assignee) { timeline_event.assignee }
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "#{assignee.name} is assigned as the assessor"
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "reviewer assigned" do
+    let(:timeline_event) { create(:timeline_event, :reviewer_assigned) }
+    let(:assignee) { timeline_event.assignee }
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "#{assignee.name} is assigned as the reviewer"
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "state changed" do
+    let(:timeline_event) { create(:timeline_event, :state_changed) }
+    let(:old_state) do
+      I18n.t("application_form.status.#{timeline_event.old_state}")
+    end
+    let(:new_state) do
+      I18n.t("application_form.status.#{timeline_event.new_state}")
+    end
+
+    it "describes the event" do
+      expect(component.text.squish).to include(
+        "Status changed from #{old_state} to #{new_state}"
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "assessment section recorded" do
+    let(:timeline_event) do
+      create(:timeline_event, :assessment_section_recorded)
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("Personal Information: Completed")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+end

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -48,5 +48,17 @@ FactoryBot.define do
       old_state { ApplicationForm.states.keys.sample }
       new_state { ApplicationForm.states.keys.sample }
     end
+
+    trait :assessment_section_recorded do
+      event_type { "assessment_section_recorded" }
+      eventable do
+        build(
+          :assessment_section,
+          :passed,
+          :personal_information,
+          assessment: build(:assessment, application_form:)
+        )
+      end
+    end
   end
 end

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -6,6 +6,7 @@
 #  annotation          :string           default(""), not null
 #  creator_type        :string
 #  event_type          :string           not null
+#  eventable_type      :string
 #  new_state           :string           default(""), not null
 #  old_state           :string           default(""), not null
 #  created_at          :datetime         not null
@@ -13,11 +14,13 @@
 #  application_form_id :bigint           not null
 #  assignee_id         :bigint
 #  creator_id          :integer
+#  eventable_id        :bigint
 #
 # Indexes
 #
 #  index_timeline_events_on_application_form_id  (application_form_id)
 #  index_timeline_events_on_assignee_id          (assignee_id)
+#  index_timeline_events_on_eventable            (eventable_type,eventable_id)
 #
 # Foreign Keys
 #

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe TimelineEvent do
       is_expected.to define_enum_for(:event_type).with_values(
         assessor_assigned: "assessor_assigned",
         reviewer_assigned: "reviewer_assigned",
-        state_changed: "state_changed"
+        state_changed: "state_changed",
+        assessment_section_recorded: "assessment_section_recorded"
       ).backed_by_column_of_type(:string)
     end
 

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -6,6 +6,7 @@
 #  annotation          :string           default(""), not null
 #  creator_type        :string
 #  event_type          :string           not null
+#  eventable_type      :string
 #  new_state           :string           default(""), not null
 #  old_state           :string           default(""), not null
 #  created_at          :datetime         not null
@@ -13,11 +14,13 @@
 #  application_form_id :bigint           not null
 #  assignee_id         :bigint
 #  creator_id          :integer
+#  eventable_id        :bigint
 #
 # Indexes
 #
 #  index_timeline_events_on_application_form_id  (application_form_id)
 #  index_timeline_events_on_assignee_id          (assignee_id)
+#  index_timeline_events_on_eventable            (eventable_type,eventable_id)
 #
 # Foreign Keys
 #

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal
+
+require "rails_helper"
+
+RSpec.describe UpdateAssessmentSection do
+  let(:assessment_section) { create(:assessment_section, :personal_information) }
+  let(:selected_failure_reason) { assessment_section.failure_reasons.sample }
+  let(:params) { { passed: false, selected_failure_reasons: [selected_failure_reason] } }
+  subject { described_class.call(assessment_section:, params:) }
+
+  context "when the update is successful" do
+    it "returns true" do
+      expect(subject).to eq(true)
+    end
+
+    it "sets the state" do
+      expect { subject }.to change { assessment_section.state }.from(:not_started).to(:action_required)
+    end
+
+    it "sets the failure reasons" do
+      expect { subject }.to change { assessment_section.selected_failure_reasons }
+        .from([]).to([selected_failure_reason])
+    end
+  end
+
+  context "when the update fails" do
+    before { allow(assessment_section).to receive(:update).and_return(false) }
+
+    it "returns false" do
+      expect(subject).to eq(false)
+    end
+  end
+end

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -3,10 +3,15 @@
 require "rails_helper"
 
 RSpec.describe UpdateAssessmentSection do
-  let(:assessment_section) { create(:assessment_section, :personal_information) }
+  let(:user) { build(:staff, id: 1) }
+  let(:assessment_section) do
+    create(:assessment_section, :personal_information)
+  end
   let(:selected_failure_reason) { assessment_section.failure_reasons.sample }
-  let(:params) { { passed: false, selected_failure_reasons: [selected_failure_reason] } }
-  subject { described_class.call(assessment_section:, params:) }
+  let(:params) do
+    { passed: false, selected_failure_reasons: [selected_failure_reason] }
+  end
+  subject { described_class.call(assessment_section:, user:, params:) }
 
   context "when the update is successful" do
     it "returns true" do
@@ -14,12 +19,19 @@ RSpec.describe UpdateAssessmentSection do
     end
 
     it "sets the state" do
-      expect { subject }.to change { assessment_section.state }.from(:not_started).to(:action_required)
+      expect { subject }.to change { assessment_section.state }.from(
+        :not_started
+      ).to(:action_required)
+    end
+
+    it "creates a timeline event" do
+      expect { subject }.to change { TimelineEvent.count }.by(1)
     end
 
     it "sets the failure reasons" do
-      expect { subject }.to change { assessment_section.selected_failure_reasons }
-        .from([]).to([selected_failure_reason])
+      expect { subject }.to change {
+        assessment_section.selected_failure_reasons
+      }.from([]).to([selected_failure_reason])
     end
   end
 
@@ -28,6 +40,10 @@ RSpec.describe UpdateAssessmentSection do
 
     it "returns false" do
       expect(subject).to eq(false)
+    end
+
+    it "doesn't create a timeline event" do
+      expect { subject }.not_to(change { TimelineEvent.count })
     end
   end
 end

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+RSpec.describe AssessorInterface::AssessmentSectionViewObject do
+  subject { described_class.new(params:) }
+  let(:assessment_section) do
+    create(:assessment_section, :personal_information, assessment:)
+  end
+  let(:assessment) { create(:assessment, application_form:) }
+  let(:application_form) { create(:application_form) }
+
+  let(:params) do
+    {
+      key: "personal_information",
+      assessment_id: assessment.id,
+      application_form_id: application_form.id
+    }
+  end
+
+  before { assessment_section }
+
+  describe "assessment_section" do
+    it "returns the correct assessment section" do
+      expect(subject.assessment_section).to eq(assessment_section)
+    end
+  end
+
+  describe "assessment" do
+    it "returns the correct assessment" do
+      expect(subject.assessment).to eq(assessment)
+    end
+  end
+
+  describe "application_form" do
+    it "returns the correct application_form" do
+      expect(subject.application_form).to eq(application_form)
+    end
+  end
+
+  describe "registration_number" do
+    it "returns the correct registration_number" do
+      expect(subject.registration_number).to eq(
+        application_form.registration_number
+      )
+    end
+  end
+
+  describe "qualifications" do
+    it "returns an ordered list of qualifications" do
+      expect(subject.qualifications).to match_array(
+        application_form.qualifications.ordered
+      )
+    end
+  end
+
+  describe "work_histories" do
+    it "returns an ordered list of work histories" do
+      expect(subject.work_histories).to match_array(
+        application_form.work_histories.ordered
+      )
+    end
+  end
+
+  describe "show_registration_number_summary" do
+    subject { super().show_registration_number_summary }
+
+    context "registration number is present" do
+      before { application_form.update(registration_number: "1233445") }
+      it { is_expected.to eq(true) }
+    end
+
+    context "registration number not present" do
+      before { application_form.update(registration_number: nil) }
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  describe "show_written_statement_summary" do
+    subject { super().show_written_statement_summary }
+
+    context "written statement is present" do
+      let(:application_form) do
+        create(:application_form, :with_written_statement)
+      end
+      it { is_expected.to eq(true) }
+    end
+
+    context "written statement is not present" do
+      it { is_expected.to eq(false) }
+    end
+  end
+end


### PR DESCRIPTION
When a assessor completes a section (pass or fail) we want to record it on the timeline.

* Add a new timeline event type
* Add an 'eventable' polymorphic association to the `TimelineEvent`. We could maybe refactor some of the other event types to use this but I haven't as yet. 
* Add `UpdateAssessmentSection` service 
* Add `TimelineEntry` component and refactor timeline to use that

![image](https://user-images.githubusercontent.com/5216/190404577-fd99dd36-4c1d-484c-9a88-528020bc7513.png)
