### PR TITLE
Disable further information requests for decline reasons

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -50,10 +50,12 @@ class Assessment < ApplicationRecord
   end
 
   def can_decline?
-    sections.any? { |section| section.state == :action_required }
+    action_required?
   end
 
-  alias_method :can_request_further_information?, :can_decline?
+  def can_request_further_information?
+    action_required? && !must_decline?
+  end
 
   def available_recommendations
     [].tap do |recommendations|
@@ -63,5 +65,15 @@ class Assessment < ApplicationRecord
       end
       recommendations << "decline" if can_decline?
     end
+  end
+
+  private
+
+  def action_required?
+    sections.any? { |section| section.state == :action_required }
+  end
+
+  def must_decline?
+    sections.any?(&:declines_assessment?)
   end
 end

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -52,4 +52,21 @@ class AssessmentSection < ApplicationRecord
     return :not_started if passed.nil?
     passed ? :completed : :action_required
   end
+
+  DECLINE_FAILURE_REASONS = %w[
+    duplicate_application
+    applicant_already_qts
+    teaching_qualifications_from_ineligible_country
+    teaching_qualifications_not_at_required_level
+    not_qualified_to_teach_mainstream
+    teaching_hours_not_fulfilled
+    authorisation_to_teach
+    teaching_qualification
+    age_ranges_subjects
+    full_professional_status
+  ].freeze
+
+  def declines_assessment?
+    DECLINE_FAILURE_REASONS.intersection(selected_failure_reasons.keys).present?
+  end
 end

--- a/spec/factories/assessment_sections.rb
+++ b/spec/factories/assessment_sections.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
 
     trait :failed do
       passed { false }
-      selected_failure_reasons { %w[failure_reason] }
+      selected_failure_reasons { { failure_reason: "Notes." } }
     end
 
     trait :personal_information do

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -69,4 +69,32 @@ RSpec.describe AssessmentSection, type: :model do
       it { is_expected.to eq(:not_started) }
     end
   end
+
+  describe "#declines_assessment?" do
+    subject(:declines_assessment?) { assessment_section.declines_assessment? }
+
+    context "with a decline failure reason" do
+      before do
+        assessment_section.selected_failure_reasons = {
+          duplicate_application: "Duplicate.",
+        }
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "with no decline failure reasons" do
+      before do
+        assessment_section.selected_failure_reasons = {
+          identification_document_expired: "Expired.",
+        }
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "with no failure reasons" do
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -160,13 +160,16 @@ RSpec.describe Assessment, type: :model do
   end
 
   describe "#can_request_further_information?" do
-    subject(:can_decline?) { assessment.can_request_further_information? }
+    subject(:can_request_further_information?) do
+      assessment.can_request_further_information?
+    end
 
     context "with a passed assessment" do
       before do
         create(:assessment_section, :personal_information, :passed, assessment:)
         create(:assessment_section, :qualifications, :passed, assessment:)
       end
+
       it { is_expected.to be false }
     end
 
@@ -175,7 +178,25 @@ RSpec.describe Assessment, type: :model do
         create(:assessment_section, :personal_information, :passed, assessment:)
         create(:assessment_section, :qualifications, :failed, assessment:)
       end
+
       it { is_expected.to be true }
+    end
+
+    context "with a declined assessment" do
+      before do
+        create(:assessment_section, :personal_information, :passed, assessment:)
+        create(
+          :assessment_section,
+          :qualifications,
+          :failed,
+          assessment:,
+          selected_failure_reasons: {
+            duplicate_application: "Notes.",
+          },
+        )
+      end
+
+      it { is_expected.to be false }
     end
   end
 
@@ -183,18 +204,18 @@ RSpec.describe Assessment, type: :model do
     subject(:available_recommendations) { assessment.available_recommendations }
 
     context "with an award-able assessment" do
-      before { expect(assessment).to receive(:can_award?).and_return(true) }
+      before { allow(assessment).to receive(:can_award?).and_return(true) }
       it { is_expected.to include("award") }
     end
 
     context "with a decline-able assessment" do
-      before { expect(assessment).to receive(:can_decline?).and_return(true) }
+      before { allow(assessment).to receive(:can_decline?).and_return(true) }
       it { is_expected.to include("decline") }
     end
 
     context "with can_request_further_information-able assessment" do
       before do
-        expect(assessment).to receive(
+        allow(assessment).to receive(
           :can_request_further_information?,
         ).and_return(true)
       end


### PR DESCRIPTION
There are certain failure reasons which will prevent the assessor from being able to request further information, and instead only allow an application form to be declined.

[Trello Card](https://trello.com/c/UhGwqDlZ/956-spike-further-information-request-reasons)