### PR TITLE
Add subjects

### DIFF
--- a/app/lib/dqt/country_code.rb
+++ b/app/lib/dqt/country_code.rb
@@ -1,4 +1,6 @@
-class DqtCountryCode
+# frozen_string_literal: true
+
+class DQT::CountryCode
   class << self
     def for_code(code)
       # Cyprus (European Union)

--- a/app/lib/dqt/subject.rb
+++ b/app/lib/dqt/subject.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+class DQT::Subject
+  class << self
+    def for_id(id)
+      # these three subjects are not coded by HESA so we've agreed these encodings with the DQT team
+      return "999001" if id == :citizenship
+      return "999002" if id == :physical_education
+      return "999003" if id == :design_and_technology
+
+      MAPPING.invert.fetch(id)
+    end
+
+    # https://www.hesa.ac.uk/collection/c22053/xml/c22053/c22053codelists.xsd
+    # https://www.hesa.ac.uk/collection/c22053/e/sbjca
+    MAPPING = {
+      "101117" => :ancient_hebrew,
+      "100343" => :applied_biology,
+      "101038" => :applied_chemistry,
+      "100358" => :applied_computing,
+      "101060" => :applied_physics,
+      "101192" => :arabic_languages,
+      "100346" => :biology,
+      "100078" => :business_management,
+      "100079" => :business_studies,
+      "100417" => :chemistry,
+      "100456" => :child_development,
+      "101165" => :chinese_languages,
+      "101126" => :classical_greek_studies,
+      "100300" => :classical_studies,
+      "100366" => :computer_science,
+      "100150" => :construction_and_the_built_environment,
+      "101361" => :art_and_design,
+      "100068" => :dance,
+      "100048" => :design,
+      "100069" => :drama,
+      "100510" => :early_years_teaching,
+      "100450" => :economics,
+      "100320" => :english_studies,
+      "100381" => :environmental_sciences,
+      "101017" => :food_and_beverage_studies,
+      "100321" => :french_language,
+      "100184" => :general_or_integrated_engineering,
+      "100390" => :general_sciences,
+      "100409" => :geography,
+      "100323" => :german_language,
+      "100061" => :graphic_design,
+      "101373" => :hair_and_beauty_sciences,
+      "100476" => :health_and_social_care,
+      "100473" => :health_studies,
+      "101410" => :historical_linguistics,
+      "100302" => :history,
+      "100891" => :hospitality,
+      "100372" => :information_technology,
+      "100326" => :italian_language,
+      "101420" => :latin_language,
+      "100485" => :law,
+      "100202" => :manufacturing_engineering,
+      "100225" => :materials_science,
+      "100403" => :mathematics,
+      "100444" => :media_and_communication_studies,
+      "100329" => :modern_languages,
+      "100642" => :music_education_and_teaching,
+      "100071" => :performing_arts,
+      "100337" => :philosophy,
+      "100425" => :physics,
+      "101142" => :portuguese_language,
+      "100511" => :primary_teaching,
+      "100050" => :product_design,
+      "100209" => :production_and_manufacturing_engineering,
+      "100497" => :psychology,
+      "100091" => :public_services,
+      "100893" => :recreation_and_leisure_studies,
+      "100339" => :religious_studies,
+      "100092" => :retail_management,
+      "100330" => :russian_languages,
+      "100471" => :social_sciences,
+      "100332" => :spanish_language,
+      "101085" => :specialist_teaching_primary_with_mathematics,
+      "100433" => :sport_and_exercise_sciences,
+      "100097" => :sports_management,
+      "100406" => :statistics,
+      "100214" => :textiles_technology,
+      "100101" => :travel_and_tourism,
+      "100610" => :uk_government_parliamentary_studies,
+      "100333" => :welsh_language,
+    }.freeze
+  end
+end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+class Subject
+  include ActiveModel::Model
+
+  attr_accessor :id, :name
+
+  def self.all
+    @all ||=
+      ALL_IDS.map { |id| Subject.new(id:, name: I18n.t("subjects.#{id}")) }
+  end
+
+  ALL_IDS = %i[
+    ancient_hebrew
+    applied_biology
+    applied_chemistry
+    applied_computing
+    applied_physics
+    arabic_languages
+    art_and_design
+    biology
+    business_management
+    business_studies
+    chemistry
+    child_development
+    chinese_languages
+    citizenship
+    classical_greek_studies
+    classical_studies
+    computer_science
+    construction_and_the_built_environment
+    dance
+    design
+    design_and_technology
+    drama
+    early_years_teaching
+    economics
+    english_studies
+    environmental_sciences
+    food_and_beverage_studies
+    french_language
+    general_or_integrated_engineering
+    general_sciences
+    geography
+    german_language
+    graphic_design
+    hair_and_beauty_sciences
+    health_and_social_care
+    health_studies
+    historical_linguistics
+    history
+    hospitality
+    information_technology
+    italian_language
+    latin_language
+    law
+    manufacturing_engineering
+    materials_science
+    mathematics
+    media_and_communication_studies
+    modern_languages
+    music_education_and_teaching
+    performing_arts
+    philosophy
+    physical_education
+    physics
+    portuguese_language
+    primary_teaching
+    production_and_manufacturing_engineering
+    product_design
+    psychology
+    public_services
+    recreation_and_leisure_studies
+    religious_studies
+    retail_management
+    russian_languages
+    social_sciences
+    spanish_language
+    specialist_teaching_primary_with_mathematics
+    sports_management
+    sport_and_exercise_sciences
+    statistics
+    textiles_technology
+    travel_and_tourism
+    uk_government_parliamentary_studies
+    welsh_language
+  ].freeze
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,5 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "DQT"
   inflect.uncountable %w[staff]
 end

--- a/config/locales/subjects.en.yml
+++ b/config/locales/subjects.en.yml
@@ -1,0 +1,75 @@
+en:
+  subjects:
+    ancient_hebrew: Ancient Hebrew
+    applied_biology: Applied biology
+    applied_chemistry: Applied chemistry
+    applied_computing: Applied computing
+    applied_physics: Applied physics
+    arabic_languages: Arabic languages
+    art_and_design: Art and design
+    biology: Biology
+    business_management: Business and management
+    business_studies: Business studies
+    chemistry: Chemistry
+    child_development: Child development
+    chinese_languages: Chinese languages
+    citizenship: Citizenship
+    classical_greek_studies: Classical greek studies
+    classical_studies: Classical studies
+    computer_science: Computer science
+    construction_and_the_built_environment: Construction and the built environment"
+    dance: Dance
+    design: Design"
+    design_and_technology: Design and technology
+    drama: Drama
+    early_years_teaching: Early years teaching
+    economics: Economics
+    english_studies: English studies
+    environmental_sciences: Environmental sciences
+    food_and_beverage_studies: Food and beverage studies
+    french_language: French language
+    general_or_integrated_engineering: General or integrated engineering
+    general_sciences: General sciences
+    geography: Geography
+    german_language: German language
+    graphic_design: Graphic design
+    hair_and_beauty_sciences: Hair and beauty sciences
+    health_and_social_care: Health and social care
+    health_studies: Health studies
+    historical_linguistics: Historical linguistics
+    history: History
+    hospitality: Hospitality
+    information_technology: Information technology
+    italian_language: Italian language
+    latin_language: Latin language
+    law: Law
+    manufacturing_engineering: Manufacturing engineering
+    materials_science: Materials science
+    mathematics: Mathematics
+    media_and_communication_studies: Media and communication studies
+    modern_languages: Modern languages
+    music_education_and_teaching: Music education and teaching
+    performing_arts: Performing arts
+    philosophy: Philosophy
+    physical_education: Physical education
+    physics: Physics
+    portuguese_language: Portuguese language
+    primary_teaching: Primary teaching
+    production_and_manufacturing_engineering: Production and manufacturing engineering
+    product_design: Product design
+    psychology: Psychology
+    public_services: Public services
+    recreation_and_leisure_studies: Recreation and leisure studies
+    religious_studies: Religious studies
+    retail_management: Retail management
+    russian_languages: Russian languages
+    social_sciences: Social sciences
+    spanish_language: Spanish language
+    specialist_teaching_primary_with_mathematics: Specialist teaching (primary with mathematics)
+    sports_management: Sports management
+    sport_and_exercise_sciences: Sport and exercise sciences
+    statistics: Statistics
+    textiles_technology: Textiles technology
+    travel_and_tourism: Travel and tourism
+    uk_government_parliamentary_studies: UK government / parliamentary studies
+    welsh_language: Welsh language

--- a/spec/lib/dqt/country_code_spec.rb
+++ b/spec/lib/dqt/country_code_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
-RSpec.describe DqtCountryCode do
+RSpec.describe DQT::CountryCode do
   describe "#for_code" do
     subject(:dqt_code) { described_class.for_code(code) }
 

--- a/spec/lib/dqt/subject_spec.rb
+++ b/spec/lib/dqt/subject_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DQT::Subject do
+  describe "#for_id" do
+    subject(:dqt_code) { described_class.for_id(id) }
+
+    shared_examples "DQT code" do |id|
+      let(:id) { id }
+      it { is_expected.to_not be_nil }
+    end
+
+    Subject.all.map { |subject| it_behaves_like "DQT code", subject.id }
+  end
+end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Subject do
+  describe "#all" do
+    subject(:all) { described_class.all }
+
+    it { is_expected.to_not be_empty }
+  end
+end


### PR DESCRIPTION
This adds a model and DQT class for the subjects we know about in this application, and I've implemented them as models so they can be used easily in [dfe-autocomplete](https://github.com/DFE-Digital/dfe-autocomplete).

These are based off:

- https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/lib/hesa/code_sets/course_subjects.rb
- https://github.com/DFE-Digital/register-trainee-teachers/blob/main/app/lib/dqt/params/trn_request.rb#L143-L145

[Trello Card](https://trello.com/c/tEV44pKM/981-add-assessment-age-range-and-subjects)