### PR TITLE
Remove custom email content form

### DIFF
--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -13,12 +13,10 @@ module AssessorInterface
     def create
       @further_information_request =
         assessment.further_information_requests.create!(
-          further_information_request_params.merge(
-            items:
-              FurtherInformationRequestItemsFactory.call(
-                assessment_sections: assessment.sections,
-              ),
-          ),
+          items:
+            FurtherInformationRequestItemsFactory.call(
+              assessment_sections: assessment.sections,
+            ),
         )
 
       redirect_to [
@@ -84,10 +82,6 @@ module AssessorInterface
         ApplicationForm.includes(
           assessment: :further_information_requests,
         ).find(params[:application_form_id])
-    end
-
-    def further_information_request_params
-      params.require(:further_information_request).permit(:email_content)
     end
   end
 end

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -17,7 +17,6 @@ class TeacherMailer < ApplicationMailer
     teacher = params[:teacher]
 
     @date = "[date]"
-    @extra_content = params[:further_information_request].email_content
 
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -3,7 +3,6 @@
 # Table name: further_information_requests
 #
 #  id            :bigint           not null, primary key
-#  email_content :text
 #  received_at   :datetime
 #  state         :string           not null
 #  created_at    :datetime         not null

--- a/app/views/assessor_interface/further_information_requests/new.html.erb
+++ b/app/views/assessor_interface/further_information_requests/new.html.erb
@@ -22,7 +22,6 @@
 <p class="govuk-body">On the next screen, you’ll see a preview of the email.</p>
 
 <%= form_with model: [:assessor_interface, @application_form, @assessment, @further_information_request] do |f| %>
-  <%= f.govuk_text_area :email_content, label: { size: "s" } %>
   <%= f.govuk_submit do %>
     <%= govuk_button_link_to "Back to overview", assessor_interface_application_form_path(@application_form), secondary: true %>
   <% end %>

--- a/app/views/teacher_mailer/further_information_requested.text.erb
+++ b/app/views/teacher_mailer/further_information_requested.text.erb
@@ -8,8 +8,6 @@ You must respond to this request by <%= @date %>.
 
 Once you respond with all of the information we’ve requested, the assessor will be able to continue reviewing your application.
 
-<%= @extra_content %>
-
 You can sign in to add the requested information to your application at:
 
 <%= new_teacher_session_url %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -106,7 +106,6 @@
     - created_at
     - updated_at
     - assessment_id
-    - email_content
   :further_information_request_items:
     - id
     - information_type

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -32,8 +32,6 @@ en:
           decline: Decline QTS
       assessor_interface_create_note_form:
         text: Add a note to this application
-      further_information_request:
-        email_content: Email content
       qualification:
         add_another_options:
           true: "Yes"

--- a/db/migrate/20221005080511_remove_email_content_from_further_information_requests.rb
+++ b/db/migrate/20221005080511_remove_email_content_from_further_information_requests.rb
@@ -1,0 +1,7 @@
+class RemoveEmailContentFromFurtherInformationRequests < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    remove_column :further_information_requests, :email_content, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_03_132452) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_05_080511) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -159,7 +159,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_03_132452) do
     t.datetime "received_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "email_content"
     t.index ["assessment_id"], name: "index_further_information_requests_on_assessment_id"
   end
 

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -5,7 +5,6 @@
 # Table name: further_information_requests
 #
 #  id            :bigint           not null, primary key
-#  email_content :text
 #  received_at   :datetime
 #  state         :string           not null
 #  created_at    :datetime         not null

--- a/spec/lib/further_information_template_preview_spec.rb
+++ b/spec/lib/further_information_template_preview_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 RSpec.describe FurtherInformationTemplatePreview do
-  let(:further_information_request) do
-    create(:further_information_request, email_content: "raw email")
-  end
+  let(:further_information_request) { create(:further_information_request) }
   let(:teacher) { create(:teacher, :with_application_form) }
   let(:notify_key) { "notify-key" }
   let(:notify_client) do

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -47,9 +47,7 @@ RSpec.describe TeacherMailer, type: :mailer do
       ).further_information_requested
     end
 
-    let(:further_information_request) do
-      create(:further_information_request, email_content: "Email content.")
-    end
+    let(:further_information_request) { create(:further_information_request) }
 
     describe "#subject" do
       subject(:subject) { mail.subject }
@@ -76,7 +74,6 @@ RSpec.describe TeacherMailer, type: :mailer do
           "The assessor reviewing your QTS application needs more information.",
         )
       end
-      it { is_expected.to include("Email content.") }
       it { is_expected.to include("http://localhost:3000/teacher/sign_in") }
     end
   end

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -5,7 +5,6 @@
 # Table name: further_information_requests
 #
 #  id            :bigint           not null, primary key
-#  email_content :text
 #  received_at   :datetime
 #  state         :string           not null
 #  created_at    :datetime         not null

--- a/spec/support/autoload/page_objects/assessor_interface/request_further_information.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/request_further_information.rb
@@ -9,7 +9,6 @@ module PageObjects
       end
 
       section :form, "form" do
-        element :email_content_textarea, ".govuk-textarea"
         element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
         element :back_to_overview_button,
                 ".govuk-button.govuk-button--secondary"

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -37,8 +37,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
     )
     and_i_see_the_further_information_request_items
 
-    when_i_enter_email_content
-    and_i_click_continue
+    when_i_click_continue
     then_i_see_the(
       :further_information_request_preview_page,
       application_id:,
@@ -75,11 +74,6 @@ RSpec.describe "Assessor requesting further information", type: :system do
     expect(
       request_further_information_page.items.first.assessor_notes.text,
     ).to eq("A note.")
-  end
-
-  def when_i_enter_email_content
-    request_further_information_page.form.email_content_textarea.fill_in with:
-      "I am an email"
   end
 
   def and_i_see_the_email_preview


### PR DESCRIPTION
When sending the email for further information we previously allowed the assessor to add custom content to the email but we no longer want this feature so we need to remove the form.

[Trello Card](https://trello.com/c/5ZkRHUdG/983-remove-text-area-and-edit-email-content-from-fi-request-show-page)