### PR TITLE
Add reference filter

### DIFF
--- a/app/forms/assessor_interface/filter_form.rb
+++ b/app/forms/assessor_interface/filter_form.rb
@@ -5,6 +5,7 @@ class AssessorInterface::FilterForm
   attr_accessor :assessor_ids,
                 :location,
                 :name,
+                :reference,
                 :states,
                 :submitted_at_before,
                 :submitted_at_after

--- a/app/lib/filters/reference.rb
+++ b/app/lib/filters/reference.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Filters
+  class Reference < Base
+    def apply
+      if reference.present?
+        scope.where("reference ILIKE ?", "%#{reference}%")
+      else
+        scope
+      end
+    end
+
+    private
+
+    def reference
+      params[:reference]
+    end
+  end
+end

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -55,6 +55,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
       assessor_interface_filter_form: [
         :location,
         :name,
+        :reference,
         :submitted_at_before,
         :submitted_at_after,
         { assessor_ids: [], states: [] },
@@ -85,6 +86,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
           ::Filters::Assessor,
           ::Filters::Country,
           ::Filters::Name,
+          ::Filters::Reference,
           ::Filters::SubmittedAt,
         ]
         filters.reduce(

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -1,17 +1,17 @@
-<% content_for :page_title, "Applications" %>
+<% content_for :page_title, t(".title") %>
 
-<h1 class="govuk-heading-xl">Applications</h1>
+<h1 class="govuk-heading-xl"><%= t(".title") %></h1>
 
 <div class="govuk-grid-column-one-third app-application-forms__filters">
-  <h2 class="govuk-heading-m">Filters</h2>
+  <h2 class="govuk-heading-m"><%= t(".filters.title") %></h2>
 
   <%= form_with model: @view_object.filter_form, method: :get, url: assessor_interface_application_forms_path, class: "app-application-forms__filter-form" do |f| %>
-    <%= f.govuk_submit "Apply filters" do %>
-      <%= govuk_link_to "Clear selection"%>
+    <%= f.govuk_submit t(".filters.apply") do %>
+      <%= govuk_link_to t(".filters.clear") %>
     <%- end -%>
 
     <section id="app-applications-filters-assessor">
-      <%= f.govuk_check_boxes_fieldset :assessor_ids, legend: { text: "Assessor name", size: "s" }, small: true do %>
+      <%= f.govuk_check_boxes_fieldset :assessor_ids, legend: { size: "s" }, small: true do %>
         <%- @view_object.assessor_filter_options.each do |option| -%>
           <%= f.govuk_check_box :assessor_ids, option.id, label: { text: option.name }, checked: @view_object.filter_form.assessor_ids&.include?(option.id.to_s) %>
         <%- end -%>
@@ -19,10 +19,7 @@
     </section>
 
     <section id="app-applications-filters-country">
-      <%= f.govuk_select :location,
-                         @view_object.country_filter_options,
-                         label: { text: "Country trained in", size: "s" },
-                         options: { include_blank: true } %>
+      <%= f.govuk_select :location, @view_object.country_filter_options, label: { size: "s" }, options: { include_blank: true } %>
     </section>
 
     <section id="app-applications-filters-reference">
@@ -30,18 +27,18 @@
     </section>
 
     <section id="app-applications-filters-name">
-      <%= f.govuk_text_field :name, label: { text: "Applicant name", size: "s" } %>
+      <%= f.govuk_text_field :name, label: { size: "s" } %>
     </section>
 
     <section id="app-applications-filters-submitted-at">
-      <%= f.govuk_fieldset legend: { text: "Created date", size: "s" } do %>
-        <%= f.govuk_date_field :submitted_at_after, legend: { text: "Start date", size: "s" } %>
-        <%= f.govuk_date_field :submitted_at_before, legend: { text: "End date", size: "s" } %>
+      <%= f.govuk_fieldset legend: { text: I18n.t("helpers.legend.assessor_interface_filter_form.submitted_at"), size: "s" } do %>
+        <%= f.govuk_date_field :submitted_at_after, legend: { size: "s" } %>
+        <%= f.govuk_date_field :submitted_at_before, legend: { size: "s" } %>
       <% end %>
     </section>
 
     <section id="app-applications-filters-state">
-      <%= f.govuk_check_boxes_fieldset :states, legend: { text: "Status of application", size: "s" }, small: true do %>
+      <%= f.govuk_check_boxes_fieldset :states, legend: { size: "s" }, small: true do %>
         <%- @view_object.state_filter_options.each do |option| -%>
           <%= f.govuk_check_box :states, option.id, label: { text: option.label }, checked: @view_object.filter_form.states&.include?(option.id) %>
         <%- end -%>
@@ -61,8 +58,6 @@
 
     <%= govuk_pagination(pagy: @view_object.application_forms_pagy) %>
   <% else %>
-    <h2 class="govuk-heading-m">
-      No applications found. Use the filters on the left to try again or refine your search.
-    </h2>
+    <h2 class="govuk-heading-m"><%= t(".results.empty") %></h2>
   <% end %>
 </div>

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -25,6 +25,10 @@
                          options: { include_blank: true } %>
     </section>
 
+    <section id="app-applications-filters-reference">
+      <%= f.govuk_text_field :reference, label: { size: "s" }, placeholder: I18n.t("helpers.placeholder.assessor_interface_filter_form.reference") %>
+    </section>
+
     <section id="app-applications-filters-name">
       <%= f.govuk_text_field :name, label: { text: "Applicant name", size: "s" } %>
     </section>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -1,6 +1,15 @@
 en:
   assessor_interface:
     application_forms:
+      index:
+        title: Applications
+        filters:
+          title: Filters
+          apply: Apply filters
+          clear: Clear selection
+        results:
+          empty: No applications found. Use the filters on the left to try again or refine your search.
+
       show:
         assessment_tasks:
           sections:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -40,6 +40,8 @@ en:
         subject_3: Subject 3 (optional)
         subjects_note: If you've edited the subjects please explain why (optional)
         failure_reason_notes: Note to the applicant
+      assessor_interface_filter_form:
+        reference: Application reference number
       qualification:
         add_another_options:
           true: "Yes"
@@ -68,6 +70,8 @@ en:
     placeholder:
       assessor_interface_assessment_section_form:
         failure_reason_notes: "Example: The right-hand section of your teaching qualification document is missing, please take a new image and upload it."
+      assessor_interface_filter_form:
+        reference: "Example: 210245"
     legend:
       assessment:
         recommendation: QTS review completed

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -41,6 +41,8 @@ en:
         subjects_note: If you've edited the subjects please explain why (optional)
         failure_reason_notes: Note to the applicant
       assessor_interface_filter_form:
+        location: Country trained in
+        name: Applicant name
         reference: Application reference number
       qualification:
         add_another_options:
@@ -77,6 +79,12 @@ en:
         recommendation: QTS review completed
       assessor_interface_assessment_section_form:
         selected_failure_reasons: What are the reasons for your recommendation?
+      assessor_interface_filter_form:
+        assessor_ids: Assessor name
+        states: Status of application
+        submitted_at: Created date
+        submitted_at_after: Start date
+        submitted_at_before: End date
       qualification:
         add_another: Add another qualification?
       teacher_interface_alternative_name_form:

--- a/spec/lib/filters/reference_spec.rb
+++ b/spec/lib/filters/reference_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Filters::Reference do
+  subject(:filtered_scope) { described_class.apply(scope:, params:) }
+
+  context "the params include reference" do
+    let(:params) { { reference: "ABC" } }
+    let(:scope) { ApplicationForm.all }
+
+    context "exact match" do
+      let!(:included) { create(:application_form, reference: "ABC") }
+
+      before { create(:application_form, reference: "XYZ") }
+
+      it { is_expected.to contain_exactly(included) }
+    end
+
+    context "partial match" do
+      let!(:included) { create(:application_form, reference: "ABCDEF") }
+
+      before { create(:application_form, reference: "XYZ") }
+
+      it { is_expected.to contain_exactly(included) }
+    end
+
+    context "match with different case" do
+      let(:params) { { reference: "abc" } }
+
+      let!(:included) { create(:application_form, reference: "ABC") }
+
+      it { is_expected.to contain_exactly(included) }
+    end
+  end
+
+  context "the params don't include reference" do
+    let(:params) { {} }
+    let(:scope) { double }
+
+    it { is_expected.to eq(scope) }
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/applications.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/applications.rb
@@ -13,6 +13,10 @@ module PageObjects
         element :country, "input"
       end
 
+      section :reference_filter, "#app-applications-filters-reference" do
+        element :reference, "input"
+      end
+
       section :name_filter, "#app-applications-filters-name" do
         element :name, "input"
       end

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe "Assessor filtering application forms", type: :system do
     then_i_see_a_list_of_applications_filtered_by_country
 
     when_i_clear_the_filters
+    and_i_apply_the_reference_filter
+    then_i_see_a_list_of_applications_filtered_by_reference
+
+    when_i_clear_the_filters
     and_i_apply_the_name_filter
     then_i_see_a_list_of_applications_filtered_by_name
 
@@ -73,6 +77,16 @@ RSpec.describe "Assessor filtering application forms", type: :system do
     )
   end
 
+  def and_i_apply_the_reference_filter
+    applications_page.reference_filter.reference.set("CHER")
+    applications_page.apply_filters.click
+  end
+
+  def then_i_see_a_list_of_applications_filtered_by_reference
+    expect(applications_page.search_results.count).to eq(1)
+    expect(applications_page.search_results.first.name.text).to eq("Cher Bert")
+  end
+
   def and_i_apply_the_name_filter
     applications_page.name_filter.name.set("cher")
     applications_page.apply_filters.click
@@ -118,6 +132,7 @@ RSpec.describe "Assessor filtering application forms", type: :system do
         given_names: "Cher",
         family_name: "Bert",
         submitted_at: Date.new(2019, 12, 1),
+        reference: "CHERBERT",
       ),
       create(
         :application_form,

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -32,16 +32,6 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
 
       it { is_expected.to include(application_form) }
 
-      context "with a name filter" do
-        before do
-          expect_any_instance_of(Filters::Name).to receive(:apply).and_return(
-            ApplicationForm.none,
-          )
-        end
-
-        it { is_expected.to be_empty }
-      end
-
       context "with an assessor filter" do
         before do
           expect_any_instance_of(Filters::Assessor).to receive(
@@ -55,6 +45,26 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
       context "with a country filter" do
         before do
           expect_any_instance_of(Filters::Country).to receive(
+            :apply,
+          ).and_return(ApplicationForm.none)
+        end
+
+        it { is_expected.to be_empty }
+      end
+
+      context "with a name filter" do
+        before do
+          expect_any_instance_of(Filters::Name).to receive(:apply).and_return(
+            ApplicationForm.none,
+          )
+        end
+
+        it { is_expected.to be_empty }
+      end
+
+      context "with a reference filter" do
+        before do
+          expect_any_instance_of(Filters::Reference).to receive(
             :apply,
           ).and_return(ApplicationForm.none)
         end
@@ -240,6 +250,7 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
             assessor_ids: ["assessor_id"],
             location: "location",
             name: "name",
+            reference: "reference",
             states: ["state"],
           },
           location_autocomplete: "location_autocomplete",
@@ -254,6 +265,7 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
               "assessor_ids" => ["assessor_id"],
               "location" => "location",
               "name" => "name",
+              "reference" => "reference",
               "states" => ["state"],
             },
             "location_autocomplete" => "location_autocomplete",


### PR DESCRIPTION
This adds a new filter to the assessor application form index view allowing them to filter on a match or partial match of the reference number.

[Trello Card](https://trello.com/c/8hEPRuLY/1008-add-filter-by-reference)

## Screenshot

![Screenshot 2022-10-12 at 13 08 59](https://user-images.githubusercontent.com/510498/195341664-1fe9b746-cdaa-40f4-a013-28ba91332cd7.png)
