### PR TITLE
Create further information request items from assessment

### DIFF
--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -10,8 +10,14 @@ module AssessorInterface
     def create
       @further_information_request =
         assessment.further_information_requests.create!(
-          further_information_request_params,
+          further_information_request_params.merge(
+            items:
+              FurtherInformationRequestItemsFactory.call(
+                assessment_sections: assessment.sections,
+              ),
+          ),
         )
+
       redirect_to [
                     :assessor_interface,
                     application_form,

--- a/app/lib/further_information_request_items_factory.rb
+++ b/app/lib/further_information_request_items_factory.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class FurtherInformationRequestItemsFactory
+  include ServicePattern
+
+  def initialize(assessment_sections:)
+    @assessment_sections = assessment_sections
+  end
+
+  def call
+    assessment_sections.flat_map do |assessment_section|
+      build_further_information_request_items(assessment_section)
+    end
+  end
+
+  private
+
+  attr_reader :further_information_request, :assessment_sections
+
+  def build_further_information_request_items(assessment_section)
+    assessment_section
+      .selected_failure_reasons
+      .filter_map do |failure_reason, assessor_notes|
+      build_further_information_request_item(failure_reason, assessor_notes)
+    end
+  end
+
+  def build_further_information_request_item(failure_reason, assessor_notes)
+    if TEXT_FAILURE_REASONS.include?(failure_reason)
+      FurtherInformationRequestItem.new(
+        information_type: :text,
+        failure_reason:,
+        assessor_notes:,
+      )
+    elsif (document_type = DOCUMENT_FAILURE_REASONS[failure_reason]).present?
+      FurtherInformationRequestItem.new(
+        information_type: :document,
+        failure_reason:,
+        assessor_notes:,
+        document: Document.new(document_type:),
+      )
+    end
+  end
+
+  TEXT_FAILURE_REASONS = %w[
+    qualifications_dont_support_subjects
+    qualifications_dont_match_those_entered
+    satisfactory_evidence_work_history
+  ].freeze
+
+  DOCUMENT_FAILURE_REASONS = {
+    "identification_document_expired" => :identification,
+    "identification_document_illegible" => :identification,
+    "identification_document_mismatch" => :name_change,
+    "name_change_document_illegible" => :name_change,
+    "teaching_certificate_illegible" => :qualification_certificate,
+    "teaching_qualification_illegible" => :qualification_transcript,
+    "degree_certificate_illegible" => :qualification_certificate,
+    "degree_qualification_illegible" => :qualification_transcript,
+    "application_and_qualification_names_do_not_match" => :name_change,
+    "written_statement_illegible" => :written_statement,
+    "written_statement_recent" => :written_statement,
+    "qualified_to_teach" => :written_statement,
+  }.freeze
+end

--- a/spec/lib/further_information_request_items_factory_spec.rb
+++ b/spec/lib/further_information_request_items_factory_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FurtherInformationRequestItemsFactory do
+  subject(:items) { described_class.call(assessment_sections:) }
+
+  context "with no assessment sections" do
+    let(:assessment_sections) { [] }
+
+    it { is_expected.to be_empty }
+  end
+
+  context "with assessment sections" do
+    let(:assessment_sections) do
+      [
+        create(
+          :assessment_section,
+          :personal_information,
+          :failed,
+          selected_failure_reasons: {
+            identification_document_expired: "Expired.",
+          },
+        ),
+        create(
+          :assessment_section,
+          :qualifications,
+          :failed,
+          selected_failure_reasons: {
+            qualifications_dont_support_subjects: "Subjects.",
+            unknown_reason: "Unknown.",
+          },
+        ),
+      ]
+    end
+
+    it { is_expected.to_not be_empty }
+
+    describe "first item" do
+      subject(:item) { items.first }
+
+      it "has attributes" do
+        expect(item).to be_document
+        expect(item.failure_reason).to eq("identification_document_expired")
+        expect(item.assessor_notes).to eq("Expired.")
+        expect(item.document.identification?).to be true
+      end
+    end
+
+    describe "second item" do
+      subject(:item) { items.second }
+
+      it "has attributes" do
+        expect(item).to be_text
+        expect(item.failure_reason).to eq(
+          "qualifications_dont_support_subjects",
+        )
+        expect(item.assessor_notes).to eq("Subjects.")
+      end
+    end
+
+    describe "third item" do
+      subject(:item) { items.third }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
         :further_information_request_item,
         :with_document_response,
         further_information_request:,
+        document: create(:document, :identification_document),
       )
     end
 


### PR DESCRIPTION
This changes how further information requests are created to automatically populate the items based on the assessment sections selected failure reasons.

[Trello Card](https://trello.com/c/UhGwqDlZ/956-spike-further-information-request-reasons)