### PR TITLE
Restrict access to non-draft application forms

### DIFF
--- a/app/controllers/teacher_interface/age_range_controller.rb
+++ b/app/controllers/teacher_interface/age_range_controller.rb
@@ -1,5 +1,6 @@
 module TeacherInterface
   class AgeRangeController < BaseController
+    before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
 
     def edit

--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -1,5 +1,7 @@
 module TeacherInterface
   class ApplicationFormsController < BaseController
+    before_action :redirect_unless_application_form_is_draft,
+                  only: %i[edit update]
     before_action :load_application_form, except: %i[new create]
 
     def new

--- a/app/controllers/teacher_interface/base_controller.rb
+++ b/app/controllers/teacher_interface/base_controller.rb
@@ -31,4 +31,10 @@ class TeacherInterface::BaseController < ApplicationController
       redirect_to %i[teacher_interface application_form]
     end
   end
+
+  def redirect_unless_application_form_is_draft
+    unless application_form.draft?
+      redirect_to %i[teacher_interface application_form]
+    end
+  end
 end

--- a/app/controllers/teacher_interface/documents_controller.rb
+++ b/app/controllers/teacher_interface/documents_controller.rb
@@ -1,5 +1,6 @@
 module TeacherInterface
   class DocumentsController < BaseController
+    before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
     before_action :load_document
 

--- a/app/controllers/teacher_interface/personal_information_controller.rb
+++ b/app/controllers/teacher_interface/personal_information_controller.rb
@@ -1,5 +1,6 @@
 module TeacherInterface
   class PersonalInformationController < BaseController
+    before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
 
     def show

--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -1,5 +1,6 @@
 module TeacherInterface
   class QualificationsController < BaseController
+    before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
     before_action :load_qualification,
                   only: %i[

--- a/app/controllers/teacher_interface/registration_number_controller.rb
+++ b/app/controllers/teacher_interface/registration_number_controller.rb
@@ -1,5 +1,6 @@
 module TeacherInterface
   class RegistrationNumberController < BaseController
+    before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
 
     def edit

--- a/app/controllers/teacher_interface/subjects_controller.rb
+++ b/app/controllers/teacher_interface/subjects_controller.rb
@@ -1,5 +1,6 @@
 module TeacherInterface
   class SubjectsController < BaseController
+    before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
 
     def edit

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -1,5 +1,6 @@
 module TeacherInterface
   class UploadsController < BaseController
+    before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
     before_action :load_document
     before_action :load_upload, only: %i[delete destroy]

--- a/app/controllers/teacher_interface/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/work_histories_controller.rb
@@ -1,5 +1,6 @@
 module TeacherInterface
   class WorkHistoriesController < BaseController
+    before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
     before_action :load_work_history, only: %i[edit update delete destroy]
 

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -2,13 +2,7 @@
 
 <h1 class="govuk-heading-xl">Apply for qualified teacher status (QTS)</h1>
 
-<% if @application_form.submitted? %>
-  <%= govuk_panel(title_text: "Application complete") do %>
-    Your reference number
-    <br />
-    <strong><%= @application_form.reference %></strong>
-  <% end %>
-<% else %>
+<% if @application_form.draft? %>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
     <% if @application_form.can_submit? %>
       Application complete
@@ -54,4 +48,10 @@
     <%= govuk_button_link_to "Check your answers", edit_teacher_interface_application_form_path %>
     <%= govuk_button_link_to "Save and sign out", destroy_teacher_session_path, secondary: true %>
   </div>
+<% else %>
+  <%= govuk_panel(title_text: "Application complete") do %>
+    Your reference number
+    <br />
+    <strong><%= @application_form.reference %></strong>
+  <% end %>
 <% end %>

--- a/spec/controllers/teacher_interface/age_range_controller_spec.rb
+++ b/spec/controllers/teacher_interface/age_range_controller_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::AgeRangeController, type: :controller do
+  before { FeatureFlag.activate(:service_open) }
+
+  let(:teacher) { create(:teacher, :confirmed) }
+  let(:application_form) { create(:application_form, teacher:) }
+
+  before { sign_in teacher, scope: :teacher }
+
+  describe "GET edit" do
+    subject(:perform) { get :edit }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "PATCH update" do
+    subject(:perform) { patch :update }
+
+    include_examples "redirect unless application form is draft"
+  end
+end

--- a/spec/controllers/teacher_interface/documents_controller_spec.rb
+++ b/spec/controllers/teacher_interface/documents_controller_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::DocumentsController, type: :controller do
+  before { FeatureFlag.activate(:service_open) }
+
+  let(:teacher) { create(:teacher, :confirmed) }
+  let(:application_form) { create(:application_form, teacher:) }
+
+  before { sign_in teacher, scope: :teacher }
+
+  describe "GET edit" do
+    let(:document) { create(:document, documentable: application_form) }
+
+    subject(:perform) { get :edit, params: { id: document.id } }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "PATCH update" do
+    let(:document) { create(:document, documentable: application_form) }
+
+    subject(:perform) { patch :update, params: { id: document.id } }
+
+    include_examples "redirect unless application form is draft"
+  end
+end

--- a/spec/controllers/teacher_interface/personal_information_controller_spec.rb
+++ b/spec/controllers/teacher_interface/personal_information_controller_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::PersonalInformationController,
+               type: :controller do
+  before { FeatureFlag.activate(:service_open) }
+
+  let(:teacher) { create(:teacher, :confirmed) }
+  let(:application_form) { create(:application_form, teacher:) }
+
+  before { sign_in teacher, scope: :teacher }
+
+  describe "GET show" do
+    subject(:perform) { get :show }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET name_and_date_of_birth" do
+    subject(:perform) { get :name_and_date_of_birth }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "PATCH name_and_date_of_birth" do
+    subject(:perform) { patch :name_and_date_of_birth }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET alternative_name" do
+    subject(:perform) { get :name_and_date_of_birth }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "PATCH alternative_name" do
+    subject(:perform) { patch :alternative_name }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET check" do
+    subject(:perform) { get :check }
+
+    include_examples "redirect unless application form is draft"
+  end
+end

--- a/spec/controllers/teacher_interface/qualifications_controller_spec.rb
+++ b/spec/controllers/teacher_interface/qualifications_controller_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::QualificationsController, type: :controller do
+  before { FeatureFlag.activate(:service_open) }
+
+  let(:teacher) { create(:teacher, :confirmed) }
+  let(:application_form) { create(:application_form, teacher:) }
+
+  before { sign_in teacher, scope: :teacher }
+
+  describe "GET index" do
+    subject(:perform) { get :index }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET check" do
+    subject(:perform) { get :check }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET new" do
+    subject(:perform) { get :new }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "POST create" do
+    subject(:perform) { post :create }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET add_another" do
+    subject(:perform) { get :add_another }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "POST add_another" do
+    subject(:perform) { post :add_another }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET edit" do
+    let(:qualification) { create(:qualification, application_form:) }
+
+    subject(:perform) { get :edit, params: { id: qualification.id } }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "PATCH update" do
+    let(:qualification) { create(:qualification, application_form:) }
+
+    subject(:perform) { patch :update, params: { id: qualification.id } }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET part_of_university_degree" do
+    let(:qualification) { create(:qualification, application_form:) }
+
+    subject(:perform) do
+      get :edit_part_of_university_degree, params: { id: qualification.id }
+    end
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "PATCH part_of_university_degree" do
+    let(:qualification) { create(:qualification, application_form:) }
+
+    subject(:perform) do
+      patch :update_part_of_university_degree, params: { id: qualification.id }
+    end
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET delete" do
+    let(:qualification) { create(:qualification, application_form:) }
+
+    subject(:perform) { get :delete, params: { id: qualification.id } }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "DELETE destroy" do
+    let(:qualification) { create(:qualification, application_form:) }
+
+    subject(:perform) { delete :destroy, params: { id: qualification.id } }
+
+    include_examples "redirect unless application form is draft"
+  end
+end

--- a/spec/controllers/teacher_interface/registration_number_controller_spec.rb
+++ b/spec/controllers/teacher_interface/registration_number_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::RegistrationNumberController,
+               type: :controller do
+  before { FeatureFlag.activate(:service_open) }
+
+  let(:teacher) { create(:teacher, :confirmed) }
+  let(:application_form) { create(:application_form, teacher:) }
+
+  before { sign_in teacher, scope: :teacher }
+
+  describe "GET edit" do
+    subject(:perform) { get :edit }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "PATCH update" do
+    subject(:perform) { patch :update }
+
+    include_examples "redirect unless application form is draft"
+  end
+end

--- a/spec/controllers/teacher_interface/subjects_controller_spec.rb
+++ b/spec/controllers/teacher_interface/subjects_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::SubjectsController, type: :controller do
+  before { FeatureFlag.activate(:service_open) }
+
+  let(:teacher) { create(:teacher, :confirmed) }
+  let(:application_form) { create(:application_form, teacher:) }
+
+  before { sign_in teacher, scope: :teacher }
+
+  describe "GET edit" do
+    subject(:perform) { get :edit }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "PATCH update" do
+    subject(:perform) { patch :update }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET delete" do
+    subject(:perform) { get :delete }
+
+    include_examples "redirect unless application form is draft"
+  end
+end

--- a/spec/controllers/teacher_interface/uploads_controller_spec.rb
+++ b/spec/controllers/teacher_interface/uploads_controller_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::UploadsController, type: :controller do
+  before { FeatureFlag.activate(:service_open) }
+
+  let(:teacher) { create(:teacher, :confirmed) }
+  let(:application_form) { create(:application_form, teacher:) }
+
+  before { sign_in teacher, scope: :teacher }
+
+  describe "GET new" do
+    let(:document) { create(:document, documentable: application_form) }
+
+    subject(:perform) { get :new, params: { document_id: document.id } }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "POST create" do
+    let(:document) { create(:document, documentable: application_form) }
+
+    subject(:perform) { post :create, params: { document_id: document.id } }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET delete" do
+    let(:document) { create(:document, documentable: application_form) }
+    let(:upload) { create(:upload, document:) }
+
+    subject(:perform) do
+      get :delete, params: { document_id: document.id, id: upload.id }
+    end
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "DELETE destroy" do
+    let(:document) { create(:document, documentable: application_form) }
+    let(:upload) { create(:upload, document:) }
+
+    subject(:perform) do
+      get :delete, params: { document_id: document.id, id: upload.id }
+    end
+
+    include_examples "redirect unless application form is draft"
+  end
+end

--- a/spec/controllers/teacher_interface/work_histories_controller_spec.rb
+++ b/spec/controllers/teacher_interface/work_histories_controller_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::WorkHistoriesController, type: :controller do
+  before { FeatureFlag.activate(:service_open) }
+
+  let(:teacher) { create(:teacher, :confirmed) }
+  let(:application_form) { create(:application_form, teacher:) }
+
+  before { sign_in teacher, scope: :teacher }
+
+  describe "GET index" do
+    subject(:perform) { get :index }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET check" do
+    subject(:perform) { get :check }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET new" do
+    subject(:perform) { get :new }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "POST create" do
+    subject(:perform) { post :create }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET add_another" do
+    subject(:perform) { get :add_another }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "POST add_another" do
+    subject(:perform) { post :add_another }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET has_work_history" do
+    subject(:perform) { get :edit_has_work_history }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "PATCH has_work_history" do
+    subject(:perform) { patch :update_has_work_history }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET edit" do
+    let(:work_history) { create(:work_history, application_form:) }
+
+    subject(:perform) { get :edit, params: { id: work_history.id } }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "PATCH update" do
+    let(:work_history) { create(:work_history, application_form:) }
+
+    subject(:perform) { patch :update, params: { id: work_history.id } }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET delete" do
+    let(:work_history) { create(:work_history, application_form:) }
+
+    subject(:perform) { get :delete, params: { id: work_history.id } }
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "DELETE destroy" do
+    let(:work_history) { create(:work_history, application_form:) }
+
+    subject(:perform) { delete :destroy, params: { id: work_history.id } }
+
+    include_examples "redirect unless application form is draft"
+  end
+end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "redirect unless application form is draft" do
+  context "with a submitted application form" do
+    before do
+      application_form.update!(state: "submitted", submitted_at: Time.zone.now)
+    end
+
+    it "redirects to the application form" do
+      perform
+      expect(response).to redirect_to(teacher_interface_application_form_path)
+    end
+  end
+end


### PR DESCRIPTION
Once an application form has been submitted, we don't want teachers to be able to go in and make changes to the application form. We will need to open changes up again when we implement further information, but until that's built we can lock the application form (and all associated models) as soon as it's submitted.

[Trello Card](https://trello.com/c/PyM3bWiq/927-redirect-teachers-following-login-and-restrict-access)