### PR TITLE
Show further information request items when requesting

### DIFF
--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -1,10 +1,13 @@
 module AssessorInterface
   class FurtherInformationRequestsController < BaseController
-    layout "full_from_desktop", only: %i[show]
-
     def new
       @further_information_request =
-        assessment.further_information_requests.build
+        assessment.further_information_requests.build(
+          items:
+            FurtherInformationRequestItemsFactory.call(
+              assessment_sections: assessment.sections,
+            ),
+        )
     end
 
     def create

--- a/app/views/assessor_interface/further_information_requests/new.html.erb
+++ b/app/views/assessor_interface/further_information_requests/new.html.erb
@@ -1,7 +1,29 @@
+<% content_for :page_title, "Check the further information you’re asking the applicant for" %>
 <% content_for :back_link_url, edit_assessor_interface_application_form_assessment_path(@application_form, @assessment) %>
 
-<h1 class="govuk-heading-xl">Compose and send your further information request email</h1>
-<%= form_for [:assessor_interface, @application_form, @assessment, @further_information_request] do |form| %> 
-  <%= form.govuk_text_area :email_content, label: { text: "Email content" } %>
-  <%= form.govuk_submit %>
-<%- end -%>
+<h1 class="govuk-heading-xl">
+  Check the further information you’re asking the applicant for
+</h1>
+
+<p class="govuk-body">This screen shows your reasons for requesting further information, along with your notes to the applicant. They’ll see this information in the email they receive.</p>
+<p class="govuk-body">If you need to change your notes, you’ll need to go back to the relevant section.</p>
+
+<h2 class="govuk-heading-l">Your further information request reasons and notes</h2>
+
+<% @further_information_request.items.each do |item| %>
+  <section class="app-further-information-request-item">
+    <h3 class="govuk-heading-s"><%= I18n.t("assessor_interface.assessment_sections.show.failure_reasons.#{item.failure_reason}") %></h3>
+    <p class="govuk-body govuk-!-margin-bottom-2">Your note to the applicant:</p>
+    <p class="govuk-inset-text"><%= item.assessor_notes %></p>
+  </section>
+<% end %>
+
+<h2 class="govuk-heading-l">Compose and send your further information request email</h2>
+<p class="govuk-body">On the next screen, you’ll see a preview of the email.</p>
+
+<%= form_with model: [:assessor_interface, @application_form, @assessment, @further_information_request] do |f| %>
+  <%= f.govuk_text_area :email_content, label: { size: "s" } %>
+  <%= f.govuk_submit do %>
+    <%= govuk_button_link_to "Back to overview", assessor_interface_application_form_path(@application_form), secondary: true %>
+  <% end %>
+<% end %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -70,6 +70,7 @@ en:
           age_ranges_subjects: We were not provided with sufficient evidence to confirm qualification to teach the age ranges and subjects entered on the online application form.
           qualified_to_teach: We were not provided with sufficient evidence to confirm qualification to teach at state or government schools.
           full_professional_status: Recognition level as a teacher does not match the required level, or has outstanding additional conditions.
+
   components:
     timeline_entry:
       title:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -32,6 +32,8 @@ en:
           decline: Decline QTS
       assessor_interface_create_note_form:
         text: Add a note to this application
+      further_information_request:
+        email_content: Email content
       qualification:
         add_another_options:
           true: "Yes"

--- a/spec/support/autoload/page_objects/assessor_interface/request_further_information.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/request_further_information.rb
@@ -3,7 +3,17 @@ module PageObjects
     class RequestFurtherInformation < SitePrism::Page
       set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/further-information-requests/new"
 
-      element :email_content, "textarea"
+      sections :items, ".app-further-information-request-item" do
+        element :heading, ".govuk-heading-s"
+        element :assessor_notes, ".govuk-inset-text"
+      end
+
+      section :form, "form" do
+        element :email_content_textarea, ".govuk-textarea"
+        element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
+        element :back_to_overview_button,
+                ".govuk-button.govuk-button--secondary"
+      end
     end
   end
 end

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -35,9 +35,10 @@ RSpec.describe "Assessor requesting further information", type: :system do
       application_id:,
       assessment_id:,
     )
+    and_i_see_the_further_information_request_items
 
     when_i_enter_email_content
-    when_i_click_continue
+    and_i_click_continue
     then_i_see_the(
       :further_information_request_preview_page,
       application_id:,
@@ -53,25 +54,23 @@ RSpec.describe "Assessor requesting further information", type: :system do
     application_form
   end
 
-  def when_i_visit_the_complete_assessment_page
-    complete_assessment_page.load(application_id: application_form.id)
-  end
-
-  def then_i_see_the_complete_assessment_form
-    expect(complete_assessment_page.award_qts).to be_visible
-    expect(complete_assessment_page.decline_qts).to be_visible
-  end
-
   def when_i_select_request_further_information
     complete_assessment_page.request_further_information.input.choose
   end
 
-  def when_i_enter_email_content
-    request_further_information_page.email_content.fill_in with: "I am an email"
+  def and_i_see_the_further_information_request_items
+    expect(request_further_information_page.items.count).to eq(1)
+    expect(request_further_information_page.items.first.heading.text).to eq(
+      "The qualifications do not support the teaching subjects entered.",
+    )
+    expect(
+      request_further_information_page.items.first.assessor_notes.text,
+    ).to eq("A note.")
   end
 
-  def then_the_application_form_is_awarded
-    expect(assessor_application_page.overview.status.text).to eq("AWARDED")
+  def when_i_enter_email_content
+    request_further_information_page.form.email_content_textarea.fill_in with:
+      "I am an email"
   end
 
   def and_i_see_the_email_preview
@@ -90,8 +89,11 @@ RSpec.describe "Assessor requesting further information", type: :system do
       ).tap do |application_form|
         application_form.assessment.sections << create(
           :assessment_section,
-          :personal_information,
+          :qualifications,
           :failed,
+          selected_failure_reasons: {
+            qualifications_dont_support_subjects: "A note.",
+          },
         )
       end
   end


### PR DESCRIPTION
This improves the new controller for further information requests so the assessor can see which items they've requested from the user, and matches the page in the prototype.

## Screenshot

<img width="680" alt="Screenshot 2022-09-30 at 12 51 16" src="https://user-images.githubusercontent.com/510498/193266386-3ea397bb-7b9c-4eca-8cf4-cce3e8298557.png">
