### PR TITLE
Further information requested start page

### DIFF
--- a/app/components/application_form_status_tag/component.html.erb
+++ b/app/components/application_form_status_tag/component.html.erb
@@ -1,1 +1,1 @@
-<%= govuk_tag(text:, colour:, html_attributes: { id: }, classes: ["#{class_context}__tag"]) %>
+<%= govuk_tag(text:, colour:, html_attributes: { id: }, classes:) %>

--- a/app/components/application_form_status_tag/component.rb
+++ b/app/components/application_form_status_tag/component.rb
@@ -2,7 +2,7 @@ module ApplicationFormStatusTag
   class Component < ViewComponent::Base
     attr_reader :class_context
 
-    def initialize(key:, status:, class_context:)
+    def initialize(key:, status:, class_context: nil)
       super
       @key = key
       @status = status.to_sym
@@ -15,6 +15,10 @@ module ApplicationFormStatusTag
 
     def text
       I18n.t("application_form.status.#{@status}")
+    end
+
+    def classes
+      class_context ? ["#{class_context}__tag"] : []
     end
 
     COLOURS = {

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -48,6 +48,17 @@
     <%= govuk_button_link_to "Check your answers", edit_teacher_interface_application_form_path %>
     <%= govuk_button_link_to "Save and sign out", destroy_teacher_session_path, secondary: true %>
   </div>
+<% elsif @application_form.further_information_requested? %>
+  <h2 class="govuk-heading-m">We need some more information</h2>
+  <p class="govuk-body">The status of your qualified teacher status application is currently:</p>
+  <p class="govuk-body"><%= render(ApplicationFormStatusTag::Component.new(key: "state", status: @application_form.state)) %></p>
+  <h3 class="govuk-heading-m">What you need to do</h3>
+  <p class="govuk-body">The assessor needs you to provide some additional information so they can continue reviewing your application.</p>
+  <div class="govuk-inset-text">
+    You may need to upload 1 or more documents. Make sure any files you upload clearly show the whole document or page, and that any text is easy to read.
+  </div>
+  <p class="govuk-body">You must add all of the requested information, so the assessor can continue reviewing your QTS application.</p>
+  <p class="govuk-body">The next screen will take you to the first section you need to complete.</p>
 <% else %>
   <%= govuk_panel(title_text: "Application complete") do %>
     Your reference number

--- a/spec/support/autoload/page_objects/teacher_interface/further_information_requested_start.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/further_information_requested_start.rb
@@ -1,0 +1,10 @@
+module PageObjects
+  module TeacherInterface
+    class FurtherInformationRequestedStart < SitePrism::Page
+      set_url "/teacher/application"
+
+      element :heading, ".govuk-heading-xl"
+      element :status_tag, ".govuk-tag"
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -65,6 +65,11 @@ module PageHelpers
     @eligible_page = PageObjects::EligibilityInterface::Eligible.new
   end
 
+  def further_information_requested_start_page
+    @further_information_requested_start_page =
+      PageObjects::TeacherInterface::FurtherInformationRequestedStart.new
+  end
+
   def ineligible_page
     @ineligible_page = PageObjects::EligibilityInterface::Ineligible.new
   end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -54,8 +54,8 @@ module SystemHelpers
     given_an_eligible_eligibility_check(country_check: :written)
   end
 
-  def given_i_am_authorized_as_an_assessor_user(user)
-    login_as(user)
+  def given_i_am_authorized_as_a_user(user)
+    sign_in(user)
   end
 
   def when_i_am_authorized_as_an_assessor_user

--- a/spec/system/assessor_interface/assigning_assessor_spec.rb
+++ b/spec/system/assessor_interface/assigning_assessor_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Assigning an assessor", type: :system do
   it "assigns an assessor" do
     given_the_service_is_open
-    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_i_am_authorized_as_a_user(assessor)
     given_there_is_an_application_form
     given_an_assessor_exists
 
@@ -16,7 +16,7 @@ RSpec.describe "Assigning an assessor", type: :system do
 
   it "assigns a reviewer" do
     given_the_service_is_open
-    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_i_am_authorized_as_a_user(assessor)
     given_there_is_an_application_form
     given_an_assessor_exists
 

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     given_the_service_is_open
     given_an_assessor_exists
     given_there_is_an_application_form
-    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_i_am_authorized_as_a_user(assessor)
   end
 
   it "allows passing the personal information" do

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Assessor completing assessment", type: :system do
   it "completes an assessment" do
     given_the_service_is_open
-    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_i_am_authorized_as_a_user(assessor)
     given_there_is_an_application_form
 
     when_i_visit_the(:complete_assessment_page, application_id:, assessment_id:)

--- a/spec/system/assessor_interface/creating_note_spec.rb
+++ b/spec/system/assessor_interface/creating_note_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Creating a note", type: :system do
   it "creates a note" do
     given_the_service_is_open
-    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_i_am_authorized_as_a_user(assessor)
     given_there_is_an_application_form
     given_an_assessor_exists
 

--- a/spec/system/assessor_interface/view_timeline_events_spec.rb
+++ b/spec/system/assessor_interface/view_timeline_events_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Assessor view timeline events", type: :system do
     given_the_service_is_open
     given_an_assessor_exists
     given_an_application_form_exists
-    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_i_am_authorized_as_a_user(assessor)
   end
 
   it "displays the timeline events" do

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Teacher further information", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_a_user(teacher)
+    given_there_is_an_application_form
+  end
+
+  it "shows start page" do
+    when_i_visit_the(:further_information_requested_start_page)
+    then_i_see_the(:further_information_requested_start_page)
+  end
+
+  def given_there_is_an_application_form
+    application_form
+  end
+
+  def teacher
+    @teacher ||= create(:teacher, :confirmed)
+  end
+
+  def application_form
+    @application_form ||=
+      create(:application_form, :further_information_requested, teacher:)
+  end
+end


### PR DESCRIPTION
This is the start page which a user sees once their sign in to their application if the state is further information requested. At the moment there's no start button until the task list has been built.

Depends on #532.

[Trello Card](https://trello.com/c/oUG60nNv/928-fi-request-start-page-and-task-list)

## Screenshot

![Screenshot 2022-09-23 at 10 57 44](https://user-images.githubusercontent.com/510498/191936763-3a3c0dfa-b7bd-4a69-ba9c-79b7a65dd698.png)
