### PR TITLE
Add age ranges to assessments

### DIFF
--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -5,10 +5,8 @@ module AssessorInterface
     def show
       @assessment_section_form =
         assessment_section_form.new(
-          assessment_section:,
           user: current_staff,
-          passed: assessment_section.passed,
-          selected_failure_reasons: assessment_section.selected_failure_reasons,
+          **AssessmentSectionForm.initial_attributes(assessment_section)
         )
     end
 

--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -6,7 +6,9 @@ module AssessorInterface
       @assessment_section_form =
         assessment_section_form.new(
           user: current_staff,
-          **AssessmentSectionForm.initial_attributes(assessment_section)
+          **assessment_section_form_class.initial_attributes(
+            assessment_section,
+          ),
         )
     end
 
@@ -41,7 +43,15 @@ module AssessorInterface
     end
 
     def assessment_section_form
-      AssessmentSectionForm.for_assessment_section(assessment_section)
+      assessment_section_form_class.for_assessment_section(assessment_section)
+    end
+
+    def assessment_section_form_class
+      if assessment_section.age_range_subjects?
+        AgeRangeSubjectsForm
+      else
+        AssessmentSectionForm
+      end
     end
 
     def assessment_section_form_params

--- a/app/forms/assessor_interface/age_range_subjects_form.rb
+++ b/app/forms/assessor_interface/age_range_subjects_form.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+class AssessorInterface::AgeRangeSubjectsForm < AssessorInterface::AssessmentSectionForm
+  attribute :age_range_min, :string
+  attribute :age_range_max, :string
+  attribute :age_range_note, :string
+
+  validates :age_range_min,
+            presence: true,
+            numericality: {
+              only_integer: true,
+              greater_than_or_equal_to: 0,
+            }
+  validates :age_range_max,
+            presence: true,
+            numericality: {
+              only_integer: true,
+              greater_than_or_equal_to: :age_range_min,
+            }
+
+  def save
+    return false unless valid?
+
+    ActiveRecord::Base.transaction do
+      existing_note = assessment.age_range_note
+
+      note =
+        if age_range_note != existing_note&.text
+          CreateNote.call(application_form:, author: user, text: age_range_note)
+        else
+          existing_note
+        end
+
+      assessment.update!(age_range_min:, age_range_max:, age_range_note: note)
+
+      super
+    end
+
+    true
+  end
+
+  class << self
+    def initial_attributes(assessment_section)
+      assessment = assessment_section.assessment
+      super.merge(
+        age_range_min: assessment.age_range_min,
+        age_range_max: assessment.age_range_max,
+        age_range_note: assessment.age_range_note&.text,
+      )
+    end
+
+    def permittable_parameters
+      args, kwargs = super
+      args += %i[age_range_min age_range_max age_range_note]
+      [args, kwargs]
+    end
+  end
+
+  private
+
+  def assessment
+    @assessment ||= assessment_section.assessment
+  end
+
+  def application_form
+    @application_form ||= assessment.application_form
+  end
+end

--- a/app/forms/assessor_interface/assessment_section_form.rb
+++ b/app/forms/assessor_interface/assessment_section_form.rb
@@ -68,15 +68,29 @@ class AssessorInterface::AssessmentSectionForm
       klass
     end
 
+    def initial_attributes(assessment_section)
+      {
+        assessment_section:,
+        passed: assessment_section.passed,
+        selected_failure_reasons: assessment_section.selected_failure_reasons,
+      }
+    end
+
     def permit_parameters(params)
+      args, kwargs = permittable_parameters
+      params.permit(:passed, *args, **kwargs)
+    end
+
+    protected
+
+    def permittable_parameters
       args =
         attribute_names.filter { |attr_name| attr_name.ends_with?("_notes") }
       kwargs =
         attribute_names
           .filter { |attr_name| attr_name.ends_with?("_checked") }
           .index_with { |_key| [] }
-
-      params.permit(:passed, *args, **kwargs)
+      [args, kwargs]
     end
   end
 end

--- a/app/forms/assessor_interface/create_note_form.rb
+++ b/app/forms/assessor_interface/create_note_form.rb
@@ -11,17 +11,11 @@ class AssessorInterface::CreateNoteForm
   validates :application_form, :author, :text, presence: true
 
   def save!
-    return false unless valid?
-
-    ActiveRecord::Base.transaction do
-      note = Note.create!(application_form:, author:, text:)
-
-      TimelineEvent.create!(
-        application_form:,
-        event_type: "note_created",
-        creator: author,
-        note:,
-      )
+    if valid?
+      CreateNote.call(application_form:, author:, text:)
+      true
+    else
+      false
     end
   end
 end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -3,17 +3,22 @@
 # Table name: assessments
 #
 #  id                  :bigint           not null, primary key
+#  age_range_max       :integer
+#  age_range_min       :integer
 #  recommendation      :string           default("unknown"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  age_range_note_id   :bigint
 #  application_form_id :bigint           not null
 #
 # Indexes
 #
+#  index_assessments_on_age_range_note_id    (age_range_note_id)
 #  index_assessments_on_application_form_id  (application_form_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (age_range_note_id => notes.id)
 #  fk_rails_...  (application_form_id => application_forms.id)
 #
 class Assessment < ApplicationRecord
@@ -21,6 +26,8 @@ class Assessment < ApplicationRecord
 
   has_many :sections, class_name: "AssessmentSection"
   has_many :further_information_requests
+
+  belongs_to :age_range_note, class_name: "Note", optional: true
 
   enum :recommendation,
        {

--- a/app/services/create_note.rb
+++ b/app/services/create_note.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class CreateNote
+  include ServicePattern
+
+  def initialize(application_form:, author:, text:)
+    @application_form = application_form
+    @author = author
+    @text = text
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      note = Note.create!(application_form:, author:, text:)
+
+      TimelineEvent.create!(
+        application_form:,
+        event_type: :note_created,
+        creator: author,
+        note:,
+      )
+
+      note
+    end
+  end
+
+  private
+
+  attr_reader :application_form, :author, :text
+end

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -57,12 +57,21 @@
   ), method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
+  <% if @assessment_section_view_object.assessment_section.age_range_subjects? %>
+    <h2 class="govuk-heading-m">What age range is the applicant qualified to teach?</h2>
+    <p class="govuk-body">Based on the evidence the applicant has provided, you can either copy the age range they entered if you agree, or enter a new range.</p>
+
+    <%= f.govuk_number_field :age_range_min, width: 3 %>
+    <%= f.govuk_number_field :age_range_max, width: 3 %>
+    <%= f.govuk_text_area :age_range_note %>
+  <% end %>
+
   <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "Has the applicant completed this section to your satisfaction?", size: "s" } do %>
     <%= f.govuk_radio_button :passed, true, label: { text: "Yes" }, link_errors: true %>
     <%= f.govuk_radio_button :passed, false, label: { text: "No" } do %>
       <%= f.govuk_check_boxes_fieldset :selected_failure_reasons, legend: { size: "s" } do %>
         <% @assessment_section_view_object.assessment_section.failure_reasons.each do |failure_reason| %>
-          <%= f.govuk_check_box "#{failure_reason}_checked", true, label: { text: t(".failure_reasons.#{failure_reason}") } do %>
+          <%= f.govuk_check_box "#{failure_reason}_checked", true, label: { text: t(".failure_reasons.#{failure_reason}") }, link_errors: true do %>
             <%= f.govuk_text_area "#{failure_reason}_notes", label: { text: "Note to the applicant", size: "s" }, hint: { text: "Use this space to tell the applicant what they need to do. Make sure your instructions are clear." } %>
           <% end %>
         <% end %>

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -13,17 +13,17 @@
              application_form: @assessment_section_view_object.application_form,
              changeable: false %>
 <% when "qualifications" %>
+  <%= render "shared/application_form/qualifications_summary",
+             application_form: @assessment_section_view_object.application_form,
+             qualifications: @assessment_section_view_object.qualifications,
+             changeable: false %>
+<% when "age_range_subjects" %>
   <%= render "shared/application_form/age_range_summary",
              application_form: @assessment_section_view_object.application_form,
              changeable: false %>
 
   <%= render "shared/application_form/subjects_summary",
              application_form: @assessment_section_view_object.application_form,
-             changeable: false %>
-
-  <%= render "shared/application_form/qualifications_summary",
-             application_form: @assessment_section_view_object.application_form,
-             qualifications: @assessment_section_view_object.qualifications,
              changeable: false %>
 <% when "work_history" %>
   <%= render "shared/application_form/work_history_summary",

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -63,6 +63,9 @@
     - recommendation
     - created_at
     - updated_at
+    - age_range_min
+    - age_range_max
+    - age_range_note_id
   :countries:
     - id
     - code

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -103,3 +103,7 @@ en:
           attributes:
             assessor_id:
               blank: Select an assessor to assign
+        assessor_interface/assessment_section_form:
+          attributes:
+            selected_failure_reasons:
+              blank: Select the reasons for your recommendation

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -32,6 +32,10 @@ en:
           decline: Decline QTS
       assessor_interface_create_note_form:
         text: Add a note to this application
+      assessor_interface_assessment_section_form:
+        age_range_min: From
+        age_range_max: To
+        age_range_note: If you've entered a new range please explain why (optional)
       qualification:
         add_another_options:
           true: "Yes"

--- a/db/migrate/20221005143211_add_age_range_to_assessments.rb
+++ b/db/migrate/20221005143211_add_age_range_to_assessments.rb
@@ -1,0 +1,9 @@
+class AddAgeRangeToAssessments < ActiveRecord::Migration[7.0]
+  def change
+    change_table :assessments, bulk: true do |t|
+      t.column :age_range_min, :integer
+      t.column :age_range_max, :integer
+      t.references :age_range_note, foreign_key: { to_table: :notes }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_05_080511) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_05_143211) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -95,6 +95,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_05_080511) do
     t.string "recommendation", default: "unknown", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "age_range_min"
+    t.integer "age_range_max"
+    t.bigint "age_range_note_id"
+    t.index ["age_range_note_id"], name: "index_assessments_on_age_range_note_id"
     t.index ["application_form_id"], name: "index_assessments_on_application_form_id"
   end
 
@@ -309,6 +313,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_05_080511) do
   add_foreign_key "application_forms", "teachers"
   add_foreign_key "assessment_sections", "assessments"
   add_foreign_key "assessments", "application_forms"
+  add_foreign_key "assessments", "notes", column: "age_range_note_id"
   add_foreign_key "eligibility_checks", "regions"
   add_foreign_key "notes", "application_forms"
   add_foreign_key "notes", "staff", column: "author_id"

--- a/spec/factories/assessment_sections.rb
+++ b/spec/factories/assessment_sections.rb
@@ -75,6 +75,14 @@ FactoryBot.define do
       end
     end
 
+    trait :age_range_subjects do
+      key { "age_range_subjects" }
+      checks do
+        %w[qualified_in_mainstream_education age_range_subjects_matches]
+      end
+      failure_reasons { %w[not_qualified_to_teach_mainstream age_range] }
+    end
+
     trait :work_history do
       key { "work_history" }
       checks { %w[satisfactory_evidence_work_history] }

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -3,17 +3,22 @@
 # Table name: assessments
 #
 #  id                  :bigint           not null, primary key
+#  age_range_max       :integer
+#  age_range_min       :integer
 #  recommendation      :string           default("unknown"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  age_range_note_id   :bigint
 #  application_form_id :bigint           not null
 #
 # Indexes
 #
+#  index_assessments_on_age_range_note_id    (age_range_note_id)
 #  index_assessments_on_application_form_id  (application_form_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (age_range_note_id => notes.id)
 #  fk_rails_...  (application_form_id => application_forms.id)
 #
 FactoryBot.define do

--- a/spec/forms/assessor_interface/age_range_subjects_form_spec.rb
+++ b/spec/forms/assessor_interface/age_range_subjects_form_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::AgeRangeSubjectsForm, type: :model do
+  let(:assessment_section) { create(:assessment_section, :age_range_subjects) }
+  let(:user) { create(:staff, :confirmed) }
+  let(:attributes) { {} }
+
+  subject(:form) do
+    described_class.for_assessment_section(assessment_section).new(
+      assessment_section:,
+      user:,
+      **attributes,
+    )
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:assessment_section) }
+    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to allow_values(true, false).for(:passed) }
+
+    it { is_expected.to validate_presence_of(:age_range_min) }
+    it do
+      is_expected.to validate_numericality_of(
+        :age_range_min,
+      ).only_integer.is_greater_than_or_equal_to(0)
+    end
+
+    it { is_expected.to validate_presence_of(:age_range_max) }
+
+    context "when minimum is set" do
+      let(:attributes) { { age_range_min: "7" } }
+      it do
+        is_expected.to validate_numericality_of(
+          :age_range_max,
+        ).only_integer.is_greater_than_or_equal_to(7)
+      end
+    end
+
+    it { is_expected.to_not validate_presence_of(:age_range_note) }
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:assessment) { assessment_section.assessment }
+
+    describe "when invalid attributes" do
+      it { is_expected.to be false }
+    end
+
+    describe "with valid attributes and no note" do
+      let(:attributes) do
+        { passed: true, age_range_min: "7", age_range_max: "11" }
+      end
+
+      it { is_expected.to be true }
+
+      it "sets the attributes" do
+        save # rubocop:disable Rails/SaveBang
+
+        expect(assessment.age_range_min).to eq(7)
+        expect(assessment.age_range_max).to eq(11)
+        expect(assessment.age_range_note).to be_nil
+      end
+    end
+
+    describe "with valid attributes and a note" do
+      let(:attributes) do
+        {
+          passed: true,
+          age_range_min: "7",
+          age_range_max: "11",
+          age_range_note: "A note.",
+        }
+      end
+
+      it { is_expected.to be true }
+
+      it "sets the attributes" do
+        save # rubocop:disable Rails/SaveBang
+
+        expect(assessment.age_range_note.text).to eq("A note.")
+      end
+    end
+  end
+end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -5,17 +5,22 @@
 # Table name: assessments
 #
 #  id                  :bigint           not null, primary key
+#  age_range_max       :integer
+#  age_range_min       :integer
 #  recommendation      :string           default("unknown"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  age_range_note_id   :bigint
 #  application_form_id :bigint           not null
 #
 # Indexes
 #
+#  index_assessments_on_age_range_note_id    (age_range_note_id)
 #  index_assessments_on_application_form_id  (application_form_id)
 #
 # Foreign Keys
 #
+#  fk_rails_...  (age_range_note_id => notes.id)
 #  fk_rails_...  (application_form_id => application_forms.id)
 #
 require "rails_helper"
@@ -26,6 +31,7 @@ RSpec.describe Assessment, type: :model do
   describe "associations" do
     it { is_expected.to have_many(:sections) }
     it { is_expected.to have_many(:further_information_requests) }
+    it { is_expected.to belong_to(:age_range_note).optional }
   end
 
   describe "validations" do

--- a/spec/services/create_note_spec.rb
+++ b/spec/services/create_note_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CreateNote do
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:author) { create(:staff, :confirmed) }
+  let(:text) { "Note text." }
+
+  subject(:call) { described_class.call(application_form:, author:, text:) }
+
+  describe "record note" do
+    subject(:note) { Note.find_by(application_form:) }
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to_not be_nil }
+
+      it "sets the attributes correctly" do
+        expect(note.text).to eq(text)
+      end
+    end
+  end
+
+  describe "record timeline event" do
+    subject(:timeline_event) do
+      TimelineEvent.note_created.find_by(application_form:)
+    end
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to_not be_nil }
+
+      it "sets the attributes correctly" do
+        expect(timeline_event.creator).to eq(author)
+        expect(timeline_event.note).to eq(Note.first)
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -32,6 +32,10 @@ module PageObjects
         task_item_for("Check qualifications")
       end
 
+      def age_range_subjects_task
+        task_item_for("Verify age range and subjects")
+      end
+
       def work_history_task
         task_item_for("Check work history")
       end

--- a/spec/support/autoload/page_objects/assessor_interface/assessment_section.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/assessment_section.rb
@@ -13,7 +13,8 @@ module PageObjects
         sections :failure_reason_checkbox_items,
                  PageObjects::GovukCheckboxItem,
                  ".govuk-checkboxes__item"
-        elements :failure_reason_note_textareas, ".govuk-textarea"
+        elements :failure_reason_note_textareas,
+                 ".govuk-checkboxes__conditional .govuk-textarea"
         element :continue_button, "button"
       end
     end

--- a/spec/support/autoload/page_objects/assessor_interface/check_qualifications.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_qualifications.rb
@@ -12,7 +12,7 @@ module PageObjects
       sections :cards, QualificationCard, ".govuk-summary-list__card"
 
       def teaching_qualification
-        cards&.third
+        cards&.first
       end
     end
   end

--- a/spec/support/autoload/page_objects/assessor_interface/verify_age_range_subjects_page.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/verify_age_range_subjects_page.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class AgeRangeSubjectCard < SitePrism::Section
+      element :heading, "h2"
+    end
+
+    class VerifyAgeRangeSubjectsPage < AssessmentSection
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/age_range_subjects"
+
+      sections :cards, AgeRangeSubjectCard, ".govuk-summary-list__card"
+
+      def age_range
+        cards&.first
+      end
+
+      def subjects
+        cards&.second
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/verify_age_range_subjects_page.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/verify_age_range_subjects_page.rb
@@ -11,6 +11,15 @@ module PageObjects
 
       sections :cards, AgeRangeSubjectCard, ".govuk-summary-list__card"
 
+      section :age_range_form, "form" do
+        element :minimum,
+                "#assessor-interface-assessment-section-form-age-range-min-field"
+        element :maximum,
+                "#assessor-interface-assessment-section-form-age-range-max-field"
+        element :note,
+                "#assessor-interface-assessment-section-form-age-range-note-field"
+      end
+
       def age_range
         cards&.first
       end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -256,4 +256,9 @@ module PageHelpers
     @further_information_request_preview_page ||=
       PageObjects::AssessorInterface::FurtherInformationRequestPreview.new
   end
+
+  def verify_age_range_subjects_page
+    @verify_age_range_subjects_page ||=
+      PageObjects::AssessorInterface::VerifyAgeRangeSubjectsPage.new
+  end
 end

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -68,7 +68,8 @@ RSpec.describe "Assessor check submitted details", type: :system do
     )
     then_i_see_the_age_range_and_subjects
 
-    when_i_choose_verify_age_range_subjects_yes
+    when_i_fill_in_age_range
+    and_i_choose_verify_age_range_subjects_yes
     then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_verify_age_range_subjects_completed
   end
@@ -81,7 +82,8 @@ RSpec.describe "Assessor check submitted details", type: :system do
     )
     then_i_see_the_age_range_and_subjects
 
-    when_i_choose_verify_age_range_subjects_no
+    when_i_fill_in_age_range
+    and_i_choose_verify_age_range_subjects_no
     then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_verify_age_range_subjects_action_required
   end
@@ -236,12 +238,18 @@ RSpec.describe "Assessor check submitted details", type: :system do
     )
   end
 
-  def when_i_choose_verify_age_range_subjects_yes
+  def when_i_fill_in_age_range
+    verify_age_range_subjects_page.age_range_form.minimum.fill_in with: "7"
+    verify_age_range_subjects_page.age_range_form.maximum.fill_in with: "11"
+    verify_age_range_subjects_page.age_range_form.note.fill_in with: "A note."
+  end
+
+  def and_i_choose_verify_age_range_subjects_yes
     verify_age_range_subjects_page.form.yes_radio_item.input.click
     verify_age_range_subjects_page.form.continue_button.click
   end
 
-  def when_i_choose_verify_age_range_subjects_no
+  def and_i_choose_verify_age_range_subjects_no
     verify_age_range_subjects_page.form.no_radio_item.input.click
     verify_age_range_subjects_page
       .form

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -60,6 +60,32 @@ RSpec.describe "Assessor check submitted details", type: :system do
     and_i_see_check_qualifications_action_required
   end
 
+  it "allows passing the age range and subjects" do
+    when_i_visit_the(
+      :verify_age_range_subjects_page,
+      application_id:,
+      assessment_id:,
+    )
+    then_i_see_the_age_range_and_subjects
+
+    when_i_choose_verify_age_range_subjects_yes
+    then_i_see_the(:assessor_application_page, application_id:)
+    and_i_see_verify_age_range_subjects_completed
+  end
+
+  it "allows failing the age range and subjects" do
+    when_i_visit_the(
+      :verify_age_range_subjects_page,
+      application_id:,
+      assessment_id:,
+    )
+    then_i_see_the_age_range_and_subjects
+
+    when_i_choose_verify_age_range_subjects_no
+    then_i_see_the(:assessor_application_page, application_id:)
+    and_i_see_verify_age_range_subjects_action_required
+  end
+
   it "allows passing the work history" do
     when_i_visit_the(:check_work_history_page, application_id:, assessment_id:)
     then_i_see_the_work_history
@@ -201,6 +227,47 @@ RSpec.describe "Assessor check submitted details", type: :system do
     )
   end
 
+  def then_i_see_the_age_range_and_subjects
+    expect(verify_age_range_subjects_page.age_range.heading.text).to eq(
+      "Enter the age range you can teach",
+    )
+    expect(verify_age_range_subjects_page.subjects.heading.text).to eq(
+      "Enter the subjects you can teach",
+    )
+  end
+
+  def when_i_choose_verify_age_range_subjects_yes
+    verify_age_range_subjects_page.form.yes_radio_item.input.click
+    verify_age_range_subjects_page.form.continue_button.click
+  end
+
+  def when_i_choose_verify_age_range_subjects_no
+    verify_age_range_subjects_page.form.no_radio_item.input.click
+    verify_age_range_subjects_page
+      .form
+      .failure_reason_checkbox_items
+      .first
+      .checkbox
+      .click
+    verify_age_range_subjects_page
+      .form
+      .failure_reason_note_textareas
+      .first.fill_in with: "Note."
+    verify_age_range_subjects_page.form.continue_button.click
+  end
+
+  def and_i_see_verify_age_range_subjects_completed
+    expect(assessor_application_page.age_range_subjects_task.status.text).to eq(
+      "COMPLETED",
+    )
+  end
+
+  def and_i_see_verify_age_range_subjects_action_required
+    expect(assessor_application_page.age_range_subjects_task.status.text).to eq(
+      "ACTION REQUIRED",
+    )
+  end
+
   def then_i_see_the_work_history
     most_recent_role = application_form.work_histories.first
     expect(check_work_history_page.most_recent_role.school_name.text).to eq(
@@ -307,6 +374,11 @@ RSpec.describe "Assessor check submitted details", type: :system do
         create(
           :assessment_section,
           :qualifications,
+          assessment: application_form.assessment,
+        )
+        create(
+          :assessment_section,
+          :age_range_subjects,
           assessment: application_form.assessment,
         )
         create(


### PR DESCRIPTION
This adds a new age range section to the assessment section view allowing assessors to provide overridden values for the minimum and maximum age range value.

[Trello Card](https://trello.com/c/tEV44pKM/981-add-assessment-age-range-and-subjects)

## Screenshot

![Screenshot 2022-10-06 at 17 11 09](https://user-images.githubusercontent.com/510498/194369798-9f51ce77-ea91-436f-bae4-eae909997294.png)
