### PR TITLE
Add further information check your answers

### DIFF
--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -32,8 +32,7 @@ module CheckYourAnswersSummary
     end
 
     def has_translation?(field)
-      object = model.send(field[:key])
-
+      object = value_for(field)
       return false unless object.is_a?(Document)
       object.translated_uploads.any?
     end
@@ -53,11 +52,15 @@ module CheckYourAnswersSummary
       fields.filter_map { |key, options| options&.merge(key:) }
     end
 
+    def value_for(field)
+      field[:value].presence || model.send(field[:key])
+    end
+
     def row_for_field(field)
       {
         key: field[:key],
         title: row_title_for(field),
-        value: format_value(model.send(field[:key]), field),
+        value: format_value(value_for(field), field),
         href: changeable ? field.fetch(:href) : nil,
       }
     end

--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -56,12 +56,26 @@ module CheckYourAnswersSummary
       field[:value].presence || model.send(field[:key])
     end
 
+    def href_for(field)
+      path = field.fetch(:href)
+      next_path = request.path
+
+      if path.is_a?(String)
+        return "#{path}?#{URI.encode_www_form(next: next_path)}"
+      end
+
+      Rails.application.routes.url_helpers.polymorphic_path(
+        path,
+        next: next_path,
+      )
+    end
+
     def row_for_field(field)
       {
         key: field[:key],
         title: row_title_for(field),
         value: format_value(value_for(field), field),
-        href: changeable ? field.fetch(:href) : nil,
+        href: changeable ? href_for(field) : nil,
       }
     end
 

--- a/app/controllers/concerns/handle_application_form_section.rb
+++ b/app/controllers/concerns/handle_application_form_section.rb
@@ -15,7 +15,8 @@ module HandleApplicationFormSection
         redirect_to if_success_then_redirect.try(:call) ||
                       if_success_then_redirect
       else
-        redirect_to %i[teacher_interface application_form]
+        redirect_to params[:next].presence ||
+                      %i[teacher_interface application_form]
       end
     else
       render if_failure_then_render, status: :unprocessable_entity

--- a/app/controllers/concerns/handle_application_form_section.rb
+++ b/app/controllers/concerns/handle_application_form_section.rb
@@ -8,7 +8,7 @@ module HandleApplicationFormSection
     if_success_then_redirect:,
     if_failure_then_render:
   )
-    save_and_continue = params[:next] == "save_and_continue"
+    save_and_continue = params[:button] == "save_and_continue"
 
     if form.save(validate: save_and_continue)
       if save_and_continue

--- a/app/controllers/teacher_interface/documents_controller.rb
+++ b/app/controllers/teacher_interface/documents_controller.rb
@@ -32,9 +32,11 @@ module TeacherInterface
           if @add_another_upload_form.add_another
             new_teacher_interface_application_form_document_upload_path(
               document,
+              next: params[:next],
             )
           else
-            DocumentContinueRedirection.call(document:)
+            params[:next].presence ||
+              DocumentContinueRedirection.call(document:)
           end
         end,
         if_failure_then_render: :edit,

--- a/app/controllers/teacher_interface/further_information_request_items_controller.rb
+++ b/app/controllers/teacher_interface/further_information_request_items_controller.rb
@@ -46,7 +46,7 @@ module TeacherInterface
     end
 
     def update_document
-      if params[:next] == "save_and_continue"
+      if params[:button] == "save_and_continue"
         redirect_to document_redirection
       else
         redirect_to further_information_request_redirection

--- a/app/controllers/teacher_interface/further_information_request_items_controller.rb
+++ b/app/controllers/teacher_interface/further_information_request_items_controller.rb
@@ -40,16 +40,16 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @further_information_request_item_text_form,
-        if_success_then_redirect: further_information_request_redirection,
+        if_success_then_redirect: further_information_request_path,
         if_failure_then_render: :edit,
       )
     end
 
     def update_document
       if params[:button] == "save_and_continue"
-        redirect_to document_redirection
+        redirect_to document_path
       else
-        redirect_to further_information_request_redirection
+        redirect_to further_information_request_path
       end
     end
 
@@ -79,17 +79,16 @@ module TeacherInterface
       ).permit(:response)
     end
 
-    def further_information_request_redirection
-      [:teacher_interface, :application_form, further_information_request]
+    def further_information_request_path
+      params[:next].presence ||
+        [:teacher_interface, :application_form, further_information_request]
     end
 
-    def document_redirection
-      [
-        :edit,
-        :teacher_interface,
-        :application_form,
+    def document_path
+      edit_teacher_interface_application_form_document_path(
         further_information_request_item.document,
-      ]
+        next: params[:next],
+      )
     end
   end
 end

--- a/app/controllers/teacher_interface/further_information_requests_controller.rb
+++ b/app/controllers/teacher_interface/further_information_requests_controller.rb
@@ -1,6 +1,16 @@
 module TeacherInterface
   class FurtherInformationRequestsController < BaseController
+    before_action :load_view_object
+
     def show
+    end
+
+    def edit
+    end
+
+    private
+
+    def load_view_object
       @view_object =
         FurtherInformationRequestViewObject.new(current_teacher:, params:)
     end

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -16,12 +16,7 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @upload_form,
-        if_success_then_redirect: [
-          :edit,
-          :teacher_interface,
-          :application_form,
-          @document,
-        ],
+        if_success_then_redirect: document_path,
         if_failure_then_render: :new,
       )
     end
@@ -38,7 +33,7 @@ module TeacherInterface
         )
 
       if @delete_upload_form.save(validate: true)
-        redirect_to [:edit, :teacher_interface, :application_form, @document]
+        redirect_to document_path
       else
         render :delete, status: :unprocessable_entity
       end
@@ -59,6 +54,13 @@ module TeacherInterface
       )[
         :teacher_interface_upload_form
       ] || {}
+    end
+
+    def document_path
+      edit_teacher_interface_application_form_document_path(
+        @document,
+        next: params[:next],
+      )
     end
   end
 end

--- a/app/helpers/back_link_helper.rb
+++ b/app/helpers/back_link_helper.rb
@@ -1,5 +1,5 @@
 module BackLinkHelper
   def back_link_url(back = url_for(:back))
-    back
+    params[:next].presence || back
   end
 end

--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -27,8 +27,6 @@ class FurtherInformationRequestItem < ApplicationRecord
     completed? ? :completed : :not_started
   end
 
-  private
-
   def completed?
     (text? && response.present?) || (document? && document.uploaded?)
   end

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -27,6 +27,10 @@ module TeacherInterface
         end
     end
 
+    def can_check_answers?
+      further_information_request.items.all?(&:completed?)
+    end
+
     private
 
     attr_reader :current_teacher, :params

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -40,6 +40,25 @@ module TeacherInterface
       further_information_request.items.all?(&:completed?)
     end
 
+    def check_your_answers_fields
+      further_information_request
+        .items
+        .order(:created_at)
+        .each_with_object({}) do |item, memo|
+          memo[item.id] = {
+            title: item_text(item),
+            value: item.text? ? item.response : item.document,
+            href: [
+              :edit,
+              :teacher_interface,
+              :application_form,
+              further_information_request,
+              item,
+            ],
+          }
+        end
+    end
+
     private
 
     attr_reader :current_teacher, :params

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -7,6 +7,15 @@ module TeacherInterface
       @params = params
     end
 
+    def further_information_request
+      @further_information_request ||=
+        FurtherInformationRequest
+          .joins(:assessment)
+          .requested
+          .where(assessments: { application_form: })
+          .find(params[:id])
+    end
+
     def task_items
       further_information_request
         .items
@@ -37,15 +46,6 @@ module TeacherInterface
 
     def application_form
       @application_form ||= current_teacher.application_form
-    end
-
-    def further_information_request
-      @further_information_request ||=
-        FurtherInformationRequest
-          .joins(:assessment)
-          .requested
-          .where(assessments: { application_form: })
-          .find(params[:id])
     end
 
     def item_text(item)

--- a/app/views/shared/_save_submit_buttons.html.erb
+++ b/app/views/shared/_save_submit_buttons.html.erb
@@ -1,3 +1,3 @@
-<%= f.govuk_submit "Continue", name: "next", value: "save_and_continue", prevent_double_click: false do %>
-  <%= f.govuk_submit "Save and come back later", name: "next", value: "save_and_return", secondary: true, prevent_double_click: false %>
+<%= f.govuk_submit name: "button", value: "save_and_continue", prevent_double_click: false do %>
+  <%= f.govuk_submit "Save and come back later", name: "button", value: "save_and_return", secondary: true, prevent_double_click: false %>
 <% end %>

--- a/app/views/teacher_interface/documents/edit.html.erb
+++ b/app/views/teacher_interface/documents/edit.html.erb
@@ -12,7 +12,7 @@
       row.value(text: upload.attachment.filename)
       row.action(
         text: "Delete",
-        href: delete_teacher_interface_application_form_document_upload_path(@document, upload),
+        href: delete_teacher_interface_application_form_document_upload_path(@document, upload, next: params[:next]),
         visually_hidden_text: upload.attachment.filename
       )
     end
@@ -20,6 +20,8 @@
 end %>
 
 <%= form_with model: @add_another_upload_form, url: [:teacher_interface, :application_form, @document], method: :patch do |f| %>
+  <%= hidden_field_tag :next, params[:next] %>
+
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_radio_buttons_fieldset :add_another,

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -1,11 +1,13 @@
 <% content_for :page_title, "Apply for qualified teacher status (QTS)" %>
-<% content_for :back_link_url, teacher_interface_application_form_further_information_request_path %>
+<% content_for :back_link_url, back_link_url(teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
 
 <h1 class="govuk-heading-l">Further information required</h1>
 <h3 class="govuk-heading-s">Notes from the assessor</h3>
 <p class="govuk-inset-text"><%= @further_information_request_item.assessor_notes %></p>
 
 <%= form_with model: @further_information_request_item_text_form, url: teacher_interface_application_form_further_information_request_further_information_request_item_path, method: :put do |f| %>
+  <%= hidden_field_tag :next, params[:next] %>
+
   <% if @further_information_request_item.text? %>
     <%= f.govuk_text_area :response, label: { size: "s" } %>
   <% end %>

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -14,7 +14,5 @@
     <p class="govuk-body">You can upload this document on the next screen.</p>
   <% end %>
 
-  <%= f.govuk_submit name: "next", value: "save_and_continue", prevent_double_click: false do %>
-    <%= f.govuk_submit "Save and come back later", name: "next", value: "save_and_return", secondary: true, prevent_double_click: false %>
-  <% end %>
+  <%= render "shared/save_submit_buttons", f: %>
 <% end %>

--- a/app/views/teacher_interface/further_information_requests/edit.html.erb
+++ b/app/views/teacher_interface/further_information_requests/edit.html.erb
@@ -1,0 +1,6 @@
+<% content_for :page_title, "Apply for qualified teacher status (QTS)" %>
+<% content_for :back_link_url, teacher_interface_application_form_further_information_request_path(@view_object.further_information_request) %>
+
+<h1 class="govuk-heading-xl">
+  Check your answers before submitting your application
+</h1>

--- a/app/views/teacher_interface/further_information_requests/edit.html.erb
+++ b/app/views/teacher_interface/further_information_requests/edit.html.erb
@@ -4,3 +4,9 @@
 <h1 class="govuk-heading-xl">
   Check your answers before submitting your application
 </h1>
+
+<%= render(CheckYourAnswersSummary::Component.new(
+  model: @view_object.further_information_request,
+  title: t(".check_your_answers"),
+  fields: @view_object.check_your_answers_fields
+)) %>

--- a/app/views/teacher_interface/further_information_requests/show.html.erb
+++ b/app/views/teacher_interface/further_information_requests/show.html.erb
@@ -25,4 +25,8 @@
   </li>
 </ol>
 
+<% if @view_object.can_check_answers? %>
+  <%= govuk_button_link_to "Check your answers", edit_teacher_interface_application_form_further_information_request_path(@view_object.further_information_request) %>
+<% end %>
+
 <%= govuk_button_link_to "Save and sign out", destroy_teacher_session_path, secondary: true %>

--- a/app/views/teacher_interface/uploads/delete.html.erb
+++ b/app/views/teacher_interface/uploads/delete.html.erb
@@ -2,6 +2,8 @@
 <% content_for :back_link_url, edit_teacher_interface_application_form_document_path(@document) %>
 
 <%= form_with model: @delete_upload_form, url: [:teacher_interface, :application_form, @document, @upload], method: :delete do |f| %>
+  <%= hidden_field_tag :next, params[:next] %>
+
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :confirm,
@@ -11,5 +13,5 @@
                                        inline: true,
                                        legend: { text: "Are you sure you want to delete #{@upload.attachment.filename}?", size: "l", tag: "h1" } %>
 
-  <%= f.govuk_submit "Continue", prevent_double_click: false %>
+  <%= f.govuk_submit prevent_double_click: false %>
 <% end %>

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -85,6 +85,8 @@
 <% end %>
 
 <%= form_with model: @upload_form, url: [:teacher_interface, :application_form, @document, :uploads] do |f| %>
+  <%= hidden_field_tag :next, params[:next] %>
+
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_file_field :original_attachment,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,7 +161,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :further_information_requests, only: %i[show] do
+      resources :further_information_requests, only: %i[show edit] do
         resources :further_information_request_items,
                   path: "/items",
                   only: %i[edit update]

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change string")
-      expect(a.attribute("href").value).to eq("/string")
+      expect(a.attribute("href").value).to eq("/string?next=%2F")
     end
   end
 
@@ -136,7 +136,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change number")
-      expect(a.attribute("href").value).to eq("/number")
+      expect(a.attribute("href").value).to eq("/number?next=%2F")
     end
   end
 
@@ -157,7 +157,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change date")
-      expect(a.attribute("href").value).to eq("/date")
+      expect(a.attribute("href").value).to eq("/date?next=%2F")
     end
   end
 
@@ -180,7 +180,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change date without day")
-      expect(a.attribute("href").value).to eq("/date_without_day")
+      expect(a.attribute("href").value).to eq("/date_without_day?next=%2F")
     end
   end
 
@@ -201,7 +201,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change a custom key")
-      expect(a.attribute("href").value).to eq("/custom_key")
+      expect(a.attribute("href").value).to eq("/custom_key?next=%2F")
     end
   end
 
@@ -220,7 +220,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change nil value")
-      expect(a.attribute("href").value).to eq("/nil_value")
+      expect(a.attribute("href").value).to eq("/nil_value?next=%2F")
     end
   end
 
@@ -239,7 +239,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change boolean")
-      expect(a.attribute("href").value).to eq("/boolean")
+      expect(a.attribute("href").value).to eq("/boolean?next=%2F")
     end
   end
 
@@ -263,7 +263,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change document")
-      expect(a.attribute("href").value).to eq("/document")
+      expect(a.attribute("href").value).to eq("/document?next=%2F")
     end
   end
 
@@ -282,7 +282,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change array")
-      expect(a.attribute("href").value).to eq("/array")
+      expect(a.attribute("href").value).to eq("/array?next=%2F")
     end
   end
 
@@ -309,7 +309,9 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
         a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
         expect(a.text.strip).to eq("Change translatable document")
-        expect(a.attribute("href").value).to eq("/translatable-document")
+        expect(a.attribute("href").value).to eq(
+          "/translatable-document?next=%2F",
+        )
       end
     end
 
@@ -335,7 +337,9 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
         a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
         expect(a.text.strip).to eq("Change translatable document translation")
-        expect(a.attribute("href").value).to eq("/translatable-document")
+        expect(a.attribute("href").value).to eq(
+          "/translatable-document?next=%2F",
+        )
       end
     end
 

--- a/spec/controllers/concerns/handle_application_form_section_spec.rb
+++ b/spec/controllers/concerns/handle_application_form_section_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe HandleApplicationFormSection, type: :controller do
     end
 
     context "when save and come back later" do
-      let(:params) { { next: "save_and_return" } }
+      let(:params) { { button: "save_and_return" } }
 
       before { allow(form).to receive(:save).and_return(true) }
 

--- a/spec/controllers/concerns/handle_application_form_section_spec.rb
+++ b/spec/controllers/concerns/handle_application_form_section_spec.rb
@@ -58,6 +58,15 @@ RSpec.describe HandleApplicationFormSection, type: :controller do
         )
         handle_application_form_section
       end
+
+      context "with a next path" do
+        before { params[:next] = "/next" }
+
+        it "redirects to application form" do
+          expect(controller).to receive(:redirect_to).with("/next")
+          handle_application_form_section
+        end
+      end
     end
   end
 end

--- a/spec/factories/further_information_request_items.rb
+++ b/spec/factories/further_information_request_items.rb
@@ -30,7 +30,9 @@ FactoryBot.define do
     trait :with_document_response do
       information_type { "document" }
 
-      after(:create) { |item| create(:document, documentable: item) }
+      after(:create) do |item|
+        create(:document, :identification_document, documentable: item)
+      end
     end
 
     trait :completed do

--- a/spec/factories/further_information_request_items.rb
+++ b/spec/factories/further_information_request_items.rb
@@ -32,5 +32,13 @@ FactoryBot.define do
 
       after(:create) { |item| create(:document, documentable: item) }
     end
+
+    trait :completed do
+      response { Faker::Lorem.paragraph if text? }
+
+      after(:create) do |item, _evaluator|
+        create(:upload, document: item) if item.document?
+      end
+    end
   end
 end

--- a/spec/factories/further_information_request_items.rb
+++ b/spec/factories/further_information_request_items.rb
@@ -39,7 +39,7 @@ FactoryBot.define do
       response { Faker::Lorem.paragraph if text? }
 
       after(:create) do |item, _evaluator|
-        create(:upload, document: item) if item.document?
+        create(:upload, document: item.document) if item.document?
       end
     end
   end

--- a/spec/support/autoload/page_objects/govuk_summary_list.rb
+++ b/spec/support/autoload/page_objects/govuk_summary_list.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  class GovukSummaryList < SitePrism::Section
+    sections :rows, ".govuk-summary-list__row" do
+      element :key, ".govuk-summary-list__key"
+      element :value, ".govuk-summary-list__value"
+      sections :actions, ".govuk-summary-list__actions" do
+        element :link, ".govuk-link"
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/check_further_information_request_answers.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/check_further_information_request_answers.rb
@@ -4,6 +4,7 @@ module PageObjects
       set_url "/teacher/application/further_information_requests/{request_id}/edit"
 
       element :heading, ".govuk-heading-xl"
+      section :summary_list, GovukSummaryList, ".govuk-summary-list"
     end
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/check_further_information_request_answers.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/check_further_information_request_answers.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module TeacherInterface
+    class CheckFurtherInformationRequestAnswers < SitePrism::Page
+      set_url "/teacher/application/further_information_requests/{request_id}/edit"
+
+      element :heading, ".govuk-heading-xl"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/further_information_requested.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/further_information_requested.rb
@@ -5,7 +5,10 @@ module PageObjects
 
       element :heading, ".govuk-heading-l"
       section :task_list, TaskList, ".app-task-list"
-      element :save_and_sign_out_button, ".govuk-button"
+
+      element :check_your_answers_button,
+              ".govuk-button:not(.govuk-button--secondary)"
+      element :save_and_sign_out_button, ".govuk-button.govuk-button--secondary"
     end
   end
 end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -24,6 +24,11 @@ module PageHelpers
     @assign_reviewer_page ||= PageObjects::AssessorInterface::AssignReviewer.new
   end
 
+  def check_further_information_request_answers_page
+    @check_further_information_request_answers_page =
+      PageObjects::TeacherInterface::CheckFurtherInformationRequestAnswers.new
+  end
+
   def check_personal_information_page
     @check_personal_information_page ||=
       PageObjects::AssessorInterface::CheckPersonalInformation.new

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Teacher further information", type: :system do
     given_there_is_an_application_form
   end
 
-  it "shows start page" do
+  it "save and sign out" do
     when_i_visit_the(:further_information_requested_start_page)
     then_i_see_the(:further_information_requested_start_page)
 
@@ -20,7 +20,7 @@ RSpec.describe "Teacher further information", type: :system do
     then_i_see_the(:signed_out_page)
   end
 
-  it "allows filling in a text item" do
+  it "check your answers" do
     when_i_visit_the(
       :further_information_requested_page,
       request_id: further_information_request.id,
@@ -33,13 +33,6 @@ RSpec.describe "Teacher further information", type: :system do
     and_i_click_continue
     then_i_see_the(:further_information_requested_page)
     and_i_see_a_completed_text_task_list_item
-  end
-
-  it "allows filling in a document item" do
-    when_i_visit_the(
-      :further_information_requested_page,
-      request_id: further_information_request.id,
-    )
 
     when_i_click_the_document_task_list_item
     then_i_see_the(:further_information_required_page)
@@ -52,6 +45,9 @@ RSpec.describe "Teacher further information", type: :system do
     when_i_dont_need_to_upload_another_file
     then_i_see_the(:further_information_requested_page)
     and_i_see_a_completed_document_task_list_item
+
+    when_i_click_the_check_your_answers_button
+    then_i_see_the(:check_further_information_request_answers_page)
   end
 
   def given_there_is_an_application_form
@@ -111,29 +107,17 @@ RSpec.describe "Teacher further information", type: :system do
     further_information_requested_page.save_and_sign_out_button.click
   end
 
+  def when_i_click_the_check_your_answers_button
+    further_information_requested_page.check_your_answers_button.click
+  end
+
   def teacher
     @teacher ||= create(:teacher, :confirmed)
   end
 
   def application_form
     @application_form ||=
-      begin
-        application_form =
-          create(:application_form, :further_information_requested, teacher:)
-        request = application_form.assessment.further_information_requests.first
-        create(
-          :further_information_request_item,
-          :with_text_response,
-          further_information_request: request,
-        )
-        create(
-          :further_information_request_item,
-          :with_document_response,
-          further_information_request: request,
-          document: create(:document, :written_statement),
-        )
-        application_form
-      end
+      create(:application_form, :further_information_requested, teacher:)
   end
 
   def further_information_request
@@ -148,7 +132,7 @@ RSpec.describe "Teacher further information", type: :system do
 
   def document_task_list_item
     further_information_requested_page.task_list.find_item(
-      "Upload your written statement document",
+      "Upload your identity document",
     )
   end
 end

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe "Teacher further information", type: :system do
     when_i_click_the_check_your_answers_button
     then_i_see_the(:check_further_information_request_answers_page)
     and_i_see_the_check_your_answers_items
+
+    when_i_click_the_text_check_your_answers_item
+    and_i_click_continue
+    then_i_see_the(:check_further_information_request_answers_page)
+
+    when_i_click_the_document_check_your_answers_item
+    and_i_click_continue
+    when_i_dont_need_to_upload_another_file
+    then_i_see_the(:check_further_information_request_answers_page)
   end
 
   def given_there_is_an_application_form
@@ -121,7 +130,15 @@ RSpec.describe "Teacher further information", type: :system do
       "Tell us more about the subjects you can teach",
     )
 
-    expect(rows.second.key.text).to eq("Upload your written statement document")
+    expect(rows.second.key.text).to eq("Upload your identity document")
+  end
+
+  def when_i_click_the_text_check_your_answers_item
+    text_check_answers_item.actions.first.link.click
+  end
+
+  def when_i_click_the_document_check_your_answers_item
+    document_check_answers_item.actions.first.link.click
   end
 
   def teacher
@@ -143,9 +160,17 @@ RSpec.describe "Teacher further information", type: :system do
     )
   end
 
+  def text_check_answers_item
+    check_further_information_request_answers_page.summary_list.rows.first
+  end
+
   def document_task_list_item
     further_information_requested_page.task_list.find_item(
       "Upload your identity document",
     )
+  end
+
+  def document_check_answers_item
+    check_further_information_request_answers_page.summary_list.rows.second
   end
 end

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe "Teacher further information", type: :system do
 
     when_i_click_the_check_your_answers_button
     then_i_see_the(:check_further_information_request_answers_page)
+    and_i_see_the_check_your_answers_items
   end
 
   def given_there_is_an_application_form
@@ -109,6 +110,18 @@ RSpec.describe "Teacher further information", type: :system do
 
   def when_i_click_the_check_your_answers_button
     further_information_requested_page.check_your_answers_button.click
+  end
+
+  def and_i_see_the_check_your_answers_items
+    rows = check_further_information_request_answers_page.summary_list.rows
+
+    expect(rows.count).to eq(2)
+
+    expect(rows.first.key.text).to eq(
+      "Tell us more about the subjects you can teach",
+    )
+
+    expect(rows.second.key.text).to eq("Upload your written statement document")
   end
 
   def teacher

--- a/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
@@ -11,26 +11,22 @@ RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
   end
 
   let(:current_teacher) { create(:teacher, :confirmed) }
-  let(:params) { {} }
+  let(:application_form) { create(:application_form, teacher: current_teacher) }
+  let(:further_information_request) do
+    create(
+      :further_information_request,
+      :requested,
+      assessment: create(:assessment, application_form:),
+    )
+  end
+  let(:params) do
+    {
+      id: further_information_request.id,
+      application_form_id: application_form.id,
+    }
+  end
 
   describe "#task_items" do
-    let(:application_form) do
-      create(:application_form, teacher: current_teacher)
-    end
-    let(:further_information_request) do
-      create(
-        :further_information_request,
-        :requested,
-        assessment: create(:assessment, application_form:),
-      )
-    end
-    let(:params) do
-      {
-        id: further_information_request.id,
-        application_form_id: application_form.id,
-      }
-    end
-
     let!(:text_item) do
       create(
         :further_information_request_item,
@@ -78,6 +74,31 @@ RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
           },
         ],
       )
+    end
+  end
+
+  describe "#can_check_answers?" do
+    subject(:can_check_answers?) { view_object.can_check_answers? }
+
+    context "with uncomplete items" do
+      before do
+        create(:further_information_request_item, further_information_request:)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "with complete items" do
+      before do
+        create(
+          :further_information_request_item,
+          :with_text_response,
+          :completed,
+          further_information_request:,
+        )
+      end
+
+      it { is_expected.to be true }
     end
   end
 end

--- a/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
         :further_information_request_item,
         :with_document_response,
         further_information_request:,
-        document: create(:document, :identification_document),
       )
     end
 
@@ -99,6 +98,58 @@ RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
       end
 
       it { is_expected.to be true }
+    end
+  end
+
+  describe "#check_your_answers_fields" do
+    let!(:text_item) do
+      create(
+        :further_information_request_item,
+        :with_text_response,
+        :completed,
+        further_information_request:,
+      )
+    end
+    let!(:document_item) do
+      create(
+        :further_information_request_item,
+        :with_document_response,
+        :completed,
+        further_information_request:,
+      )
+    end
+
+    subject(:check_your_answers_fields) do
+      view_object.check_your_answers_fields
+    end
+
+    it do
+      is_expected.to eq(
+        {
+          text_item.id => {
+            title: "Tell us more about the subjects you can teach",
+            href: [
+              :edit,
+              :teacher_interface,
+              :application_form,
+              further_information_request,
+              text_item,
+            ],
+            value: text_item.response,
+          },
+          document_item.id => {
+            title: "Upload your identity document",
+            href: [
+              :edit,
+              :teacher_interface,
+              :application_form,
+              further_information_request,
+              document_item,
+            ],
+            value: document_item.document,
+          },
+        },
+      )
     end
   end
 end


### PR DESCRIPTION
This adds a new page for teachers when they're submitting a further information request where they check the answers they gave. I've also added functionality where the user will be taken back to that page if they click on a "Change" link which we can re-use for the application form.

[Trello Card](https://trello.com/c/Ndataxwr/989-teacher-fi-check-your-answers)

## Screenshots

<img width="689" alt="Screenshot 2022-10-10 at 09 30 18" src="https://user-images.githubusercontent.com/510498/194826408-6ea56bc9-bf92-4fcb-abc5-60c8700b050b.png">
<img width="701" alt="Screenshot 2022-10-10 at 09 30 27" src="https://user-images.githubusercontent.com/510498/194826413-3a22637f-c427-4285-a4b9-25742fd285ef.png">
