### PR TITLE
Rename timeline events eventable field

### DIFF
--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -41,7 +41,7 @@ module TimelineEntry
     alias_method :reviewer_assigned_vars, :assessor_assigned_vars
 
     def assessment_section_recorded_vars
-      section = timeline_event.eventable
+      section = timeline_event.assessment_section
       {
         section_name: section.key.titleize,
         section_state:

--- a/app/controllers/assessor_interface/timeline_events_controller.rb
+++ b/app/controllers/assessor_interface/timeline_events_controller.rb
@@ -5,7 +5,7 @@ module AssessorInterface
 
       @timeline_events =
         TimelineEvent
-          .includes(:note)
+          .includes(:assignee, :assessment_section, :note)
           .where(application_form: @application_form)
           .order(created_at: :desc)
     end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -4,38 +4,37 @@
 #
 # Table name: timeline_events
 #
-#  id                  :bigint           not null, primary key
-#  annotation          :string           default(""), not null
-#  creator_type        :string
-#  event_type          :string           not null
-#  eventable_type      :string
-#  new_state           :string           default(""), not null
-#  old_state           :string           default(""), not null
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  application_form_id :bigint           not null
-#  assignee_id         :bigint
-#  creator_id          :integer
-#  eventable_id        :bigint
-#  note_id             :bigint
+#  id                    :bigint           not null, primary key
+#  annotation            :string           default(""), not null
+#  creator_type          :string
+#  event_type            :string           not null
+#  new_state             :string           default(""), not null
+#  old_state             :string           default(""), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  application_form_id   :bigint           not null
+#  assessment_section_id :bigint
+#  assignee_id           :bigint
+#  creator_id            :integer
+#  note_id               :bigint
 #
 # Indexes
 #
-#  index_timeline_events_on_application_form_id  (application_form_id)
-#  index_timeline_events_on_assignee_id          (assignee_id)
-#  index_timeline_events_on_eventable            (eventable_type,eventable_id)
-#  index_timeline_events_on_note_id              (note_id)
+#  index_timeline_events_on_application_form_id    (application_form_id)
+#  index_timeline_events_on_assessment_section_id  (assessment_section_id)
+#  index_timeline_events_on_assignee_id            (assignee_id)
+#  index_timeline_events_on_note_id                (note_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (application_form_id => application_forms.id)
+#  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #  fk_rails_...  (assignee_id => staff.id)
 #  fk_rails_...  (note_id => notes.id)
 #
 class TimelineEvent < ApplicationRecord
   belongs_to :application_form
   belongs_to :creator, polymorphic: true
-  belongs_to :eventable, polymorphic: true, optional: true
 
   enum event_type: {
          assessor_assigned: "assessor_assigned",
@@ -56,6 +55,14 @@ class TimelineEvent < ApplicationRecord
 
   validates :old_state, :new_state, presence: true, if: :state_changed?
   validates :old_state, :new_state, absence: true, unless: :state_changed?
+
+  belongs_to :assessment_section, optional: true
+  validates :assessment_section,
+            presence: true,
+            if: :assessment_section_recorded?
+  validates :assessment_section,
+            absence: true,
+            unless: :assessment_section_recorded?
 
   belongs_to :note, optional: true
   validates :note, presence: true, if: :note_created?

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -29,7 +29,7 @@ class UpdateAssessmentSection
     TimelineEvent.create!(
       creator: user,
       event_type: :assessment_section_recorded,
-      eventable: assessment_section,
+      assessment_section:,
       application_form:,
     )
   end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -198,8 +198,7 @@
     - assignee_id
     - old_state
     - new_state
-    - eventable_type
-    - eventable_id
+    - assessment_section_id
     - note_id
   :uploads:
     - id

--- a/db/migrate/20220921145557_change_timeline_events_eventable_to_assessment_section.rb
+++ b/db/migrate/20220921145557_change_timeline_events_eventable_to_assessment_section.rb
@@ -1,0 +1,12 @@
+class ChangeTimelineEventsEventableToAssessmentSection < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    change_table :timeline_events, bulk: true do |t|
+      t.rename :eventable_id, :assessment_section_id
+      t.remove :eventable_type, type: :string
+      t.foreign_key :assessment_sections
+      t.index :assessment_section_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_21_083326) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_21_145557) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -268,12 +268,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_21_083326) do
     t.bigint "assignee_id"
     t.string "old_state", default: "", null: false
     t.string "new_state", default: "", null: false
-    t.string "eventable_type"
-    t.bigint "eventable_id"
+    t.bigint "assessment_section_id"
     t.bigint "note_id"
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
+    t.index ["assessment_section_id"], name: "index_timeline_events_on_assessment_section_id"
     t.index ["assignee_id"], name: "index_timeline_events_on_assignee_id"
-    t.index ["eventable_type", "eventable_id"], name: "index_timeline_events_on_eventable"
     t.index ["note_id"], name: "index_timeline_events_on_note_id"
   end
 
@@ -314,6 +313,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_21_083326) do
   add_foreign_key "qualifications", "application_forms"
   add_foreign_key "regions", "countries"
   add_foreign_key "timeline_events", "application_forms"
+  add_foreign_key "timeline_events", "assessment_sections"
   add_foreign_key "timeline_events", "notes"
   add_foreign_key "timeline_events", "staff", column: "assignee_id"
   add_foreign_key "uploads", "documents"

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -2,31 +2,31 @@
 #
 # Table name: timeline_events
 #
-#  id                  :bigint           not null, primary key
-#  annotation          :string           default(""), not null
-#  creator_type        :string
-#  event_type          :string           not null
-#  eventable_type      :string
-#  new_state           :string           default(""), not null
-#  old_state           :string           default(""), not null
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  application_form_id :bigint           not null
-#  assignee_id         :bigint
-#  creator_id          :integer
-#  eventable_id        :bigint
-#  note_id             :bigint
+#  id                    :bigint           not null, primary key
+#  annotation            :string           default(""), not null
+#  creator_type          :string
+#  event_type            :string           not null
+#  new_state             :string           default(""), not null
+#  old_state             :string           default(""), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  application_form_id   :bigint           not null
+#  assessment_section_id :bigint
+#  assignee_id           :bigint
+#  creator_id            :integer
+#  note_id               :bigint
 #
 # Indexes
 #
-#  index_timeline_events_on_application_form_id  (application_form_id)
-#  index_timeline_events_on_assignee_id          (assignee_id)
-#  index_timeline_events_on_eventable            (eventable_type,eventable_id)
-#  index_timeline_events_on_note_id              (note_id)
+#  index_timeline_events_on_application_form_id    (application_form_id)
+#  index_timeline_events_on_assessment_section_id  (assessment_section_id)
+#  index_timeline_events_on_assignee_id            (assignee_id)
+#  index_timeline_events_on_note_id                (note_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (application_form_id => application_forms.id)
+#  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #  fk_rails_...  (assignee_id => staff.id)
 #  fk_rails_...  (note_id => notes.id)
 #
@@ -54,7 +54,7 @@ FactoryBot.define do
 
     trait :assessment_section_recorded do
       event_type { "assessment_section_recorded" }
-      eventable do
+      assessment_section do
         build(
           :assessment_section,
           :passed,

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -2,31 +2,31 @@
 #
 # Table name: timeline_events
 #
-#  id                  :bigint           not null, primary key
-#  annotation          :string           default(""), not null
-#  creator_type        :string
-#  event_type          :string           not null
-#  eventable_type      :string
-#  new_state           :string           default(""), not null
-#  old_state           :string           default(""), not null
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  application_form_id :bigint           not null
-#  assignee_id         :bigint
-#  creator_id          :integer
-#  eventable_id        :bigint
-#  note_id             :bigint
+#  id                    :bigint           not null, primary key
+#  annotation            :string           default(""), not null
+#  creator_type          :string
+#  event_type            :string           not null
+#  new_state             :string           default(""), not null
+#  old_state             :string           default(""), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  application_form_id   :bigint           not null
+#  assessment_section_id :bigint
+#  assignee_id           :bigint
+#  creator_id            :integer
+#  note_id               :bigint
 #
 # Indexes
 #
-#  index_timeline_events_on_application_form_id  (application_form_id)
-#  index_timeline_events_on_assignee_id          (assignee_id)
-#  index_timeline_events_on_eventable            (eventable_type,eventable_id)
-#  index_timeline_events_on_note_id              (note_id)
+#  index_timeline_events_on_application_form_id    (application_form_id)
+#  index_timeline_events_on_assessment_section_id  (assessment_section_id)
+#  index_timeline_events_on_assignee_id            (assignee_id)
+#  index_timeline_events_on_note_id                (note_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (application_form_id => application_forms.id)
+#  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #  fk_rails_...  (assignee_id => staff.id)
 #  fk_rails_...  (note_id => notes.id)
 #
@@ -36,6 +36,7 @@ RSpec.describe TimelineEvent do
   subject(:timeline_event) { build(:timeline_event) }
 
   describe "associations" do
+    it { is_expected.to belong_to(:assessment_section).optional }
     it { is_expected.to belong_to(:note).optional }
   end
 
@@ -56,6 +57,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:assignee) }
       it { is_expected.to validate_absence_of(:old_state) }
       it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
     end
 
@@ -65,6 +67,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:assignee) }
       it { is_expected.to validate_absence_of(:old_state) }
       it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
     end
 
@@ -74,6 +77,17 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:assignee) }
       it { is_expected.to validate_presence_of(:old_state) }
       it { is_expected.to validate_presence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
+      it { is_expected.to validate_absence_of(:note) }
+    end
+
+    context "with an assessment section recorded event type" do
+      before { timeline_event.event_type = :assessment_section_recorded }
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_presence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
     end
 
@@ -83,6 +97,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:assignee) }
       it { is_expected.to validate_absence_of(:old_state) }
       it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_presence_of(:note) }
     end
   end


### PR DESCRIPTION
Since it was only being used for one thing we don't need it to be polymorphic, and by using a non-polymorphic column it allows us to have a foreign key constraint.