### PR TITLE
Send further information request email 

### DIFF
--- a/app/lib/further_information_template_preview.rb
+++ b/app/lib/further_information_template_preview.rb
@@ -20,9 +20,9 @@ class FurtherInformationTemplatePreview
     client.generate_template_preview(
       GOVUK_NOTIFY_TEMPLATE_ID,
       personalisation: {
-        to:,
-        subject:,
-        body:,
+        to: mail.to.first,
+        subject: mail.subject,
+        body: mail.body.encoded,
       },
     ).html
   end
@@ -31,19 +31,14 @@ class FurtherInformationTemplatePreview
 
   attr_reader :teacher, :further_information_request
 
-  def to
-    teacher.email
-  end
-
-  def subject
-    I18n.t("mailer.further_information.required.subject")
-  end
-
-  def body
-    further_information_request.email_content
-  end
-
   def client
     @client ||= Notifications::Client.new(ENV.fetch("GOVUK_NOTIFY_API_KEY"))
+  end
+
+  def mail
+    TeacherMailer.with(
+      teacher:,
+      further_information_request:,
+    ).further_information_requested
   end
 end

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -1,21 +1,41 @@
 class TeacherMailer < ApplicationMailer
-  GOVUK_NOTIFY_TEMPLATE_ID =
-    ENV.fetch(
-      "GOVUK_NOTIFY_TEMPLATE_ID_TEACHER",
-      "95adafaf-0920-4623-bddc-340853c047af",
-    )
+  before_action :set_name
 
   def application_received
     teacher = params[:teacher]
-    application_form = teacher.application_form
 
-    @name = "#{application_form.given_names} #{application_form.family_name}"
-    @reference = application_form.reference
+    @reference = teacher.application_form.reference
 
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
       to: teacher.email,
       subject: I18n.t("mailer.teacher.application_received.subject"),
     )
+  end
+
+  def further_information_requested
+    teacher = params[:teacher]
+
+    @date = "[date]"
+    @extra_content = params[:further_information_request].email_content
+
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: teacher.email,
+      subject: I18n.t("mailer.teacher.further_information_requested.subject"),
+    )
+  end
+
+  private
+
+  GOVUK_NOTIFY_TEMPLATE_ID =
+    ENV.fetch(
+      "GOVUK_NOTIFY_TEMPLATE_ID_TEACHER",
+      "95adafaf-0920-4623-bddc-340853c047af",
+    )
+
+  def set_name
+    application_form = params[:teacher].application_form
+    @name = "#{application_form.given_names} #{application_form.family_name}"
   end
 end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -58,7 +58,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
       further_information_request = further_information_requests[index]
       return nil unless further_information_request.draft?
 
-      url_helpers.assessor_interface_application_form_assessment_further_information_request_path(
+      url_helpers.edit_assessor_interface_application_form_assessment_further_information_request_path(
         application_form,
         assessment,
         further_information_request,

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, t(".title.#{@assessment_section_view_object.assessment_section.key}") %>
-
 <% content_for :back_link_url, assessor_interface_application_form_path(@assessment_section_view_object.application_form) %>
 
 <h1 class="govuk-heading-xl"><%= t(".title.#{@assessment_section_view_object.assessment_section.key}") %></h1>

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for :back_link_url, new_assessor_interface_application_form_assessment_further_information_request_path(@application_form, @assessment) %>
+
+<h1 class="govuk-heading-xl">Further information request email preview</h1>
+
+<div class="app-email-preview govuk-body">
+  <div class="app-email-preview__header">
+    <div class="app-email-preview__header__logo">
+      GOV.UK
+    </div>
+  </div>
+
+  <div class="app-email-preview__content">
+    <%= @email_preview.html_safe %>
+  </div>
+</div>
+
+<%= form_with model: [:assessor_interface, @application_form, @assessment, @further_information_request] do |f| %>
+  <%= f.govuk_submit "Send email to applicant" do %>
+    <%= govuk_button_link_to "Back to overview", assessor_interface_application_form_path(@application_form), secondary: true %>
+  <% end %>
+<% end %>

--- a/app/views/assessor_interface/further_information_requests/show.html.erb
+++ b/app/views/assessor_interface/further_information_requests/show.html.erb
@@ -1,15 +1,9 @@
-<% content_for :back_link_url, new_assessor_interface_application_form_assessment_further_information_request_path(@application_form, @assessment) %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
-<h1 class="govuk-heading-xl">Further information request email preview</h1>
+<%= govuk_panel(title_text: "Further information email sent successfully") %>
 
-<div class="app-email-preview govuk-body">
-  <div class="app-email-preview__header">
-    <div class="app-email-preview__header__logo">
-      GOV.UK
-    </div>
-  </div>
+<p class="govuk-body">You’ve successfully sent your further information request email to the applicant.</p>
+<p class="govuk-body">You can now return to the application itself, or go back to your list of applications.</p>
 
-  <div class="app-email-preview__content">
-    <%= @email_preview.html_safe %>
-  </div>
-</div>
+<%= govuk_button_link_to "See application overview", assessor_interface_application_form_path(@application_form) %>
+<%= govuk_button_link_to "Back to application list", assessor_interface_application_forms_path, secondary: true %>

--- a/app/views/assessor_interface/further_information_requests/show.html.erb
+++ b/app/views/assessor_interface/further_information_requests/show.html.erb
@@ -1,10 +1,6 @@
 <% content_for :back_link_url, new_assessor_interface_application_form_assessment_further_information_request_path(@application_form, @assessment) %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Further information request email preview</h1>
-  </div>
-</div>
+<h1 class="govuk-heading-xl">Further information request email preview</h1>
 
 <div class="app-email-preview govuk-body">
   <div class="app-email-preview__header">
@@ -12,6 +8,7 @@
       GOV.UK
     </div>
   </div>
+
   <div class="app-email-preview__content">
     <%= @email_preview.html_safe %>
   </div>

--- a/app/views/teacher_mailer/application_received.text.erb
+++ b/app/views/teacher_mailer/application_received.text.erb
@@ -11,7 +11,6 @@ Your reference number is:
 We’ll be back in touch once we’ve assigned a QTS assessor to review your application. At that point we’ll be able to update you on how long the process will take.
 
 If you have any questions, contact:
-
 qts.enquiries@education.gov.uk
 
 Kind regards,

--- a/app/views/teacher_mailer/further_information_requested.text.erb
+++ b/app/views/teacher_mailer/further_information_requested.text.erb
@@ -1,0 +1,21 @@
+Dear <%= @name %>
+
+The assessor reviewing your QTS application needs more information.
+
+# What happens next
+
+You must respond to this request by <%= @date %>.
+
+Once you respond with all of the information we’ve requested, the assessor will be able to continue reviewing your application.
+
+<%= @extra_content %>
+
+You can sign in to add the requested information to your application at:
+
+<%= new_teacher_session_url %>
+
+If you have any questions, contact:
+qts.enquiries@education.gov.uk
+
+Kind regards,
+The Teacher Qualifications Team

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -6,3 +6,5 @@ en:
     teacher:
       application_received:
         subject: We’ve received your application for qualified teacher status (QTS)
+      further_information_requested:
+        subject: We need more information for your application for qualified teacher status (QTS)

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -1,8 +1,5 @@
 en:
   mailer:
-    further_information:
-      required:
-        subject: Further information required
     teacher:
       application_received:
         subject: We’ve received your application for qualified teacher status (QTS)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
                   only: %i[show update]
         resources :further_information_requests,
                   path: "/further-information-requests",
-                  only: %i[new create show]
+                  only: %i[new create show edit update]
       end
     end
   end

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -27,5 +27,9 @@ FactoryBot.define do
     trait :confirmed do
       confirmed_at { Time.zone.now }
     end
+
+    trait :with_application_form do
+      association :application_form
+    end
   end
 end

--- a/spec/lib/further_information_template_preview_spec.rb
+++ b/spec/lib/further_information_template_preview_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe FurtherInformationTemplatePreview do
   let(:further_information_request) do
     create(:further_information_request, email_content: "raw email")
   end
-  let(:teacher) { create(:teacher) }
+  let(:teacher) { create(:teacher, :with_application_form) }
   let(:notify_key) { "notify-key" }
   let(:notify_client) do
     double(generate_template_preview: notify_template_preview)
@@ -43,8 +43,9 @@ RSpec.describe FurtherInformationTemplatePreview do
         instance_of(String),
         personalisation: {
           to: teacher.email,
-          subject: "Further information required",
-          body: "raw email",
+          subject:
+            "We need more information for your application for qualified teacher status (QTS)",
+          body: instance_of(String),
         },
       )
       subject

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -38,4 +38,46 @@ RSpec.describe TeacherMailer, type: :mailer do
       it { is_expected.to include("abc") }
     end
   end
+
+  describe "#further_information_requested" do
+    subject(:mail) do
+      described_class.with(
+        teacher:,
+        further_information_request:,
+      ).further_information_requested
+    end
+
+    let(:further_information_request) do
+      create(:further_information_request, email_content: "Email content.")
+    end
+
+    describe "#subject" do
+      subject(:subject) { mail.subject }
+
+      it do
+        is_expected.to eq(
+          "We need more information for your application for qualified teacher status (QTS)",
+        )
+      end
+    end
+
+    describe "#to" do
+      subject(:to) { mail.to }
+
+      it { is_expected.to eq(["teacher@example.com"]) }
+    end
+
+    describe "#body" do
+      subject(:body) { mail.body.encoded }
+
+      it { is_expected.to include("Dear First Last") }
+      it do
+        is_expected.to include(
+          "The assessor reviewing your QTS application needs more information.",
+        )
+      end
+      it { is_expected.to include("Email content.") }
+      it { is_expected.to include("http://localhost:3000/teacher/sign_in") }
+    end
+  end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/further_information_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/further_information_request.rb
@@ -1,0 +1,8 @@
+module PageObjects
+  module AssessorInterface
+    class FurtherInformationRequest < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+                "/further-information-requests/{further_information_request_id}"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/further_information_request_preview.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/further_information_request_preview.rb
@@ -2,9 +2,16 @@ module PageObjects
   module AssessorInterface
     class FurtherInformationRequestPreview < SitePrism::Page
       set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
-                "/further-information-requests/{further_information_request_id}"
+                "/further-information-requests/{further_information_request_id}/edit"
 
       element :email_preview, "div.app-email-preview"
+
+      section :form, "form" do
+        element :send_to_applicant_button,
+                ".govuk-button:not(.govuk-button--secondary)"
+        element :back_to_overview_button,
+                ".govuk-button.govuk-button--secondary"
+      end
     end
   end
 end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -247,6 +247,11 @@ module PageHelpers
       PageObjects::AssessorInterface::RequestFurtherInformation.new
   end
 
+  def further_information_request_page
+    @further_information_request_page ||=
+      PageObjects::AssessorInterface::FurtherInformationRequest.new
+  end
+
   def further_information_request_preview_page
     @further_information_request_preview_page ||=
       PageObjects::AssessorInterface::FurtherInformationRequestPreview.new

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe "Assessor requesting further information", type: :system do
       further_information_request_id:,
     )
     and_i_see_the_email_preview
+
+    when_i_click_send_to_applicant
+    then_i_see_the(
+      :further_information_request_page,
+      application_id:,
+      assessment_id:,
+      further_information_request_id:,
+    )
+    and_i_receive_a_further_information_requested_email
   end
 
   private
@@ -77,6 +86,20 @@ RSpec.describe "Assessor requesting further information", type: :system do
     expect(
       further_information_request_preview_page.email_preview,
     ).to have_content("I am an email")
+  end
+
+  def when_i_click_send_to_applicant
+    further_information_request_preview_page.form.send_to_applicant_button.click
+  end
+
+  def and_i_receive_a_further_information_requested_email
+    message = ActionMailer::Base.deliveries.last
+    expect(message).to_not be_nil
+
+    expect(message.subject).to eq(
+      "We need more information for your application for qualified teacher status (QTS)",
+    )
+    expect(message.to).to include(application_form.teacher.email)
   end
 
   def application_form

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       it do
         is_expected.to eq(
           "/assessor/applications/#{application_form.id}/assessments/#{assessment.id}" \
-            "/further-information-requests/#{further_information_request.id}",
+            "/further-information-requests/#{further_information_request.id}/edit",
         )
       end
     end


### PR DESCRIPTION
This adds the ability for assessors to send the further information request email to teachers and update the state of the further information request to requested.

Depends on #554 and #559 

[Trello Card](https://trello.com/c/MkHH68cD/925-send-basic-email-for-fi-request)

# Screenshot

<img width="706" alt="Screenshot 2022-10-03 at 12 47 06" src="https://user-images.githubusercontent.com/510498/193569588-103d6729-e200-464d-875a-fea061f1be65.png">

<img width="697" alt="Screenshot 2022-10-03 at 12 27 59" src="https://user-images.githubusercontent.com/510498/193569222-9730e53d-2869-4ba5-88e2-e4cb0fa0e6cf.png">
