### PR TITLE
[913] Further information request models

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -20,6 +20,7 @@ class Assessment < ApplicationRecord
   belongs_to :application_form
 
   has_many :sections, class_name: "AssessmentSection"
+  has_many :further_information_requests
 
   enum :recommendation,
        { unknown: "unknown", award: "award", decline: "decline" },

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -32,6 +32,7 @@ class Document < ApplicationRecord
     qualification_certificate
     qualification_transcript
     written_statement
+    further_information_request
   ].freeze
   DOCUMENT_TYPES = (UNTRANSLATABLE_TYPES + TRANSLATABLE_TYPES).freeze
 

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -15,6 +15,9 @@
 #
 class FurtherInformationRequest < ApplicationRecord
   belongs_to :assessment
+  has_many :items,
+           class_name: "FurtherInformationRequestItem",
+           inverse_of: :further_information_request
 
   enum :state,
        { requested: "requested", received: "received" },

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: further_information_requests
+#
+#  id            :bigint           not null, primary key
+#  received_at   :datetime
+#  state         :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  assessment_id :bigint
+#
+# Indexes
+#
+#  index_further_information_requests_on_assessment_id  (assessment_id)
+#
+class FurtherInformationRequest < ApplicationRecord
+  belongs_to :assessment
+
+  enum :state,
+       { requested: "requested", received: "received" },
+       default: :requested
+end

--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: further_information_request_items
+#
+#  id                             :bigint           not null, primary key
+#  assessor_notes                 :text
+#  information_type               :string
+#  response                       :text
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  further_information_request_id :bigint
+#
+# Indexes
+#
+#  index_fi_request_items_on_fi_request_id  (further_information_request_id)
+#
+class FurtherInformationRequestItem < ApplicationRecord
+  belongs_to :further_information_request, inverse_of: :items
+
+  enum :information_type, { text: "text", document: "document" }
+end

--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -18,6 +18,7 @@
 #
 class FurtherInformationRequestItem < ApplicationRecord
   belongs_to :further_information_request, inverse_of: :items
+  has_one :document, as: :documentable
 
   enum :information_type, { text: "text", document: "document" }
 end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -46,6 +46,16 @@
     - needs_work_history
     - needs_written_statement
     - needs_registration_number
+  :assessment_sections:
+    - id
+    - assessment_id
+    - key
+    - passed
+    - checks
+    - failure_reasons
+    - selected_failure_reasons
+    - created_at
+    - updated_at
   :assessments:
     - id
     - application_form_id
@@ -88,6 +98,21 @@
     - active
     - created_at
     - updated_at
+  :further_information_requests:
+    - id
+    - received_at
+    - state
+    - created_at
+    - updated_at
+    - assessment_id
+  :further_information_request_items:
+    - id
+    - information_type
+    - created_at
+    - updated_at
+    - further_information_request_id
+    - assessor_notes
+    - response
   :qualifications:
     - id
     - application_form_id
@@ -116,16 +141,6 @@
     - teaching_authority_other
     - teaching_authority_certificate
     - application_form_enabled
-  :assessment_sections:
-    - id
-    - assessment_id
-    - key
-    - passed
-    - checks
-    - failure_reasons
-    - selected_failure_reasons
-    - created_at
-    - updated_at
   :staff:
     - id
     - email

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -16,6 +16,9 @@
     - registration_number
     - has_work_history
     - subjects
+  :further_information_request_items:
+    - assessor_notes
+    - response
   :qualifications:
     - title
     - institution_name

--- a/db/migrate/20220919100309_create_further_information_request.rb
+++ b/db/migrate/20220919100309_create_further_information_request.rb
@@ -1,0 +1,10 @@
+class CreateFurtherInformationRequest < ActiveRecord::Migration[7.0]
+  def change
+    create_table :further_information_requests do |t|
+      t.references :assessment
+      t.string :state, null: false
+      t.datetime :received_at
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220919110134_create_further_information_request_items.rb
+++ b/db/migrate/20220919110134_create_further_information_request_items.rb
@@ -1,0 +1,14 @@
+class CreateFurtherInformationRequestItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :further_information_request_items do |t|
+      t.references :further_information_request,
+                   index: {
+                     name: "index_fi_request_items_on_fi_request_id"
+                   }
+      t.text :assessor_notes
+      t.string :information_type
+      t.text :response
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_19_100309) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_19_110134) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -139,6 +139,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_19_100309) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_features_on_name", unique: true
+  end
+
+  create_table "further_information_request_items", force: :cascade do |t|
+    t.bigint "further_information_request_id"
+    t.text "assessor_notes"
+    t.string "information_type"
+    t.text "response"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["further_information_request_id"], name: "index_fi_request_items_on_fi_request_id"
   end
 
   create_table "further_information_requests", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_14_121554) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_19_100309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -139,6 +139,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_14_121554) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_features_on_name", unique: true
+  end
+
+  create_table "further_information_requests", force: :cascade do |t|
+    t.bigint "assessment_id"
+    t.string "state", null: false
+    t.datetime "received_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessment_id"], name: "index_further_information_requests_on_assessment_id"
   end
 
   create_table "qualifications", force: :cascade do |t|

--- a/spec/factories/further_information_request_items.rb
+++ b/spec/factories/further_information_request_items.rb
@@ -1,0 +1,31 @@
+#frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: further_information_request_items
+#
+#  id                             :bigint           not null, primary key
+#  assessor_notes                 :text
+#  information_type               :string
+#  response                       :text
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  further_information_request_id :bigint
+#
+# Indexes
+#
+#  index_fi_request_items_on_fi_request_id  (further_information_request_id)
+#
+FactoryBot.define do
+  factory :further_information_request_item do
+    association :further_information_request
+
+    trait :with_text_response do
+      information_type { "text" }
+    end
+
+    trait :with_document_response do
+      information_type { "document" }
+    end
+  end
+end

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: further_information_requests
+#
+#  id            :bigint           not null, primary key
+#  received_at   :datetime
+#  state         :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  assessment_id :bigint
+#
+# Indexes
+#
+#  index_further_information_requests_on_assessment_id  (assessment_id)
+#
+FactoryBot.define do
+  factory :further_information_request do
+    trait :requested do
+      state { "requested" }
+    end
+
+    trait :received do
+      state { "received" }
+      received_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
+    end
+  end
+end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -23,9 +23,12 @@ require "rails_helper"
 RSpec.describe Assessment, type: :model do
   subject(:assessment) { create(:assessment) }
 
-  describe "validations" do
+  describe "associations" do
     it { is_expected.to have_many(:sections) }
+    it { is_expected.to have_many(:further_information_requests) }
+  end
 
+  describe "validations" do
     it { is_expected.to validate_presence_of(:recommendation) }
 
     it do

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Document, type: :model do
         name_change: "name_change",
         qualification_certificate: "qualification_certificate",
         qualification_transcript: "qualification_transcript",
-        written_statement: "written_statement"
+        written_statement: "written_statement",
+        further_information_request: "further_information_request"
       ).backed_by_column_of_type(:string)
     end
   end

--- a/spec/models/further_information_request_item_spec.rb
+++ b/spec/models/further_information_request_item_spec.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+#
+# Table name: further_information_request_items
+#
+#  id                             :bigint           not null, primary key
+#  assessor_notes                 :text
+#  information_type               :string
+#  response                       :text
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  further_information_request_id :bigint
+#
+# Indexes
+#
+#  index_fi_request_items_on_fi_request_id  (further_information_request_id)
+#
+#frozen_string_literal :true
+
+require "rails_helper"
+
+RSpec.describe FurtherInformationRequestItem do
+  describe "associations" do
+    it { is_expected.to belong_to(:further_information_request) }
+  end
+
+  it do
+    is_expected.to define_enum_for(:information_type).with_values(
+      text: "text",
+      document: "document"
+    ).backed_by_column_of_type(:string)
+  end
+end

--- a/spec/models/further_information_request_item_spec.rb
+++ b/spec/models/further_information_request_item_spec.rb
@@ -21,6 +21,7 @@ require "rails_helper"
 RSpec.describe FurtherInformationRequestItem do
   describe "associations" do
     it { is_expected.to belong_to(:further_information_request) }
+    it { is_expected.to have_one(:document) }
   end
 
   it do

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: further_information_requests
+#
+#  id            :bigint           not null, primary key
+#  received_at   :datetime
+#  state         :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  assessment_id :bigint
+#
+# Indexes
+#
+#  index_further_information_requests_on_assessment_id  (assessment_id)
+#
+require "rails_helper"
+
+RSpec.describe FurtherInformationRequest do
+  describe "associations" do
+    it { is_expected.to belong_to(:assessment) }
+  end
+
+  it do
+    is_expected.to define_enum_for(:state).with_values(
+      requested: "requested",
+      received: "received"
+    ).backed_by_column_of_type(:string)
+  end
+end


### PR DESCRIPTION
We are building functionality to allow an assessor to request further information from an applicant. 

Some basic models to allow us to build this out.

```
Assessment
  -> has_many `FurtherInformationRequest`
      -> has_many `FurtherInformationRequestItem` (as `items`)
           -> has_many `FurtherInformationRequestDocument` (this might maybe should be has_one)
                 -> has_many `Upload`
```

The existing `Document` class is quite tightly bound to the `Application` with its types and URL helpers. I think we'll most likely end up needing these types in the FI process as the current prototype seems to render a different page depending on the document type that is being requested. It's not clear yet how we map 'failure reasons' to specific document types or whether we should have that level of complexity initially. 

As the design is still in flux with all that, I've refactored `Upload` to be associated polymorphically and added an FI specific  document class `FurtherInformationRequestDocument`. We can switch this out for the `Document` class if it makes sense as we iterate. 

The migration of `Upload` to make it polymorphic is destructive but I think this is ok as we only have test data that we can reseed in non-production environments.