### PR TITLE
[920] Require confirmation that the applicant has no sanctions

### DIFF
--- a/app/assets/stylesheets/_teacher_application_form.scss
+++ b/app/assets/stylesheets/_teacher_application_form.scss
@@ -1,0 +1,3 @@
+label.app-application-form__confirmed-no-sanctions {
+  margin-top: -2%;
+}

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -16,6 +16,7 @@ $moj-images-path: "/";
 @import "_summary_list_card";
 @import "_support";
 @import "_task_list";
+@import "_teacher_application_form";
 
 ul.autocomplete__menu {
   li {

--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -41,14 +41,27 @@ module TeacherInterface
     end
 
     def edit
+      @sanction_confirmation_form =
+        SanctionConfirmationForm.new(
+          application_form:,
+          confirmed_no_sanctions: application_form.confirmed_no_sanctions,
+        )
     end
 
     def update
-      if application_form.can_submit?
+      if (
+           @sanction_confirmation_form =
+             SanctionConfirmationForm.new(
+               application_form:,
+               confirmed_no_sanctions:
+                 application_form_params[:confirmed_no_sanctions],
+             )
+         ).save(validate: true)
         SubmitApplicationForm.call(application_form:, user: current_teacher)
+        redirect_to %i[teacher_interface application_form]
+      else
+        render :edit, status: :unprocessable_entity
       end
-
-      redirect_to %i[teacher_interface application_form]
     end
 
     private
@@ -57,6 +70,12 @@ module TeacherInterface
       params.require(:teacher_interface_country_region_form).permit(
         :location,
         :region_id,
+      )
+    end
+
+    def application_form_params
+      params.fetch(:teacher_interface_sanction_confirmation_form, {}).permit(
+        :confirmed_no_sanctions,
       )
     end
   end

--- a/app/forms/teacher_interface/sanction_confirmation_form.rb
+++ b/app/forms/teacher_interface/sanction_confirmation_form.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class SanctionConfirmationForm < BaseForm
+    attribute :application_form
+    attribute :confirmed_no_sanctions
+
+    validates :confirmed_no_sanctions, presence: true
+
+    private
+
+    def update_model
+      application_form.update!(confirmed_no_sanctions:)
+    end
+  end
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -7,6 +7,7 @@
 #  age_range_min                 :integer
 #  alternative_family_name       :text             default(""), not null
 #  alternative_given_names       :text             default(""), not null
+#  confirmed_no_sanctions        :boolean          default(FALSE)
 #  date_of_birth                 :date
 #  family_name                   :text             default(""), not null
 #  given_names                   :text             default(""), not null

--- a/app/views/teacher_interface/application_forms/edit.html.erb
+++ b/app/views/teacher_interface/application_forms/edit.html.erb
@@ -3,32 +3,52 @@
 
 <h1 class="govuk-heading-xl">Check your answers before submitting your application</h1>
 
+<section id="app-application-form-about-you">
 <h2 class="govuk-heading-m">About you</h2>
 <%= render "shared/application_form/personal_information_summary", application_form: @application_form, changeable: true %>
 <%= render "shared/application_form/identity_document_summary", application_form: @application_form, changeable: true %>
+</section>
 
+<section id="app-application-form-who-you-can-teach">
 <h2 class="govuk-heading-m">Who you can teach</h2>
 <%= render "shared/application_form/qualifications_summary", application_form: @application_form, qualifications: @application_form.qualifications.ordered, changeable: true %>
 <%= render "shared/application_form/age_range_summary", application_form: @application_form, changeable: true %>
 <%= render "shared/application_form/subjects_summary", application_form: @application_form, changeable: true %>
+</section>
 
 <% if @application_form.needs_work_history %>
-  <h2 class="govuk-heading-m">Your work history</h2>
-  <%= render "shared/application_form/work_history_summary", application_form: @application_form, work_histories: @application_form.work_histories.ordered, changeable: true %>
+  <section id="app-application-form-work-history">
+    <h2 class="govuk-heading-m">Your work history</h2>
+    <%= render "shared/application_form/work_history_summary", application_form: @application_form, work_histories: @application_form.work_histories.ordered, changeable: true %>
+  </section>
 <% end %>
 
 <% if @application_form.needs_written_statement || @application_form.needs_registration_number %>
-  <h2 class="govuk-heading-m">Proof that you’re recognised as a teacher</h2>
-  <% if @application_form.needs_registration_number %>
-    <%= render "shared/application_form/registration_number_summary", application_form: @application_form, changeable: true %>
-  <% end %>
-  <% if @application_form.needs_written_statement %>
-    <%= render "shared/application_form/written_statement_summary", application_form: @application_form, changeable: true %>
-  <% end %>
+  <section id="app-application-form-proof-of-recognition">
+    <h2 class="govuk-heading-m">Proof that you’re recognised as a teacher</h2>
+    <% if @application_form.needs_registration_number %>
+      <%= render "shared/application_form/registration_number_summary", application_form: @application_form, changeable: true %>
+    <% end %>
+    <% if @application_form.needs_written_statement %>
+      <%= render "shared/application_form/written_statement_summary", application_form: @application_form, changeable: true %>
+    <% end %>
+  </section>
 <% end %>
 
 <% if @application_form.can_submit? %>
-  <h2 class="govuk-heading-m">Submitting your application</h2>
-  <p class="govuk-body">By selecting the ‘Submit application button’ you confirm that, to the best of your knowledge, the details you’ve provided are correct.</p>
-  <%= govuk_button_to "Submit your application", teacher_interface_application_form_path, method: :patch %>
+  <section id="app-application-form-submission-declaration">
+    <%= form_with model: @sanction_confirmation_form, url: [:teacher_interface, :application_form], method: :put do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <h2 class="govuk-heading-m">How we handle your data</h2>
+      <p class="govuk-body">You can read about the data we collect from you, how we use it and how it’s stored, in our <%= govuk_link_to "privacy policy", privacy_path %>.</p>
+      <h2 class="govuk-heading-m">About sanctions and restrictions</h2>
+      <p class="govuk-body">
+      <%= f.govuk_check_box :confirmed_no_sanctions, true, false, multiple: false,  link_errors: true, label: {class: "govuk-label govuk-checkboxes__label app-application-form__confirmed-no-sanctions", text: "Tick the box to confirm your employment record does not contain any sanctions, restrictions, penalties or instances of misconduct." } %>
+      </p>
+      <h2 class="govuk-heading-m">Submitting your application</h2>
+      <p class="govuk-body">By selecting the ‘Submit application button’ you confirm that, to the best of your knowledge, the details you’ve provided are correct.</p>
+      <%= f.govuk_submit "Submit your application" %>
+    <%- end -%>
+  </section>
 <% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -47,6 +47,7 @@
     - needs_work_history
     - needs_written_statement
     - needs_registration_number
+    - confirmed_no_sanctions
   :assessment_sections:
     - id
     - assessment_id

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -40,6 +40,10 @@ en:
           attributes:
             email:
               blank: Enter your email address
+        teacher_interface/sanction_confirmation_form:
+          attributes:
+            confirmed_no_sanctions:
+              blank: You must confirm that you have no sanctions or restrictions
   application_form:
     status:
       not_started: Not started

--- a/db/migrate/20221007134833_add_confirm_no_sanctions_to_application_forms.rb
+++ b/db/migrate/20221007134833_add_confirm_no_sanctions_to_application_forms.rb
@@ -1,0 +1,9 @@
+class AddConfirmNoSanctionsToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_forms,
+               :confirmed_no_sanctions,
+               :boolean,
+               default: false,
+               nullable: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_07_090326) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_07_134833) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,6 +67,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_07_090326) do
     t.boolean "needs_written_statement", null: false
     t.boolean "needs_registration_number", null: false
     t.integer "working_days_since_submission"
+    t.boolean "confirmed_no_sanctions", default: false
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["family_name"], name: "index_application_forms_on_family_name"
     t.index ["given_names"], name: "index_application_forms_on_given_names"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -7,6 +7,7 @@
 #  age_range_min                 :integer
 #  alternative_family_name       :text             default(""), not null
 #  alternative_given_names       :text             default(""), not null
+#  confirmed_no_sanctions        :boolean          default(FALSE)
 #  date_of_birth                 :date
 #  family_name                   :text             default(""), not null
 #  given_names                   :text             default(""), not null

--- a/spec/forms/teacher_interface/sanction_confirmation_form_spec.rb
+++ b/spec/forms/teacher_interface/sanction_confirmation_form_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe TeacherInterface::SanctionConfirmationForm, type: :model do
+  let(:application_form) { build(:application_form) }
+
+  subject(:form) do
+    described_class.new(application_form:, confirmed_no_sanctions:)
+  end
+
+  describe "validations" do
+    context "when confirmed is false" do
+      let(:confirmed_no_sanctions) { false }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when confirmed is true" do
+      let(:confirmed_no_sanctions) { true }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when confirmed is nil" do
+      let(:confirmed_no_sanctions) { false }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+
+  describe "#save" do
+    let(:confirmed_no_sanctions) { true }
+
+    before { form.save(validate: true) }
+
+    it "updates the application form" do
+      expect(application_form).to be_confirmed_no_sanctions
+    end
+  end
+end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -7,6 +7,7 @@
 #  age_range_min                 :integer
 #  alternative_family_name       :text             default(""), not null
 #  alternative_given_names       :text             default(""), not null
+#  confirmed_no_sanctions        :boolean          default(FALSE)
 #  date_of_birth                 :date
 #  family_name                   :text             default(""), not null
 #  given_names                   :text             default(""), not null

--- a/spec/support/autoload/page_objects/teacher_interface/check_your_answers.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/check_your_answers.rb
@@ -3,10 +3,16 @@ module PageObjects
     class CheckYourAnswers < SitePrism::Page
       element :heading, "h1"
       element :content_title, "app-task-list_section"
-      element :heading_1, ".govuk-heading-m:nth-of-type(1)"
-      element :heading_2, ".govuk-heading-m:nth-of-type(2)"
-      element :heading_3, ".govuk-heading-m:nth-of-type(3)"
-      element :content, ".govuk-summary-list__card:nth-of-type(4)"
+      element :about_you_section, "section#app-application-form-about-you"
+      element :who_you_can_teach_section,
+              "section#app-application-form-who-you-can-teach"
+      element :work_history_section, "section#app-application-form-work-history"
+      element :proof_of_recognition_section,
+              "section#app-application-form-proof-of-recognition"
+      element :submission_declaration_section,
+              "section#app-application-form-submission-declaration"
+
+      element :confirm_no_sanctions, ".govuk-checkboxes__input", visible: false
     end
   end
 end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe "Teacher application", type: :system do
     then_i_see_the_check_your_answers_page
     and_i_see_check_your_work_history
 
+    when_i_confirm_i_have_no_sanctions
     when_i_click_submit
     then_i_see_the(:submitted_application_page)
     and_i_see_the_submitted_application_information
@@ -216,6 +217,7 @@ RSpec.describe "Teacher application", type: :system do
     and_i_see_check_proof_of_recognition
     and_i_see_check_registration_number
 
+    when_i_confirm_i_have_no_sanctions
     when_i_click_submit
     then_i_see_the(:submitted_application_page)
     and_i_see_the_submitted_application_information
@@ -323,6 +325,7 @@ RSpec.describe "Teacher application", type: :system do
     then_i_see_the_check_your_answers_page
     and_i_see_check_proof_of_recognition
 
+    when_i_confirm_i_have_no_sanctions
     when_i_click_submit
     then_i_see_the(:submitted_application_page)
     and_i_see_the_submitted_application_information
@@ -487,6 +490,7 @@ RSpec.describe "Teacher application", type: :system do
   def when_i_click_submit
     click_button "Submit your application"
   end
+  alias_method :and_i_click_submit, :when_i_click_submit
 
   def when_i_click_continue
     click_link "Continue"
@@ -1059,12 +1063,11 @@ RSpec.describe "Teacher application", type: :system do
     expect(check_your_answers_page.heading.text).to eq(
       "Check your answers before submitting your application",
     )
-    expect(check_your_answers_page.heading_1.text).to have_content("About you")
-    expect(check_your_answers_page.heading_2.text).to have_content(
-      "Who you can teach",
-    )
-    expect(check_your_answers_page.content).to have_content("Minimum age\t7")
-    expect(check_your_answers_page.content).to have_content("Maximum age\t11")
+    expect(check_your_answers_page.about_you_section).to be_visible
+    expect(check_your_answers_page.who_you_can_teach_section).to be_visible
+
+    expect(check_your_answers_page).to have_content("Minimum age\t7")
+    expect(check_your_answers_page).to have_content("Maximum age\t11")
     expect(check_your_answers_page).to have_content("Subjects\tSubject")
     expect(check_your_answers_page).to have_content(
       "Your teaching qualification",
@@ -1072,13 +1075,11 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def and_i_see_check_your_work_history
-    expect(check_your_answers_page).to have_content("Your work history")
+    expect(check_your_answers_page.work_history_section).to be_visible
   end
 
   def and_i_see_check_proof_of_recognition
-    expect(check_your_answers_page.heading_3.text).to have_content(
-      "Proof that you’re recognised as a teacher",
-    )
+    expect(check_your_answers_page.proof_of_recognition_section).to be_visible
   end
 
   def and_i_see_check_registration_number
@@ -1099,5 +1100,9 @@ RSpec.describe "Teacher application", type: :system do
     expect(delete_confirmation_page.heading).to have_content(
       "Are you sure you want to delete",
     )
+  end
+
+  def when_i_confirm_i_have_no_sanctions
+    check_your_answers_page.confirm_no_sanctions.click
   end
 end


### PR DESCRIPTION
Prior to submission of a completed application form we want the applicant to confirm that they have no sanctions.

* Add `ApplicationForm#confirmed_no_sanctions`
* Add `SanctionConfirmationForm` form object to validate when the application is submitted
* Add sections to the confirmation page and use them in the page object to avoid ambiguous heading references

<img width="825" alt="Screenshot 2022-10-10 at 17 40 06" src="https://user-images.githubusercontent.com/5216/194919658-d9ee3fec-a968-4480-aaad-6260c10fa8a1.png">

### Review

* should we store the date rather than a boolean field?