### PR TITLE
Improve failure reasons for qualifications

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -60,21 +60,21 @@ class AssessmentFactory
       has_university_degree_transcript
       has_additional_qualification_certificate
       has_additional_degree_transcript
-    ].compact
+    ]
 
     failure_reasons = %i[
+      application_and_qualification_names_do_not_match
       teaching_qualifications_from_ineligible_country
       teaching_qualifications_not_at_required_level
+      teaching_hours_not_fulfilled
       not_qualified_to_teach_mainstream
+      qualifications_dont_match_subjects
+      qualifications_dont_match_other_details
       teaching_certificate_illegible
-      teaching_qualification_illegible
+      teaching_transcript_illegible
       degree_certificate_illegible
       degree_transcript_illegible
-      application_and_qualification_names_do_not_match
-      teaching_hours_not_fulfilled
-      qualifications_dont_support_subjects
-      qualifications_dont_match_those_entered
-    ].compact
+    ]
 
     AssessmentSection.new(key: "qualifications", checks:, failure_reasons:)
   end

--- a/app/lib/further_information_request_items_factory.rb
+++ b/app/lib/further_information_request_items_factory.rb
@@ -43,8 +43,8 @@ class FurtherInformationRequestItemsFactory
   end
 
   TEXT_FAILURE_REASONS = %w[
-    qualifications_dont_support_subjects
-    qualifications_dont_match_those_entered
+    qualifications_dont_match_subjects
+    qualifications_dont_match_other_details
     satisfactory_evidence_work_history
   ].freeze
 
@@ -54,9 +54,9 @@ class FurtherInformationRequestItemsFactory
     "identification_document_mismatch" => :name_change,
     "name_change_document_illegible" => :name_change,
     "teaching_certificate_illegible" => :qualification_certificate,
-    "teaching_qualification_illegible" => :qualification_transcript,
+    "teaching_transcript_illegible" => :qualification_transcript,
     "degree_certificate_illegible" => :qualification_certificate,
-    "degree_qualification_illegible" => :qualification_transcript,
+    "degree_transcript_illegible" => :qualification_transcript,
     "application_and_qualification_names_do_not_match" => :name_change,
     "written_statement_illegible" => :written_statement,
     "written_statement_recent" => :written_statement,

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -72,15 +72,15 @@ en:
           applicant_already_qts: The applicant already holds QTS and induction exemption.
           teaching_qualifications_from_ineligible_country: Teaching qualifications were completed in an ineligible country.
           teaching_qualifications_not_at_required_level: Teaching qualifications do not meet the required academic level.
-          not_qualified_to_teach_mainstream: Not qualified to teach in mainstream education.
+          not_qualified_to_teach_mainstream: Applicant is not qualified to teach in mainstream education.
           teaching_certificate_illegible: The teaching qualification certificate (or translation) is illegible.
-          teaching_qualification_illegible: The teaching qualification transcript (or translation) is illegible.
+          teaching_transcript_illegible: The teaching qualification transcript (or translation) is illegible.
           degree_certificate_illegible: The university degree certificate (or translation) is illegible.
           degree_transcript_illegible: University degree transcript (or translation) is illegible.
           application_and_qualification_names_do_not_match: The name on the online application form is different from 1 or more qualification documents, but no evidence of change of name was provided.
           teaching_hours_not_fulfilled: The required teaching hours have not been fulfilled.
-          qualifications_dont_support_subjects: The qualifications do not support the teaching subjects entered.
-          qualifications_dont_match_those_entered: The qualifications do not match what was entered on the form.
+          qualifications_dont_match_subjects: Subjects entered are acceptable for QTS, but the uploaded qualifications do not match them.
+          qualifications_dont_match_other_details: Uploaded qualifications do not match other details entered, for example, name of qualification, name of institution or dates.
           age_range: The age range the applicant is qualified to teach does not fall within the requirements of QTS.
           satisfactory_evidence_work_history: The information provided on work history is not sufficient to award QTS.
           registration_number: We could not verify the reference number using the online checker.

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -3,8 +3,8 @@ en:
     further_information_request:
       show:
         failure_reason:
-          qualifications_dont_support_subjects: Tell us more about the subjects you can teach
-          qualifications_dont_match_those_entered: Tell us more about your qualifications
+          qualifications_dont_match_subjects: Tell us more about the subjects you can teach
+          qualifications_dont_match_other_details: Tell us more about your qualifications
           satisfactory_evidence_work_history: Tell us more about your work history
           registration_number: Tell us your registration number
   activemodel:

--- a/spec/factories/assessment_sections.rb
+++ b/spec/factories/assessment_sections.rb
@@ -64,13 +64,13 @@ FactoryBot.define do
           teaching_qualifications_not_at_required_level
           not_qualified_to_teach_mainstream
           teaching_certificate_illegible
-          teaching_qualification_illegible
+          teaching_transcript_illegible
           degree_certificate_illegible
           degree_transcript_illegible
           application_and_qualification_names_do_not_match
           teaching_hours_not_fulfilled
-          qualifications_dont_support_subjects
-          qualifications_dont_match_those_entered
+          qualifications_dont_match_subjects
+          qualifications_dont_match_other_details
         ]
       end
     end

--- a/spec/factories/further_information_request_items.rb
+++ b/spec/factories/further_information_request_items.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
 
     trait :with_text_response do
       information_type { "text" }
-      failure_reason { "qualifications_dont_support_subjects" }
+      failure_reason { "qualifications_dont_match_subjects" }
     end
 
     trait :with_document_response do

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -94,17 +94,17 @@ RSpec.describe AssessmentFactory do
 
           expect(section.failure_reasons).to eq(
             %w[
+              application_and_qualification_names_do_not_match
               teaching_qualifications_from_ineligible_country
               teaching_qualifications_not_at_required_level
+              teaching_hours_not_fulfilled
               not_qualified_to_teach_mainstream
+              qualifications_dont_match_subjects
+              qualifications_dont_match_other_details
               teaching_certificate_illegible
-              teaching_qualification_illegible
+              teaching_transcript_illegible
               degree_certificate_illegible
               degree_transcript_illegible
-              application_and_qualification_names_do_not_match
-              teaching_hours_not_fulfilled
-              qualifications_dont_support_subjects
-              qualifications_dont_match_those_entered
             ],
           )
         end

--- a/spec/lib/further_information_request_items_factory_spec.rb
+++ b/spec/lib/further_information_request_items_factory_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe FurtherInformationRequestItemsFactory do
           :qualifications,
           :failed,
           selected_failure_reasons: {
-            qualifications_dont_support_subjects: "Subjects.",
+            qualifications_dont_match_subjects: "Subjects.",
             unknown_reason: "Unknown.",
           },
         ),
@@ -52,9 +52,7 @@ RSpec.describe FurtherInformationRequestItemsFactory do
 
       it "has attributes" do
         expect(item).to be_text
-        expect(item.failure_reason).to eq(
-          "qualifications_dont_support_subjects",
-        )
+        expect(item.failure_reason).to eq("qualifications_dont_match_subjects")
         expect(item.assessor_notes).to eq("Subjects.")
       end
     end

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
   def and_i_see_the_further_information_request_items
     expect(request_further_information_page.items.count).to eq(1)
     expect(request_further_information_page.items.first.heading.text).to eq(
-      "The qualifications do not support the teaching subjects entered.",
+      "Subjects entered are acceptable for QTS, but the uploaded qualifications do not match them.",
     )
     expect(
       request_further_information_page.items.first.assessor_notes.text,
@@ -112,7 +112,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
           :qualifications,
           :failed,
           selected_failure_reasons: {
-            qualifications_dont_support_subjects: "A note.",
+            qualifications_dont_match_subjects: "A note.",
           },
         )
       end

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
           :failed,
           assessment:,
           selected_failure_reasons: {
-            qualifications_dont_support_subjects: "A note.",
+            qualifications_dont_match_subjects: "A note.",
           },
         )
       end


### PR DESCRIPTION
These changes have been requested by our content designer to make the failure reasons clearer for users. Since we haven't launched yet I've taken the opportunity to rename the keys, which is something we won't be able to do once we've got real assessments using them.

[Trello Card](https://trello.com/c/xkRU6POG/899-iterate-quals-assessment-check-box-content)