### PR TITLE
Further information request text response

### DIFF
--- a/app/controllers/teacher_interface/further_information_request_items_controller.rb
+++ b/app/controllers/teacher_interface/further_information_request_items_controller.rb
@@ -1,30 +1,60 @@
 module TeacherInterface
   class FurtherInformationRequestItemsController < BaseController
-    before_action :load_application_form
+    before_action :load_application_form,
+                  :load_further_information_request_and_item
 
     def edit
+      send("edit_#{further_information_request_item.information_type}")
+    end
+
+    def update
+      send("update_#{further_information_request_item.information_type}")
+    end
+
+    private
+
+    def load_further_information_request_and_item
       @further_information_request_item = further_information_request_item
       @further_information_request = further_information_request
     end
 
-    def update
+    def edit_text
+      @further_information_request_item_text_form =
+        FurtherInformationRequestItemTextForm.new(
+          response: further_information_request_item.response,
+        )
+    end
+
+    def edit_document
+    end
+
+    def update_text
+      @further_information_request_item_text_form =
+        FurtherInformationRequestItemTextForm.new(
+          further_information_request_item_text_form_params.merge(
+            further_information_request_item:,
+          ),
+        )
+
       if params[:next] == "save_and_continue"
-        redirect_to [
-                      :edit,
-                      :teacher_interface,
-                      :application_form,
-                      further_information_request_item.document,
-                    ]
+        if @further_information_request_item_text_form.save
+          redirect_to_further_information_request
+        else
+          render :edit, status: :unprocessable_entity
+        end
       else
-        redirect_to [
-                      :teacher_interface,
-                      :application_form,
-                      further_information_request,
-                    ]
+        @further_information_request_item_text_form.update_model
+        redirect_to_further_information_request
       end
     end
 
-    private
+    def update_document
+      if params[:next] == "save_and_continue"
+        redirect_to_document
+      else
+        redirect_to_further_information_request
+      end
+    end
 
     def further_information_request_item
       @further_information_request_item ||=
@@ -43,8 +73,30 @@ module TeacherInterface
     end
 
     def further_information_request
-      @further_information_request =
-        further_information_request_item.further_information_request
+      further_information_request_item.further_information_request
+    end
+
+    def further_information_request_item_text_form_params
+      params.require(
+        :teacher_interface_further_information_request_item_text_form,
+      ).permit(:response)
+    end
+
+    def redirect_to_further_information_request
+      redirect_to [
+                    :teacher_interface,
+                    :application_form,
+                    further_information_request,
+                  ]
+    end
+
+    def redirect_to_document
+      redirect_to [
+                    :edit,
+                    :teacher_interface,
+                    :application_form,
+                    further_information_request_item.document,
+                  ]
     end
   end
 end

--- a/app/forms/teacher_interface/further_information_request_item_text_form.rb
+++ b/app/forms/teacher_interface/further_information_request_item_text_form.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class TeacherInterface::FurtherInformationRequestItemTextForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :further_information_request_item
+  attribute :response, :string
+
+  validates :further_information_request_item, presence: true
+  validates :response, presence: true
+
+  def save
+    return false unless valid?
+    update_model
+    true
+  end
+
+  def update_model
+    further_information_request_item.update!(response:)
+  end
+end

--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -23,6 +23,12 @@ class FurtherInformationRequestItem < ApplicationRecord
   enum :information_type, { text: "text", document: "document" }
 
   def state
-    document? && document.uploaded? ? :completed : :not_started
+    completed? ? :completed : :not_started
+  end
+
+  private
+
+  def completed?
+    (text? && response.present?) || (document? && document.uploaded?)
   end
 end

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -5,7 +5,11 @@
 <h3 class="govuk-heading-s">Notes from the assessor</h3>
 <p class="govuk-inset-text"><%= @further_information_request_item.assessor_notes %></p>
 
-<%= form_with model: @further_information_request_item_form, url: teacher_interface_application_form_further_information_request_further_information_request_item_path, method: :put do |f| %>
+<%= form_with model: @further_information_request_item_text_form, url: teacher_interface_application_form_further_information_request_further_information_request_item_path, method: :put do |f| %>
+  <% if @further_information_request_item.text? %>
+    <%= f.govuk_text_area :response, label: { size: "s" } %>
+  <% end %>
+
   <% if @further_information_request_item.document? %>
     <p class="govuk-body">You can upload this document on the next screen.</p>
   <% end %>

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -16,6 +16,8 @@ en:
         has_alternative_name: If your name appears differently on your ID documents or qualifications you need to upload proof of your name change, for example, your marriage or civil partnership certificate.
         alternative_given_names: Enter your full name apart from your family name
         alternative_family_name: Enter just your family name
+      teacher_interface_further_information_request_item_text_form:
+        response: Use the text box below to respond to the assessor’s question.
       teacher_interface_new_session_form:
         email: Enter the email address you used to register, and we will send you a link to sign in.
       teacher_interface_registration_number_form:
@@ -45,6 +47,8 @@ en:
       teacher_interface_age_range_form:
         minimum: From
         maximum: To
+      teacher_interface_further_information_request_item_text_form:
+        response: Enter your response
       teacher_interface_new_session_form:
         email: Email address
       teacher_interface_registration_number_form:

--- a/spec/forms/teacher_interface/further_information_request_item_text_form.rb
+++ b/spec/forms/teacher_interface/further_information_request_item_text_form.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe TeacherInterface::FurtherInformationRequestItemTextForm,
+               type: :model do
+  subject(:form) do
+    described_class.new(further_information_request_item:, response:)
+  end
+
+  let(:further_information_request_item) do
+    build(:further_information_request_item)
+  end
+  let(:response) { nil }
+
+  it { is_expected.to validate_presence_of(:further_information_request_item) }
+  it { is_expected.to validate_presence_of(:response) }
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    context "with a blank value" do
+      let(:response) { "" }
+
+      it { is_expected.to be false }
+    end
+
+    context "with a present value" do
+      let(:response) { "response" }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "#update_model" do
+    subject(:response) { further_information_request_item.response }
+
+    before { form.update_model }
+
+    context "with a blank value" do
+      let(:response) { "" }
+
+      it { is_expected.to eq("") }
+    end
+
+    context "with a present value" do
+      let(:response) { "response" }
+
+      it { is_expected.to eq("response") }
+    end
+  end
+end

--- a/spec/models/further_information_request_item_spec.rb
+++ b/spec/models/further_information_request_item_spec.rb
@@ -43,7 +43,17 @@ RSpec.describe FurtherInformationRequestItem do
         further_information_request_item.update!(information_type: "text")
       end
 
-      it { is_expected.to eq(:not_started) }
+      context "without a response" do
+        it { is_expected.to eq(:not_started) }
+      end
+
+      context "with a response" do
+        before do
+          further_information_request_item.update!(response: "response")
+        end
+
+        it { is_expected.to eq(:completed) }
+      end
     end
 
     context "with document information" do
@@ -52,7 +62,9 @@ RSpec.describe FurtherInformationRequestItem do
         further_information_request_item.document = create(:document)
       end
 
-      it { is_expected.to eq(:not_started) }
+      context "without an upload" do
+        it { is_expected.to eq(:not_started) }
+      end
 
       context "with an upload" do
         before do

--- a/spec/support/autoload/page_objects/teacher_interface/further_information_required.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/further_information_required.rb
@@ -8,6 +8,7 @@ module PageObjects
       element :assessor_notes, ".govuk-inset-text"
 
       section :form, "form" do
+        element :response_textarea, ".govuk-textarea"
         element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
         element :save_and_come_back_later_button,
                 ".govuk-button.govuk-button--secondary"

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe "Teacher further information", type: :system do
 
     when_i_click_the_text_task_list_item
     then_i_see_the(:further_information_required_page)
+
+    when_i_fill_in_the_response
+    and_i_click_continue
+    then_i_see_the(:further_information_requested_page)
+    and_i_see_a_completed_text_task_list_item
   end
 
   it "allows filling in a document item" do
@@ -58,10 +63,13 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def and_i_see_the_text_task_list_item
-    item =
-      further_information_requested_page.task_list.sections.first.items.first
-    expect(item.link.text).to eq("Text")
-    expect(item.status_tag.text).to eq("NOT STARTED")
+    expect(text_task_list_item.link.text).to eq("Text")
+    expect(text_task_list_item.status_tag.text).to eq("NOT STARTED")
+  end
+
+  def and_i_see_a_completed_text_task_list_item
+    expect(text_task_list_item.link.text).to eq("Text")
+    expect(text_task_list_item.status_tag.text).to eq("COMPLETED")
   end
 
   def and_i_see_the_document_task_list_item
@@ -75,18 +83,16 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def when_i_click_the_text_task_list_item
-    further_information_requested_page
-      .task_list
-      .sections
-      .first
-      .items
-      .first
-      .link
-      .click
+    text_task_list_item.link.click
   end
 
   def when_i_click_the_document_task_list_item
     document_task_list_item.link.click
+  end
+
+  def when_i_fill_in_the_response
+    further_information_required_page.form.response_textarea.fill_in with:
+      "Response"
   end
 
   def when_i_upload_a_file
@@ -99,6 +105,10 @@ RSpec.describe "Teacher further information", type: :system do
   def when_i_dont_need_to_upload_another_file
     document_form_page.form.no_radio_item.input.click
     document_form_page.form.continue_button.click
+  end
+
+  def and_i_click_continue
+    further_information_required_page.form.continue_button.click
   end
 
   def when_i_click_the_save_and_sign_out_button
@@ -131,6 +141,10 @@ RSpec.describe "Teacher further information", type: :system do
 
   def further_information_request
     application_form.assessment.further_information_requests.first
+  end
+
+  def text_task_list_item
+    further_information_requested_page.task_list.find_item("Text")
   end
 
   def document_task_list_item


### PR DESCRIPTION
This adds the ability for a teacher to respond to a text further information request.

[Trello Card](https://trello.com/c/e4ZUBUwF/929-fi-request-text-submission)

## Screenshot

<img width="718" alt="Screenshot 2022-09-27 at 08 21 45" src="https://user-images.githubusercontent.com/510498/192460246-a2ba32b2-18c7-4ec7-9c80-b1bfe5ea9354.png">
