### PR TITLE
Work history updates

### DIFF
--- a/app/forms/teacher_interface/work_history_form.rb
+++ b/app/forms/teacher_interface/work_history_form.rb
@@ -11,19 +11,20 @@ module TeacherInterface
     attribute :country_code, :string
     attribute :contact_name, :string
     attribute :contact_email, :string
-    attribute :start_date, :date
+    attribute :start_date
+    attribute :end_date
     attribute :still_employed, :boolean
-    attribute :end_date, :date
 
+    validate :start_date_valid
+    validate :end_date_valid
+    validate :end_date_is_after_start_date
     validates :job, presence: true
     validates :school_name, presence: true
     validates :city, presence: true
     validates :country_code, presence: true
     validates :contact_name, presence: true
     validates :contact_email, presence: true, valid_for_notify: true
-    validates :start_date, presence: true
     validates :still_employed, inclusion: [true, false]
-    validates :end_date, presence: true, unless: :still_employed
 
     def country_code=(value)
       super(CountryCode.from_location(value))
@@ -41,6 +42,57 @@ module TeacherInterface
         still_employed:,
         end_date:,
       )
+    end
+
+    private
+
+    def start_date_valid
+      unless date_params_present?(start_date)
+        errors.add(:start_date, :blank) && return
+      end
+      unless date_params_are_valid?(start_date)
+        errors.add(:start_date, :invalid)
+      end
+      if date_params_are_valid?(start_date) &&
+           as_date(start_date) >= Time.zone.now
+        errors.add(:start_date, :future)
+      end
+    end
+
+    def end_date_valid
+      unless still_employed
+        unless date_params_present?(end_date)
+          errors.add(:end_date, :blank) && return
+        end
+        errors.add(:end_date, :invalid) unless date_params_are_valid?(end_date)
+      end
+    end
+
+    def end_date_is_after_start_date
+      if !still_employed && date_params_present?(start_date) &&
+           date_params_present?(end_date) &&
+           date_params_are_valid?(start_date) &&
+           date_params_are_valid?(end_date) &&
+           (as_date(end_date) <= as_date(start_date))
+        errors.add(:end_date, :before_start_date)
+      end
+    end
+
+    def date_params_are_valid?(date_hash)
+      as_date(date_hash)
+      true
+    rescue Date::Error
+      false
+    end
+
+    def as_date(date_hash)
+      Date.new(date_hash[1], date_hash[2], date_hash[3])
+    end
+
+    def date_params_present?(date_hash)
+      return false if date_hash.blank?
+
+      date_hash.compact.length == 3
     end
   end
 end

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -27,7 +27,7 @@
 class WorkHistory < ApplicationRecord
   belongs_to :application_form
 
-  scope :ordered, -> { order(start_date: :asc, created_at: :asc) }
+  scope :ordered, -> { order(start_date: :desc, created_at: :desc) }
 
   def status
     values = [

--- a/app/views/shared/application_form/_work_history_summary.html.erb
+++ b/app/views/shared/application_form/_work_history_summary.html.erb
@@ -43,7 +43,7 @@
         format: :without_day,
         href: [:edit, :teacher_interface, :application_form, work_history]
       },
-      end_date: work_history.still_employed ? {
+      end_date: !work_history.still_employed ? {
         title: "Role end date",
         format: :without_day,
         href: [:edit, :teacher_interface, :application_form, work_history]

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -58,12 +58,16 @@ en:
               blank: Enter the contact name
             contact_email:
               blank: Enter the contact email
-            start_date:
-              blank: Enter the start date
             still_employed:
               inclusion: Select whether you are still employed
             end_date:
-              blank: Enter the end date
+              blank: Enter an end date
+              before_start_date: End date must be after start date
+              invalid: End date is invalid
+            start_date:
+              blank: Enter a start date
+              invalid: Start date is invalid
+              future: Start date must be in the past
   application_form:
     status:
       not_started: Not started

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -46,28 +46,30 @@ en:
               blank: You must confirm that you have no sanctions or restrictions
         teacher_interface/work_history_form:
           attributes:
-            job:
-              blank: Enter the job
-            school_name:
-              blank: Enter the school name
-            city:
-              blank: Enter the city
-            country_code:
-              blank: Enter the country
             contact_name:
-              blank: Enter the contact name
+              blank: Enter a contact name
             contact_email:
-              blank: Enter the contact email
-            still_employed:
-              inclusion: Select whether you are still employed
+              blank: Enter a contact email
             end_date:
               blank: Enter an end date
               before_start_date: End date must be after start date
-              invalid: End date is invalid
+              invalid: End date is not a valid date
             start_date:
               blank: Enter a start date
-              invalid: Start date is invalid
+              invalid: Start date is not a valid date
               future: Start date must be in the past
+            school_name:
+              blank: Enter a school name
+            city:
+              blank: Enter a city
+            country_code:
+              blank: Enter a country
+            job:
+              blank: Enter a job role
+            email:
+              blank: Enter an email
+            still_employed:
+              inclusion: Tell us whether you are still employed at this school
   application_form:
     status:
       not_started: Not started

--- a/spec/forms/teacher_interface/work_history_form_spec.rb
+++ b/spec/forms/teacher_interface/work_history_form_spec.rb
@@ -47,7 +47,9 @@ RSpec.describe TeacherInterface::WorkHistoryForm, type: :model do
       it "must be valid" do
         form.start_date = { 1 => 2022, 2 => 13, 3 => 1 }
         form.valid?
-        expect(form.errors[:start_date]).to eq(["Start date is invalid"])
+        expect(form.errors[:start_date]).to eq(
+          ["Start date is not a valid date"],
+        )
       end
 
       it "must be in the past" do
@@ -81,7 +83,7 @@ RSpec.describe TeacherInterface::WorkHistoryForm, type: :model do
         it "must be valid" do
           form.end_date = { 1 => 2022, 2 => 13, 3 => 1 }
           form.valid?
-          expect(form.errors[:end_date]).to eq(["End date is invalid"])
+          expect(form.errors[:end_date]).to eq(["End date is not a valid date"])
         end
 
         it "must be after start_date" do

--- a/spec/forms/teacher_interface/work_history_form_spec.rb
+++ b/spec/forms/teacher_interface/work_history_form_spec.rb
@@ -38,16 +38,61 @@ RSpec.describe TeacherInterface::WorkHistoryForm, type: :model do
     it { is_expected.to validate_presence_of(:start_date) }
     it { is_expected.to allow_values(true, false).for(:still_employed) }
 
-    context "when still employed" do
-      let(:still_employed) { "true" }
+    describe "start_date" do
+      it "is required" do
+        form.valid?
+        expect(form.errors[:start_date]).to eq(["Enter a start date"])
+      end
 
-      it { is_expected.to_not validate_presence_of(:end_date) }
+      it "must be valid" do
+        form.start_date = { 1 => 2022, 2 => 13, 3 => 1 }
+        form.valid?
+        expect(form.errors[:start_date]).to eq(["Start date is invalid"])
+      end
+
+      it "must be in the past" do
+        future = 1.month.from_now
+        form.start_date = { 1 => future.year, 2 => future.month, 3 => 1 }
+        form.valid?
+        expect(form.errors[:start_date]).to eq(
+          ["Start date must be in the past"],
+        )
+      end
     end
 
-    context "when not still employed" do
-      let(:still_employed) { "false" }
+    describe "end_date" do
+      context "when still employed" do
+        let(:still_employed) { "true" }
 
-      it { is_expected.to validate_presence_of(:end_date) }
+        it "isn't required" do
+          form.valid?
+          expect(form.errors[:end_date]).to eq([])
+        end
+      end
+
+      context "when not still employed" do
+        let(:still_employed) { "false" }
+
+        it "is required" do
+          form.valid?
+          expect(form.errors[:end_date]).to eq(["Enter an end date"])
+        end
+
+        it "must be valid" do
+          form.end_date = { 1 => 2022, 2 => 13, 3 => 1 }
+          form.valid?
+          expect(form.errors[:end_date]).to eq(["End date is invalid"])
+        end
+
+        it "must be after start_date" do
+          form.end_date = { 1 => 2022, 2 => 10, 3 => 1 }
+          form.start_date = { 1 => 2022, 2 => 11, 3 => 1 }
+          form.valid?
+          expect(form.errors[:end_date]).to eq(
+            ["End date must be after start date"],
+          )
+        end
+      end
     end
   end
 
@@ -58,7 +103,7 @@ RSpec.describe TeacherInterface::WorkHistoryForm, type: :model do
     let(:country_code) { "country:FR" }
     let(:contact_name) { "First Last" }
     let(:contact_email) { "school@example.com" }
-    let(:start_date) { "2020-01-01" }
+    let(:start_date) { { 1 => 2020, 2 => 10, 3 => 1 } }
     let(:still_employed) { "true" }
     let(:end_date) { "" }
 
@@ -71,7 +116,7 @@ RSpec.describe TeacherInterface::WorkHistoryForm, type: :model do
       expect(work_history.country_code).to eq("FR")
       expect(work_history.contact_name).to eq("First Last")
       expect(work_history.contact_email).to eq("school@example.com")
-      expect(work_history.start_date).to eq(Date.new(2020, 1, 1))
+      expect(work_history.start_date).to eq(Date.new(2020, 10, 1))
       expect(work_history.still_employed).to be true
       expect(work_history.end_date).to be_nil
     end

--- a/spec/models/work_history_spec.rb
+++ b/spec/models/work_history_spec.rb
@@ -80,6 +80,20 @@ RSpec.describe WorkHistory, type: :model do
     end
   end
 
+  describe ".ordered" do
+    let(:newest) { create(:work_history, start_date: 1.week.ago) }
+    let(:oldest) { create(:work_history, start_date: 1.month.ago) }
+
+    before do
+      oldest
+      newest
+    end
+
+    it "orders in reverse order of start date" do
+      expect(described_class.ordered).to eq([newest, oldest])
+    end
+  end
+
   describe "#current_or_most_recent_role?" do
     subject(:current_or_most_recent_role?) do
       work_history.current_or_most_recent_role?


### PR DESCRIPTION
* Add start and end date validation
* Update error messages
* Hide end date when there isn't one
* Show the most recent position first and order newest to oldest.

We were hoping to remove the use of `ActiveRecord::AttributeAssignment` in the form with this but it got quite messy without it. I think it's simpler to leave it and be able to use the date component. Open to discussion on that though.