### PR TITLE
Further information requested task list

### DIFF
--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -24,8 +24,19 @@ module TeacherInterface
     end
 
     def show
-      unless @application_form
+      unless application_form
         redirect_to %i[new teacher_interface application_form]
+        return
+      end
+
+      if application_form.further_information_requested?
+        @further_information_request =
+          FurtherInformationRequest
+            .joins(:assessment)
+            .requested
+            .where(assessments: { application_form: })
+            .order(:created_at)
+            .first
       end
     end
 

--- a/app/controllers/teacher_interface/further_information_request_items_controller.rb
+++ b/app/controllers/teacher_interface/further_information_request_items_controller.rb
@@ -1,0 +1,29 @@
+module TeacherInterface
+  class FurtherInformationRequestItemsController < BaseController
+    before_action :load_application_form
+
+    def edit
+      @further_information_request_item = further_information_request_item
+      @further_information_request =
+        further_information_request_item.further_information_request
+    end
+
+    private
+
+    def further_information_request_item
+      @further_information_request_item ||=
+        FurtherInformationRequestItem
+          .joins(further_information_request: :assessment)
+          .includes(:further_information_request)
+          .where(
+            further_information_request: {
+              id: params[:further_information_request_id],
+              assessments: {
+                application_form:,
+              },
+            },
+          )
+          .find(params[:id])
+    end
+  end
+end

--- a/app/controllers/teacher_interface/further_information_requests_controller.rb
+++ b/app/controllers/teacher_interface/further_information_requests_controller.rb
@@ -1,0 +1,20 @@
+module TeacherInterface
+  class FurtherInformationRequestsController < BaseController
+    before_action :load_application_form
+
+    def show
+      @further_information_request = further_information_request
+    end
+
+    private
+
+    def further_information_request
+      @further_information_request ||=
+        FurtherInformationRequest
+          .joins(:assessment)
+          .requested
+          .where(assessments: { application_form: })
+          .find(params[:id])
+    end
+  end
+end

--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -21,4 +21,8 @@ class FurtherInformationRequestItem < ApplicationRecord
   has_one :document, as: :documentable
 
   enum :information_type, { text: "text", document: "document" }
+
+  def state
+    :not_started
+  end
 end

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -59,6 +59,7 @@
   </div>
   <p class="govuk-body">You must add all of the requested information, so the assessor can continue reviewing your QTS application.</p>
   <p class="govuk-body">The next screen will take you to the first section you need to complete.</p>
+  <%= govuk_start_button(text: "Start now", href: teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
 <% else %>
   <%= govuk_panel(title_text: "Application complete") do %>
     Your reference number

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -1,0 +1,4 @@
+<% content_for :page_title, "Apply for qualified teacher status (QTS)" %>
+<% content_for :back_link_url, teacher_interface_application_form_further_information_request_path %>
+
+<h1 class="govuk-heading-l">Apply for qualified teacher status (QTS)</h1>

--- a/app/views/teacher_interface/further_information_requests/show.html.erb
+++ b/app/views/teacher_interface/further_information_requests/show.html.erb
@@ -1,0 +1,4 @@
+<% content_for :page_title, "Apply for qualified teacher status (QTS)" %>
+<% content_for :back_link_url, teacher_interface_application_form_path %>
+
+<h1 class="govuk-heading-l">Further information required</h1>

--- a/app/views/teacher_interface/further_information_requests/show.html.erb
+++ b/app/views/teacher_interface/further_information_requests/show.html.erb
@@ -1,4 +1,32 @@
 <% content_for :page_title, "Apply for qualified teacher status (QTS)" %>
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
-<h1 class="govuk-heading-l">Further information required</h1>
+<h1 class="govuk-heading-l">Apply for qualified teacher status (QTS)</h1>
+
+<ol class="app-task-list">
+  <li>
+    <h2 class="app-task-list__section">
+      Further information requested
+    </h2>
+
+    <ul class="app-task-list__items">
+      <% @further_information_request.items.each do |item| %>
+        <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <%= link_to t(".items.title.#{item.information_type}"),
+                          edit_teacher_interface_application_form_further_information_request_further_information_request_item_path(@further_information_request, item),
+                          aria: { describedby: "#{item.id}-status" } %>
+            </span>
+
+          <%= render(ApplicationFormStatusTag::Component.new(
+            key: item.id,
+            status: item.state,
+            class_context: "app-task-list"
+          )) %>
+        </li>
+      <% end %>
+    </ul>
+  </li>
+</ol>
+
+<%= govuk_button_link_to "Save and sign out", destroy_teacher_session_path, secondary: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,6 +160,8 @@ Rails.application.routes.draw do
           get "delete", on: :member
         end
       end
+
+      resources :further_information_requests, only: %i[show]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,7 +161,11 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :further_information_requests, only: %i[show]
+      resources :further_information_requests, only: %i[show] do
+        resources :further_information_request_items,
+                  path: "/items",
+                  only: %i[edit]
+      end
     end
   end
 

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -80,6 +80,11 @@ FactoryBot.define do
     trait :further_information_requested do
       state { "further_information_requested" }
       submitted_at { Time.zone.now }
+
+      after(:create) do |application_form, _evaluator|
+        assessment = create(:assessment, application_form:)
+        create(:further_information_request, assessment:)
+      end
     end
 
     trait :further_information_received do

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -17,6 +17,8 @@
 #
 FactoryBot.define do
   factory :further_information_request do
+    association :assessment
+
     trait :requested do
       state { "requested" }
     end

--- a/spec/models/further_information_request_item_spec.rb
+++ b/spec/models/further_information_request_item_spec.rb
@@ -30,4 +30,14 @@ RSpec.describe FurtherInformationRequestItem do
       document: "document",
     ).backed_by_column_of_type(:string)
   end
+
+  subject(:further_information_request_item) do
+    create(:further_information_request_item)
+  end
+
+  describe "#state" do
+    subject(:state) { further_information_request_item.state }
+
+    it { is_expected.to eq(:not_started) }
+  end
 end

--- a/spec/support/autoload/page_objects/task_list.rb
+++ b/spec/support/autoload/page_objects/task_list.rb
@@ -1,0 +1,16 @@
+module PageObjects
+  class TaskList < SitePrism::Section
+    sections :sections, TaskListSection, ".app-task-list > li"
+
+    def find_item(link_text)
+      sections
+        .flat_map(&:items)
+        .map(&:link)
+        .find { |link| link.text == link_text }
+    end
+
+    def click_item(link_text)
+      find_item(link_text).click
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/task_list_item.rb
+++ b/spec/support/autoload/page_objects/task_list_item.rb
@@ -1,0 +1,6 @@
+module PageObjects
+  class TaskListItem < SitePrism::Section
+    element :link, "a"
+    element :status_tag, ".govuk-tag"
+  end
+end

--- a/spec/support/autoload/page_objects/task_list_section.rb
+++ b/spec/support/autoload/page_objects/task_list_section.rb
@@ -1,0 +1,6 @@
+module PageObjects
+  class TaskListSection < SitePrism::Section
+    element :heading, "h2"
+    sections :items, TaskListItem, ".app-task-list__item"
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/application.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/application.rb
@@ -1,15 +1,5 @@
 module PageObjects
   module TeacherInterface
-    class TaskListItem < SitePrism::Section
-      element :link, "a"
-      element :status, ".govuk-tag"
-    end
-
-    class TaskListSection < SitePrism::Section
-      element :heading, "h2"
-      sections :task_list_items, TaskListItem, ".app-task-list__item"
-    end
-
     class Application < SitePrism::Page
       set_url "/teacher/application"
 
@@ -20,18 +10,7 @@ module PageObjects
       element :check_answers, ".govuk-button:nth-of-type(1)"
       element :save_and_sign_out, ".govuk-button:nth-of-type(2)"
 
-      sections :task_list_sections, TaskListSection, ".app-task-list>li"
-
-      def find_item(link_text)
-        task_list_sections
-          .flat_map(&:task_list_items)
-          .map(&:link)
-          .find { |link| link.text == link_text }
-      end
-
-      def click_item(link_text)
-        find_item(link_text).click
-      end
+      section :task_list, TaskList, ".app-task-list"
     end
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/further_information_requested.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/further_information_requested.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module TeacherInterface
+    class FurtherInformationRequested < SitePrism::Page
+      set_url "/teacher/application/further_information_requests/{further_information_request_id}"
+
+      element :heading, ".govuk-heading-l"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/further_information_requested.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/further_information_requested.rb
@@ -4,6 +4,7 @@ module PageObjects
       set_url "/teacher/application/further_information_requests/{further_information_request_id}"
 
       element :heading, ".govuk-heading-l"
+      section :task_list, TaskList, ".app-task-list"
     end
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/further_information_requested.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/further_information_requested.rb
@@ -5,6 +5,7 @@ module PageObjects
 
       element :heading, ".govuk-heading-l"
       section :task_list, TaskList, ".app-task-list"
+      element :save_and_sign_out_button, ".govuk-button"
     end
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/further_information_requested_start.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/further_information_requested_start.rb
@@ -5,6 +5,7 @@ module PageObjects
 
       element :heading, ".govuk-heading-xl"
       element :status_tag, ".govuk-tag"
+      element :start_button, ".govuk-button"
     end
   end
 end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -65,6 +65,11 @@ module PageHelpers
     @eligible_page = PageObjects::EligibilityInterface::Eligible.new
   end
 
+  def further_information_requested_page
+    @further_information_requested_page =
+      PageObjects::TeacherInterface::FurtherInformationRequested.new
+  end
+
   def further_information_requested_start_page
     @further_information_requested_start_page =
       PageObjects::TeacherInterface::FurtherInformationRequestedStart.new

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Assessor requesting further information", type: :system do
   it "completes an assessment" do
     given_the_service_is_open
-    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_i_am_authorized_as_a_user(assessor)
     given_there_is_an_application_form_with_failure_reasons
 
     when_i_visit_the(:complete_assessment_page, application_id:, assessment_id:)

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -494,7 +494,9 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_personal_information
-    teacher_application_page.click_item("Enter your personal information")
+    teacher_application_page.task_list.click_item(
+      "Enter your personal information",
+    )
   end
 
   def when_i_fill_in_the_name_and_date_of_birth_form
@@ -533,7 +535,9 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_qualifications
-    teacher_application_page.click_item("Add your teaching qualifications")
+    teacher_application_page.task_list.click_item(
+      "Add your teaching qualifications",
+    )
   end
 
   def when_i_fill_in_qualifications
@@ -568,7 +572,9 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_subjects
-    teacher_application_page.click_item("Enter the subjects you can teach")
+    teacher_application_page.task_list.click_item(
+      "Enter the subjects you can teach",
+    )
   end
 
   def and_i_click_add_another_subject
@@ -580,7 +586,7 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_work_history
-    teacher_application_page.click_item("Add your work history")
+    teacher_application_page.task_list.click_item("Add your work history")
   end
 
   def when_i_fill_in_has_work_history
@@ -599,7 +605,9 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_registration_number
-    teacher_application_page.click_item("Enter your registration number")
+    teacher_application_page.task_list.click_item(
+      "Enter your registration number",
+    )
   end
 
   def when_i_fill_in_registration_number
@@ -608,7 +616,9 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_click_written_statement
-    teacher_application_page.click_item("Upload your written statement")
+    teacher_application_page.task_list.click_item(
+      "Upload your written statement",
+    )
   end
 
   def when_i_click_delete

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -10,10 +10,17 @@ RSpec.describe "Teacher further information", type: :system do
   it "shows start page" do
     when_i_visit_the(:further_information_requested_start_page)
     then_i_see_the(:further_information_requested_start_page)
+
+    when_i_click_the_start_button
+    then_i_see_the(:further_information_requested_page)
   end
 
   def given_there_is_an_application_form
     application_form
+  end
+
+  def when_i_click_the_start_button
+    further_information_requested_start_page.start_button.click
   end
 
   def teacher

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe "Teacher further information", type: :system do
 
     when_i_click_the_start_button
     then_i_see_the(:further_information_requested_page)
+    and_i_see_the_text_task_list_item
+    and_i_see_the_document_task_list_item
+
+    when_i_click_the_save_and_sign_out_button
+    then_i_see_the(:signed_out_page)
   end
 
   def given_there_is_an_application_form
@@ -23,12 +28,45 @@ RSpec.describe "Teacher further information", type: :system do
     further_information_requested_start_page.start_button.click
   end
 
+  def and_i_see_the_text_task_list_item
+    item =
+      further_information_requested_page.task_list.sections.first.items.first
+    expect(item.link.text).to eq("Text")
+    expect(item.status_tag.text).to eq("NOT STARTED")
+  end
+
+  def and_i_see_the_document_task_list_item
+    item =
+      further_information_requested_page.task_list.sections.first.items.second
+    expect(item.link.text).to eq("Document")
+    expect(item.status_tag.text).to eq("NOT STARTED")
+  end
+
+  def when_i_click_the_save_and_sign_out_button
+    further_information_requested_page.save_and_sign_out_button.click
+  end
+
   def teacher
     @teacher ||= create(:teacher, :confirmed)
   end
 
   def application_form
     @application_form ||=
-      create(:application_form, :further_information_requested, teacher:)
+      begin
+        application_form =
+          create(:application_form, :further_information_requested, teacher:)
+        request = application_form.assessment.further_information_requests.first
+        create(
+          :further_information_request_item,
+          :with_text_response,
+          further_information_request: request,
+        )
+        create(
+          :further_information_request_item,
+          :with_document_response,
+          further_information_request: request,
+        )
+        application_form
+      end
   end
 end


### PR DESCRIPTION
This adds a task list which renders a list of request items when a user needs to provide further information. For now, the text of each item is based on the type of request, but it's likely this will change in the future.

[Trello Card](https://trello.com/c/oUG60nNv/928-fi-request-start-page-and-task-list)

## Screenshot

![Screenshot 2022-09-26 at 11 11 07](https://user-images.githubusercontent.com/510498/192251107-e07d616b-8384-4c42-a4eb-3527e04e573c.png)
