### PR TITLE
Add titles to further information request items

### DIFF
--- a/app/controllers/teacher_interface/further_information_requests_controller.rb
+++ b/app/controllers/teacher_interface/further_information_requests_controller.rb
@@ -1,20 +1,8 @@
 module TeacherInterface
   class FurtherInformationRequestsController < BaseController
-    before_action :load_application_form
-
     def show
-      @further_information_request = further_information_request
-    end
-
-    private
-
-    def further_information_request
-      @further_information_request ||=
-        FurtherInformationRequest
-          .joins(:assessment)
-          .requested
-          .where(assessments: { application_form: })
-          .find(params[:id])
+      @view_object =
+        FurtherInformationRequestViewObject.new(current_teacher:, params:)
     end
   end
 end

--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -6,6 +6,7 @@
 #
 #  id                             :bigint           not null, primary key
 #  assessor_notes                 :text
+#  failure_reason                 :string           default(""), not null
 #  information_type               :string
 #  response                       :text
 #  created_at                     :datetime         not null

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -14,7 +14,7 @@ module TeacherInterface
         .map do |item|
           {
             key: item.id,
-            text: item.information_type.humanize,
+            text: item_text(item),
             href: [
               :edit,
               :teacher_interface,
@@ -42,6 +42,15 @@ module TeacherInterface
           .requested
           .where(assessments: { application_form: })
           .find(params[:id])
+    end
+
+    def item_text(item)
+      case item.information_type
+      when "text"
+        item.information_type.humanize
+      when "document"
+        "Upload your #{I18n.t("document.document_type.#{item.document.document_type}")} document"
+      end
     end
   end
 end

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class FurtherInformationRequestViewObject
+    def initialize(current_teacher:, params:)
+      @current_teacher = current_teacher
+      @params = params
+    end
+
+    def task_items
+      further_information_request
+        .items
+        .order(:created_at)
+        .map do |item|
+          {
+            key: item.id,
+            text: item.information_type.humanize,
+            href: [
+              :edit,
+              :teacher_interface,
+              :application_form,
+              further_information_request,
+              item,
+            ],
+            status: item.state,
+          }
+        end
+    end
+
+    private
+
+    attr_reader :current_teacher, :params
+
+    def application_form
+      @application_form ||= current_teacher.application_form
+    end
+
+    def further_information_request
+      @further_information_request ||=
+        FurtherInformationRequest
+          .joins(:assessment)
+          .requested
+          .where(assessments: { application_form: })
+          .find(params[:id])
+    end
+  end
+end

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -47,7 +47,9 @@ module TeacherInterface
     def item_text(item)
       case item.information_type
       when "text"
-        item.information_type.humanize
+        I18n.t(
+          "teacher_interface.further_information_request.show.failure_reason.#{item.failure_reason}",
+        )
       when "document"
         "Upload your #{I18n.t("document.document_type.#{item.document.document_type}")} document"
       end

--- a/app/views/teacher_interface/further_information_requests/show.html.erb
+++ b/app/views/teacher_interface/further_information_requests/show.html.erb
@@ -10,18 +10,14 @@
     </h2>
 
     <ul class="app-task-list__items">
-      <% @further_information_request.items.each do |item| %>
+      <% @view_object.task_items.each do |item| %>
         <li class="app-task-list__item">
-            <span class="app-task-list__task-name">
-              <%= link_to t(".items.title.#{item.information_type}"),
-                          edit_teacher_interface_application_form_further_information_request_further_information_request_item_path(@further_information_request, item),
-                          aria: { describedby: "#{item.id}-status" } %>
-            </span>
+          <span class="app-task-list__task-name">
+            <%= link_to item[:text], item[:href], aria: { describedby: "#{item[:key]}-status" } %>
+          </span>
 
           <%= render(ApplicationFormStatusTag::Component.new(
-            key: item.id,
-            status: item.state,
-            class_context: "app-task-list"
+            **item.slice(:key, :status).merge(class_context: "app-task-list")
           )) %>
         </li>
       <% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -114,6 +114,7 @@
     - further_information_request_id
     - assessor_notes
     - response
+    - failure_reason
   :notes:
     - id
     - application_form_id

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -1,0 +1,9 @@
+en:
+  teacher_interface:
+    further_information_request:
+      show:
+        failure_reason:
+          qualifications_dont_support_subjects: Tell us more about the subjects you can teach
+          qualifications_dont_match_those_entered: Tell us more about your qualifications
+          satisfactory_evidence_work_history: Tell us more about your work history
+          registration_number: Tell us your registration number

--- a/db/migrate/20220929080026_add_failure_reason_to_further_information_request_item.rb
+++ b/db/migrate/20220929080026_add_failure_reason_to_further_information_request_item.rb
@@ -1,0 +1,11 @@
+class AddFailureReasonToFurtherInformationRequestItem < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    add_column :further_information_request_items,
+               :failure_reason,
+               :string,
+               null: false,
+               default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_09_28_084959) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_29_080026) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -148,6 +148,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_28_084959) do
     t.text "response"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "failure_reason", default: "", null: false
     t.index ["further_information_request_id"], name: "index_fi_request_items_on_fi_request_id"
   end
 

--- a/spec/factories/further_information_request_items.rb
+++ b/spec/factories/further_information_request_items.rb
@@ -6,6 +6,7 @@
 #
 #  id                             :bigint           not null, primary key
 #  assessor_notes                 :text
+#  failure_reason                 :string           default(""), not null
 #  information_type               :string
 #  response                       :text
 #  created_at                     :datetime         not null
@@ -22,6 +23,7 @@ FactoryBot.define do
 
     trait :with_text_response do
       information_type { "text" }
+      failure_reason { "qualifications_dont_support_subjects" }
     end
 
     trait :with_document_response do

--- a/spec/models/further_information_request_item_spec.rb
+++ b/spec/models/further_information_request_item_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                             :bigint           not null, primary key
 #  assessor_notes                 :text
+#  failure_reason                 :string           default(""), not null
 #  information_type               :string
 #  response                       :text
 #  created_at                     :datetime         not null
@@ -14,7 +15,6 @@
 #
 #  index_fi_request_items_on_fi_request_id  (further_information_request_id)
 #
-#frozen_string_literal :true
 
 require "rails_helper"
 

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -63,12 +63,10 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def and_i_see_the_text_task_list_item
-    expect(text_task_list_item.link.text).to eq("Text")
     expect(text_task_list_item.status_tag.text).to eq("NOT STARTED")
   end
 
   def and_i_see_a_completed_text_task_list_item
-    expect(text_task_list_item.link.text).to eq("Text")
     expect(text_task_list_item.status_tag.text).to eq("COMPLETED")
   end
 
@@ -143,7 +141,9 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def text_task_list_item
-    further_information_requested_page.task_list.find_item("Text")
+    further_information_requested_page.task_list.find_item(
+      "Tell us more about the subjects you can teach",
+    )
   end
 
   def document_task_list_item

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -73,12 +73,10 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def and_i_see_the_document_task_list_item
-    expect(document_task_list_item.link.text).to eq("Document")
     expect(document_task_list_item.status_tag.text).to eq("NOT STARTED")
   end
 
   def and_i_see_a_completed_document_task_list_item
-    expect(document_task_list_item.link.text).to eq("Document")
     expect(document_task_list_item.status_tag.text).to eq("COMPLETED")
   end
 
@@ -134,6 +132,7 @@ RSpec.describe "Teacher further information", type: :system do
           :further_information_request_item,
           :with_document_response,
           further_information_request: request,
+          document: create(:document, :written_statement),
         )
         application_form
       end
@@ -148,6 +147,8 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def document_task_list_item
-    further_information_requested_page.task_list.find_item("Document")
+    further_information_requested_page.task_list.find_item(
+      "Upload your written statement document",
+    )
   end
 end

--- a/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
+  subject(:view_object) do
+    described_class.new(
+      current_teacher:,
+      params: ActionController::Parameters.new(params),
+    )
+  end
+
+  let(:current_teacher) { create(:teacher, :confirmed) }
+  let(:params) { {} }
+
+  describe "#task_items" do
+    let(:application_form) do
+      create(:application_form, teacher: current_teacher)
+    end
+    let(:further_information_request) do
+      create(
+        :further_information_request,
+        assessment: create(:assessment, application_form:),
+      )
+    end
+    let(:params) do
+      {
+        id: further_information_request.id,
+        application_form_id: application_form.id,
+      }
+    end
+
+    let!(:text_item) do
+      create(
+        :further_information_request_item,
+        :with_text_response,
+        further_information_request:,
+      )
+    end
+    let!(:document_item) do
+      create(
+        :further_information_request_item,
+        :with_document_response,
+        further_information_request:,
+      )
+    end
+
+    subject(:task_items) { view_object.task_items }
+
+    it do
+      is_expected.to eq(
+        [
+          {
+            key: text_item.id,
+            text: "Text",
+            href: [
+              :edit,
+              :teacher_interface,
+              :application_form,
+              further_information_request,
+              text_item,
+            ],
+            status: :not_started,
+          },
+          {
+            key: document_item.id,
+            text: "Document",
+            href: [
+              :edit,
+              :teacher_interface,
+              :application_form,
+              further_information_request,
+              document_item,
+            ],
+            status: :not_started,
+          },
+        ],
+      )
+    end
+  end
+end

--- a/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
         [
           {
             key: text_item.id,
-            text: "Text",
+            text: "Tell us more about the subjects you can teach",
             href: [
               :edit,
               :teacher_interface,

--- a/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
           },
           {
             key: document_item.id,
-            text: "Document",
+            text: "Upload your identity document",
             href: [
               :edit,
               :teacher_interface,


### PR DESCRIPTION
This determines the title from either the failure reason (if it's a text item) or the document type (if it's a document item).

[Trello Card](https://trello.com/c/UhGwqDlZ/956-spike-further-information-request-reasons)

## Screenshot

<img width="724" alt="Screenshot 2022-09-29 at 09 08 09" src="https://user-images.githubusercontent.com/510498/192976779-b14e10dd-f8d6-4a02-ac39-5cf4c42dcce7.png">
