### PR TITLE
Order applications by oldest first

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -75,7 +75,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
         ::Filters::State.apply(
           scope: application_forms_without_state_filter,
           params: filter_params,
-        ).order(submitted_at: :desc),
+        ).order(submitted_at: :asc),
       )
   end
 

--- a/spec/system/assessor_interface/listing_application_forms_spec.rb
+++ b/spec/system/assessor_interface/listing_application_forms_spec.rb
@@ -70,6 +70,6 @@ RSpec.describe "Assessor listing application forms", type: :system do
         25,
         :with_personal_information,
         :submitted,
-      ).sort_by(&:submitted_at).reverse
+      ).sort_by(&:submitted_at)
   end
 end

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
         )
       end
 
-      it { is_expected.to eq([application_form_2, application_form_1]) }
+      it { is_expected.to eq([application_form_1, application_form_2]) }
     end
 
     context "with lots of application forms" do


### PR DESCRIPTION
This changes the order in which applications are listed in the assessor interface so that the oldest ones are shown at the top.