### PR TITLE
Add age range and subjects assessment section

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -11,6 +11,7 @@ class AssessmentFactory
     sections = [
       personal_information_section,
       qualifications_section,
+      age_range_subjects_section,
       work_history_section,
       professional_standing_section,
     ].compact
@@ -76,6 +77,14 @@ class AssessmentFactory
     ].compact
 
     AssessmentSection.new(key: "qualifications", checks:, failure_reasons:)
+  end
+
+  def age_range_subjects_section
+    checks = %i[qualified_in_mainstream_education age_range_subjects_matches]
+
+    failure_reasons = %i[not_qualified_to_teach_mainstream age_range]
+
+    AssessmentSection.new(key: "age_range_subjects", checks:, failure_reasons:)
   end
 
   def work_history_section

--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -51,7 +51,7 @@ class AssessmentFactory
   def qualifications_section
     checks = %i[
       qualifications_meet_level_6_or_equivalent
-      teaching_qualifcations_completed_in_eligible_country
+      teaching_qualifications_completed_in_eligible_country
       qualified_in_mainstream_education
       has_teacher_qualification_certificate
       has_teacher_qualification_transcript

--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -103,7 +103,7 @@ class AssessmentFactory
       (:written_statement_recent if application_form.needs_written_statement),
       :authorisation_to_teach,
       :teaching_qualification,
-      :age_ranges_subjects,
+      :confirm_age_range_subjects,
       :qualified_to_teach,
       :full_professional_status,
     ].compact
@@ -116,7 +116,7 @@ class AssessmentFactory
       (:written_statement_recent if application_form.needs_written_statement),
       :authorisation_to_teach,
       :teaching_qualification,
-      :age_ranges_subjects,
+      :confirm_age_range_subjects,
       :qualified_to_teach,
       :full_professional_status,
     ].compact

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -62,7 +62,7 @@ class AssessmentSection < ApplicationRecord
     teaching_hours_not_fulfilled
     authorisation_to_teach
     teaching_qualification
-    age_ranges_subjects
+    confirm_age_range_subjects
     full_professional_status
   ].freeze
 

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -28,6 +28,7 @@ class AssessmentSection < ApplicationRecord
        {
          personal_information: "personal_information",
          qualifications: "qualifications",
+         age_range_subjects: "age_range_subjects",
          work_history: "work_history",
          professional_standing: "professional_standing",
        }

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -23,6 +23,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
       %i[
         personal_information
         qualifications
+        age_range_subjects
         work_history
         professional_standing
       ].select { |key| assessment_section_keys.include?(key) }

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -26,7 +26,7 @@ en:
           duplicate_application: up-front duplication check shows the applicant does not have another in-flight application
           applicant_already_qts: applicant does not already hold QTS and induction exemption
           qualifications_meet_level_6_or_equivalent: applicant holds qualifications that meet the required academic level (level 6 academic qualification or equivalent)
-          teaching_qualifcations_completed_in_eligible_country: teaching qualifications were completed in an eligible country (for example, we cannot award QTS where they applied through Spain, but their teaching was completed in South Africa)
+          teaching_qualifications_completed_in_eligible_country: teaching qualifications were completed in an eligible country (for example, we cannot award QTS where they applied through Spain, but their teaching was completed in South Africa)
           qualified_in_mainstream_education: they’re qualified to teach in mainstream education (not vocationally only/SEN only/early years/pre-school only)
           has_teacher_qualification_certificate: teacher qualification certificate is present (and translation if required)
           has_teacher_qualfication_transcript: teacher qualification transcript is present (and translation if required)

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -9,15 +9,18 @@ en:
           items:
             personal_information: Check personal information
             qualifications: Check qualifications
+            age_range_subjects: Verify age range and subjects
             work_history: Check work history
             professional_standing: Check professional standing
             initial_assessment: Initial assessment recommendation
             review_requested_information: Review requested information from applicant
+
     assessment_sections:
       show:
         title:
           personal_information: Check personal information
           qualifications: Check qualifications
+          age_range_subjects: Verify age range and subjects
           work_history: Check work history
           professional_standing: Check professional standing
         checks:
@@ -34,6 +37,7 @@ en:
           has_university_degree_transcript: university degree transcript is present (and translation if required)
           has_additional_qualification_certificate: additional degree qualification certificate is present (and translation if required)
           has_additional_degree_transcript: additional degree transcript is present (and translation if required)
+          age_range_subjects_matches: that the age range and subjects information the applicant has entered matches the qualifications they’ve provided
           email_contact_current_employer: the applicant has entered an email contact for their current/most recent employer
           satisfactory_evidence_work_history: the applicant has provided satisfactory evidence of their work history
           registration_number: registration number provided and verified
@@ -62,6 +66,7 @@ en:
           teaching_hours_not_fulfilled: The required teaching hours have not been fulfilled.
           qualifications_dont_support_subjects: The qualifications do not support the teaching subjects entered.
           qualifications_dont_match_those_entered: The qualifications do not match what was entered on the form.
+          age_range: The age range the applicant is qualified to teach does not fall within the requirements of QTS.
           satisfactory_evidence_work_history: The information provided on work history is not sufficient to award QTS.
           registration_number: We could not verify the reference number using the online checker.
           written_statement_illegible: The letter from the country or state’s authority is illegible.

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -41,7 +41,7 @@ en:
           written_statement_recent: letter from the country or state’s competent authority was issued within the last 3 months
           authorisation_to_teach: confirmation that authorisation to teach has never been suspended, barred, cancelled, revoked or restricted, and there are no sanctions present
           teaching_qualification: confirmation of the applicant’s teaching qualification
-          age_ranges_subjects: confirmation of the age ranges and subjects the applicant is qualified to teach
+          confirm_age_range_subjects: confirmation of the age ranges and subjects the applicant is qualified to teach
           qualified_to_teach: the applicant is qualified to teach at state or government schools
           full_professional_status: the applicant holds full professional status or has achieved the required level (for example, where we require only provisional registration) and has no outstanding additional conditions
         failure_reasons:
@@ -68,7 +68,7 @@ en:
           written_statement_recent: The letter from the country or state’s authority was not issued within the last 3 months.
           authorisation_to_teach: Sanctions or restrictions were detected on professional record.
           teaching_qualification: We were not provided with sufficient evidence to confirm the teaching qualification entered on the online application form.
-          age_ranges_subjects: We were not provided with sufficient evidence to confirm qualification to teach the age ranges and subjects entered on the online application form.
+          confirm_age_range_subjects: We were not provided with sufficient evidence to confirm qualification to teach the age ranges and subjects entered on the online application form.
           qualified_to_teach: We were not provided with sufficient evidence to confirm qualification to teach at state or government schools.
           full_professional_status: Recognition level as a teacher does not match the required level, or has outstanding additional conditions.
 

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -43,11 +43,11 @@ namespace :example_data do
 
     Staff.where(email: assessors.map { |assessor| assessor[:email] }).delete_all
 
+    TimelineEvent.delete_all
     AssessmentSection.delete_all
     Assessment.delete_all
     Qualification.delete_all
     WorkHistory.delete_all
-    TimelineEvent.delete_all
     Note.delete_all
     ApplicationForm.delete_all
     Teacher.delete_all

--- a/spec/factories/assessment_sections.rb
+++ b/spec/factories/assessment_sections.rb
@@ -48,7 +48,7 @@ FactoryBot.define do
         %w[
           identification_document_present
           qualifications_meet_level_6_or_equivalent
-          teaching_qualifcations_completed_in_eligible_country
+          teaching_qualifications_completed_in_eligible_country
           qualified_in_mainstream_education
           has_teacher_qualification_certificate
           has_teacher_qualification_transcript

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe AssessmentFactory do
       subject(:sections) { call.sections }
 
       it "creates two sections" do
-        expect(sections.count).to eq(2)
+        expect(sections.count).to eq(3)
       end
 
       describe "personal information section" do
@@ -98,6 +98,22 @@ RSpec.describe AssessmentFactory do
               qualifications_dont_support_subjects
               qualifications_dont_match_those_entered
             ],
+          )
+        end
+      end
+
+      describe "age range and subjects section" do
+        it "is created" do
+          expect(sections.age_range_subjects.count).to eq(1)
+        end
+
+        it "has the right checks and failure reasons" do
+          section = sections.age_range_subjects.first
+          expect(section.checks).to eq(
+            %w[qualified_in_mainstream_education age_range_subjects_matches],
+          )
+          expect(section.failure_reasons).to eq(
+            %w[not_qualified_to_teach_mainstream age_range],
           )
         end
       end

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe AssessmentFactory do
                 written_statement_recent
                 authorisation_to_teach
                 teaching_qualification
-                age_ranges_subjects
+                confirm_age_range_subjects
                 qualified_to_teach
                 full_professional_status
               ],
@@ -160,7 +160,7 @@ RSpec.describe AssessmentFactory do
                 written_statement_recent
                 authorisation_to_teach
                 teaching_qualification
-                age_ranges_subjects
+                confirm_age_range_subjects
                 qualified_to_teach
                 full_professional_status
               ],
@@ -182,7 +182,7 @@ RSpec.describe AssessmentFactory do
                 registration_number
                 authorisation_to_teach
                 teaching_qualification
-                age_ranges_subjects
+                confirm_age_range_subjects
                 qualified_to_teach
                 full_professional_status
               ],
@@ -192,7 +192,7 @@ RSpec.describe AssessmentFactory do
                 registration_number
                 authorisation_to_teach
                 teaching_qualification
-                age_ranges_subjects
+                confirm_age_range_subjects
                 qualified_to_teach
                 full_professional_status
               ],

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe AssessmentFactory do
           expect(section.checks).to eq(
             %w[
               qualifications_meet_level_6_or_equivalent
-              teaching_qualifcations_completed_in_eligible_country
+              teaching_qualifications_completed_in_eligible_country
               qualified_in_mainstream_education
               has_teacher_qualification_certificate
               has_teacher_qualification_transcript

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe AssessmentSection, type: :model do
       is_expected.to define_enum_for(:key).with_values(
         personal_information: "personal_information",
         qualifications: "qualifications",
+        age_range_subjects: "age_range_subjects",
         work_history: "work_history",
         professional_standing: "professional_standing",
       ).backed_by_column_of_type(:string)


### PR DESCRIPTION
This will be used to render the verify age range and subjects page, allowing assessors to amend the age range and subjects given by the applicant.

[Trello Card](https://trello.com/c/tEV44pKM/981-add-assessment-age-range-and-subjects)

## Screenshot

<img width="742" alt="Screenshot 2022-10-06 at 08 41 18" src="https://user-images.githubusercontent.com/510498/194247049-12b1c94d-1a93-4eba-9801-ea23f9a247fb.png">
