### PR TITLE
Fix when other content is displayed

### DIFF
--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -42,7 +42,9 @@
           As your education department or authority has an online register of teachers,
           you’ll need to provide any reference numbers we need to check your record.
         </p>
+      <% end %>
 
+      <% if region.status_check_online? && region.sanction_check_online? %>
         <% if region.teaching_authority_other.present? %>
           <%= raw GovukMarkdown.render(region.teaching_authority_other) %>
         <% end %>


### PR DESCRIPTION
We only want this to show if both status and sanction checks are online otherwise we end up duplicating this content in the section below with a written status or sanction check.