### PR TITLE
Filter parameter logging

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -13,4 +13,5 @@ Rails.application.config.filter_parameters += %i[
   certificate
   otp
   ssn
+  email
 ]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -7,6 +7,7 @@ Rails.application.config.filter_parameters += %i[
   passw
   secret
   token
+  confirmation_token
   _key
   crypt
   salt


### PR DESCRIPTION
This adds `email` and `confirmation_token` as new fields we should filter from the logging to avoid any tokens or personal information being leaked in to our logs.

[Trello Card](https://trello.com/c/yb2B9DSd/229-filter-parameter-logging)