### PR TITLE
Show teaching authority other for online regions

### DIFF
--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -42,6 +42,10 @@
           As your education department or authority has an online register of teachers,
           you’ll need to provide any reference numbers we need to check your record.
         </p>
+
+        <% if region.teaching_authority_other.present? %>
+          <%= raw GovukMarkdown.render(region.teaching_authority_other) %>
+        <% end %>
       <% end %>
 
       <% if region.status_check_written? && region.sanction_check_written? %>


### PR DESCRIPTION
Sometimes the other information is relevant for regions which are online only, and at the moment this won't be shown.

This has been requested by our content designer as we enable more regions.