### PR TITLE
Add content to submission page

### DIFF
--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -65,4 +65,15 @@
     <br />
     <strong><%= @application_form.reference %></strong>
   <% end %>
+
+  <p class="govuk-body">We’ve received your application for QTS and we’ve sent you a confirmation email.</p>
+  <p class="govuk-body">Keep the email safe, as you may need your reference number for future correspondence about your application.</p>
+
+  <h2 class="govuk-heading-m">What happens next</h2>
+  <p class="govuk-body">We aim to review your application within 1 month. If we need more information, we’ll email you again.</p>
+  <p class="govuk-body">We aim to reach a final decision on applications within 90 days of submission.</p>
+
+  <h2 class="govuk-heading-s govuk-!-font-weight-regular">If you have any questions, contact:</h2>
+  <p class="govuk-body"><a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.</p>
+  <p class="govuk-body"><a class="govuk-link" href="https://docs.google.com/forms/d/1OpMhXJ1blJu2qFqW7VWwKnfjIoU-5SmOLXdgI0Z_kZg/viewform?edit_requested=true">What did you think of this service?</a> (takes 30 seconds)</p>
 <% end %>

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Assessor requesting further information", type: :system do
   it "completes an assessment" do
     given_the_service_is_open
-    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_i_am_authorized_as_a_user(assessor)
     given_there_is_an_application_form_with_failure_reasons
 
     when_i_visit_the(:complete_assessment_page, application_id:, assessment_id:)


### PR DESCRIPTION
This adds more content to the submission page so it matches the prototype.

<img width="702" alt="Screenshot 2022-09-27 at 07 05 31" src="https://user-images.githubusercontent.com/510498/192445860-a6e6f34c-e575-47da-bff2-0737183645a8.png">
