### PR TITLE
Fix bug when signing up twice

### DIFF
--- a/app/controllers/teachers/registrations_controller.rb
+++ b/app/controllers/teachers/registrations_controller.rb
@@ -8,7 +8,7 @@ class Teachers::RegistrationsController < Devise::RegistrationsController
   layout "two_thirds"
 
   def create
-    if (resource = Teacher.find_by(email: sign_up_params[:email]))
+    if (self.resource = Teacher.find_by(email: sign_up_params[:email]))
       if resource.active_for_authentication?
         resource.send_magic_link
       else

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -154,6 +154,32 @@ RSpec.describe "Teacher authentication", type: :system do
     then_i_see_the_sign_in_form
   end
 
+  it "signing up with existing email address" do
+    given_countries_exist
+
+    when_i_visit_the(:teacher_sign_up_page)
+    then_i_see_the_sign_up_form
+    when_i_fill_create_teacher_email_address
+    and_i_click_continue
+    then_i_see_the_check_your_email_page
+    and_i_receive_a_teacher_confirmation_email
+
+    when_i_visit_the_teacher_confirmation_email
+    then_i_see_successful_confirmation
+
+    given_i_clear_my_session
+
+    when_i_visit_the(:teacher_sign_up_page)
+    then_i_see_the_sign_up_form
+    when_i_fill_create_teacher_email_address
+    and_i_click_continue
+    then_i_see_the_check_your_email_page
+    and_i_receive_a_magic_link_email
+
+    when_i_visit_the_magic_link_email
+    then_i_see_the_new_application_form
+  end
+
   private
 
   def given_countries_exist


### PR DESCRIPTION
This fixes a bug that users would see if they tried to sign up with an email address they had already used to sign up previously.

[Sentry Issue](https://sentry.io/organizations/dfe-teacher-services/issues/3553938123/?project=6426061&query=is%3Aignored)