### PR TITLE
Add subjects to assessments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,8 @@ gem "sidekiq-cron"
 gem "sitemap_generator"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby] # Windows
 
-gem "dfe-analytics", git: "https://github.com/DFE-Digital/dfe-analytics"
+gem "dfe-analytics", github: "DFE-Digital/dfe-analytics"
+gem "dfe-autocomplete", github: "DFE-Digital/dfe-autocomplete"
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 gem "govuk_markdown"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,21 @@
 GIT
-  remote: https://github.com/DFE-Digital/dfe-analytics
+  remote: https://github.com/DFE-Digital/dfe-analytics.git
   revision: 4f7369d0e1bde1f9252ac0f94f37b543fd279161
   specs:
     dfe-analytics (1.5.3)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
+
+GIT
+  remote: https://github.com/DFE-Digital/dfe-autocomplete.git
+  revision: 7bf95631e7c912795b1994b04bfd86997d8bd2ff
+  specs:
+    dfe-autocomplete (0.1.0)
+      actionview (>= 7.0.2.3)
+      activemodel (>= 7.0.2.3)
+      govuk-components
+      rails (>= 7.0.2.3)
+      view_component
 
 GEM
   remote: https://rubygems.org/
@@ -493,6 +504,7 @@ DEPENDENCIES
   devise-passwordless
   devise_invitable
   dfe-analytics!
+  dfe-autocomplete!
   dotenv-rails
   factory_bot_rails
   faker

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -5,6 +5,7 @@ $moj-images-path: "/";
 
 @import "govuk-frontend/govuk/all";
 @import "@ministryofjustice/frontend/moj/components/timeline/timeline";
+@import "dfe-autocomplete/src/dfe-autocomplete";
 @import "location-autocomplete.min";
 
 @import "_application_forms";

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
+import dfeAutocomplete from "dfe-autocomplete";
 import { initAll } from "govuk-frontend";
 import openregisterLocationPicker from "govuk-country-and-territory-autocomplete";
 
@@ -46,3 +47,4 @@ var loadCountryAutoComplete = () => {
 };
 
 loadCountryAutoComplete();
+dfeAutocomplete({});

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -6,20 +6,24 @@
 #  age_range_max       :integer
 #  age_range_min       :integer
 #  recommendation      :string           default("unknown"), not null
+#  subjects            :text             default([]), not null, is an Array
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  age_range_note_id   :bigint
 #  application_form_id :bigint           not null
+#  subjects_note_id    :bigint
 #
 # Indexes
 #
 #  index_assessments_on_age_range_note_id    (age_range_note_id)
 #  index_assessments_on_application_form_id  (application_form_id)
+#  index_assessments_on_subjects_note_id     (subjects_note_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (age_range_note_id => notes.id)
 #  fk_rails_...  (application_form_id => application_forms.id)
+#  fk_rails_...  (subjects_note_id => notes.id)
 #
 class Assessment < ApplicationRecord
   belongs_to :application_form
@@ -28,6 +32,7 @@ class Assessment < ApplicationRecord
   has_many :further_information_requests
 
   belongs_to :age_range_note, class_name: "Note", optional: true
+  belongs_to :subjects_note, class_name: "Note", optional: true
 
   enum :recommendation,
        {

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -64,6 +64,26 @@
     <%= f.govuk_number_field :age_range_min, width: 3 %>
     <%= f.govuk_number_field :age_range_max, width: 3 %>
     <%= f.govuk_text_area :age_range_note %>
+
+    <h2 class="govuk-heading-m">Which subjects can the applicant teach in England?</h2>
+    <p class="govuk-hint">You can enter up to three</p>
+    <p class="govuk-body">Based on the evidence the applicant has provided, you can either copy the subjects they entered if you agree, or edit them.</p>
+
+    <% (1..3).map { |i| "subject_#{i}" }.each do |field| %>
+      <%= render DfE::Autocomplete::View.new(
+        f,
+        attribute_name: field,
+        form_field: f.govuk_select(
+          field,
+          options_for_select(
+            Subject.all.map { |subject| [subject.name, subject.id] }.unshift([nil, nil]),
+            f.object.send(field),
+          ),
+        )
+      ) %>
+    <% end %>
+
+    <%= f.govuk_text_area :subjects_note %>
   <% end %>
 
   <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "Has the applicant completed this section to your satisfaction?", size: "s" } do %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -66,6 +66,8 @@
     - age_range_min
     - age_range_max
     - age_range_note_id
+    - subjects
+    - subjects_note_id
   :countries:
     - id
     - code

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,6 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "DfE"
   inflect.acronym "DQT"
   inflect.uncountable %w[staff]
 end

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -105,5 +105,7 @@ en:
               blank: Select an assessor to assign
         assessor_interface/assessment_section_form:
           attributes:
+            subject_1:
+              blank: Enter the subject
             selected_failure_reasons:
               blank: Select the reasons for your recommendation

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -37,6 +37,10 @@ en:
         age_range_min: From
         age_range_max: To
         age_range_note: If you've entered a new range please explain why (optional)
+        subject_1: Subject 1
+        subject_2: Subject 2 (optional)
+        subject_3: Subject 3 (optional)
+        subjects_note: If you've edited the subjects please explain why (optional)
         failure_reason_notes: Note to the applicant
       qualification:
         add_another_options:

--- a/config/locales/subjects.en.yml
+++ b/config/locales/subjects.en.yml
@@ -19,7 +19,7 @@ en:
     computer_science: Computer science
     construction_and_the_built_environment: Construction and the built environment"
     dance: Dance
-    design: Design"
+    design: Design
     design_and_technology: Design and technology
     drama: Drama
     early_years_teaching: Early years teaching

--- a/db/migrate/20221007090326_add_subjects_to_assessments.rb
+++ b/db/migrate/20221007090326_add_subjects_to_assessments.rb
@@ -1,0 +1,8 @@
+class AddSubjectsToAssessments < ActiveRecord::Migration[7.0]
+  def change
+    change_table :assessments, bulk: true do |t|
+      t.column :subjects, :text, array: true, default: [], null: false
+      t.references :subjects_note, foreign_key: { to_table: :notes }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_05_143211) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_07_090326) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -98,8 +98,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_05_143211) do
     t.integer "age_range_min"
     t.integer "age_range_max"
     t.bigint "age_range_note_id"
+    t.text "subjects", default: [], null: false, array: true
+    t.bigint "subjects_note_id"
     t.index ["age_range_note_id"], name: "index_assessments_on_age_range_note_id"
     t.index ["application_form_id"], name: "index_assessments_on_application_form_id"
+    t.index ["subjects_note_id"], name: "index_assessments_on_subjects_note_id"
   end
 
   create_table "countries", force: :cascade do |t|
@@ -314,6 +317,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_05_143211) do
   add_foreign_key "assessment_sections", "assessments"
   add_foreign_key "assessments", "application_forms"
   add_foreign_key "assessments", "notes", column: "age_range_note_id"
+  add_foreign_key "assessments", "notes", column: "subjects_note_id"
   add_foreign_key "eligibility_checks", "regions"
   add_foreign_key "notes", "application_forms"
   add_foreign_key "notes", "staff", column: "author_id"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": "true",
   "dependencies": {
     "@ministryofjustice/frontend": "^1.6.0",
+    "dfe-autocomplete": "github:DFE-Digital/dfe-autocomplete",
     "esbuild": "^0.15.10",
     "govuk-country-and-territory-autocomplete": "^1.0.2",
     "govuk-frontend": "^4.3.1",

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -6,20 +6,24 @@
 #  age_range_max       :integer
 #  age_range_min       :integer
 #  recommendation      :string           default("unknown"), not null
+#  subjects            :text             default([]), not null, is an Array
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  age_range_note_id   :bigint
 #  application_form_id :bigint           not null
+#  subjects_note_id    :bigint
 #
 # Indexes
 #
 #  index_assessments_on_age_range_note_id    (age_range_note_id)
 #  index_assessments_on_application_form_id  (application_form_id)
+#  index_assessments_on_subjects_note_id     (subjects_note_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (age_range_note_id => notes.id)
 #  fk_rails_...  (application_form_id => application_forms.id)
+#  fk_rails_...  (subjects_note_id => notes.id)
 #
 FactoryBot.define do
   factory :assessment do

--- a/spec/forms/assessor_interface/age_range_subjects_form_spec.rb
+++ b/spec/forms/assessor_interface/age_range_subjects_form_spec.rb
@@ -39,6 +39,11 @@ RSpec.describe AssessorInterface::AgeRangeSubjectsForm, type: :model do
     end
 
     it { is_expected.to_not validate_presence_of(:age_range_note) }
+
+    it { is_expected.to validate_presence_of(:subject_1) }
+    it { is_expected.to_not validate_presence_of(:subject_2) }
+    it { is_expected.to_not validate_presence_of(:subject_3) }
+    it { is_expected.to_not validate_presence_of(:subjects_note) }
   end
 
   describe "#save" do
@@ -52,7 +57,12 @@ RSpec.describe AssessorInterface::AgeRangeSubjectsForm, type: :model do
 
     describe "with valid attributes and no note" do
       let(:attributes) do
-        { passed: true, age_range_min: "7", age_range_max: "11" }
+        {
+          passed: true,
+          age_range_min: "7",
+          age_range_max: "11",
+          subject_1: "Subject",
+        }
       end
 
       it { is_expected.to be true }
@@ -63,6 +73,9 @@ RSpec.describe AssessorInterface::AgeRangeSubjectsForm, type: :model do
         expect(assessment.age_range_min).to eq(7)
         expect(assessment.age_range_max).to eq(11)
         expect(assessment.age_range_note).to be_nil
+
+        expect(assessment.subjects).to eq(%w[Subject])
+        expect(assessment.subjects_note).to be_nil
       end
     end
 
@@ -73,6 +86,8 @@ RSpec.describe AssessorInterface::AgeRangeSubjectsForm, type: :model do
           age_range_min: "7",
           age_range_max: "11",
           age_range_note: "A note.",
+          subject_1: "Subject",
+          subjects_note: "Another note.",
         }
       end
 
@@ -82,6 +97,7 @@ RSpec.describe AssessorInterface::AgeRangeSubjectsForm, type: :model do
         save # rubocop:disable Rails/SaveBang
 
         expect(assessment.age_range_note.text).to eq("A note.")
+        expect(assessment.subjects_note.text).to eq("Another note.")
       end
     end
   end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -8,20 +8,24 @@
 #  age_range_max       :integer
 #  age_range_min       :integer
 #  recommendation      :string           default("unknown"), not null
+#  subjects            :text             default([]), not null, is an Array
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  age_range_note_id   :bigint
 #  application_form_id :bigint           not null
+#  subjects_note_id    :bigint
 #
 # Indexes
 #
 #  index_assessments_on_age_range_note_id    (age_range_note_id)
 #  index_assessments_on_application_form_id  (application_form_id)
+#  index_assessments_on_subjects_note_id     (subjects_note_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (age_range_note_id => notes.id)
 #  fk_rails_...  (application_form_id => application_forms.id)
+#  fk_rails_...  (subjects_note_id => notes.id)
 #
 require "rails_helper"
 

--- a/spec/support/autoload/page_objects/assessor_interface/verify_age_range_subjects_page.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/verify_age_range_subjects_page.rb
@@ -20,6 +20,17 @@ module PageObjects
                 "#assessor-interface-assessment-section-form-age-range-note-field"
       end
 
+      section :subjects_form, "form" do
+        element :first_field,
+                "#assessor-interface-assessment-section-form-subject-1-field"
+        element :second_field,
+                "#assessor-interface-assessment-section-form-subject-2-field"
+        element :third_field,
+                "#assessor-interface-assessment-section-form-subject-3-field"
+        element :note_textarea,
+                "#assessor-interface-assessment-section-form-subjects-note-field"
+      end
+
       def age_range
         cards&.first
       end

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_age_range_and_subjects
 
     when_i_fill_in_age_range
+    and_i_fill_in_subjects
     and_i_choose_verify_age_range_subjects_yes
     then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_verify_age_range_subjects_completed
@@ -83,6 +84,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_age_range_and_subjects
 
     when_i_fill_in_age_range
+    and_i_fill_in_subjects
     and_i_choose_verify_age_range_subjects_no
     then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_verify_age_range_subjects_action_required
@@ -242,6 +244,13 @@ RSpec.describe "Assessor check submitted details", type: :system do
     verify_age_range_subjects_page.age_range_form.minimum.fill_in with: "7"
     verify_age_range_subjects_page.age_range_form.maximum.fill_in with: "11"
     verify_age_range_subjects_page.age_range_form.note.fill_in with: "A note."
+  end
+
+  def and_i_fill_in_subjects
+    verify_age_range_subjects_page.subjects_form.first_field.fill_in with:
+      "Physics"
+    verify_age_range_subjects_page.subjects_form.note_textarea.fill_in with:
+      "Another note."
   end
 
   def and_i_choose_verify_age_range_subjects_yes

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,6 +81,12 @@ corejs-typeahead@^1.1.1:
   dependencies:
     jquery ">=1.11"
 
+"dfe-autocomplete@github:DFE-Digital/dfe-autocomplete":
+  version "0.0.1"
+  resolved "https://codeload.github.com/DFE-Digital/dfe-autocomplete/tar.gz/7bf95631e7c912795b1994b04bfd86997d8bd2ff"
+  dependencies:
+    accessible-autocomplete "^2.0.4"
+
 esbuild-android-64@0.15.10:
   version "0.15.10"
   resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.10.tgz#8a59a84acbf2eca96996cadc35642cf055c494f0"


### PR DESCRIPTION
This adds a new subjects section to the assessment section view allowing assessors to provide overridden values for the subjects provided by the teacher.

[Trello Card](https://trello.com/c/tEV44pKM/981-add-assessment-age-range-and-subjects)

## Screenshot

![Screenshot 2022-10-07 at 11 53 09](https://user-images.githubusercontent.com/510498/194541974-51abcd87-856f-4400-865f-2a0cad209787.png)
