### PR TITLE
Change application form assessor for assessment section 

### DIFF
--- a/app/forms/assessor_interface/assessor_assignment_form.rb
+++ b/app/forms/assessor_interface/assessor_assignment_form.rb
@@ -11,19 +11,10 @@ class AssessorInterface::AssessorAssignmentForm
   def save!
     return false unless valid?
 
-    application_form.assessor_id = assessor_id
-    application_form.save!
-    create_timeline_event!
-  end
-
-  private
-
-  def create_timeline_event!
-    TimelineEvent.create!(
+    AssignApplicationFormAssessor.call(
       application_form:,
-      event_type: "assessor_assigned",
-      creator: staff,
-      assignee_id: assessor_id
+      user: staff,
+      assessor: Staff.find(assessor_id)
     )
   end
 end

--- a/app/services/assign_application_form_assessor.rb
+++ b/app/services/assign_application_form_assessor.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AssignApplicationFormAssessor
+  include ServicePattern
+
+  def initialize(application_form:, user:, assessor:)
+    @application_form = application_form
+    @user = user
+    @assessor = assessor
+  end
+
+  def call
+    return if application_form.assessor == assessor
+
+    ActiveRecord::Base.transaction do
+      application_form.update!(assessor:)
+
+      TimelineEvent.create!(
+        application_form:,
+        event_type: "assessor_assigned",
+        creator: user,
+        assignee: assessor
+      )
+    end
+  end
+
+  private
+
+  attr_reader :application_form, :user, :assessor
+end

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -14,6 +14,7 @@ class UpdateAssessmentSection
       next false unless assessment_section.update(params)
 
       create_timeline_event
+      update_application_form_assessor
       update_application_form_state
 
       true
@@ -31,6 +32,16 @@ class UpdateAssessmentSection
       eventable: assessment_section,
       application_form:
     )
+  end
+
+  def update_application_form_assessor
+    if application_form.assessor.nil?
+      AssignApplicationFormAssessor.call(
+        application_form:,
+        user:,
+        assessor: user
+      )
+    end
   end
 
   def update_application_form_state

--- a/spec/services/assign_application_form_assessor_spec.rb
+++ b/spec/services/assign_application_form_assessor_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssignApplicationFormAssessor do
+  let!(:application_form) { create(:application_form, :submitted) }
+  let(:user) { create(:staff) }
+  let(:assessor) { create(:staff) }
+
+  subject(:call) { described_class.call(application_form:, user:, assessor:) }
+
+  describe "application form assessor" do
+    subject(:assessor) { application_form.assessor }
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to be(assessor) }
+    end
+  end
+
+  describe "record timeline event" do
+    subject(:timeline_event) do
+      TimelineEvent.assessor_assigned.find_by(application_form:)
+    end
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to_not be_nil }
+
+      it "sets the attributes correctly" do
+        expect(timeline_event.creator).to eq(user)
+        expect(timeline_event.assignee).to eq(assessor)
+      end
+    end
+  end
+end

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -41,6 +41,20 @@ RSpec.describe UpdateAssessmentSection do
       }.from([]).to([selected_failure_reason])
     end
 
+    it "changes the assessor" do
+      expect { subject }.to change { application_form.assessor }.from(nil).to(
+        user
+      )
+    end
+
+    context "with an existing assessor" do
+      before { application_form.assessor = create(:staff) }
+
+      it "doesn't change the assessor" do
+        expect { subject }.to_not(change { application_form.assessor })
+      end
+    end
+
     it "changes the application form state" do
       expect { subject }.to change { application_form.state }.from(
         "submitted"
@@ -57,6 +71,10 @@ RSpec.describe UpdateAssessmentSection do
 
     it "doesn't create a timeline event" do
       expect { subject }.to_not(change { TimelineEvent.count })
+    end
+
+    it "doesn't change the assessor" do
+      expect { subject }.to_not(change { application_form.assessor })
     end
 
     it "doesn't change the application form state" do


### PR DESCRIPTION
This ensures that an application form has an assessor assigned to it if the assessment has started.

[Trello Card](https://trello.com/c/IV3wWu3H/892-assign-assessment-to-the-first-user-that-completes-a-section)