### PR TITLE
Change application form state for assessment section

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -68,6 +68,7 @@ class ApplicationForm < ApplicationRecord
   enum state: {
          draft: "draft",
          submitted: "submitted",
+         initial_assessment: "initial_assessment",
          awarded: "awarded",
          declined: "declined"
        }

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -33,7 +33,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
 
   def state_filter_options
     counts = application_forms_without_state_filter.group(:state).count
-    states = %w[submitted awarded declined]
+    states = %w[submitted initial_assessment awarded declined]
 
     states.map do |state|
       text = I18n.t("application_form.status.#{state}")

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -72,6 +72,11 @@ FactoryBot.define do
       end
     end
 
+    trait :initial_assessment do
+      state { "initial_assessment" }
+      submitted_at { Time.zone.now }
+    end
+
     trait :awarded do
       state { "awarded" }
       submitted_at { Time.zone.now }

--- a/spec/models/application_spec.rb
+++ b/spec/models/application_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe ApplicationForm, type: :model do
       is_expected.to define_enum_for(:state).with_values(
         draft: "draft",
         submitted: "submitted",
+        initial_assessment: "initial_assessment",
         awarded: "awarded",
         declined: "declined"
       ).backed_by_column_of_type(:string)

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -176,6 +176,10 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
       is_expected.to eq(
         [
           OpenStruct.new(id: "submitted", label: "Not started (0)"),
+          OpenStruct.new(
+            id: "initial_assessment",
+            label: "Initial assessment (0)"
+          ),
           OpenStruct.new(id: "awarded", label: "Awarded (0)"),
           OpenStruct.new(id: "declined", label: "Declined (0)")
         ]
@@ -185,16 +189,21 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
     context "with application forms" do
       before do
         create_list(:application_form, 2, :submitted)
-        create_list(:application_form, 3, :awarded)
-        create_list(:application_form, 4, :declined)
+        create_list(:application_form, 3, :initial_assessment)
+        create_list(:application_form, 4, :awarded)
+        create_list(:application_form, 5, :declined)
       end
 
       it do
         is_expected.to eq(
           [
             OpenStruct.new(id: "submitted", label: "Not started (2)"),
-            OpenStruct.new(id: "awarded", label: "Awarded (3)"),
-            OpenStruct.new(id: "declined", label: "Declined (4)")
+            OpenStruct.new(
+              id: "initial_assessment",
+              label: "Initial assessment (3)"
+            ),
+            OpenStruct.new(id: "awarded", label: "Awarded (4)"),
+            OpenStruct.new(id: "declined", label: "Declined (5)")
           ]
         )
       end


### PR DESCRIPTION
This ensures that the state of application forms is always up to date if a user starts the assessment.

[Trello Card](https://trello.com/c/FwmW7k7p/893-assessment-state-initial-assessment)