### PR TITLE
[932] Email preview

### DIFF
--- a/app/assets/stylesheets/_email_preview.scss
+++ b/app/assets/stylesheets/_email_preview.scss
@@ -1,0 +1,20 @@
+.app-email-preview__header {
+  background-color: govuk-colour("black");
+  color: govuk-colour("white");
+  padding: govuk-spacing(2);
+}
+
+.app-email-preview__header__logo {
+  font-size: 28px;
+  font-weight: bold;
+  width: 580px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.app-email-preview__content {
+  border-top: 10px govuk-colour("blue") solid;
+  width: 580px;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -9,6 +9,7 @@ $moj-images-path: "/";
 
 @import "_application_forms";
 @import "_description_list";
+@import "_email_preview";
 @import "_environments";
 @import "_search_results";
 @import "_summary_list_card";

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -7,7 +7,7 @@ module AssessorInterface
 
     def create
       @further_information_request =
-        assessment.further_information_requests.create!
+        assessment.further_information_requests.create!(further_information_request_params)
       redirect_to [
                     :assessor_interface,
                     application_form,
@@ -18,7 +18,7 @@ module AssessorInterface
 
     def show
       @further_information_request =
-        assessment.further_information_requests.first
+        assessment.further_information_requests.find(params[:id])
     end
 
     private
@@ -29,6 +29,10 @@ module AssessorInterface
 
     def application_form
       @application_form ||= ApplicationForm.find(params[:application_form_id])
+    end
+
+    def further_information_request_params
+      params.require(:further_information_request).permit(:email_content)
     end
   end
 end

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -1,5 +1,7 @@
 module AssessorInterface
   class FurtherInformationRequestsController < BaseController
+    layout "full_from_desktop", only: %i[show]
+
     def new
       @further_information_request =
         assessment.further_information_requests.build
@@ -7,7 +9,9 @@ module AssessorInterface
 
     def create
       @further_information_request =
-        assessment.further_information_requests.create!(further_information_request_params)
+        assessment.further_information_requests.create!(
+          further_information_request_params,
+        )
       redirect_to [
                     :assessor_interface,
                     application_form,
@@ -19,6 +23,11 @@ module AssessorInterface
     def show
       @further_information_request =
         assessment.further_information_requests.find(params[:id])
+      @email_preview =
+        FurtherInformationTemplatePreview.with(
+          teacher:,
+          further_information_request: @further_information_request,
+        ).render
     end
 
     private
@@ -29,6 +38,10 @@ module AssessorInterface
 
     def application_form
       @application_form ||= ApplicationForm.find(params[:application_form_id])
+    end
+
+    def teacher
+      application_form.teacher
     end
 
     def further_information_request_params

--- a/app/mailers/further_information_template_preview.rb
+++ b/app/mailers/further_information_template_preview.rb
@@ -1,0 +1,49 @@
+class FurtherInformationTemplatePreview
+  GOVUK_NOTIFY_TEMPLATE_ID =
+    ENV.fetch(
+      "GOVUK_NOTIFY_TEMPLATE_ID_MAILER",
+      "95adafaf-0920-4623-bddc-340853c047af",
+    )
+
+  class << self
+    def with(teacher:, further_information_request:)
+      new(teacher:, further_information_request:)
+    end
+  end
+
+  def initialize(teacher:, further_information_request:)
+    @teacher = teacher
+    @further_information_request = further_information_request
+  end
+
+  def render
+    client.generate_template_preview(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      personalisation: {
+        to:,
+        subject:,
+        body:,
+      },
+    ).html
+  end
+
+  private
+
+  attr_reader :teacher, :further_information_request
+
+  def to
+    teacher.email
+  end
+
+  def subject
+    I18n.t("mailer.further_information.required.subject")
+  end
+
+  def body
+    further_information_request.email_content
+  end
+
+  def client
+    @client ||= Notifications::Client.new(ENV.fetch("GOVUK_NOTIFY_API_KEY"))
+  end
+end

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -3,6 +3,7 @@
 # Table name: further_information_requests
 #
 #  id            :bigint           not null, primary key
+#  email_content :text
 #  received_at   :datetime
 #  state         :string           not null
 #  created_at    :datetime         not null

--- a/app/views/assessor_interface/further_information_requests/new.html.erb
+++ b/app/views/assessor_interface/further_information_requests/new.html.erb
@@ -2,5 +2,6 @@
 
 <h1 class="govuk-heading-xl">Compose and send your further information request email</h1>
 <%= form_for [:assessor_interface, @application_form, @assessment, @further_information_request] do |form| %> 
+  <%= form.govuk_text_area :email_content, label: { text: "Email content" } %>
   <%= form.govuk_submit %>
 <%- end -%>

--- a/app/views/assessor_interface/further_information_requests/show.html.erb
+++ b/app/views/assessor_interface/further_information_requests/show.html.erb
@@ -1,3 +1,7 @@
 <% content_for :back_link_url, new_assessor_interface_application_form_assessment_further_information_request_path(@application_form, @assessment) %>
 
 <h1 class="govuk-heading-xl">Further information request email preview</h1>
+
+<div class="app-email-preview">
+  <%= @further_information_request.email_content %>
+</div>

--- a/app/views/assessor_interface/further_information_requests/show.html.erb
+++ b/app/views/assessor_interface/further_information_requests/show.html.erb
@@ -1,7 +1,18 @@
 <% content_for :back_link_url, new_assessor_interface_application_form_assessment_further_information_request_path(@application_form, @assessment) %>
 
-<h1 class="govuk-heading-xl">Further information request email preview</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Further information request email preview</h1>
+  </div>
+</div>
 
-<div class="app-email-preview">
-  <%= @further_information_request.email_content %>
+<div class="app-email-preview govuk-body">
+  <div class="app-email-preview__header">
+    <div class="app-email-preview__header__logo">
+      GOV.UK
+    </div>
+  </div>
+  <div class="app-email-preview__content">
+    <%= @email_preview.html_safe %>
+  </div>
 </div>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -105,6 +105,7 @@
     - created_at
     - updated_at
     - assessment_id
+    - email_content
   :further_information_request_items:
     - id
     - information_type

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,6 +121,9 @@ en:
       hint: This means you have all the qualifications needed to teach in a state school. You'll need to provide evidence of this if you apply for QTS.
 
   mailer:
+    further_information:
+      required:
+        subject: Further information required
     teacher:
       application_received:
         subject: We’ve received your application for qualified teacher status (QTS)

--- a/db/migrate/20220926125807_add_email_content_to_further_information_requests.rb
+++ b/db/migrate/20220926125807_add_email_content_to_further_information_requests.rb
@@ -1,0 +1,5 @@
+class AddEmailContentToFurtherInformationRequests < ActiveRecord::Migration[7.0]
+  def change
+    add_column :further_information_requests, :email_content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_21_145557) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_26_125807) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -157,6 +157,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_21_145557) do
     t.datetime "received_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "email_content"
     t.index ["assessment_id"], name: "index_further_information_requests_on_assessment_id"
   end
 

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -5,6 +5,7 @@
 # Table name: further_information_requests
 #
 #  id            :bigint           not null, primary key
+#  email_content :text
 #  received_at   :datetime
 #  state         :string           not null
 #  created_at    :datetime         not null

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -18,6 +18,8 @@
 #
 FactoryBot.define do
   factory :further_information_request do
+    association :assessment
+
     trait :requested do
       state { "requested" }
     end

--- a/spec/mailers/further_information_template_preview_spec.rb
+++ b/spec/mailers/further_information_template_preview_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe FurtherInformationTemplatePreview do
+  let(:further_information_request) do
+    create(:further_information_request, email_content: "raw email")
+  end
+  let(:teacher) { create(:teacher) }
+  let(:notify_key) { "notify-key" }
+  let(:notify_client) do
+    double(generate_template_preview: notify_template_preview)
+  end
+  let(:notify_template_preview) { double(html: "email html") }
+
+  around do |example|
+    ClimateControl.modify GOVUK_NOTIFY_API_KEY: notify_key do
+      example.run
+    end
+  end
+
+  before do
+    allow(Notifications::Client).to receive(:new).with(notify_key).and_return(
+      notify_client,
+    )
+  end
+
+  describe "render" do
+    subject do
+      described_class.with(teacher:, further_information_request:).render
+    end
+
+    it { is_expected.to eq("email html") }
+
+    it "renders the correct template" do
+      expect(notify_client).to receive(:generate_template_preview).with(
+        "95adafaf-0920-4623-bddc-340853c047af",
+        instance_of(Hash),
+      )
+      subject
+    end
+
+    it "passes the correct parameters" do
+      expect(notify_client).to receive(:generate_template_preview).with(
+        instance_of(String),
+        personalisation: {
+          to: teacher.email,
+          subject: "Further information required",
+          body: "raw email",
+        },
+      )
+      subject
+    end
+  end
+end

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -5,6 +5,7 @@
 # Table name: further_information_requests
 #
 #  id            :bigint           not null, primary key
+#  email_content :text
 #  received_at   :datetime
 #  state         :string           not null
 #  created_at    :datetime         not null

--- a/spec/support/autoload/page_objects/assessor_interface/further_information_request_preview.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/further_information_request_preview.rb
@@ -3,6 +3,8 @@ module PageObjects
     class FurtherInformationRequestPreview < SitePrism::Page
       set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
                 "/further-information-requests/{further_information_request_id}"
+
+      element :email_preview, "div.app-email-preview"
     end
   end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/request_further_information.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/request_further_information.rb
@@ -2,6 +2,8 @@ module PageObjects
   module AssessorInterface
     class RequestFurtherInformation < SitePrism::Page
       set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/further-information-requests/new"
+
+      element :email_content, "textarea"
     end
   end
 end

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe "Assessor requesting further information", type: :system do
   it "completes an assessment" do
     given_the_service_is_open
-    given_i_am_authorized_as_an_assessor_user(assessor)
+    given_i_am_authorized_as_a_user(assessor)
     given_there_is_an_application_form_with_failure_reasons
 
     when_i_visit_the(:complete_assessment_page, application_id:, assessment_id:)
@@ -18,6 +18,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
       assessment_id:,
     )
 
+    when_i_enter_email_content
     when_i_click_continue
     then_i_see_the(
       :further_information_request_preview_page,
@@ -25,6 +26,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
       assessment_id:,
       further_information_request_id:,
     )
+    and_i_see_the_email_preview
   end
 
   private
@@ -46,8 +48,16 @@ RSpec.describe "Assessor requesting further information", type: :system do
     complete_assessment_page.request_further_information.input.choose
   end
 
+  def when_i_enter_email_content
+    request_further_information_page.email_content.fill_in with: "I am an email"
+  end
+
   def then_the_application_form_is_awarded
     expect(assessor_application_page.overview.status.text).to eq("AWARDED")
+  end
+
+  def and_i_see_the_email_preview
+    expect(further_information_request_preview_page.email_preview).to have_content("I am an email")
   end
 
   def application_form


### PR DESCRIPTION
Add a basic email preview to the further information request flow. The design for this part is in flux so this doesn't currently match the prototype. The intention is to get the code in place for storing email content and previewing using the notify template.

I tried a couple of approaches. This implementation uses the notify client to render the template. This doesn't give us much but does:

* process the markdown
* escape the input
* marks everything up in tables and tags with style attributes etc like notify does

<img width="1070" alt="Screenshot 2022-09-27 at 16 43 46" src="https://user-images.githubusercontent.com/5216/192572858-d316b117-6b8a-4d10-92da-f8ca5b6b66f7.png">

<img width="1053" alt="Screenshot 2022-09-27 at 16 45 12" src="https://user-images.githubusercontent.com/5216/192573433-9ad8226d-4b23-477b-bc1c-d9b544224b14.png">

### Review

* The further information request 'new' form is temporary as the email will be generated automatically. I have included it in the system spec for now but it's using the wrong layout currently.
* The system spec is a bit messy now as I've had to stub out the Notify client. Going with the 'stub at the boundaries' approach I've stubbed the Notify client. I think maybe we could just stub our own preview class here to make it simpler. I did start with a controller spec here too but I've left that for a subsequent PR as the actions and the flow are almost certainly going to change
* I've put the preview class in app/mailers as I originally tried (and failed) to implement it as a method on a `FurtherInformationRequestMailer` class. Are we happy with it in there?