### PR TITLE
Update assessor task list states

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -38,7 +38,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
     }.compact_blank
   end
 
-  def assessment_task_path(section, item, index)
+  def assessment_task_path(section, item, _index)
     case section
     when :submitted_details
       url_helpers.assessor_interface_application_form_assessment_assessment_section_path(
@@ -47,14 +47,14 @@ class AssessorInterface::ApplicationFormsShowViewObject
         item,
       )
     when :recommendation
-      status = assessment_task_status(section, item, index)
+      return nil unless assessment.sections_finished?
 
-      return nil unless status == :not_started
-
-      url_helpers.edit_assessor_interface_application_form_assessment_path(
-        application_form,
-        assessment,
-      )
+      if assessment_editable?
+        url_helpers.edit_assessor_interface_application_form_assessment_path(
+          application_form,
+          assessment,
+        )
+      end
     end
   end
 
@@ -64,9 +64,9 @@ class AssessorInterface::ApplicationFormsShowViewObject
       assessment.sections.find { |s| s.key == item.to_s }.state
     when :recommendation
       return :cannot_start_yet unless assessment.sections_finished?
-      return :completed if assessment.finished?
-      return :not_started if further_information_requests.empty?
-      :further_information_requested
+      return :not_started if assessment.unknown?
+      return :in_progress if assessment_editable?
+      :completed
     when :further_information
       further_information_requests[index].state.to_sym
     end
@@ -78,6 +78,14 @@ class AssessorInterface::ApplicationFormsShowViewObject
 
   def assessment
     @assessment ||= application_form.assessment
+  end
+
+  def assessment_editable?
+    assessment.unknown? ||
+      (
+        assessment.request_further_information? &&
+          further_information_requests.empty?
+      )
   end
 
   def further_information_requests

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -68,7 +68,9 @@ class AssessorInterface::ApplicationFormsShowViewObject
       return :in_progress if assessment_editable?
       :completed
     when :further_information
-      further_information_requests[index].state.to_sym
+      further_information_request = further_information_requests[index]
+      return :cannot_start_yet if further_information_request.requested?
+      :not_started
     end
   end
 

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -172,15 +172,24 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
         before { assessment_section.update!(passed: true) }
         it { is_expected.to eq(:not_started) }
 
-        context "with a finished assessment" do
+        context "and award" do
           before { assessment.award! }
           it { is_expected.to eq(:completed) }
         end
 
-        context "with further information request" do
-          before { create(:further_information_request, assessment:) }
+        context "and decline" do
+          before { assessment.decline! }
+          it { is_expected.to eq(:completed) }
+        end
 
-          it { is_expected.to eq(:further_information_requested) }
+        context "and request further information" do
+          before { assessment.request_further_information! }
+          it { is_expected.to eq(:in_progress) }
+
+          context "and further information requested" do
+            before { create(:further_information_request, assessment:) }
+            it { is_expected.to eq(:completed) }
+          end
         end
       end
     end

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -198,9 +198,15 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       let(:section) { :further_information }
       let(:item) { :review_requested_information }
 
-      before { create(:further_information_request, assessment:) }
+      context "and a requested further information request" do
+        before { create(:further_information_request, :requested, assessment:) }
+        it { is_expected.to eq(:cannot_start_yet) }
+      end
 
-      it { is_expected.to eq(:requested) }
+      context "and a received further information request" do
+        before { create(:further_information_request, :received, assessment:) }
+        it { is_expected.to eq(:not_started) }
+      end
     end
   end
 end


### PR DESCRIPTION
This fixes the states in the assessor task list when reviewing an application.

Depends on #583 

[Trello Card](https://trello.com/c/iXT8dbyE/987-states-displayed-when-fi-received)

## Screenshots

![Screenshot 2022-10-10 at 11 39 14](https://user-images.githubusercontent.com/510498/194867903-7364d1e8-2fd6-4178-b367-20687bea5914.png)
![Screenshot 2022-10-10 at 11 39 50](https://user-images.githubusercontent.com/510498/194867907-857ffa10-840f-424b-aa7c-cc86c7c0a99a.png)
![Screenshot 2022-10-10 at 13 26 00](https://user-images.githubusercontent.com/510498/194867910-1349e372-75c5-4d00-9524-083b53358a87.png)
![Screenshot 2022-10-10 at 13 32 56](https://user-images.githubusercontent.com/510498/194867913-1653246b-8321-4bfe-99d6-9ff7403e6fc1.png)
