### PR TITLE
Submit further information

### DIFF
--- a/app/controllers/teacher_interface/further_information_requests_controller.rb
+++ b/app/controllers/teacher_interface/further_information_requests_controller.rb
@@ -8,6 +8,15 @@ module TeacherInterface
     def edit
     end
 
+    def update
+      SubmitFurtherInformationRequest.call(
+        further_information_request: @view_object.further_information_request,
+        user: current_teacher,
+      )
+
+      redirect_to %i[teacher_interface application_form]
+    end
+
     private
 
     def load_view_object

--- a/app/services/submit_further_information_request.rb
+++ b/app/services/submit_further_information_request.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class SubmitFurtherInformationRequest
+  include ServicePattern
+
+  def initialize(further_information_request:, user:)
+    @further_information_request = further_information_request
+    @user = user
+  end
+
+  def call
+    raise AlreadySubmitted if further_information_request.received?
+
+    ActiveRecord::Base.transaction do
+      further_information_request.received!
+
+      ChangeApplicationFormState.call(
+        application_form:,
+        user:,
+        new_state: :further_information_received,
+      )
+    end
+  end
+
+  class AlreadySubmitted < StandardError
+  end
+
+  private
+
+  attr_reader :further_information_request, :user
+
+  def application_form
+    @application_form ||=
+      further_information_request.assessment.application_form
+  end
+end

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -40,6 +40,8 @@ module TeacherInterface
       further_information_request.items.all?(&:completed?)
     end
 
+    alias_method :can_submit?, :can_check_answers?
+
     def check_your_answers_fields
       further_information_request
         .items

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -61,18 +61,25 @@
   <p class="govuk-body">The next screen will take you to the first section you need to complete.</p>
   <%= govuk_start_button(text: "Start now", href: teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
 <% else %>
-  <%= govuk_panel(title_text: "Application complete") do %>
+  <%= govuk_panel(title_text: @application_form.further_information_received? ? "Further information successfully submitted" : "Application complete") do %>
     Your reference number
     <br />
     <strong><%= @application_form.reference %></strong>
   <% end %>
 
-  <p class="govuk-body">We’ve received your application for QTS and we’ve sent you a confirmation email.</p>
-  <p class="govuk-body">Keep the email safe, as you may need your reference number for future correspondence about your application.</p>
+  <% if @application_form.further_information_received? %>
+    <h3 class="govuk-heading-m">You’ve successfully submitted your further information</h3>
+    <p class="govuk-body">We’ve sent you an email to confirm that we’ve received it.</p>
+    <p class="govuk-body">Once the assessor has checked the documents to make sure you’ve provided all of the requested information, they’ll continue reviewing your QTS application.</p>
+    <p class="govuk-body">You can now close this page.</p>
+  <% else %>
+    <p class="govuk-body">We’ve received your application for QTS and we’ve sent you a confirmation email.</p>
+    <p class="govuk-body">Keep the email safe, as you may need your reference number for future correspondence about your application.</p>
 
-  <h2 class="govuk-heading-m">What happens next</h2>
-  <p class="govuk-body">We aim to review your application within 1 month. If we need more information, we’ll email you again.</p>
-  <p class="govuk-body">We aim to reach a final decision on QTS applications within 80 working days (4 months) of submission.</p>
+    <h2 class="govuk-heading-m">What happens next</h2>
+    <p class="govuk-body">We aim to review your application within 1 month. If we need more information, we’ll email you again.</p>
+    <p class="govuk-body">We aim to reach a final decision on QTS applications within 80 working days (4 months) of submission.</p>
+  <% end %>
 
   <h2 class="govuk-heading-s govuk-!-font-weight-regular">If you have any questions, contact:</h2>
   <p class="govuk-body"><a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.</p>

--- a/app/views/teacher_interface/further_information_requests/edit.html.erb
+++ b/app/views/teacher_interface/further_information_requests/edit.html.erb
@@ -10,3 +10,9 @@
   title: t(".check_your_answers"),
   fields: @view_object.check_your_answers_fields
 )) %>
+
+<% if @view_object.can_submit? %>
+  <h3 class="govuk-heading-m">Submitting your further information</h3>
+  <p class="govuk-body">By selecting the ‘Submit application button’ you confirm that, to the best of your knowledge, the details you’ve provided are correct.</p>
+  <%= govuk_button_to "Submit your application", teacher_interface_application_form_further_information_request_path(@view_object.further_information_request), method: :patch %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,7 +165,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :further_information_requests, only: %i[show edit] do
+      resources :further_information_requests, only: %i[show edit update] do
         resources :further_information_request_items,
                   path: "/items",
                   only: %i[edit update]

--- a/spec/services/submit_further_information_request_spec.rb
+++ b/spec/services/submit_further_information_request_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubmitFurtherInformationRequest do
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:further_information_request) do
+    create(
+      :further_information_request,
+      :requested,
+      assessment: create(:assessment, application_form:),
+    )
+  end
+  let(:user) { application_form.teacher }
+
+  subject(:call) { described_class.call(further_information_request:, user:) }
+
+  context "with an already received further information request" do
+    before { further_information_request.received! }
+
+    it "raises an error" do
+      expect { call }.to raise_error(
+        SubmitFurtherInformationRequest::AlreadySubmitted,
+      )
+    end
+  end
+
+  it "changes the further information request state to received" do
+    expect { call }.to change(further_information_request, :received?).from(
+      false,
+    ).to(true)
+  end
+
+  it "changes the application form state to further information received" do
+    expect { call }.to change(
+      application_form,
+      :further_information_received?,
+    ).from(false).to(true)
+  end
+
+  describe "recording timeline event" do
+    subject(:timeline_event) do
+      TimelineEvent.state_changed.where(application_form:).last
+    end
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to_not be_nil }
+
+      it "sets the attributes correctly" do
+        expect(timeline_event.creator).to eq(user)
+        expect(timeline_event.old_state).to eq("submitted")
+        expect(timeline_event.new_state).to eq("further_information_received")
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/govuk_panel.rb
+++ b/spec/support/autoload/page_objects/govuk_panel.rb
@@ -1,0 +1,6 @@
+module PageObjects
+  class GovukPanel < SitePrism::Section
+    element :title, ".govuk-panel__title"
+    element :body, ".govuk-panel__body"
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/check_further_information_request_answers.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/check_further_information_request_answers.rb
@@ -5,6 +5,7 @@ module PageObjects
 
       element :heading, ".govuk-heading-xl"
       section :summary_list, GovukSummaryList, ".govuk-summary-list"
+      element :submit_button, ".govuk-button"
     end
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/submitted_application.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/submitted_application.rb
@@ -1,9 +1,10 @@
 module PageObjects
   module TeacherInterface
     class SubmittedApplication < SitePrism::Page
-      element :heading_1, ".govuk-heading-xl"
-      element :heading_2, ".govuk-panel__title"
-      element :reference, ".govuk-panel__body"
+      set_url "/teacher/application"
+
+      element :heading, ".govuk-heading-xl"
+      section :panel, GovukPanel, ".govuk-panel"
     end
   end
 end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -113,7 +113,8 @@ RSpec.describe "Teacher application", type: :system do
     and_i_see_check_your_work_history
 
     when_i_click_submit
-    then_i_see_the_submitted_application_page
+    then_i_see_the(:submitted_application_page)
+    and_i_see_the_submitted_application_information
     and_i_receive_an_application_email
   end
 
@@ -216,7 +217,8 @@ RSpec.describe "Teacher application", type: :system do
     and_i_see_check_registration_number
 
     when_i_click_submit
-    then_i_see_the_submitted_application_page
+    then_i_see_the(:submitted_application_page)
+    and_i_see_the_submitted_application_information
     and_i_receive_an_application_email
   end
 
@@ -322,7 +324,8 @@ RSpec.describe "Teacher application", type: :system do
     and_i_see_check_proof_of_recognition
 
     when_i_click_submit
-    then_i_see_the_submitted_application_page
+    then_i_see_the(:submitted_application_page)
+    and_i_see_the_submitted_application_information
     and_i_receive_an_application_email
   end
 
@@ -1082,26 +1085,12 @@ RSpec.describe "Teacher application", type: :system do
     expect(check_your_answers_page).to have_content("Registration number")
   end
 
-  def then_i_see_the_submitted_application_page
-    application_form = ApplicationForm.last
-
-    expect(submitted_application_page).to have_current_path(
-      "/teacher/application",
-    )
-    expect(submitted_application_page).to have_title(
-      "Apply for qualified teacher status (QTS)",
-    )
-    expect(submitted_application_page.heading_1.text).to have_content(
-      "Apply for qualified teacher status (QTS)",
-    )
-    expect(submitted_application_page.heading_2.text).to have_content(
+  def and_i_see_the_submitted_application_information
+    expect(submitted_application_page.panel.title.text).to eq(
       "Application complete",
     )
-    expect(submitted_application_page.reference).to have_content(
-      "Your reference number",
-    )
-    expect(submitted_application_page.reference).to have_content(
-      application_form.reference,
+    expect(submitted_application_page.panel.body.text).to eq(
+      "Your reference number\n#{ApplicationForm.last.reference}",
     )
   end
 

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe "Teacher further information", type: :system do
 
   def and_i_see_the_further_information_received_information
     expect(submitted_application_page.panel.title.text).to eq(
-      "Application complete",
+      "Further information successfully submitted",
     )
     expect(submitted_application_page.panel.body.text).to eq(
       "Your reference number\n#{ApplicationForm.last.reference}",

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -58,6 +58,10 @@ RSpec.describe "Teacher further information", type: :system do
     and_i_click_continue
     when_i_dont_need_to_upload_another_file
     then_i_see_the(:check_further_information_request_answers_page)
+
+    when_i_submit_the_further_information
+    then_i_see_the(:submitted_application_page)
+    and_i_see_the_further_information_received_information
   end
 
   def given_there_is_an_application_form
@@ -139,6 +143,19 @@ RSpec.describe "Teacher further information", type: :system do
 
   def when_i_click_the_document_check_your_answers_item
     document_check_answers_item.actions.first.link.click
+  end
+
+  def when_i_submit_the_further_information
+    check_further_information_request_answers_page.submit_button.click
+  end
+
+  def and_i_see_the_further_information_received_information
+    expect(submitted_application_page.panel.title.text).to eq(
+      "Application complete",
+    )
+    expect(submitted_application_page.panel.body.text).to eq(
+      "Your reference number\n#{ApplicationForm.last.reference}",
+    )
   end
 
   def teacher


### PR DESCRIPTION
This adds the functionality that allows a teacher to submit a further information request.

Depends on #580

## Screenshots

![Screenshot 2022-10-10 at 11 20 39](https://user-images.githubusercontent.com/510498/194846408-483e0d55-3cf7-41ca-8a3a-c8b9192dc64c.png)
![Screenshot 2022-10-10 at 11 27 34](https://user-images.githubusercontent.com/510498/194846417-0e8ad3dd-1da3-428d-b5fe-6604e5f5d85e.png)
