### PR TITLE
Add notes to application forms

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -43,3 +43,9 @@ ul.autocomplete__menu {
 .app-teacher-personas .govuk-button {
   margin-bottom: 0;
 }
+
+.app-inline-action {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -54,5 +54,9 @@ module TimelineEntry
           ),
       }
     end
+
+    def note_created_vars
+      { text: timeline_event.note.text }
+    end
   end
 end

--- a/app/controllers/assessor_interface/notes_controller.rb
+++ b/app/controllers/assessor_interface/notes_controller.rb
@@ -1,0 +1,36 @@
+module AssessorInterface
+  class NotesController < BaseController
+    def new
+      @application_form = application_form
+      @create_note_form = CreateNoteForm.new
+    end
+
+    def create
+      @application_form = application_form
+      @create_note_form =
+        CreateNoteForm.new(
+          create_new_form_params.merge(application_form:, author:),
+        )
+
+      if @create_note_form.save!
+        redirect_to [:assessor_interface, application_form]
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def application_form
+      @application_form ||= ApplicationForm.find(params[:application_form_id])
+    end
+
+    def author
+      @author ||= current_staff
+    end
+
+    def create_new_form_params
+      params.require(:assessor_interface_create_note_form).permit(:text)
+    end
+  end
+end

--- a/app/controllers/assessor_interface/timeline_events_controller.rb
+++ b/app/controllers/assessor_interface/timeline_events_controller.rb
@@ -4,9 +4,10 @@ module AssessorInterface
       @application_form = ApplicationForm.find(params[:application_form_id])
 
       @timeline_events =
-        TimelineEvent.where(application_form: @application_form).order(
-          created_at: :desc,
-        )
+        TimelineEvent
+          .includes(:note)
+          .where(application_form: @application_form)
+          .order(created_at: :desc)
     end
   end
 end

--- a/app/forms/assessor_interface/create_note_form.rb
+++ b/app/forms/assessor_interface/create_note_form.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class AssessorInterface::CreateNoteForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  attr_accessor :application_form, :author
+  attribute :text, :string
+
+  validates :application_form, :author, :text, presence: true
+
+  def save!
+    return false unless valid?
+
+    ActiveRecord::Base.transaction do
+      note = Note.create!(application_form:, author:, text:)
+
+      TimelineEvent.create!(
+        application_form:,
+        event_type: "note_created",
+        creator: author,
+        note:,
+      )
+    end
+  end
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -53,6 +53,7 @@ class ApplicationForm < ApplicationRecord
   has_many :documents, as: :documentable
   has_many :timeline_events
   has_one :assessment
+  has_many :notes
 
   before_create :build_documents
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: notes
+#
+#  id                  :bigint           not null, primary key
+#  text                :text             not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  application_form_id :bigint           not null
+#  author_id           :bigint           not null
+#
+# Indexes
+#
+#  index_notes_on_application_form_id  (application_form_id)
+#  index_notes_on_author_id            (author_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (application_form_id => application_forms.id)
+#  fk_rails_...  (author_id => staff.id)
+#
+class Note < ApplicationRecord
+  belongs_to :application_form
+  belongs_to :author, class_name: "Staff"
+
+  validates :text, presence: true
+end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -17,17 +17,20 @@
 #  assignee_id         :bigint
 #  creator_id          :integer
 #  eventable_id        :bigint
+#  note_id             :bigint
 #
 # Indexes
 #
 #  index_timeline_events_on_application_form_id  (application_form_id)
 #  index_timeline_events_on_assignee_id          (assignee_id)
 #  index_timeline_events_on_eventable            (eventable_type,eventable_id)
+#  index_timeline_events_on_note_id              (note_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (application_form_id => application_forms.id)
 #  fk_rails_...  (assignee_id => staff.id)
+#  fk_rails_...  (note_id => notes.id)
 #
 class TimelineEvent < ApplicationRecord
   belongs_to :application_form
@@ -39,6 +42,7 @@ class TimelineEvent < ApplicationRecord
          reviewer_assigned: "reviewer_assigned",
          state_changed: "state_changed",
          assessment_section_recorded: "assessment_section_recorded",
+         note_created: "note_created",
        }
   validates :event_type, inclusion: { in: event_types.values }
 
@@ -52,4 +56,8 @@ class TimelineEvent < ApplicationRecord
 
   validates :old_state, :new_state, presence: true, if: :state_changed?
   validates :old_state, :new_state, absence: true, unless: :state_changed?
+
+  belongs_to :note, optional: true
+  validates :note, presence: true, if: :note_created?
+  validates :note, absence: true, unless: :note_created?
 end

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -1,7 +1,10 @@
 <% content_for :page_title, "Application" %>
 <% content_for :back_link_url, @view_object.back_link_path %>
 
-<h1 class="govuk-heading-xl">Application</h1>
+<div class="app-inline-action">
+  <h1 class="govuk-heading-xl">Application</h1>
+  <%= govuk_button_link_to "Add note", new_assessor_interface_application_form_note_path(@view_object.application_form), secondary: true %>
+</div>
 
 <%= render(ApplicationFormOverview::Component.new(@view_object.application_form)) %>
 

--- a/app/views/assessor_interface/notes/new.html.erb
+++ b/app/views/assessor_interface/notes/new.html.erb
@@ -1,0 +1,12 @@
+<% content_for :page_title, "Add a note" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+
+<%= form_with model: @create_note_form, url: assessor_interface_application_form_notes_path(@application_form) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_text_area :text, label: { tag: "h1", size: "l" }, rows: 5 %>
+
+  <%= f.govuk_submit "Save and continue" do %>
+    <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
+  <% end %>
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -113,6 +113,13 @@
     - further_information_request_id
     - assessor_notes
     - response
+  :notes:
+    - id
+    - application_form_id
+    - author_id
+    - text
+    - created_at
+    - updated_at
   :qualifications:
     - id
     - application_form_id

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -200,6 +200,7 @@
     - new_state
     - eventable_type
     - eventable_id
+    - note_id
   :uploads:
     - id
     - document_id

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -19,6 +19,8 @@
   :further_information_request_items:
     - assessor_notes
     - response
+  :notes:
+    - text
   :qualifications:
     - title
     - institution_name

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -77,8 +77,10 @@ en:
         reviewer_assigned: Reviewer assigned
         state_changed: Status changed
         assessment_section_completed: Section completed
+        note_created: Note created
       description:
         assessor_assigned: "%{assignee_name} is assigned as the assessor."
         reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
         state_changed: Status changed from %{old_state} to %{new_state}
         assessment_section_recorded: "%{section_name}: %{section_state}"
+        note_created: "%{text}"

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -84,3 +84,11 @@ en:
         state_changed: Status changed from %{old_state} to %{new_state}
         assessment_section_recorded: "%{section_name}: %{section_state}"
         note_created: "%{text}"
+
+  activemodel:
+    errors:
+      models:
+        assessor_interface/create_note_form:
+          attributes:
+            text:
+              blank: Enter the note

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -6,6 +6,8 @@ en:
         recommendation: You've completed your review of this QTS application and marked all sections as complete to your satisfaction.
       assessment_section:
         selected_failure_reasons: Select all options that are relevant to you.
+      assessor_interface_create_note_form:
+        text: Use the text box to add a note to the application history. Other assessors will be able to see any notes you add, but they will not be visible to the applicant.
       qualification:
         add_another: You can use the next section to tell us about additional degrees if you want to.
       teacher:
@@ -23,6 +25,8 @@ en:
         recommendation_options:
           award: Award QTS
           decline: Decline QTS
+      assessor_interface_create_note_form:
+        text: Add a note to this application
       qualification:
         add_another_options:
           true: "Yes"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
       get "assign-reviewer", to: "reviewer_assignments#new"
       post "assign-reviewer", to: "reviewer_assignments#create"
 
+      resources :notes, only: %i[new create]
       resources :timeline_events, only: :index
 
       resources :assessments, only: %i[edit update] do

--- a/db/migrate/20220921080534_create_notes.rb
+++ b/db/migrate/20220921080534_create_notes.rb
@@ -1,0 +1,10 @@
+class CreateNotes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :notes do |t|
+      t.references :application_form, null: false, foreign_key: true
+      t.references :author, null: false, foreign_key: { to_table: :staff }
+      t.text :text, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220921083326_add_note_to_timeline_events.rb
+++ b/db/migrate/20220921083326_add_note_to_timeline_events.rb
@@ -1,0 +1,7 @@
+class AddNoteToTimelineEvents < ActiveRecord::Migration[7.0]
+  def change
+    change_table :timeline_events, bulk: true do |t|
+      t.references :note, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_19_110134) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_21_080534) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -160,6 +160,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_19_110134) do
     t.index ["assessment_id"], name: "index_further_information_requests_on_assessment_id"
   end
 
+  create_table "notes", force: :cascade do |t|
+    t.bigint "application_form_id", null: false
+    t.bigint "author_id", null: false
+    t.text "text", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["application_form_id"], name: "index_notes_on_application_form_id"
+    t.index ["author_id"], name: "index_notes_on_author_id"
+  end
+
   create_table "qualifications", force: :cascade do |t|
     t.bigint "application_form_id", null: false
     t.text "title", default: "", null: false
@@ -297,6 +307,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_19_110134) do
   add_foreign_key "assessment_sections", "assessments"
   add_foreign_key "assessments", "application_forms"
   add_foreign_key "eligibility_checks", "regions"
+  add_foreign_key "notes", "application_forms"
+  add_foreign_key "notes", "staff", column: "author_id"
   add_foreign_key "qualifications", "application_forms"
   add_foreign_key "regions", "countries"
   add_foreign_key "timeline_events", "application_forms"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_21_080534) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_21_083326) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -270,9 +270,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_21_080534) do
     t.string "new_state", default: "", null: false
     t.string "eventable_type"
     t.bigint "eventable_id"
+    t.bigint "note_id"
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
     t.index ["assignee_id"], name: "index_timeline_events_on_assignee_id"
     t.index ["eventable_type", "eventable_id"], name: "index_timeline_events_on_eventable"
+    t.index ["note_id"], name: "index_timeline_events_on_note_id"
   end
 
   create_table "uploads", force: :cascade do |t|
@@ -312,6 +314,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_21_080534) do
   add_foreign_key "qualifications", "application_forms"
   add_foreign_key "regions", "countries"
   add_foreign_key "timeline_events", "application_forms"
+  add_foreign_key "timeline_events", "notes"
   add_foreign_key "timeline_events", "staff", column: "assignee_id"
   add_foreign_key "uploads", "documents"
   add_foreign_key "work_histories", "application_forms"

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -69,4 +69,17 @@ RSpec.describe TimelineEntry::Component, type: :component do
       expect(component.text).to include(creator.name)
     end
   end
+
+  context "note created" do
+    let(:timeline_event) { create(:timeline_event, :note_created) }
+    let(:text) { timeline_event.note.text }
+
+    it "describes the event" do
+      expect(component.text).to include(text)
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
 end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: notes
+#
+#  id                  :bigint           not null, primary key
+#  text                :text             not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  application_form_id :bigint           not null
+#  author_id           :bigint           not null
+#
+# Indexes
+#
+#  index_notes_on_application_form_id  (application_form_id)
+#  index_notes_on_author_id            (author_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (application_form_id => application_forms.id)
+#  fk_rails_...  (author_id => staff.id)
+#
+FactoryBot.define do
+  factory :note do
+    association :application_form
+    association :author, factory: :staff
+    text { Faker::Lorem.paragraph }
+  end
+end

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -15,17 +15,20 @@
 #  assignee_id         :bigint
 #  creator_id          :integer
 #  eventable_id        :bigint
+#  note_id             :bigint
 #
 # Indexes
 #
 #  index_timeline_events_on_application_form_id  (application_form_id)
 #  index_timeline_events_on_assignee_id          (assignee_id)
 #  index_timeline_events_on_eventable            (eventable_type,eventable_id)
+#  index_timeline_events_on_note_id              (note_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (application_form_id => application_forms.id)
 #  fk_rails_...  (assignee_id => staff.id)
+#  fk_rails_...  (note_id => notes.id)
 #
 FactoryBot.define do
   factory :timeline_event do
@@ -59,6 +62,11 @@ FactoryBot.define do
           assessment: build(:assessment, application_form:),
         )
       end
+    end
+
+    trait :note_created do
+      event_type { "note_created" }
+      association :note
     end
   end
 end

--- a/spec/forms/assessor_interface/create_note_form_spec.rb
+++ b/spec/forms/assessor_interface/create_note_form_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe AssessorInterface::CreateNoteForm, type: :model do
+  let(:application_form) { create(:application_form) }
+  let(:author) { create(:staff, :confirmed) }
+  let(:text) { "A note." }
+
+  subject { described_class.new(application_form:, author:, text:) }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:application_form) }
+    it { is_expected.to validate_presence_of(:author) }
+    it { is_expected.to validate_presence_of(:text) }
+  end
+
+  describe "#save!" do
+    let(:note) { Note.last }
+    let(:timeline_event) { TimelineEvent.last }
+
+    it "creates a note" do
+      expect { subject.save! }.to change { Note.count }.by(1)
+
+      expect(note.application_form).to eq(application_form)
+      expect(note.author).to eq(author)
+      expect(note.text).to eq(text)
+    end
+
+    it "creates a timeline event" do
+      expect { subject.save! }.to change { TimelineEvent.count }.by(1)
+
+      expect(timeline_event).to be_note_created
+      expect(timeline_event.creator).to eq(author)
+      expect(timeline_event.note).to eq(Note.last)
+    end
+  end
+end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -50,6 +50,10 @@ require "rails_helper"
 RSpec.describe ApplicationForm, type: :model do
   subject(:application_form) { create(:application_form) }
 
+  describe "associations" do
+    it { is_expected.to have_many(:notes) }
+  end
+
   describe "validations" do
     it { is_expected.to be_valid }
 

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,0 +1,34 @@
+# == Schema Information
+#
+# Table name: notes
+#
+#  id                  :bigint           not null, primary key
+#  text                :text             not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  application_form_id :bigint           not null
+#  author_id           :bigint           not null
+#
+# Indexes
+#
+#  index_notes_on_application_form_id  (application_form_id)
+#  index_notes_on_author_id            (author_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (application_form_id => application_forms.id)
+#  fk_rails_...  (author_id => staff.id)
+#
+
+require "rails_helper"
+
+RSpec.describe Note, type: :model do
+  describe "associations" do
+    it { is_expected.to belong_to(:application_form) }
+    it { is_expected.to belong_to(:author) }
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:text) }
+  end
+end

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -15,22 +15,29 @@
 #  assignee_id         :bigint
 #  creator_id          :integer
 #  eventable_id        :bigint
+#  note_id             :bigint
 #
 # Indexes
 #
 #  index_timeline_events_on_application_form_id  (application_form_id)
 #  index_timeline_events_on_assignee_id          (assignee_id)
 #  index_timeline_events_on_eventable            (eventable_type,eventable_id)
+#  index_timeline_events_on_note_id              (note_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (application_form_id => application_forms.id)
 #  fk_rails_...  (assignee_id => staff.id)
+#  fk_rails_...  (note_id => notes.id)
 #
 require "rails_helper"
 
 RSpec.describe TimelineEvent do
   subject(:timeline_event) { build(:timeline_event) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:note).optional }
+  end
 
   describe "validations" do
     it do
@@ -39,6 +46,7 @@ RSpec.describe TimelineEvent do
         reviewer_assigned: "reviewer_assigned",
         state_changed: "state_changed",
         assessment_section_recorded: "assessment_section_recorded",
+        note_created: "note_created",
       ).backed_by_column_of_type(:string)
     end
 
@@ -48,6 +56,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:assignee) }
       it { is_expected.to validate_absence_of(:old_state) }
       it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:note) }
     end
 
     context "with an reviewer assigned event type" do
@@ -56,6 +65,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:assignee) }
       it { is_expected.to validate_absence_of(:old_state) }
       it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:note) }
     end
 
     context "with a state changed event type" do
@@ -64,6 +74,16 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:assignee) }
       it { is_expected.to validate_presence_of(:old_state) }
       it { is_expected.to validate_presence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:note) }
+    end
+
+    context "with a note created event type" do
+      before { timeline_event.event_type = :note_created }
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_presence_of(:note) }
     end
   end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/create_note.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/create_note.rb
@@ -1,0 +1,14 @@
+module PageObjects
+  module AssessorInterface
+    class CreateNote < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/notes/new"
+
+      element :heading, "h1"
+
+      section :form, "form" do
+        element :text_textarea, ".govuk-textarea"
+        element :submit_button, ".govuk-button"
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/moj_timeline_item.rb
+++ b/spec/support/autoload/page_objects/moj_timeline_item.rb
@@ -3,7 +3,7 @@ module PageObjects
     element :title, ".moj-timeline__title"
     element :byline, ".moj-timeline__byline"
     element :date, ".moj-timeline__date"
-    element :description, ".moj-moj-timeline__description"
+    element :description, ".moj-timeline__description"
 
     expected_elements :title, :byline, :date, :description
   end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -53,6 +53,10 @@ module PageHelpers
     @country_page ||= PageObjects::EligibilityInterface::Country.new
   end
 
+  def create_note_page
+    @create_note_page ||= PageObjects::AssessorInterface::CreateNote.new
+  end
+
   def degree_page
     @degree_page ||= PageObjects::EligibilityInterface::Degree.new
   end

--- a/spec/system/assessor_interface/creating_note_spec.rb
+++ b/spec/system/assessor_interface/creating_note_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Creating a note", type: :system do
+  it "creates a note" do
+    given_the_service_is_open
+    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_there_is_an_application_form
+    given_an_assessor_exists
+
+    when_i_visit_the(:create_note_page, application_id: application_form.id)
+    and_i_create_a_note
+    then_i_see_the(
+      :assessor_application_page,
+      application_id: application_form.id,
+    )
+
+    when_i_visit_the(:timeline_page, application_id: application_form.id)
+    then_i_see_the(:timeline_page, application_id: application_form.id)
+    and_i_see_the_note_timeline_event
+  end
+
+  private
+
+  def given_there_is_an_application_form
+    application_form
+  end
+
+  def given_an_assessor_exists
+    assessor
+  end
+
+  def and_i_create_a_note
+    create_note_page.form.text_textarea.fill_in with: "A note."
+    create_note_page.form.submit_button.click
+  end
+
+  def and_i_see_the_note_timeline_event
+    timeline_item = timeline_page.timeline_items.first
+
+    expect(timeline_item.title).to have_content("Note created")
+
+    expect(timeline_item.description).to have_content("A note.")
+  end
+
+  def application_form
+    @application_form ||=
+      create(:application_form, :submitted, :with_assessment)
+  end
+
+  def assessor
+    @assessor ||= create(:staff, :confirmed)
+  end
+end

--- a/spec/system/assessor_interface/view_timeline_events_spec.rb
+++ b/spec/system/assessor_interface/view_timeline_events_spec.rb
@@ -36,9 +36,12 @@ RSpec.describe "Assessor view timeline events", type: :system do
 
     expect(timeline_page).to have_timeline_items
     expect(timeline_page.timeline_items.first.title).to have_content(
-      "Status changed",
+      "Note created",
     )
     expect(timeline_page.timeline_items.second.title).to have_content(
+      "Status changed",
+    )
+    expect(timeline_page.timeline_items.third.title).to have_content(
       "Assessor assigned",
     )
   end
@@ -50,6 +53,7 @@ RSpec.describe "Assessor view timeline events", type: :system do
           create(:application_form, :submitted, :with_assessment)
         create(:timeline_event, :assessor_assigned, application_form:)
         create(:timeline_event, :state_changed, application_form:)
+        create(:timeline_event, :note_created, application_form:)
         application_form
       end
   end


### PR DESCRIPTION
This adds the ability for staff users to add free-text notes to application forms which are then visible in the timeline.

[Trello Card](https://trello.com/c/9vTHYLqF/917-add-a-note-to-a-case)

## Screenshots

![Screenshot 2022-09-21 at 10 42 54](https://user-images.githubusercontent.com/510498/191478855-9027e194-2e2f-49b7-a753-3ee55fa796e3.png)
![Screenshot 2022-09-21 at 10 43 00](https://user-images.githubusercontent.com/510498/191478861-4de2681b-09e9-4630-b0da-3f1a7ee3c971.png)
![Screenshot 2022-09-21 at 10 44 36](https://user-images.githubusercontent.com/510498/191478868-a2490ac5-9b17-4408-a5e2-41f065decec1.png)
