### PR TITLE
Move 'en.yml' content to its own appropriate locale file

### DIFF
--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -92,3 +92,7 @@ en:
           attributes:
             text:
               blank: Enter the note
+        assessor_interface/assessor_assignment_form:
+          attributes:
+            assessor_id:
+              blank: Select an assessor to assign

--- a/config/locales/eligibility_interface.en.yml
+++ b/config/locales/eligibility_interface.en.yml
@@ -30,3 +30,20 @@ en:
           attributes:
             teach_children:
               inclusion: Tell us whether you’re qualified to teach children aged between 5 and 16
+
+    attributes:
+      eligibility_check:
+        ineligible_reason:
+          completed_requirements: You have not completed all requirements to work as a qualified teacher in %{country_name}.
+          degree: You do not have a degree. As teaching in England is a graduate profession, you must have an undergraduate degree.
+          misconduct: To teach in England, you must not have any findings of misconduct or restrictions on your practice.
+          qualification: You have not completed a formal teaching qualification, for example, an undergraduate teaching degree or postgraduate teaching qualification.
+          teach_children: You are not qualified to teach children who are aged somewhere between 5 and 16 years.
+
+  eligibility_check:
+    country:
+      label: In which country are you currently recognised as a teacher?
+      hint: This means you have all the qualifications needed to teach in a state school. You'll need to provide evidence of this if you apply for QTS.
+    region:
+      label: In which state/territory are you currently recognised as a teacher?
+      hint: This means you have all the qualifications needed to teach in a state school. You'll need to provide evidence of this if you apply for QTS.

--- a/config/locales/eligibility_interface.en.yml
+++ b/config/locales/eligibility_interface.en.yml
@@ -1,0 +1,32 @@
+en:
+  activemodel:
+    errors:
+      models:
+        eligibility_interface/country_form:
+          attributes:
+            location:
+              blank: Tell us where you’re currently recognised as a teacher
+        eligibility_interface/completed_requirements_form:
+          attributes:
+            completed_requirements:
+              inclusion: Tell us if you have completed all requirements to work as a qualified teacher
+        eligibility_interface/degree_form:
+          attributes:
+            degree:
+              inclusion: Tell us whether you have a university degree
+        eligibility_interface/misconduct_form:
+          attributes:
+            misconduct:
+              inclusion: Tell us whether your employment record has any sanctions or restrictions
+        eligibility_interface/qualification_form:
+          attributes:
+            qualification:
+              inclusion: Tell us if you have a teaching qualification
+        eligibility_interface/region_form:
+          attributes:
+            region_id:
+              blank: Tell us where you’re currently recognised as a teacher
+        eligibility_interface/teach_children_form:
+          attributes:
+            teach_children:
+              inclusion: Tell us whether you’re qualified to teach children aged between 5 and 16

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,91 +19,6 @@ en:
     registration:
       title: Your email address
 
-  application_form:
-    status:
-      not_started: Not started
-      in_progress: In progress
-      initial_assessment: Initial assessment
-      further_information_requested: Further information requested
-      further_information_received: Further information received
-      awarded: Awarded
-      declined: Declined
-      draft: Draft
-      submitted: Not started
-      completed: Completed
-      action_required: Action required
-      cannot_start_yet: Cannot start yet
-    tasks:
-      sections:
-        about_you: About you
-        qualifications: Your qualifications
-        work_history: Your work history
-        proof_of_recognition: Proof that you’re recognised as a teacher
-      items:
-        personal_information: Enter your personal information
-        identity_document: Upload your identity document
-        qualifications: Add your teaching qualifications
-        age_range: Enter the age range you can teach
-        subjects: Enter the subjects you can teach
-        work_history: Add your work history
-        registration_number: Enter your registration number
-        written_statement: Upload your written statement
-    qualifications:
-      heading:
-        title:
-          teaching_qualification: Your teaching qualification
-          university_degree: Your university degree
-        description:
-          teaching_qualification: This is the qualification that led to you being recognised as a teacher. It might be part of your university degree course, or it could be a separate qualification.
-          university_degree: Tell us about your university degree qualification. If you have more than one degree qualification, you’ll have the opportunity to add them later.
-      form:
-        title:
-          teaching_qualification: Enter the details of your teaching qualification
-          university_degree: Enter the details of your university degree
-        fields:
-          title:
-            teaching_qualification: Qualification title
-            university_degree: University degree title
-          institution_name: Name of institution
-          institution_country: Country of institution
-          start_date:
-            teaching_qualification: When did you start your teaching qualification?
-            university_degree: When did you start this university degree?
-          complete_date:
-            teaching_qualification: When did you complete your teaching qualification?
-            university_degree: When did you complete your university degree?
-          certificate_date:
-            teaching_qualification: What is the date on your teaching qualification certificate?
-            university_degree: What is the date on your university degree certificate?
-      upload:
-        transcript:
-          description: Upload a transcript of your teaching qualification, issued by the awarding body. If your teaching qualification was completed as part of your degree, you should supply your degree transcript.
-    age_range:
-      heading: What age range are you qualified to teach?
-      hint: Tell us about the age range of the children you’re qualified to teach. for example, from 5 to 11.
-    subjects:
-      heading: What subjects are you qualified to teach?
-      hint: You can enter up to three.
-    work_history:
-      current_or_most_recent_role: Your current or most recent role
-      previous_role: Previous role
-    summary:
-      name: Name
-      country: Country trained in
-      region: State/territory trained in
-      submitted_at: Created on
-      days_remaining_sla: Days remaining in SLA
-      assessor: Assigned to
-      reviewer: Reviewer
-      reference: Reference
-      unassigned: Not assigned
-      status: Status
-      notes: Notes
-    overview:
-      title: Overview
-      application_history: Application history
-      view_timeline: View timeline of this applications actions
-
   document:
     document_type:
       identification: identity
@@ -111,32 +26,6 @@ en:
       qualification_certificate: certificate
       qualification_transcript: transcript
       written_statement: written statement
-
-  eligibility_check:
-    country:
-      label: In which country are you currently recognised as a teacher?
-      hint: This means you have all the qualifications needed to teach in a state school. You'll need to provide evidence of this if you apply for QTS.
-    region:
-      label: In which state/territory are you currently recognised as a teacher?
-      hint: This means you have all the qualifications needed to teach in a state school. You'll need to provide evidence of this if you apply for QTS.
-
-  mailer:
-    further_information:
-      required:
-        subject: Further information required
-    teacher:
-      application_received:
-        subject: We’ve received your application for qualified teacher status (QTS)
-
-  activemodel:
-    attributes:
-      eligibility_check:
-        ineligible_reason:
-          completed_requirements: You have not completed all requirements to work as a qualified teacher in %{country_name}.
-          degree: You do not have a degree. As teaching in England is a graduate profession, you must have an undergraduate degree.
-          misconduct: To teach in England, you must not have any findings of misconduct or restrictions on your practice.
-          qualification: You have not completed a formal teaching qualification, for example, an undergraduate teaching degree or postgraduate teaching qualification.
-          teach_children: You are not qualified to teach children who are aged somewhere between 5 and 16 years.
 
   activerecord:
     errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,10 +168,6 @@ en:
           attributes:
             teach_children:
               inclusion: Tell us whether you’re qualified to teach children aged between 5 and 16
-        assessor_interface/assessor_assignment_form:
-          attributes:
-            assessor_id:
-              blank: Select an assessor to assign
 
   activerecord:
     errors:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -138,37 +138,6 @@ en:
           qualification: You have not completed a formal teaching qualification, for example, an undergraduate teaching degree or postgraduate teaching qualification.
           teach_children: You are not qualified to teach children who are aged somewhere between 5 and 16 years.
 
-    errors:
-      models:
-        eligibility_interface/completed_requirements_form:
-          attributes:
-            completed_requirements:
-              inclusion: Tell us if you have completed all requirements to work as a qualified teacher
-        eligibility_interface/country_form:
-          attributes:
-            location:
-              blank: Tell us where you’re currently recognised as a teacher
-        eligibility_interface/degree_form:
-          attributes:
-            degree:
-              inclusion: Tell us whether you have a university degree
-        eligibility_interface/misconduct_form:
-          attributes:
-            misconduct:
-              inclusion: Tell us whether your employment record has any sanctions or restrictions
-        eligibility_interface/qualification_form:
-          attributes:
-            qualification:
-              inclusion: Tell us if you have a teaching qualification
-        eligibility_interface/region_form:
-          attributes:
-            region_id:
-              blank: Tell us where you’re currently recognised as a teacher
-        eligibility_interface/teach_children_form:
-          attributes:
-            teach_children:
-              inclusion: Tell us whether you’re qualified to teach children aged between 5 and 16
-
   activerecord:
     errors:
       models:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -168,36 +168,6 @@ en:
           attributes:
             teach_children:
               inclusion: Tell us whether you’re qualified to teach children aged between 5 and 16
-        teacher_interface/name_and_date_of_birth_form:
-          attributes:
-            date_of_birth:
-              too_young: You must be 18 or over to use this service
-              invalid: Enter your date of birth in the format 27 3 1980
-              too_old: Your date of birth cannot be that far in the past
-            given_names:
-              blank: Enter your given names
-            family_name:
-              blank: Enter your family name
-        teacher_interface/alternative_name_form:
-          attributes:
-            alternative_given_names:
-              blank: Enter your alternate given names
-            alternative_family_name:
-              blank: Enter your alternate family name
-            has_alternative_name:
-              inclusion: Tell us whether you have an alternative name
-        teacher_interface/add_another_upload_form:
-          attributes:
-            add_another:
-              inclusion: Select whether you need to upload another page
-        teacher_interface/delete_upload_form:
-          attributes:
-            confirm:
-              inclusion: Select whether you want to delete this file
-        teacher_interface/new_session_form:
-          attributes:
-            email:
-              blank: Enter your email address
         assessor_interface/assessor_assignment_form:
           attributes:
             assessor_id:

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -1,0 +1,8 @@
+en:
+  mailer:
+    further_information:
+      required:
+        subject: Further information required
+    teacher:
+      application_received:
+        subject: We’ve received your application for qualified teacher status (QTS)

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -40,3 +40,87 @@ en:
           attributes:
             email:
               blank: Enter your email address
+  application_form:
+    status:
+      not_started: Not started
+      in_progress: In progress
+      initial_assessment: Initial assessment
+      further_information_requested: Further information requested
+      further_information_received: Further information received
+      awarded: Awarded
+      declined: Declined
+      draft: Draft
+      submitted: Not started
+      completed: Completed
+      action_required: Action required
+      cannot_start_yet: Cannot start yet
+    tasks:
+      sections:
+        about_you: About you
+        qualifications: Your qualifications
+        work_history: Your work history
+        proof_of_recognition: Proof that you’re recognised as a teacher
+      items:
+        personal_information: Enter your personal information
+        identity_document: Upload your identity document
+        qualifications: Add your teaching qualifications
+        age_range: Enter the age range you can teach
+        subjects: Enter the subjects you can teach
+        work_history: Add your work history
+        registration_number: Enter your registration number
+        written_statement: Upload your written statement
+    qualifications:
+      heading:
+        title:
+          teaching_qualification: Your teaching qualification
+          university_degree: Your university degree
+        description:
+          teaching_qualification: This is the qualification that led to you being recognised as a teacher. It might be part of your university degree course, or it could be a separate qualification.
+          university_degree: Tell us about your university degree qualification. If you have more than one degree qualification, you’ll have the opportunity to add them later.
+      form:
+        title:
+          teaching_qualification: Enter the details of your teaching qualification
+          university_degree: Enter the details of your university degree
+        fields:
+          title:
+            teaching_qualification: Qualification title
+            university_degree: University degree title
+          institution_name: Name of institution
+          institution_country: Country of institution
+          start_date:
+            teaching_qualification: When did you start your teaching qualification?
+            university_degree: When did you start this university degree?
+          complete_date:
+            teaching_qualification: When did you complete your teaching qualification?
+            university_degree: When did you complete your university degree?
+          certificate_date:
+            teaching_qualification: What is the date on your teaching qualification certificate?
+            university_degree: What is the date on your university degree certificate?
+      upload:
+        transcript:
+          description: Upload a transcript of your teaching qualification, issued by the awarding body. If your teaching qualification was completed as part of your degree, you should supply your degree transcript.
+    age_range:
+      heading: What age range are you qualified to teach?
+      hint: Tell us about the age range of the children you’re qualified to teach. for example, from 5 to 11.
+    subjects:
+      heading: What subjects are you qualified to teach?
+      hint: You can enter up to three.
+    work_history:
+      current_or_most_recent_role: Your current or most recent role
+      previous_role: Previous role
+    summary:
+      name: Name
+      country: Country trained in
+      region: State/territory trained in
+      submitted_at: Created on
+      days_remaining_sla: Days remaining in SLA
+      assessor: Assigned to
+      reviewer: Reviewer
+      reference: Reference
+      unassigned: Not assigned
+      status: Status
+      notes: Notes
+    overview:
+      title: Overview
+      application_history: Application history
+      view_timeline: View timeline of this applications actions

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -7,3 +7,36 @@ en:
           qualifications_dont_match_those_entered: Tell us more about your qualifications
           satisfactory_evidence_work_history: Tell us more about your work history
           registration_number: Tell us your registration number
+  activemodel:
+    errors:
+      models:
+        teacher_interface/name_and_date_of_birth_form:
+          attributes:
+            date_of_birth:
+              inclusion: You must be 18 or over to use this service
+              blank: Enter your date of birth in the format 27 3 1980
+              less_than: Your date of birth must be in the past
+            given_names:
+              blank: Enter your given names
+            family_name:
+              blank: Enter your family name
+        teacher_interface/alternative_name_form:
+          attributes:
+            alternative_given_names:
+              blank: Enter your alternate given names
+            alternative_family_name:
+              blank: Enter your alternate family name
+            has_alternative_name:
+              inclusion: Tell us whether you have an alternative name
+        teacher_interface/add_another_upload_form:
+          attributes:
+            add_another:
+              inclusion: Select whether you need to upload another page
+        teacher_interface/delete_upload_form:
+          attributes:
+            confirm:
+              inclusion: Select whether you want to delete this file
+        teacher_interface/new_session_form:
+          attributes:
+            email:
+              blank: Enter your email address

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -13,9 +13,9 @@ en:
         teacher_interface/name_and_date_of_birth_form:
           attributes:
             date_of_birth:
-              inclusion: You must be 18 or over to use this service
-              blank: Enter your date of birth in the format 27 3 1980
-              less_than: Your date of birth must be in the past
+              too_young: You must be 18 or over to use this service
+              invalid: Enter your date of birth in the format 27 3 1980
+              too_old: Your date of birth cannot be that far in the past
             given_names:
               blank: Enter your given names
             family_name:


### PR DESCRIPTION
This PR moves the validation error messages for teacher interface and assessor interface out of 'en.yml' and in to their own .yml files