### PR TITLE
Error message content update

### DIFF
--- a/app/controllers/teacher_interface/documents_controller.rb
+++ b/app/controllers/teacher_interface/documents_controller.rb
@@ -4,6 +4,7 @@ module TeacherInterface
     before_action :load_document
 
     def edit
+      @add_another_upload_form = AddAnotherUploadForm.new
       if document.uploads.empty?
         redirect_to new_teacher_interface_application_form_document_upload_path(
                       @document,
@@ -12,14 +13,20 @@ module TeacherInterface
     end
 
     def update
-      add_another = params.dig(:document, :add_another)
-
-      if add_another && ActiveModel::Type::Boolean.new.cast(add_another)
-        redirect_to new_teacher_interface_application_form_document_upload_path(
-                      @document,
-                    )
+      add_another =
+        params.dig(:teacher_interface_add_another_upload_form, :add_another)
+      @add_another_upload_form =
+        TeacherInterface::AddAnotherUploadForm.new(add_another:)
+      if @add_another_upload_form.valid?
+        if @add_another_upload_form.add_another
+          redirect_to new_teacher_interface_application_form_document_upload_path(
+                        @document,
+                      )
+        else
+          redirect_to document.continue_url
+        end
       else
-        redirect_to document.continue_url
+        render :edit, status: :unprocessable_entity
       end
     end
   end

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -25,15 +25,18 @@ module TeacherInterface
     end
 
     def delete
+      @delete_upload_form = DeleteUploadForm.new
     end
 
     def destroy
-      if ActiveModel::Type::Boolean.new.cast(params.dig(:upload, :confirm))
-        @upload.attachment.purge
-        @upload.destroy!
+      confirm = params.dig(:teacher_interface_delete_upload_form, :confirm)
+      @delete_upload_form =
+        TeacherInterface::DeleteUploadForm.new(confirm:, upload: @upload)
+      if @delete_upload_form.save!
+        redirect_to [:edit, :teacher_interface, :application_form, @document]
+      else
+        render :delete, status: :unprocessable_entity
       end
-
-      redirect_to [:edit, :teacher_interface, :application_form, @document]
     end
 
     private

--- a/app/forms/teacher_interface/add_another_upload_form.rb
+++ b/app/forms/teacher_interface/add_another_upload_form.rb
@@ -1,0 +1,8 @@
+class TeacherInterface::AddAnotherUploadForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :add_another, :boolean
+
+  validates :add_another, inclusion: { in: [true, false] }
+end

--- a/app/forms/teacher_interface/alternative_name_form.rb
+++ b/app/forms/teacher_interface/alternative_name_form.rb
@@ -9,6 +9,9 @@ class TeacherInterface::AlternativeNameForm
   attribute :alternative_family_name, :string
 
   validates :application_form, presence: true
+  validates :alternative_given_names, presence: true, if: :has_alternative_name
+  validates :alternative_family_name, presence: true, if: :has_alternative_name
+  validates :has_alternative_name, inclusion: { in: [true, false] }
 
   def save
     return false unless valid?

--- a/app/forms/teacher_interface/delete_upload_form.rb
+++ b/app/forms/teacher_interface/delete_upload_form.rb
@@ -1,0 +1,21 @@
+class TeacherInterface::DeleteUploadForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :upload
+
+  attribute :confirm, :boolean
+
+  validates :confirm, inclusion: { in: [true, false] }
+  validates :upload, presence: true, if: :confirm
+
+  def save!
+    return unless valid?
+
+    if confirm
+      upload.attachment.purge
+      upload.destroy!
+    end
+    true
+  end
+end

--- a/app/forms/teacher_interface/name_and_date_of_birth_form.rb
+++ b/app/forms/teacher_interface/name_and_date_of_birth_form.rb
@@ -10,8 +10,14 @@ class TeacherInterface::NameAndDateOfBirthForm
 
   validates :application_form, presence: true
   validates :date_of_birth,
-            allow_blank: true,
+            comparison: {
+              less_than: Time.zone.today,
+            },
+            presence: true,
             inclusion: 100.years.ago..18.years.ago
+
+  validates :given_names, presence: true
+  validates :family_name, presence: true
 
   def save
     return false unless valid?

--- a/app/views/teacher_interface/documents/edit.html.erb
+++ b/app/views/teacher_interface/documents/edit.html.erb
@@ -18,8 +18,7 @@
     end
   end
 end %>
-
-<%= form_with model: [:teacher_interface, :application_form, @document] do |f| %>
+<%= form_with model: @add_another_upload_form, url: [:teacher_interface, :application_form, @document], method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_radio_buttons_fieldset :add_another,

--- a/app/views/teacher_interface/uploads/delete.html.erb
+++ b/app/views/teacher_interface/uploads/delete.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "Delete file" %>
 <% content_for :back_link_url, edit_teacher_interface_application_form_document_path(@document) %>
 
-<%= form_with model: [:teacher_interface, :application_form, @document, @upload], method: :delete do |f| %>
+<%= form_with model: @delete_upload_form, url: [:teacher_interface, :application_form, @document, @upload], method: :delete do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :confirm,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -148,11 +148,11 @@ en:
         eligibility_interface/degree_form:
           attributes:
             degree:
-              inclusion: Tell us if you have a degree
+              inclusion: Tell us whether you have a university degree
         eligibility_interface/misconduct_form:
           attributes:
             misconduct:
-              inclusion: Tell us if your employment record is free of sanctions
+              inclusion: Tell us whether your employment record has any sanctions or restrictions
         eligibility_interface/qualification_form:
           attributes:
             qualification:
@@ -164,11 +164,33 @@ en:
         eligibility_interface/teach_children_form:
           attributes:
             teach_children:
-              inclusion: Tell us if you have experience with teaching children
+              inclusion: Tell us whether you’re qualified to teach children aged between 5 and 16
         teacher_interface/name_and_date_of_birth_form:
           attributes:
             date_of_birth:
               inclusion: You must be 18 or over to use this service
+              blank: Enter your date of birth in the format 27 3 1980
+              less_than: Your date of birth must be in the past
+            given_names:
+              blank: Enter your given names
+            family_name:
+              blank: Enter your family name
+        teacher_interface/alternative_name_form:
+          attributes:
+            alternative_given_names:
+              blank: Enter your alternate given names
+            alternative_family_name:
+              blank: Enter your alternate family name
+            has_alternative_name:
+              inclusion: Tell us whether you have an alternative name
+        teacher_interface/add_another_upload_form:
+          attributes:
+            add_another:
+              inclusion: Select whether you need to upload another page
+        teacher_interface/delete_upload_form:
+          attributes:
+            confirm:
+              inclusion: Select whether you want to delete this file
         teacher_interface/new_session_form:
           attributes:
             email:

--- a/spec/forms/teacher_interface/add_another_upload_form_spec.rb
+++ b/spec/forms/teacher_interface/add_another_upload_form_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe TeacherInterface::AddAnotherUploadForm, type: :model do
+  describe "validations" do
+    subject(:form) { described_class.new(add_another:) }
+
+    context "when the fields are blank" do
+      let(:add_another) { "" }
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context "when the fields are true" do
+      let(:add_another) { true }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the fields are false" do
+      let(:add_another) { false }
+
+      it { is_expected.to be_valid }
+    end
+  end
+end

--- a/spec/forms/teacher_interface/alternative_name_form_spec.rb
+++ b/spec/forms/teacher_interface/alternative_name_form_spec.rb
@@ -1,16 +1,10 @@
 require "rails_helper"
 
 RSpec.describe TeacherInterface::AlternativeNameForm, type: :model do
-  describe "validations" do
-    it { is_expected.to validate_presence_of(:application_form) }
-  end
-
   let(:application_form) { build(:application_form) }
 
-  describe "#valid?" do
-    subject(:valid?) { form.valid? }
-
-    let(:form) do
+  describe "validations" do
+    subject(:form) do
       described_class.new(
         application_form:,
         has_alternative_name:,
@@ -18,11 +12,67 @@ RSpec.describe TeacherInterface::AlternativeNameForm, type: :model do
         alternative_family_name:,
       )
     end
-    let(:has_alternative_name) { "" }
-    let(:alternative_given_names) { "" }
-    let(:alternative_family_name) { "" }
+    let(:has_alternative_name) { nil }
+    let(:alternative_family_name) { nil }
+    let(:alternative_given_names) { nil }
 
-    it { is_expected.to be true }
+    it { is_expected.to validate_presence_of(:application_form) }
+
+    context "when the fields are all blank" do
+      let(:has_alternative_name) { "" }
+      let(:alternative_given_names) { "" }
+      let(:alternative_family_name) { "" }
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context "when the fields are blank and has_alternative_name is true" do
+      let(:has_alternative_name) { true }
+      let(:alternative_given_names) { "" }
+      let(:alternative_family_name) { "" }
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context "when the fields are filled out and has_alternative_name is true" do
+      let(:has_alternative_name) { true }
+      let(:alternative_given_names) { "given_name" }
+      let(:alternative_family_name) { "family_name" }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the fields are blank and has_alternative_name is false" do
+      let(:has_alternative_name) { false }
+      let(:alternative_given_names) { "" }
+      let(:alternative_family_name) { "" }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the fields are filled out and has_alternative_name is false" do
+      let(:has_alternative_name) { false }
+      let(:alternative_given_names) { "given_name" }
+      let(:alternative_family_name) { "family_name" }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when only one field is filled out and has_alternative_name is false" do
+      let(:has_alternative_name) { false }
+      let(:alternative_given_names) { "" }
+      let(:alternative_family_name) { "family_name" }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when only one field is filled out and has_alternative_name is true" do
+      let(:has_alternative_name) { true }
+      let(:alternative_given_names) { "given_name" }
+      let(:alternative_family_name) { "" }
+
+      it { is_expected.to_not be_valid }
+    end
   end
 
   describe "#save" do

--- a/spec/forms/teacher_interface/delete_upload_form_spec.rb
+++ b/spec/forms/teacher_interface/delete_upload_form_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe TeacherInterface::DeleteUploadForm, type: :model do
+  describe "validations" do
+    subject(:form) { described_class.new(confirm:, upload:) }
+
+    context "when the fields are blank" do
+      let(:confirm) { "" }
+      let(:upload) { "" }
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context "when confirm field is true but upload is blank" do
+      let(:confirm) { true }
+      let!(:upload) { "" }
+
+      it { is_expected.to_not be_valid }
+    end
+
+    context "when the fields are true" do
+      let(:confirm) { true }
+      let!(:upload) { true }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the fields are false" do
+      let(:confirm) { false }
+      let!(:upload) { "" }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "file is successfully deleted when confirm is true" do
+      let!(:upload) { create(:upload) }
+      let(:confirm) { true }
+
+      it "deletes the upload" do
+        expect { form.save! }.to change { Upload.count }.by(-1)
+      end
+    end
+
+    context "file is not successfully deleted" do
+      let!(:upload) { create(:upload) }
+      let(:confirm) { false }
+
+      it "doesn't delete the upload" do
+        expect { form.save! }.to change { Upload.count }.by(0)
+      end
+    end
+  end
+end

--- a/spec/forms/teacher_interface/name_and_date_of_birth_form_spec.rb
+++ b/spec/forms/teacher_interface/name_and_date_of_birth_form_spec.rb
@@ -7,10 +7,8 @@ RSpec.describe TeacherInterface::NameAndDateOfBirthForm, type: :model do
 
   let(:application_form) { build(:application_form) }
 
-  describe "#valid?" do
-    subject(:valid?) { form.valid? }
-
-    let(:form) do
+  describe "validations" do
+    subject(:form) do
       described_class.new(
         application_form:,
         given_names:,
@@ -18,22 +16,35 @@ RSpec.describe TeacherInterface::NameAndDateOfBirthForm, type: :model do
         date_of_birth:,
       )
     end
-    let(:given_names) { "" }
-    let(:family_name) { "" }
-    let(:date_of_birth) { "" }
 
-    it { is_expected.to be true }
+    context "when date of birth and names are blank" do
+      let(:given_names) { "" }
+      let(:family_name) { "" }
+      let(:date_of_birth) { "" }
+
+      it { is_expected.to_not be_valid }
+    end
 
     context "when date of birth is less than 18 years ago" do
       let(:date_of_birth) { Time.zone.now }
+      let(:given_names) { "given_name" }
+      let(:family_name) { "family_name" }
+      it { is_expected.to_not be_valid }
+    end
 
-      it { is_expected.to be false }
+    context "when date of birth is more than 18 years ago but less than 100 years ago" do
+      let(:date_of_birth) { Date.new(2003, 1, 1) }
+      let(:given_names) { "given_name" }
+      let(:family_name) { "family_name" }
+      it { is_expected.to be_valid }
     end
 
     context "when date of birth is greater than 100 years ago" do
       let(:date_of_birth) { Date.new(1900, 1, 1) }
+      let(:given_names) { "given_name" }
+      let(:family_name) { "family_name" }
 
-      it { is_expected.to be false }
+      it { is_expected.to_not be_valid }
     end
   end
 


### PR DESCRIPTION
Update content for error messages in eligiblity checker and application form 
Add two new forms to validate where none existed previously.



<img width="1416" alt="Screenshot 2022-09-22 at 14 34 30" src="https://user-images.githubusercontent.com/45995847/191761363-5be12baf-d9c3-44ba-af9e-2a669848f8dd.png">

<img width="1209" alt="Screenshot 2022-09-22 at 14 34 53" src="https://user-images.githubusercontent.com/45995847/191761480-c9b95077-f522-4b61-95bb-069684b64b06.png">

<img width="1303" alt="Screenshot 2022-09-22 at 14 35 15" src="https://user-images.githubusercontent.com/45995847/191761563-6e85091a-6864-459a-87b6-6e7e4a0c50c8.png">

<img width="1109" alt="Screenshot 2022-09-22 at 14 35 36" src="https://user-images.githubusercontent.com/45995847/191761633-3bea2855-6419-4fcd-a5ff-4d4e8afd01a4.png">
