### PR TITLE
[992] Make application form requirements dynamic

### DIFF
--- a/app/helpers/proof_of_recognition_helper.rb
+++ b/app/helpers/proof_of_recognition_helper.rb
@@ -1,28 +1,34 @@
 module ProofOfRecognitionHelper
   WRITTEN_STATUS_REASONS = [
     "that you've completed a teaching qualification/teacher training",
-    "that you’ve successfully completed any period of professional experience "\
+    "that you’ve successfully completed any period of professional experience " \
       "comparable to an induction period (if required)",
     "the age ranges and subjects you’re qualified to teach",
   ].freeze
 
   WRITTEN_SANCTION_REASONS = [
-    "that your authorisation to teach has never been suspended, barred, "\
+    "that your authorisation to teach has never been suspended, barred, " \
       "cancelled, revoked or restricted, and that you have no sanctions against you",
   ].freeze
 
   def proof_of_recognition_requirements_for(region:)
-    return WRITTEN_STATUS_REASONS + WRITTEN_SANCTION_REASONS +  [
-      "that you’re qualified to teach at state or government schools",
-    ] if region.status_check_written? && region.sanction_check_written?
+    if region.status_check_written? && region.sanction_check_written?
+      return(
+        WRITTEN_STATUS_REASONS + WRITTEN_SANCTION_REASONS +
+          ["that you’re qualified to teach at state or government schools"]
+      )
+    end
 
     return WRITTEN_STATUS_REASONS if region.status_check_written?
     return WRITTEN_SANCTION_REASONS if region.sanction_check_written?
+    []
   end
 
   def proof_of_recognition_description_for(region:)
     if region.status_check_written?
-      return "The authority or territory that recognises you as a teacher must confirm:"
+      return(
+        "The authority or territory that recognises you as a teacher must confirm:"
+      )
     end
     if region.sanction_check_written?
       "The education department or authority must also confirm in writing:"

--- a/app/helpers/proof_of_recognition_helper.rb
+++ b/app/helpers/proof_of_recognition_helper.rb
@@ -1,26 +1,14 @@
 module ProofOfRecognitionHelper
-  WRITTEN_STATUS_REASONS = [
-    "that you've completed a teaching qualification/teacher training",
-    "that you’ve successfully completed any period of professional experience " \
-      "comparable to an induction period (if required)",
-    "the age ranges and subjects you’re qualified to teach",
-  ].freeze
-
-  WRITTEN_SANCTION_REASONS = [
-    "that your authorisation to teach has never been suspended, barred, " \
-      "cancelled, revoked or restricted, and that you have no sanctions against you",
-  ].freeze
-
   def proof_of_recognition_requirements_for(region:)
     if region.status_check_written? && region.sanction_check_written?
       return(
-        WRITTEN_STATUS_REASONS + WRITTEN_SANCTION_REASONS +
+        written_status_reasons.insert(2, *written_sanction_reasons) +
           ["that you’re qualified to teach at state or government schools"]
       )
     end
 
-    return WRITTEN_STATUS_REASONS if region.status_check_written?
-    return WRITTEN_SANCTION_REASONS if region.sanction_check_written?
+    return written_status_reasons if region.status_check_written?
+    return written_sanction_reasons if region.sanction_check_written?
     []
   end
 
@@ -33,5 +21,23 @@ module ProofOfRecognitionHelper
     if region.sanction_check_written?
       "The education department or authority must also confirm in writing:"
     end
+  end
+
+  private
+
+  def written_status_reasons
+    [
+      "that you've completed a teaching qualification/teacher training",
+      "that you’ve successfully completed any period of professional experience " \
+        "comparable to an induction period (if required)",
+      "the age ranges and subjects you’re qualified to teach",
+    ]
+  end
+
+  def written_sanction_reasons
+    [
+      "that your authorisation to teach has never been suspended, barred, " \
+        "cancelled, revoked or restricted, and that you have no sanctions against you",
+    ]
   end
 end

--- a/app/helpers/proof_of_recognition_helper.rb
+++ b/app/helpers/proof_of_recognition_helper.rb
@@ -1,0 +1,31 @@
+module ProofOfRecognitionHelper
+  WRITTEN_STATUS_REASONS = [
+    "that you've completed a teaching qualification/teacher training",
+    "that you’ve successfully completed any period of professional experience "\
+      "comparable to an induction period (if required)",
+    "the age ranges and subjects you’re qualified to teach",
+  ].freeze
+
+  WRITTEN_SANCTION_REASONS = [
+    "that your authorisation to teach has never been suspended, barred, "\
+      "cancelled, revoked or restricted, and that you have no sanctions against you",
+  ].freeze
+
+  def proof_of_recognition_requirements_for(region:)
+    return WRITTEN_STATUS_REASONS + WRITTEN_SANCTION_REASONS +  [
+      "that you’re qualified to teach at state or government schools",
+    ] if region.status_check_written? && region.sanction_check_written?
+
+    return WRITTEN_STATUS_REASONS if region.status_check_written?
+    return WRITTEN_SANCTION_REASONS if region.sanction_check_written?
+  end
+
+  def proof_of_recognition_description_for(region:)
+    if region.status_check_written?
+      return "The authority or territory that recognises you as a teacher must confirm:"
+    end
+    if region.sanction_check_written?
+      "The education department or authority must also confirm in writing:"
+    end
+  end
+end

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -50,34 +50,14 @@
         <% end %>
       <% end %>
 
-      <% if region.status_check_written? && region.sanction_check_written? %>
-        <p class="govuk-body">
-          The authority or territory that recognises you as a teacher must confirm:
-        </p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>that you've completed a teaching qualification/teacher training</li>
-          <li>that you’ve successfully completed any period of professional experience comparable to an induction period (if required)</li>
-          <li>that your authorisation to teach has never been suspended, barred, cancelled, revoked or restricted, and that you have no sanctions against you</li>
-          <li>the age ranges and subjects you’re qualified to teach</li>
-          <li>that you’re qualified to teach at state or government schools</li>
-        </ul>
-        <% elsif region.status_check_written? %>
-          <p class="govuk-body">
-            The authority or territory that recognises you as a teacher must confirm:
-          </p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>that you've completed a teaching qualification/teacher training</li>
-            <li>that you’ve successfully completed any period of professional experience comparable to an induction period (if required)</li>
-            <li>the age ranges and subjects you’re qualified to teach</li>
-          </ul>
-        <% elsif region.sanction_check_written? %>
-          <p class="govuk-body">
-            The education department or authority must also confirm in writing:
-          </p>
-          <ul class="govuk-list govuk-list--bullet">
-            <li>that your authorisation to teach has never been suspended, barred, cancelled, revoked or restricted, and that you have no sanctions against you</li>
-          </ul>
-      <% end %>
+      <p class="govuk-body">
+        <%= proof_of_recognition_description_for(region:) %>
+      </p>
+      <ul class="govuk-list govuk-list--bullet">
+        <%- proof_of_recognition_requirements_for(region:).each do |requirement|%>
+          <li><%= requirement %></li>
+        <%- end -%>
+      </ul>
 
       <% if region.status_check_written? || region.sanction_check_written? %>
         <p class="govuk-body">

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -42,9 +42,9 @@
 
     <p class="govuk-body">It must confirm:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>that you’ve completed a teaching qualification/teacher training</li>
-      <li>that you’ve successfully completed any period of professional experience comparable to an induction period (if required)</li>
-      <li>the age ranges and subjects you’re qualified to teach</li>
+      <%- proof_of_recognition_requirements_for(region: @application_form.region ).each do |requirement| %>
+        <li><%= requirement %></li>
+      <%- end -%>
     </ul>
     <p class="govuk-body">This written confirmation must be dated within 3 months of you applying for QTS.</p>
 

--- a/spec/helpers/proof_of_recognition_helper_spec.rb
+++ b/spec/helpers/proof_of_recognition_helper_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 RSpec.describe ProofOfRecognitionHelper do
-  let(:region) { double(status_check_written?: status, sanction_check_written?: sanction) }
+  let(:region) do
+    double(status_check_written?: status, sanction_check_written?: sanction)
+  end
   let(:status) { false }
   let(:sanction) { false }
 
@@ -15,10 +17,10 @@ RSpec.describe ProofOfRecognitionHelper do
         is_expected.to match_array(
           [
             "that you've completed a teaching qualification/teacher training",
-            "that you’ve successfully completed any period of professional experience "\
-            "comparable to an induction period (if required)",
+            "that you’ve successfully completed any period of professional experience " \
+              "comparable to an induction period (if required)",
             "the age ranges and subjects you’re qualified to teach",
-          ]
+          ],
         )
       end
     end
@@ -29,9 +31,9 @@ RSpec.describe ProofOfRecognitionHelper do
       it do
         is_expected.to match_array(
           [
-            "that your authorisation to teach has never been suspended, barred, "\
-            "cancelled, revoked or restricted, and that you have no sanctions against you",
-          ]
+            "that your authorisation to teach has never been suspended, barred, " \
+              "cancelled, revoked or restricted, and that you have no sanctions against you",
+          ],
         )
       end
     end
@@ -44,13 +46,13 @@ RSpec.describe ProofOfRecognitionHelper do
         is_expected.to match_array(
           [
             "that you've completed a teaching qualification/teacher training",
-            "that you’ve successfully completed any period of professional experience comparable "\
-            "to an induction period (if required)",
+            "that you’ve successfully completed any period of professional experience comparable " \
+              "to an induction period (if required)",
             "the age ranges and subjects you’re qualified to teach",
-            "that your authorisation to teach has never been suspended, barred, cancelled, "\
-            "revoked or restricted, and that you have no sanctions against you",
-            "that you’re qualified to teach at state or government schools"
-          ]
+            "that your authorisation to teach has never been suspended, barred, cancelled, " \
+              "revoked or restricted, and that you have no sanctions against you",
+            "that you’re qualified to teach at state or government schools",
+          ],
         )
       end
     end
@@ -62,20 +64,32 @@ RSpec.describe ProofOfRecognitionHelper do
     context "written status only" do
       let(:status) { true }
 
-      it { is_expected.to eq("The authority or territory that recognises you as a teacher must confirm:") }
+      it do
+        is_expected.to eq(
+          "The authority or territory that recognises you as a teacher must confirm:",
+        )
+      end
     end
 
     context "written sanction only" do
       let(:sanction) { true }
 
-      it { is_expected.to eq("The education department or authority must also confirm in writing:") }
+      it do
+        is_expected.to eq(
+          "The education department or authority must also confirm in writing:",
+        )
+      end
     end
 
     context "both" do
       let(:sanction) { true }
       let(:status) { true }
 
-      it { is_expected.to eq("The authority or territory that recognises you as a teacher must confirm:") }
+      it do
+        is_expected.to eq(
+          "The authority or territory that recognises you as a teacher must confirm:",
+        )
+      end
     end
   end
 end

--- a/spec/helpers/proof_of_recognition_helper_spec.rb
+++ b/spec/helpers/proof_of_recognition_helper_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe ProofOfRecognitionHelper do
             "that you've completed a teaching qualification/teacher training",
             "that you’ve successfully completed any period of professional experience comparable " \
               "to an induction period (if required)",
-            "the age ranges and subjects you’re qualified to teach",
             "that your authorisation to teach has never been suspended, barred, cancelled, " \
               "revoked or restricted, and that you have no sanctions against you",
+            "the age ranges and subjects you’re qualified to teach",
             "that you’re qualified to teach at state or government schools",
           ],
         )

--- a/spec/helpers/proof_of_recognition_helper_spec.rb
+++ b/spec/helpers/proof_of_recognition_helper_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe ProofOfRecognitionHelper do
+  let(:region) { double(status_check_written?: status, sanction_check_written?: sanction) }
+  let(:status) { false }
+  let(:sanction) { false }
+
+  describe "proof_of_recognition_requirements_for" do
+    subject { proof_of_recognition_requirements_for(region:) }
+
+    context "written status only" do
+      let(:status) { true }
+
+      it do
+        is_expected.to match_array(
+          [
+            "that you've completed a teaching qualification/teacher training",
+            "that you’ve successfully completed any period of professional experience "\
+            "comparable to an induction period (if required)",
+            "the age ranges and subjects you’re qualified to teach",
+          ]
+        )
+      end
+    end
+
+    context "written sanction only" do
+      let(:sanction) { true }
+
+      it do
+        is_expected.to match_array(
+          [
+            "that your authorisation to teach has never been suspended, barred, "\
+            "cancelled, revoked or restricted, and that you have no sanctions against you",
+          ]
+        )
+      end
+    end
+
+    context "both" do
+      let(:sanction) { true }
+      let(:status) { true }
+
+      it do
+        is_expected.to match_array(
+          [
+            "that you've completed a teaching qualification/teacher training",
+            "that you’ve successfully completed any period of professional experience comparable "\
+            "to an induction period (if required)",
+            "the age ranges and subjects you’re qualified to teach",
+            "that your authorisation to teach has never been suspended, barred, cancelled, "\
+            "revoked or restricted, and that you have no sanctions against you",
+            "that you’re qualified to teach at state or government schools"
+          ]
+        )
+      end
+    end
+  end
+
+  describe "proof_of_recognition_description_for" do
+    subject { proof_of_recognition_description_for(region:) }
+
+    context "written status only" do
+      let(:status) { true }
+
+      it { is_expected.to eq("The authority or territory that recognises you as a teacher must confirm:") }
+    end
+
+    context "written sanction only" do
+      let(:sanction) { true }
+
+      it { is_expected.to eq("The education department or authority must also confirm in writing:") }
+    end
+
+    context "both" do
+      let(:sanction) { true }
+      let(:status) { true }
+
+      it { is_expected.to eq("The authority or territory that recognises you as a teacher must confirm:") }
+    end
+  end
+end


### PR DESCRIPTION
The proof of recognition content on the upload page should be dynamic based on the applicant's region and should be consistent between the eligibility checker and the application form.

* Extract the logic into a helper to provide the content
* Use the helper in both the eligibility checker and the application form