### PR TITLE
Review further information requests

### DIFF
--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -57,7 +57,9 @@ module CheckYourAnswersSummary
     end
 
     def href_for(field)
-      path = field.fetch(:href)
+      path = field[:href]
+      return nil if path.blank?
+
       next_path = request.path
 
       if path.is_a?(String)

--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -53,7 +53,7 @@ module CheckYourAnswersSummary
     end
 
     def value_for(field)
-      field[:value].presence || model.send(field[:key])
+      field.include?(:value) ? field[:value] : model.send(field[:key])
     end
 
     def href_for(field)

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -3,8 +3,6 @@ module AssessorInterface
     before_action :load_application_form_and_assessment,
                   only: %i[preview new show edit]
     before_action :load_new_further_information_request, only: %i[preview new]
-    before_action :load_existing_further_information_request,
-                  only: %i[show edit]
 
     def preview
     end
@@ -30,9 +28,11 @@ module AssessorInterface
     end
 
     def show
+      @further_information_request = further_information_request
     end
 
     def edit
+      @view_object = FurtherInformationRequestViewObject.new(params:)
     end
 
     private
@@ -50,10 +50,6 @@ module AssessorInterface
               assessment_sections: assessment.sections,
             ),
         )
-    end
-
-    def load_existing_further_information_request
-      @further_information_request = further_information_request
     end
 
     def further_information_request

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -1,8 +1,10 @@
 module AssessorInterface
   class FurtherInformationRequestsController < BaseController
     before_action :load_application_form_and_assessment,
-                  only: %i[preview new show]
+                  only: %i[preview new show edit]
     before_action :load_new_further_information_request, only: %i[preview new]
+    before_action :load_existing_further_information_request,
+                  only: %i[show edit]
 
     def preview
     end
@@ -28,7 +30,9 @@ module AssessorInterface
     end
 
     def show
-      @further_information_request = further_information_request
+    end
+
+    def edit
     end
 
     private
@@ -46,6 +50,10 @@ module AssessorInterface
               assessment_sections: assessment.sections,
             ),
         )
+    end
+
+    def load_existing_further_information_request
+      @further_information_request = further_information_request
     end
 
     def further_information_request

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -38,7 +38,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
     }.compact_blank
   end
 
-  def assessment_task_path(section, item, _index)
+  def assessment_task_path(section, item, index)
     case section
     when :submitted_details
       url_helpers.assessor_interface_application_form_assessment_assessment_section_path(
@@ -53,6 +53,16 @@ class AssessorInterface::ApplicationFormsShowViewObject
         url_helpers.edit_assessor_interface_application_form_assessment_path(
           application_form,
           assessment,
+        )
+      end
+    when :further_information
+      further_information_request = further_information_requests[index]
+
+      if further_information_request.received?
+        url_helpers.edit_assessor_interface_application_form_assessment_further_information_request_path(
+          application_form,
+          assessment,
+          further_information_request,
         )
       end
     end

--- a/app/view_objects/assessor_interface/further_information_request_view_object.rb
+++ b/app/view_objects/assessor_interface/further_information_request_view_object.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+class AssessorInterface::FurtherInformationRequestViewObject
+  def initialize(params:)
+    @params = params
+  end
+
+  def further_information_request
+    @further_information_request ||=
+      FurtherInformationRequest
+        .joins(assessment: :application_form)
+        .received
+        .where(
+          assessment_id: params[:assessment_id],
+          assessment: {
+            application_form_id: params[:application_form_id],
+          },
+        )
+        .find(params[:id])
+  end
+
+  def application_form
+    further_information_request.assessment.application_form
+  end
+
+  def check_your_answers_fields
+    further_information_request
+      .items
+      .order(:created_at)
+      .each_with_object({}) do |item, memo|
+        memo[item.id] = {
+          title: item_text(item),
+          value: item.text? ? item.response : item.document,
+        }
+      end
+  end
+
+  private
+
+  attr_reader :params
+
+  def item_text(item)
+    case item.information_type
+    when "text"
+      I18n.t(
+        "teacher_interface.further_information_request.show.failure_reason.#{item.failure_reason}",
+      )
+    when "document"
+      "Upload your #{I18n.t("document.document_type.#{item.document.document_type}")} document"
+    end
+  end
+end

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -1,11 +1,6 @@
 <% content_for :page_title, "Application" %>
 <% content_for :back_link_url, @view_object.back_link_path %>
 
-<div class="app-inline-action">
-  <h1 class="govuk-heading-xl">Application</h1>
-  <%= govuk_button_link_to "Add note", new_assessor_interface_application_form_note_path(@view_object.application_form), secondary: true %>
-</div>
-
 <%= render(ApplicationFormOverview::Component.new(@view_object.application_form)) %>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-9">Assessment</h2>

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -1,0 +1,4 @@
+<% content_for :title, t(".title") %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+
+<h1 class="govuk-heading-xl"><%= t(".title") %></h1>

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -1,4 +1,10 @@
 <% content_for :title, t(".title") %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@view_object.application_form) %>
 
 <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
+
+<%= render(CheckYourAnswersSummary::Component.new(
+  model: @view_object.further_information_request,
+  title: t(".check_your_answers"),
+  fields: @view_object.check_your_answers_fields
+)) %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -80,6 +80,7 @@ en:
     further_information_requests:
       edit:
         title: Review further information from applicant
+        check_your_answers: Further information requested
 
   components:
     timeline_entry:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -77,6 +77,10 @@ en:
           qualified_to_teach: We were not provided with sufficient evidence to confirm qualification to teach at state or government schools.
           full_professional_status: Recognition level as a teacher does not match the required level, or has outstanding additional conditions.
 
+    further_information_requests:
+      edit:
+        title: Review further information from applicant
+
   components:
     timeline_entry:
       title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
                   only: %i[show update]
         resources :further_information_requests,
                   path: "/further-information-requests",
-                  only: %i[new create show] do
+                  only: %i[new create show edit] do
           get "preview",
               to: "further_information_requests#preview",
               on: :collection

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -12,42 +12,30 @@ module PageObjects
         element :status, "div:nth-of-type(9) > dd:nth-of-type(1)"
       end
 
-      section :task_list, "ol.app-task-list" do
-        sections :tasks, "ol.app-task-list > li" do
-          sections :items, "li.app-task-list__item" do
-            section :name, ".app-task-list__task-name" do
-              element :link, "a"
-            end
-
-            element :status, "strong"
-          end
-        end
-      end
+      section :task_list, TaskList, ".app-task-list"
 
       def personal_information_task
-        task_item_for("Check personal information")
+        task_list.find_item("Check personal information")
       end
 
       def qualifications_task
-        task_item_for("Check qualifications")
+        task_list.find_item("Check qualifications")
       end
 
       def age_range_subjects_task
-        task_item_for("Verify age range and subjects")
+        task_list.find_item("Verify age range and subjects")
       end
 
       def work_history_task
-        task_item_for("Check work history")
+        task_list.find_item("Check work history")
       end
 
       def professional_standing_task
-        task_item_for("Check professional standing")
+        task_list.find_item("Check professional standing")
       end
 
-      private
-
-      def task_item_for(text)
-        task_list.tasks.first.items.find { |item| item.name.text == text }
+      def review_requested_information_task
+        task_list.find_item("Review requested information from applicant")
       end
     end
   end

--- a/spec/support/autoload/page_objects/assessor_interface/review_further_information_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/review_further_information_request.rb
@@ -5,6 +5,7 @@ module PageObjects
                 "/further-information-requests/{further_information_request_id}/edit"
 
       element :heading, ".govuk-heading-xl"
+      section :summary_list, GovukSummaryList, ".govuk-summary-list"
     end
   end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/review_further_information_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/review_further_information_request.rb
@@ -1,0 +1,10 @@
+module PageObjects
+  module AssessorInterface
+    class ReviewFurtherInformationRequest < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+                "/further-information-requests/{further_information_request_id}/edit"
+
+      element :heading, ".govuk-heading-xl"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/task_list.rb
+++ b/spec/support/autoload/page_objects/task_list.rb
@@ -3,7 +3,7 @@ module PageObjects
     sections :sections, TaskListSection, ".app-task-list > li"
 
     def find_item(text)
-      sections.flat_map(&:items).find { |item| item.link.text == text }
+      sections.flat_map(&:items).find { |item| item.name.text == text }
     end
 
     def click_item(link_text)

--- a/spec/support/autoload/page_objects/task_list_item.rb
+++ b/spec/support/autoload/page_objects/task_list_item.rb
@@ -1,5 +1,6 @@
 module PageObjects
   class TaskListItem < SitePrism::Section
+    element :name, "span"
     element :link, "a"
     element :status_tag, ".govuk-tag"
   end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -113,6 +113,11 @@ module PageHelpers
     @region_page ||= PageObjects::EligibilityInterface::Region.new
   end
 
+  def review_further_information_request_page
+    @review_further_information_request_page ||=
+      PageObjects::AssessorInterface::ReviewFurtherInformationRequest.new
+  end
+
   def start_page
     @start_page ||= PageObjects::EligibilityInterface::Start.new
   end

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def and_i_see_check_personal_information_completed
     expect(
-      assessor_application_page.personal_information_task.status.text,
+      assessor_application_page.personal_information_task.status_tag.text,
     ).to eq("COMPLETED")
   end
 
@@ -187,7 +187,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def and_i_see_check_personal_information_action_required
     expect(
-      assessor_application_page.personal_information_task.status.text,
+      assessor_application_page.personal_information_task.status_tag.text,
     ).to eq("ACTION REQUIRED")
   end
 
@@ -220,13 +220,13 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def and_i_see_check_qualifications_completed
-    expect(assessor_application_page.qualifications_task.status.text).to eq(
+    expect(assessor_application_page.qualifications_task.status_tag.text).to eq(
       "COMPLETED",
     )
   end
 
   def and_i_see_check_qualifications_action_required
-    expect(assessor_application_page.qualifications_task.status.text).to eq(
+    expect(assessor_application_page.qualifications_task.status_tag.text).to eq(
       "ACTION REQUIRED",
     )
   end
@@ -274,15 +274,15 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def and_i_see_verify_age_range_subjects_completed
-    expect(assessor_application_page.age_range_subjects_task.status.text).to eq(
-      "COMPLETED",
-    )
+    expect(
+      assessor_application_page.age_range_subjects_task.status_tag.text,
+    ).to eq("COMPLETED")
   end
 
   def and_i_see_verify_age_range_subjects_action_required
-    expect(assessor_application_page.age_range_subjects_task.status.text).to eq(
-      "ACTION REQUIRED",
-    )
+    expect(
+      assessor_application_page.age_range_subjects_task.status_tag.text,
+    ).to eq("ACTION REQUIRED")
   end
 
   def then_i_see_the_work_history
@@ -298,7 +298,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def and_i_see_check_work_history_completed
-    expect(assessor_application_page.work_history_task.status.text).to eq(
+    expect(assessor_application_page.work_history_task.status_tag.text).to eq(
       "COMPLETED",
     )
   end
@@ -319,7 +319,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def and_i_see_check_work_history_action_required
-    expect(assessor_application_page.work_history_task.status.text).to eq(
+    expect(assessor_application_page.work_history_task.status_tag.text).to eq(
       "ACTION REQUIRED",
     )
   end
@@ -340,7 +340,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def and_i_see_check_professional_standing_completed
     expect(
-      assessor_application_page.professional_standing_task.status.text,
+      assessor_application_page.professional_standing_task.status_tag.text,
     ).to eq("COMPLETED")
   end
 
@@ -361,7 +361,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def and_i_see_check_professional_standing_action_required
     expect(
-      assessor_application_page.professional_standing_task.status.text,
+      assessor_application_page.professional_standing_task.status_tag.text,
     ).to eq("ACTION REQUIRED")
   end
 

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def then_the_application_form_is_awarded
-    expect(assessor_application_page.overview.status.text).to eq("AWARDED")
+    expect(assessor_application_page.overview.status_tag.text).to eq("AWARDED")
   end
 
   def application_form

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def then_the_application_form_is_awarded
-    expect(assessor_application_page.overview.status_tag.text).to eq("AWARDED")
+    expect(assessor_application_page.overview.status.text).to eq("AWARDED")
   end
 
   def application_form

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
       assessment_id:,
       further_information_request_id:,
     )
+    and_i_see_the_check_your_answers_items
   end
 
   private
@@ -31,6 +32,18 @@ RSpec.describe "Assessor reviewing further information", type: :system do
 
   def and_i_click_review_requested_information
     assessor_application_page.review_requested_information_task.link.click
+  end
+
+  def and_i_see_the_check_your_answers_items
+    rows = review_further_information_request_page.summary_list.rows
+
+    expect(rows.count).to eq(2)
+
+    expect(rows.first.key.text).to eq(
+      "Tell us more about the subjects you can teach",
+    )
+
+    expect(rows.second.key.text).to eq("Upload your identity document")
   end
 
   def application_form
@@ -59,6 +72,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
       create(
         :further_information_request,
         :received,
+        :with_items,
         assessment: application_form.assessment,
       )
   end

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assessor reviewing further information", type: :system do
+  it "reviewing further information" do
+    given_the_service_is_open
+    given_i_am_authorized_as_a_user(assessor)
+    given_there_is_an_application_form_with_failure_reasons
+    given_there_is_further_information_received
+
+    when_i_visit_the(:assessor_application_page, application_id:)
+    and_i_click_review_requested_information
+    then_i_see_the(
+      :review_further_information_request_page,
+      application_id:,
+      assessment_id:,
+      further_information_request_id:,
+    )
+  end
+
+  private
+
+  def given_there_is_an_application_form_with_failure_reasons
+    application_form
+  end
+
+  def given_there_is_further_information_received
+    further_information_request
+  end
+
+  def and_i_click_review_requested_information
+    assessor_application_page.review_requested_information_task.link.click
+  end
+
+  def application_form
+    @application_form ||=
+      create(
+        :application_form,
+        :with_personal_information,
+        :submitted,
+      ).tap do |application_form|
+        assessment =
+          create(:assessment, :request_further_information, application_form:)
+        create(
+          :assessment_section,
+          :qualifications,
+          :failed,
+          assessment:,
+          selected_failure_reasons: {
+            qualifications_dont_support_subjects: "A note.",
+          },
+        )
+      end
+  end
+
+  def further_information_request
+    @further_information_request ||=
+      create(
+        :further_information_request,
+        :received,
+        assessment: application_form.assessment,
+      )
+  end
+
+  def assessor
+    @assessor ||= create(:staff, :confirmed)
+  end
+
+  def application_id
+    application_form.id
+  end
+
+  def assessment_id
+    application_form.assessment.id
+  end
+
+  def further_information_request_id
+    further_information_request.id
+  end
+end

--- a/spec/system/assessor_interface/view_application_form_spec.rb
+++ b/spec/system/assessor_interface/view_application_form_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe "Assessor view application form", type: :system do
   end
 
   def and_i_see_the_assessment_tasks
-    expect(assessor_application_page.task_list.tasks.count).to eq(2)
+    expect(assessor_application_page.task_list.sections.count).to eq(2)
 
     first_section_links =
-      assessor_application_page.task_list.tasks.first.items.map do |item|
+      assessor_application_page.task_list.sections.first.items.map do |item|
         item.name.text
       end
 
@@ -47,7 +47,7 @@ RSpec.describe "Assessor view application form", type: :system do
     )
 
     second_section_links =
-      assessor_application_page.task_list.tasks.second.items.map do |item|
+      assessor_application_page.task_list.sections.second.items.map do |item|
         item.name.text
       end
 

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -130,11 +130,24 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       let(:section) { :further_information }
       let(:item) { :review_requested_information }
 
-      let!(:further_information_request) do
-        create(:further_information_request, assessment:)
+      context "and a requested further information request" do
+        let!(:further_information_request) do
+          create(:further_information_request, :requested, assessment:)
+        end
+        it { is_expected.to be_nil }
       end
 
-      it { is_expected.to be_nil }
+      context "and a received further information request" do
+        let!(:further_information_request) do
+          create(:further_information_request, :received, assessment:)
+        end
+        it do
+          is_expected.to eq(
+            "/assessor/applications/#{application_form.id}/assessments/#{assessment.id}" \
+              "/further-information-requests/#{further_information_request.id}/edit",
+          )
+        end
+      end
     end
   end
 

--- a/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
+  subject(:view_object) do
+    described_class.new(params: ActionController::Parameters.new(params))
+  end
+
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:assessment) { create(:assessment, application_form:) }
+  let(:further_information_request) do
+    create(:further_information_request, :received, assessment:)
+  end
+  let(:params) do
+    {
+      id: further_information_request.id,
+      assessment_id: assessment.id,
+      application_form_id: application_form.id,
+    }
+  end
+
+  describe "#check_your_answers_fields" do
+    let!(:text_item) do
+      create(
+        :further_information_request_item,
+        :with_text_response,
+        :completed,
+        further_information_request:,
+      )
+    end
+    let!(:document_item) do
+      create(
+        :further_information_request_item,
+        :with_document_response,
+        :completed,
+        further_information_request:,
+      )
+    end
+
+    subject(:check_your_answers_fields) do
+      view_object.check_your_answers_fields
+    end
+
+    it do
+      is_expected.to eq(
+        {
+          text_item.id => {
+            title: "Tell us more about the subjects you can teach",
+            value: text_item.response,
+          },
+          document_item.id => {
+            title: "Upload your identity document",
+            value: document_item.document,
+          },
+        },
+      )
+    end
+  end
+end


### PR DESCRIPTION
This adds the ability for an assessor to review a further information request.

[Trello Card](https://trello.com/c/FBlG6QCl/986-review-further-information-page)

Depends on #580, #584

## Screenshot

![Screenshot 2022-10-10 at 13 44 16](https://user-images.githubusercontent.com/510498/195040500-52bf979f-f2a1-44a3-8236-da7f5c4ab9db.png)