### PR TITLE
Record notes with assessment section failure reasons

### DIFF
--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -3,16 +3,25 @@
 module AssessorInterface
   class AssessmentSectionsController < BaseController
     def show
-      assessment_section_view_object
+      @assessment_section_form =
+        assessment_section_form.new(
+          assessment_section:,
+          user: current_staff,
+          passed: assessment_section.passed,
+          selected_failure_reasons: assessment_section.selected_failure_reasons,
+        )
     end
 
     def update
-      if UpdateAssessmentSection.call(
-           assessment_section:
-             assessment_section_view_object.assessment_section,
-           user: current_staff,
-           params: assessment_section_params,
-         )
+      @assessment_section_form =
+        assessment_section_form.new(
+          assessment_section_form_params.merge(
+            assessment_section:,
+            user: current_staff,
+          ),
+        )
+
+      if @assessment_section_form.save
         redirect_to [
                       :assessor_interface,
                       assessment_section_view_object.application_form,
@@ -29,10 +38,17 @@ module AssessorInterface
         AssessmentSectionViewObject.new(params:)
     end
 
-    def assessment_section_params
-      params.require(:assessment_section).permit(
-        :passed,
-        selected_failure_reasons: [],
+    def assessment_section
+      assessment_section_view_object.assessment_section
+    end
+
+    def assessment_section_form
+      AssessmentSectionForm.for_assessment_section(assessment_section)
+    end
+
+    def assessment_section_form_params
+      assessment_section_form.permit_parameters(
+        params.require(:assessor_interface_assessment_section_form),
       )
     end
   end

--- a/app/forms/assessor_interface/assessment_section_form.rb
+++ b/app/forms/assessor_interface/assessment_section_form.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+class AssessorInterface::AssessmentSectionForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :assessment_section, :user
+  validates :assessment_section, :user, presence: true
+
+  attribute :passed, :boolean
+  validates :passed, inclusion: [true, false]
+
+  validates :selected_failure_reasons,
+            presence: true,
+            if: -> { passed == false }
+
+  def selected_failure_reasons
+    return {} if passed
+
+    assessment_section
+      .failure_reasons
+      .each_with_object({}) do |failure_reason, memo|
+        if send("#{failure_reason}_checked")
+          memo[failure_reason] = send("#{failure_reason}_notes")
+        end
+      end
+  end
+
+  def selected_failure_reasons=(value)
+    value.each do |failure_reason, notes|
+      send("#{failure_reason}_checked=", true)
+      send("#{failure_reason}_notes=", notes)
+    end
+  end
+
+  def save
+    return false unless valid?
+
+    UpdateAssessmentSection.call(
+      assessment_section:,
+      user:,
+      params: {
+        passed:,
+        selected_failure_reasons:,
+      },
+    )
+
+    true
+  end
+
+  class << self
+    def for_assessment_section(assessment_section)
+      klass =
+        Class.new(self) do
+          def self.name
+            "AssessorInterface::AssessmentSectionForm"
+          end
+        end
+
+      assessment_section.failure_reasons.each do |failure_reason|
+        klass.attribute "#{failure_reason}_checked", :boolean
+        klass.attribute "#{failure_reason}_notes", :string
+        klass.validates "#{failure_reason}_notes",
+                        presence: true,
+                        if: :"#{failure_reason}_checked"
+      end
+
+      klass
+    end
+
+    def permit_parameters(params)
+      args =
+        attribute_names.filter { |attr_name| attr_name.ends_with?("_notes") }
+      kwargs =
+        attribute_names
+          .filter { |attr_name| attr_name.ends_with?("_checked") }
+          .index_with { |_key| [] }
+
+      params.permit(:passed, *args, **kwargs)
+    end
+  end
+end

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -7,7 +7,7 @@
 #  failure_reasons          :string           default([]), is an Array
 #  key                      :string           not null
 #  passed                   :boolean
-#  selected_failure_reasons :string           default([]), is an Array
+#  selected_failure_reasons :jsonb            not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  assessment_id            :bigint           not null
@@ -59,7 +59,7 @@ class AssessmentSection < ApplicationRecord
 
   def prepare_selected_failure_reasons
     return if selected_failure_reasons.nil?
-    selected_failure_reasons.compact_blank!
+    selected_failure_reasons.try(:compact_blank!)
     selected_failure_reasons.clear if passed
   end
 end

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -48,18 +48,8 @@ class AssessmentSection < ApplicationRecord
             presence: true,
             if: -> { passed == false }
 
-  before_validation :prepare_selected_failure_reasons
-
   def state
     return :not_started if passed.nil?
     passed ? :completed : :action_required
-  end
-
-  private
-
-  def prepare_selected_failure_reasons
-    return if selected_failure_reasons.nil?
-    selected_failure_reasons.try(:compact_blank!)
-    selected_failure_reasons.clear if passed
   end
 end

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -52,20 +52,22 @@
   <% end %>
 </ul>
 
-<%= form_with model: @assessment_section_view_object.assessment_section, 
+<%= form_with model: @assessment_section_form,
   url: assessor_interface_application_form_assessment_assessment_section_path(
     @assessment_section_view_object.application_form, @assessment_section_view_object.assessment, @assessment_section_view_object.assessment_section.key
-  ) do |f| %>
+  ), method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "Has the applicant completed this section to your satisfaction?", size: "s" } do %>
     <%= f.govuk_radio_button :passed, true, label: { text: "Yes" }, link_errors: true %>
     <%= f.govuk_radio_button :passed, false, label: { text: "No" } do %>
-      <%= f.govuk_collection_check_boxes :selected_failure_reasons,
-                                         @assessment_section_view_object.assessment_section.failure_reasons.map { |id| OpenStruct.new(id:, label: t(".failure_reasons.#{id}")) },
-                                         :id,
-                                         :label,
-                                         legend: { size: "s" } %>
+      <%= f.govuk_check_boxes_fieldset :selected_failure_reasons, legend: { size: "s" } do %>
+        <% @assessment_section_view_object.assessment_section.failure_reasons.each do |failure_reason| %>
+          <%= f.govuk_check_box "#{failure_reason}_checked", true, label: { text: t(".failure_reasons.#{failure_reason}") } do %>
+            <%= f.govuk_text_area "#{failure_reason}_notes", label: { text: "Note to the applicant", size: "s" }, hint: { text: "Use this space to tell the applicant what they need to do. Make sure your instructions are clear." } %>
+          <% end %>
+        <% end %>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -4,7 +4,7 @@ en:
     hint:
       assessment:
         recommendation: You've completed your review of this QTS application and marked all sections as complete to your satisfaction.
-      assessment_section:
+      assessor_interface_assessment_section_form:
         selected_failure_reasons: Select all options that are relevant to you.
       assessor_interface_create_note_form:
         text: Use the text box to add a note to the application history. Other assessors will be able to see any notes you add, but they will not be visible to the applicant.
@@ -60,7 +60,7 @@ en:
     legend:
       assessment:
         recommendation: QTS review completed
-      assessment_section:
+      assessor_interface_assessment_section_form:
         selected_failure_reasons: What are the reasons for your recommendation?
       qualification:
         add_another: Add another qualification?

--- a/db/migrate/20220928084959_change_assessment_section_selected_failure_reasons.rb
+++ b/db/migrate/20220928084959_change_assessment_section_selected_failure_reasons.rb
@@ -1,0 +1,13 @@
+class ChangeAssessmentSectionSelectedFailureReasons < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    change_table :assessment_sections, bulk: true do |t|
+      t.remove :selected_failure_reasons,
+               type: :string,
+               array: true,
+               default: []
+      t.jsonb :selected_failure_reasons, default: {}, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_26_125807) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_28_084959) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -82,9 +82,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_26_125807) do
     t.boolean "passed"
     t.string "checks", default: [], array: true
     t.string "failure_reasons", default: [], array: true
-    t.string "selected_failure_reasons", default: [], array: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "selected_failure_reasons", default: {}, null: false
     t.index ["assessment_id", "key"], name: "index_assessment_sections_on_assessment_id_and_key", unique: true
     t.index ["assessment_id"], name: "index_assessment_sections_on_assessment_id"
   end

--- a/spec/factories/assessment_sections.rb
+++ b/spec/factories/assessment_sections.rb
@@ -7,7 +7,7 @@
 #  failure_reasons          :string           default([]), is an Array
 #  key                      :string           not null
 #  passed                   :boolean
-#  selected_failure_reasons :string           default([]), is an Array
+#  selected_failure_reasons :jsonb            not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  assessment_id            :bigint           not null

--- a/spec/forms/assessor_interface/assessment_section_form_spec.rb
+++ b/spec/forms/assessor_interface/assessment_section_form_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::AssessmentSectionForm, type: :model do
+  let(:assessment_section) do
+    create(
+      :assessment_section,
+      key: "personal_information",
+      failure_reasons: %i[reason_a reason_b reason_c],
+    )
+  end
+  let(:user) { create(:staff, :confirmed) }
+  let(:attributes) { {} }
+
+  subject(:form) do
+    described_class.for_assessment_section(assessment_section).new(
+      assessment_section:,
+      user:,
+      **attributes,
+    )
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:assessment_section) }
+    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to allow_values(true, false).for(:passed) }
+
+    context "when passed" do
+      let(:attributes) { { passed: true } }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when reasons are checked" do
+      let(:attributes) do
+        {
+          passed: false,
+          reason_a_checked: true,
+          reason_b_checked: true,
+          reason_c_checked: true,
+        }
+      end
+
+      it { is_expected.to validate_presence_of(:reason_a_notes) }
+      it { is_expected.to validate_presence_of(:reason_b_notes) }
+      it { is_expected.to validate_presence_of(:reason_c_notes) }
+    end
+
+    context "when reasons are checked and notes are provided" do
+      let(:attributes) do
+        {
+          passed: false,
+          reason_a_checked: true,
+          reason_a_notes: "Notes.",
+          reason_b_checked: true,
+          reason_b_notes: "Notes.",
+          reason_c_checked: true,
+          reason_c_notes: "Notes.",
+        }
+      end
+
+      it { is_expected.to be_valid }
+    end
+  end
+
+  describe "#selected_failure_reasons" do
+    subject(:selected_failure_reasons) { form.selected_failure_reasons }
+
+    context "when passed" do
+      let(:attributes) { { passed: true } }
+
+      it { is_expected.to eq({}) }
+    end
+
+    context "when failed" do
+      let(:attributes) do
+        { passed: false, reason_a_checked: true, reason_a_notes: "Notes." }
+      end
+
+      it { is_expected.to eq({ "reason_a" => "Notes." }) }
+    end
+  end
+
+  describe "#selected_failure_reasons=" do
+    before { form.selected_failure_reasons = { reason_a: "Notes." } }
+
+    it "sets the attributes" do
+      expect(form.reason_a_checked).to be true
+      expect(form.reason_a_notes).to eq("Notes.")
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    describe "when invalid attributes" do
+      it { is_expected.to be false }
+    end
+
+    describe "with valid attributes and passed" do
+      let(:attributes) do
+        { passed: true, reason_a_checked: true, reason_a_notes: "Notes." }
+      end
+
+      it { is_expected.to be true }
+
+      it "calls the update assessment service" do
+        expect(UpdateAssessmentSection).to receive(:call).with(
+          assessment_section:,
+          user:,
+          params: {
+            passed: true,
+            selected_failure_reasons: {
+            },
+          },
+        )
+
+        save # rubocop:disable Rails/SaveBang
+      end
+    end
+
+    describe "with valid attributes and failed" do
+      let(:attributes) do
+        {
+          passed: false,
+          reason_a_checked: true,
+          reason_a_notes: "Notes.",
+          reason_b_checked: false,
+          reason_c_checked: false,
+        }
+      end
+
+      it { is_expected.to be true }
+
+      it "calls the update assessment service" do
+        expect(UpdateAssessmentSection).to receive(:call).with(
+          assessment_section:,
+          user:,
+          params: {
+            passed: false,
+            selected_failure_reasons: {
+              "reason_a" => "Notes.",
+            },
+          },
+        )
+
+        save # rubocop:disable Rails/SaveBang
+      end
+    end
+  end
+end

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -9,7 +9,7 @@
 #  failure_reasons          :string           default([]), is an Array
 #  key                      :string           not null
 #  passed                   :boolean
-#  selected_failure_reasons :string           default([]), is an Array
+#  selected_failure_reasons :jsonb            not null
 #  created_at               :datetime         not null
 #  updated_at               :datetime         not null
 #  assessment_id            :bigint           not null

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -51,21 +51,6 @@ RSpec.describe AssessmentSection, type: :model do
     end
   end
 
-  context "when passed" do
-    before do
-      assessment_section.update!(
-        key: :personal_information,
-        passed: false,
-        selected_failure_reasons: %w[failure_reason],
-      )
-    end
-
-    it "clears selected failure reasons" do
-      assessment_section.update!(passed: true)
-      expect(assessment_section.selected_failure_reasons).to be_empty
-    end
-  end
-
   describe "#state" do
     subject(:state) { assessment_section.state }
 

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe UpdateAssessmentSection do
     it "sets the failure reasons" do
       expect { subject }.to change {
         assessment_section.selected_failure_reasons
-      }.from([]).to([selected_failure_reason])
+      }.from({}).to([selected_failure_reason])
     end
 
     it "changes the assessor" do

--- a/spec/support/autoload/page_objects/assessor_interface/assessment_section.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/assessment_section.rb
@@ -13,6 +13,7 @@ module PageObjects
         sections :failure_reason_checkbox_items,
                  PageObjects::GovukCheckboxItem,
                  ".govuk-checkboxes__item"
+        elements :failure_reason_note_textareas, ".govuk-textarea"
         element :continue_button, "button"
       end
     end

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -148,6 +148,10 @@ RSpec.describe "Assessor check submitted details", type: :system do
       .first
       .checkbox
       .click
+    check_personal_information_page
+      .form
+      .failure_reason_note_textareas
+      .first.fill_in with: "Note."
     check_personal_information_page.form.continue_button.click
   end
 
@@ -178,6 +182,10 @@ RSpec.describe "Assessor check submitted details", type: :system do
       .first
       .checkbox
       .click
+    check_qualifications_page
+      .form
+      .failure_reason_note_textareas
+      .first.fill_in with: "Note."
     check_qualifications_page.form.continue_button.click
   end
 
@@ -219,6 +227,10 @@ RSpec.describe "Assessor check submitted details", type: :system do
       .first
       .checkbox
       .click
+    check_work_history_page
+      .form
+      .failure_reason_note_textareas
+      .first.fill_in with: "Note."
     check_work_history_page.form.continue_button.click
   end
 
@@ -256,6 +268,10 @@ RSpec.describe "Assessor check submitted details", type: :system do
       .first
       .checkbox
       .click
+    check_professional_standing_page
+      .form
+      .failure_reason_note_textareas
+      .first.fill_in with: "Note."
     check_professional_standing_page.form.continue_button.click
   end
 


### PR DESCRIPTION
This changes how we record failure reasons to associate a note with them, which we can then use to generate further information request items in a later PR.

[Trello Card](https://trello.com/c/UhGwqDlZ/956-spike-further-information-request-reasons)

## Screenshots

![Screenshot 2022-09-28 at 13 44 04](https://user-images.githubusercontent.com/510498/192783086-cc9695c3-126c-499d-b3ff-7d5a3ebaec95.png)
