### PR TITLE
Simplify subjects form

### DIFF
--- a/app/controllers/teacher_interface/subjects_controller.rb
+++ b/app/controllers/teacher_interface/subjects_controller.rb
@@ -1,42 +1,43 @@
 module TeacherInterface
   class SubjectsController < BaseController
+    include HandleApplicationFormSection
+
     before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
 
     def edit
+      @subjects_form =
+        SubjectsForm.new(
+          application_form:,
+          subject_1: application_form.subjects.first,
+          subject_2: application_form.subjects.second,
+          subject_3: application_form.subjects.third,
+        )
     end
 
     def update
-      if application_form.update(subjects_params)
-        if params[:create] == "true"
-          application_form.subjects.push("")
-          application_form.save!
+      @subjects_form =
+        SubjectsForm.new(subjects_form_params.merge(application_form:))
 
-          redirect_to subjects_teacher_interface_application_form_path(
-                        next: params[:next],
-                      )
-        else
-          redirect_to params[:next].presence ||
-                        %i[teacher_interface application_form]
-        end
-      else
-        render :new, status: unprocessable_entity
-      end
-    end
-
-    def delete
-      application_form.subjects.delete_at(params[:index].to_i)
-      application_form.save!
-
-      redirect_to subjects_teacher_interface_application_form_path(
-                    next: params[:next],
-                  )
+      handle_application_form_section(
+        form: @subjects_form,
+        if_success_then_redirect:,
+        if_failure_then_render: :edit,
+      )
     end
 
     private
 
-    def subjects_params
-      params.require(:application_form).permit(subjects: [])
+    def subjects_form_params
+      params.require(:teacher_interface_subjects_form).permit(
+        :subject_1,
+        :subject_2,
+        :subject_3,
+      )
+    end
+
+    def if_success_then_redirect
+      params[:next].presence || %i[teacher_interface application_form]
     end
   end
 end

--- a/app/forms/teacher_interface/subjects_form.rb
+++ b/app/forms/teacher_interface/subjects_form.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class TeacherInterface::SubjectsForm < TeacherInterface::BaseForm
+  attr_accessor :application_form
+  attribute :subject_1, :string
+  attribute :subject_2, :string
+  attribute :subject_3, :string
+
+  validates :application_form, presence: true
+  validates :subject_1, presence: true
+
+  def update_model
+    application_form.update!(subjects:)
+  end
+
+  private
+
+  def subjects
+    [subject_1, subject_2, subject_3].compact_blank
+  end
+end

--- a/app/views/teacher_interface/subjects/edit.html.erb
+++ b/app/views/teacher_interface/subjects/edit.html.erb
@@ -5,33 +5,13 @@
 <h1 class="govuk-heading-l"><%= I18n.t("application_form.subjects.heading") %></h1>
 <p class="govuk-hint"><%= I18n.t("application_form.subjects.hint") %></p>
 
-<%= form_with model: @application_form, url: %i[subjects teacher_interface application_form], method: :post do |f| %>
+<%= form_with model: @subjects_form, url: %i[subjects teacher_interface application_form] do |f| %>
   <%= hidden_field_tag :next, params[:next] %>
 
   <%= f.govuk_error_summary %>
 
-  <% if @application_form.subjects.empty? %>
-    <%= f.govuk_text_field :subjects, multiple: true %>
-  <% else %>
-    <% @application_form.subjects.each_with_index do |value, index| %>
-      <div class="govuk-form-group">
-        <%= f.label :subjects,
-                    for: "application_form_subjects_#{index}",
-                    class: "govuk-label" %>
-        <%= f.text_field :subjects,
-                         id: "application_form_subjects_#{index}",
-                         multiple: true,
-                         class: "govuk-input",
-                         value: %>
-        <% if index != 0 %>
-          <%= govuk_link_to "Remove", subjects_delete_teacher_interface_application_form_path(index:, next: params[:next]) %>
-        <% end %>
-      </div>
-    <% end %>
-  <% end %>
-
-  <% if @application_form.subjects.count <= 2 %>
-    <%= f.govuk_submit "Add another subject", secondary: true, name: "create", value: "true" %>
+  <% (1..3).map { |i| :"subject_#{i}" }.each do |field| %>
+    <%= f.govuk_text_field field %>
   <% end %>
 
   <%= render "shared/save_submit_buttons", f: %>

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -65,6 +65,10 @@ en:
         email: Email address
       teacher_interface_registration_number_form:
         registration_number: What is your registration number?
+      teacher_interface_subjects_form:
+        subject_1: Subject 1
+        subject_2: Subject 2 (optional)
+        subject_3: Subject 3 (optional)
       teacher_interface_work_history_form:
         contact_name: Contact’s full name
         contact_email: Contact email address for this organisation

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -7,69 +7,7 @@ en:
           qualifications_dont_match_those_entered: Tell us more about your qualifications
           satisfactory_evidence_work_history: Tell us more about your work history
           registration_number: Tell us your registration number
-  activemodel:
-    errors:
-      models:
-        teacher_interface/name_and_date_of_birth_form:
-          attributes:
-            date_of_birth:
-              blank: Enter your date of birth in the format 27 3 1980
-              too_young: You must be 18 or over to use this service
-              too_old: Your date of birth cannot be that far in the past
-            given_names:
-              blank: Enter your given names
-            family_name:
-              blank: Enter your family name
-        teacher_interface/alternative_name_form:
-          attributes:
-            alternative_given_names:
-              blank: Enter your alternate given names
-            alternative_family_name:
-              blank: Enter your alternate family name
-            has_alternative_name:
-              inclusion: Tell us whether you have an alternative name
-        teacher_interface/add_another_upload_form:
-          attributes:
-            add_another:
-              inclusion: Select whether you need to upload another page
-        teacher_interface/delete_upload_form:
-          attributes:
-            confirm:
-              inclusion: Select whether you want to delete this file
-        teacher_interface/new_session_form:
-          attributes:
-            email:
-              blank: Enter your email address
-        teacher_interface/sanction_confirmation_form:
-          attributes:
-            confirmed_no_sanctions:
-              blank: You must confirm that you have no sanctions or restrictions
-        teacher_interface/work_history_form:
-          attributes:
-            contact_name:
-              blank: Enter a contact name
-            contact_email:
-              blank: Enter a contact email
-            end_date:
-              blank: Enter an end date
-              before_start_date: End date must be after start date
-              invalid: End date is not a valid date
-            start_date:
-              blank: Enter a start date
-              invalid: Start date is not a valid date
-              future: Start date must be in the past
-            school_name:
-              blank: Enter a school name
-            city:
-              blank: Enter a city
-            country_code:
-              blank: Enter a country
-            job:
-              blank: Enter a job role
-            email:
-              blank: Enter an email
-            still_employed:
-              inclusion: Tell us whether you are still employed at this school
+
   application_form:
     status:
       not_started: Not started
@@ -154,3 +92,67 @@ en:
       title: Overview
       application_history: Application history
       view_timeline: View timeline of this applications actions
+
+  activemodel:
+    errors:
+      models:
+        teacher_interface/alternative_name_form:
+          attributes:
+            alternative_given_names:
+              blank: Enter your alternate given names
+            alternative_family_name:
+              blank: Enter your alternate family name
+            has_alternative_name:
+              inclusion: Tell us whether you have an alternative name
+        teacher_interface/add_another_upload_form:
+          attributes:
+            add_another:
+              inclusion: Select whether you need to upload another page
+        teacher_interface/delete_upload_form:
+          attributes:
+            confirm:
+              inclusion: Select whether you want to delete this file
+        teacher_interface/name_and_date_of_birth_form:
+          attributes:
+            date_of_birth:
+              blank: Enter your date of birth in the format 27 3 1980
+              too_young: You must be 18 or over to use this service
+              too_old: Your date of birth cannot be that far in the past
+            given_names:
+              blank: Enter your given names
+            family_name:
+              blank: Enter your family name
+        teacher_interface/new_session_form:
+          attributes:
+            email:
+              blank: Enter your email address
+        teacher_interface/sanction_confirmation_form:
+          attributes:
+            confirmed_no_sanctions:
+              blank: You must confirm that you have no sanctions or restrictions
+        teacher_interface/work_history_form:
+          attributes:
+            contact_name:
+              blank: Enter a contact name
+            contact_email:
+              blank: Enter a contact email
+            end_date:
+              blank: Enter an end date
+              before_start_date: End date must be after start date
+              invalid: End date is not a valid date
+            start_date:
+              blank: Enter a start date
+              invalid: Start date is not a valid date
+              future: Start date must be in the past
+            school_name:
+              blank: Enter a school name
+            city:
+              blank: Enter a city
+            country_code:
+              blank: Enter a country
+            job:
+              blank: Enter a job role
+            email:
+              blank: Enter an email
+            still_employed:
+              inclusion: Tell us whether you are still employed at this school

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -130,6 +130,10 @@ en:
           attributes:
             confirmed_no_sanctions:
               blank: You must confirm that you have no sanctions or restrictions
+        teacher_interface/subjects_form:
+          attributes:
+            subject_1:
+              blank: Enter your first subject
         teacher_interface/work_history_form:
           attributes:
             contact_name:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -139,7 +139,6 @@ Rails.application.routes.draw do
 
         get "subjects", to: "subjects#edit"
         post "subjects", to: "subjects#update"
-        get "subjects/delete", to: "subjects#delete"
 
         get "registration_number", to: "registration_number#edit"
         post "registration_number", to: "registration_number#update"

--- a/spec/controllers/teacher_interface/subjects_controller_spec.rb
+++ b/spec/controllers/teacher_interface/subjects_controller_spec.rb
@@ -21,10 +21,4 @@ RSpec.describe TeacherInterface::SubjectsController, type: :controller do
 
     include_examples "redirect unless application form is draft"
   end
-
-  describe "GET delete" do
-    subject(:perform) { get :delete }
-
-    include_examples "redirect unless application form is draft"
-  end
 end

--- a/spec/forms/teacher_interface/subjects_form.rb
+++ b/spec/forms/teacher_interface/subjects_form.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe TeacherInterface::SubjectsForm, type: :model do
+  let(:application_form) { build(:application_form) }
+
+  subject(:form) do
+    described_class.new(application_form:, subject_1:, subject_2:, subject_3:)
+  end
+
+  describe "validations" do
+    let(:subject_1) { "" }
+    let(:subject_2) { "" }
+    let(:subject_3) { "" }
+
+    it { is_expected.to validate_presence_of(:application_form) }
+    it { is_expected.to validate_presence_of(:subject_1) }
+    it { is_expected.to_not validate_presence_of(:subject_2) }
+    it { is_expected.to_not validate_presence_of(:subject_3) }
+  end
+
+  describe "#save" do
+    let(:subject_1) { "Subject 1" }
+    let(:subject_2) { "Subject 2" }
+    let(:subject_3) { "" }
+
+    before { form.save(validate: true) }
+
+    it "saves the application form" do
+      expect(application_form.subjects).to eq(["Subject 1", "Subject 2"])
+    end
+  end
+end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -426,27 +426,6 @@ RSpec.describe "Teacher application", type: :system do
     then_i_see_the_qualifications_summary
   end
 
-  it "allows adding and removing subjects" do
-    given_an_eligible_eligibility_check_with_none_country_checks
-
-    when_i_click_apply_for_qts
-    and_i_sign_up
-    then_i_see_the_teacher_application_page
-    and_i_see_the_work_history_is_not_started
-
-    when_i_click_subjects
-    then_i_see_the_subjects_form
-
-    when_i_fill_in_subjects
-    and_i_click_add_another_subject
-    then_i_see_the_two_subjects_form
-
-    when_i_click_remove
-    then_i_see_the_subjects_form
-    and_i_click_continue
-    then_i_see_completed_subjects_section
-  end
-
   it "allows skipping name change document" do
     given_an_eligible_eligibility_check_with_none_country_checks
 
@@ -590,12 +569,9 @@ RSpec.describe "Teacher application", type: :system do
     )
   end
 
-  def and_i_click_add_another_subject
-    click_button "Add another subject"
-  end
-
   def when_i_fill_in_subjects
-    fill_in "application-form-subjects-field", with: "Subject"
+    fill_in "teacher-interface-subjects-form-subject-1-field", with: "Subject1"
+    fill_in "teacher-interface-subjects-form-subject-2-field", with: "Subject2"
   end
 
   def when_i_click_work_history
@@ -1097,7 +1073,7 @@ RSpec.describe "Teacher application", type: :system do
     subject_row =
       check_your_answers_page.who_you_can_teach.subjects_summary_list.rows.first
     expect(subject_row.key.text).to eq("Subjects")
-    expect(subject_row.value.text).to eq("Subject")
+    expect(subject_row.value.text).to eq("Subject1\nSubject2")
   end
 
   def and_i_see_check_your_work_history


### PR DESCRIPTION
This simplifies the subjects form by changing it to three fields, where the first one is optional, as per the prototype.

[Trello Card](https://trello.com/c/71olMOJW/1037-update-application-form-subjects-to-match-prototype)

## Screenshots

![Screenshot 2022-10-20 at 10 27 11](https://user-images.githubusercontent.com/510498/196921269-5a645d82-4a19-4fc2-936e-842d9675699f.png)
![Screenshot 2022-10-20 at 10 27 22](https://user-images.githubusercontent.com/510498/196921275-49440bb9-73d9-40c4-9341-12d09ea6faeb.png)
![Screenshot 2022-10-20 at 10 28 17](https://user-images.githubusercontent.com/510498/196921276-7fc9b955-50e0-4cc5-b1ca-7bb9d2b7d00a.png)
