### PR TITLE
Remove sign in link from application received email

### DIFF
--- a/app/views/teacher_mailer/application_received.text.erb
+++ b/app/views/teacher_mailer/application_received.text.erb
@@ -10,12 +10,6 @@ Your reference number is:
 
 We’ll be back in touch once we’ve assigned a QTS assessor to review your application. At that point we’ll be able to update you on how long the process will take.
 
-# Following the progress of your application
-
-You can sign in to view the progress of your application:
-
-<%= new_teacher_session_url %>
-
 If you have any questions, contact:
 
 qts.enquiries@education.gov.uk

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe TeacherMailer, type: :mailer do
 
       it { is_expected.to include("Dear First Last") }
       it { is_expected.to include("abc") }
-      it { is_expected.to include("http://localhost:3000/teacher/sign_in") }
     end
   end
 end

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Assessor requesting further information", type: :system do
   it "completes an assessment" do
     given_the_service_is_open
-    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_i_am_authorized_as_a_user(assessor)
     given_there_is_an_application_form_with_failure_reasons
 
     when_i_visit_the(:complete_assessment_page, application_id:, assessment_id:)


### PR DESCRIPTION
We no longer want to show this as it's not strictly true, this has been requested by our content designer.

[Trello Card](https://trello.com/c/vIMXIC8t/952-amend-email-to-remove-signing-back-in-for-mvp)