### PR TITLE
[924] Create FurtherInformationRequest request

### DIFF
--- a/app/controllers/assessor_interface/assessments_controller.rb
+++ b/app/controllers/assessor_interface/assessments_controller.rb
@@ -11,7 +11,7 @@ module AssessorInterface
            user: current_staff,
            new_recommendation: assessment_params[:recommendation],
          )
-        redirect_to [:assessor_interface, @application_form]
+        redirect_to post_update_redirect_path
       else
         render :edit, status: :unprocessable_entity
       end
@@ -31,6 +31,20 @@ module AssessorInterface
 
     def assessment_params
       params.require(:assessment).permit(:recommendation)
+    end
+
+    def post_update_redirect_path
+      if @assessment.request_further_information?
+        return [
+          :new,
+          :assessor_interface,
+          @application_form,
+          @assessment,
+          :further_information_request
+        ]
+      end
+
+      [:assessor_interface, @application_form]
     end
   end
 end

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -1,6 +1,34 @@
 module AssessorInterface
   class FurtherInformationRequestsController < BaseController
     def new
+      @further_information_request =
+        assessment.further_information_requests.build
+    end
+
+    def create
+      @further_information_request =
+        assessment.further_information_requests.create!
+      redirect_to [
+                    :assessor_interface,
+                    application_form,
+                    assessment,
+                    @further_information_request,
+                  ]
+    end
+
+    def show
+      @further_information_request =
+        assessment.further_information_requests.first
+    end
+
+    private
+
+    def assessment
+      @assessment ||= application_form.assessment
+    end
+
+    def application_form
+      @application_form ||= ApplicationForm.find(params[:application_form_id])
     end
   end
 end

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -1,0 +1,6 @@
+module AssessorInterface
+  class FurtherInformationRequestsController < BaseController
+    def new
+    end
+  end
+end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -23,7 +23,12 @@ class Assessment < ApplicationRecord
   has_many :further_information_requests
 
   enum :recommendation,
-       { unknown: "unknown", award: "award", decline: "decline" },
+       {
+         unknown: "unknown",
+         award: "award",
+         decline: "decline",
+         request_further_information: "request_further_information",
+       },
        default: :unknown
 
   validates :recommendation,
@@ -48,9 +53,14 @@ class Assessment < ApplicationRecord
     sections.any? { |section| section.state == :action_required }
   end
 
+  alias_method :can_request_further_information?, :can_decline?
+
   def available_recommendations
     [].tap do |recommendations|
       recommendations << "award" if can_award?
+      if can_request_further_information?
+        recommendations << "request_further_information"
+      end
       recommendations << "decline" if can_decline?
     end
   end

--- a/app/services/update_assessment_recommendation.rb
+++ b/app/services/update_assessment_recommendation.rb
@@ -33,6 +33,10 @@ class UpdateAssessmentRecommendation
 
   def new_application_form_state
     return "awarded" if assessment.award?
+    #TODO: maybe we should move this out of here into the FI request service
+    if assessment.request_further_information?
+      return "further_information_requested"
+    end
     "declined" if assessment.decline?
   end
 end

--- a/app/views/assessor_interface/further_information_requests/new.html.erb
+++ b/app/views/assessor_interface/further_information_requests/new.html.erb
@@ -1,3 +1,5 @@
+<% content_for :back_link_url, edit_assessor_interface_application_form_assessment_path(@application_form, @assessment) %>
+
 <h1 class="govuk-heading-xl">Compose and send your further information request email</h1>
 <%= form_for [:assessor_interface, @application_form, @assessment, @further_information_request] do |form| %> 
   <%= form.govuk_submit %>

--- a/app/views/assessor_interface/further_information_requests/new.html.erb
+++ b/app/views/assessor_interface/further_information_requests/new.html.erb
@@ -1,0 +1,1 @@
+<h1 class="govuk-heading-xl">Compose and send your further information request email</h1>

--- a/app/views/assessor_interface/further_information_requests/new.html.erb
+++ b/app/views/assessor_interface/further_information_requests/new.html.erb
@@ -1,1 +1,4 @@
 <h1 class="govuk-heading-xl">Compose and send your further information request email</h1>
+<%= form_for [:assessor_interface, @application_form, @assessment, @further_information_request] do |form| %> 
+  <%= form.govuk_submit %>
+<%- end -%>

--- a/app/views/assessor_interface/further_information_requests/show.html.erb
+++ b/app/views/assessor_interface/further_information_requests/show.html.erb
@@ -1,0 +1,1 @@
+<h1 class="govuk-heading-xl">Further information request email preview</h1>

--- a/app/views/assessor_interface/further_information_requests/show.html.erb
+++ b/app/views/assessor_interface/further_information_requests/show.html.erb
@@ -1,1 +1,3 @@
+<% content_for :back_link_url, new_assessor_interface_application_form_assessment_further_information_request_path(@application_form, @assessment) %>
+
 <h1 class="govuk-heading-xl">Further information request email preview</h1>

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -26,6 +26,7 @@ en:
       assessment:
         recommendation_options:
           award: Award QTS
+          request_further_information: Request further information
           decline: Decline QTS
       assessor_interface_create_note_form:
         text: Add a note to this application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
                   only: %i[show update]
         resources :further_information_requests,
                   path: "/further-information-requests",
-                  only: %i[new]
+                  only: %i[new create show]
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,9 @@ Rails.application.routes.draw do
                   path: "/sections",
                   param: :key,
                   only: %i[show update]
+        resources :further_information_requests,
+                  path: "/further-information-requests",
+                  only: %i[new]
       end
     end
   end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe Assessment, type: :model do
         unknown: "unknown",
         award: "award",
         decline: "decline",
+        request_further_information: "request_further_information",
       ).backed_by_column_of_type(:string)
     end
   end
@@ -158,6 +159,26 @@ RSpec.describe Assessment, type: :model do
     end
   end
 
+  describe "#can_request_further_information?" do
+    subject(:can_decline?) { assessment.can_request_further_information? }
+
+    context "with a passed assessment" do
+      before do
+        create(:assessment_section, :personal_information, :passed, assessment:)
+        create(:assessment_section, :qualifications, :passed, assessment:)
+      end
+      it { is_expected.to be false }
+    end
+
+    context "with a failed assessment" do
+      before do
+        create(:assessment_section, :personal_information, :passed, assessment:)
+        create(:assessment_section, :qualifications, :failed, assessment:)
+      end
+      it { is_expected.to be true }
+    end
+  end
+
   describe "#available_recommendations" do
     subject(:available_recommendations) { assessment.available_recommendations }
 
@@ -169,6 +190,15 @@ RSpec.describe Assessment, type: :model do
     context "with a decline-able assessment" do
       before { expect(assessment).to receive(:can_decline?).and_return(true) }
       it { is_expected.to include("decline") }
+    end
+
+    context "with can_request_further_information-able assessment" do
+      before do
+        expect(assessment).to receive(
+          :can_request_further_information?,
+        ).and_return(true)
+      end
+      it { is_expected.to include("request_further_information") }
     end
   end
 end

--- a/spec/services/update_assessment_recommendation_spec.rb
+++ b/spec/services/update_assessment_recommendation_spec.rb
@@ -35,4 +35,32 @@ RSpec.describe UpdateAssessmentRecommendation do
       it { is_expected.to eq("awarded") }
     end
   end
+
+  context "request further information recommendataion" do
+    let(:new_recommendation) { :request_further_information }
+
+    describe "recommendation" do
+      subject(:recommendation) { assessment.recommendation }
+
+      it { is_expected.to eq("unknown") }
+
+      context "after calling the service" do
+        before { call }
+
+        it { is_expected.to eq("request_further_information") }
+      end
+    end
+
+    describe "application form status" do
+      subject(:state) { application_form.state }
+
+      it { is_expected.to eq("submitted") }
+
+      context "after calling the service" do
+        before { call }
+
+        it { is_expected.to eq("further_information_requested") }
+      end
+    end
+  end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/complete_assessment.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/complete_assessment.rb
@@ -10,6 +10,12 @@ module PageObjects
         new_states.find { |radio_item| radio_item.label.text == "Award QTS" }
       end
 
+      def request_further_information
+        new_states.find do |radio_item|
+          radio_item.label.text == "Request further information"
+        end
+      end
+
       def decline_qts
         new_states.find { |radio_item| radio_item.label.text == "Decline QTS" }
       end

--- a/spec/support/autoload/page_objects/assessor_interface/further_information_request_preview.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/further_information_request_preview.rb
@@ -1,0 +1,8 @@
+module PageObjects
+  module AssessorInterface
+    class FurtherInformationRequestPreview < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+                "/further-information-requests/{further_information_request_id}"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/request_further_information.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/request_further_information.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module AssessorInterface
+    class RequestFurtherInformation < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/further-information-requests/new"
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -231,4 +231,9 @@ module PageHelpers
     @request_further_information_form =
       PageObjects::AssessorInterface::RequestFurtherInformation.new
   end
+
+  def further_information_request_preview_page
+    @further_information_request_preview_page ||=
+      PageObjects::AssessorInterface::FurtherInformationRequestPreview.new
+  end
 end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -226,4 +226,9 @@ module PageHelpers
     @registration_number_form =
       PageObjects::TeacherInterface::RegistrationNumberForm.new
   end
+
+  def request_further_information_page
+    @request_further_information_form =
+      PageObjects::AssessorInterface::RequestFurtherInformation.new
+  end
 end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -109,6 +109,8 @@ module SystemHelpers
     click_button "Continue", visible: false
   end
 
+  alias_method :when_i_click_continue, :and_i_click_continue
+
   def and_i_receive_a_teacher_confirmation_email
     message = ActionMailer::Base.deliveries.last
     expect(message).to_not be_nil

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assessor requesting further information", type: :system do
+  it "completes an assessment" do
+    given_the_service_is_open
+    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_there_is_an_application_form_with_failure_reasons
+
+    when_i_visit_the(:complete_assessment_page, application_id:, assessment_id:)
+
+    when_i_select_request_further_information
+    and_i_click_continue
+    then_i_see_the(
+      :request_further_information_page,
+      application_id:,
+      assessment_id:,
+    )
+  end
+
+  private
+
+  def given_there_is_an_application_form_with_failure_reasons
+    application_form
+  end
+
+  def when_i_visit_the_complete_assessment_page
+    complete_assessment_page.load(application_id: application_form.id)
+  end
+
+  def then_i_see_the_complete_assessment_form
+    expect(complete_assessment_page.award_qts).to be_visible
+    expect(complete_assessment_page.decline_qts).to be_visible
+  end
+
+  def when_i_select_request_further_information
+    complete_assessment_page.request_further_information.input.choose
+  end
+
+  def then_the_application_form_is_awarded
+    expect(assessor_application_page.overview.status.text).to eq("AWARDED")
+  end
+
+  def application_form
+    @application_form ||=
+      create(
+        :application_form,
+        :with_personal_information,
+        :submitted,
+        :with_assessment,
+      ).tap do |application_form|
+        application_form.assessment.sections << create(
+          :assessment_section,
+          :personal_information,
+          :failed,
+        )
+      end
+  end
+
+  def application_id
+    application_form.id
+  end
+
+  def assessment_id
+    application_form.assessment.id
+  end
+
+  def assessor
+    @assessor ||= create(:staff, :confirmed)
+  end
+end

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe "Assessor requesting further information", type: :system do
       application_id:,
       assessment_id:,
     )
+
+    when_i_click_continue
+    then_i_see_the(
+      :further_information_request_preview_page,
+      application_id:,
+      assessment_id:,
+      further_information_request_id:,
+    )
   end
 
   private
@@ -68,5 +76,9 @@ RSpec.describe "Assessor requesting further information", type: :system do
 
   def assessor
     @assessor ||= create(:staff, :confirmed)
+  end
+
+  def further_information_request_id
+    FurtherInformationRequest.last.id
   end
 end


### PR DESCRIPTION
Building out the further information request bit of the assessor interface. This PR adds an option to request FI and then placeholder pages for the journey as far as the email preview.

* Add `Assessment#can_request_further_information?` that currently returns true if there are any failure reasons. 
* If that ^ then show the option to request further information on the assessment edit form
* If that ^ is selected show the further information request new form (currently just a blank page with a button)
* Submitting that ^ creates a `FurtherInformationRequest` record and redirects to it's show page which is where we'll put the email preview (not done in this PR)

### Screenshots
<img width="1036" alt="Screenshot 2022-09-23 at 17 00 46" src="https://user-images.githubusercontent.com/5216/192003815-2052f7ff-99be-4661-ae1e-a30112b27db0.png">
<img width="1024" alt="Screenshot 2022-09-23 at 17 01 14" src="https://user-images.githubusercontent.com/5216/192003828-8b741b03-82e3-4f8b-8d1e-51773d85868b.png">
<img width="1074" alt="Screenshot 2022-09-23 at 17 01 22" src="https://user-images.githubusercontent.com/5216/192003841-43c7cefb-c274-437f-9e97-f4795ca33325.png">

### Review

* I've added the back links as per the prototype but going back and then forward again will create another FI request. This might be fine as we're not sending it at that point anyway
* I've added a `request_further_information` value to the `Assessment#recommendation` enum. We went with `further_information_requested` on the `Application#state` earlier. I think these different tenses are ok given what they're representing but it is sort of inconsistent.

