### PR TITLE
Add recommendation confirm page

### DIFF
--- a/app/controllers/assessor_interface/assessments_controller.rb
+++ b/app/controllers/assessor_interface/assessments_controller.rb
@@ -3,14 +3,24 @@ module AssessorInterface
     before_action :load_assessment_and_application_form
 
     def edit
+      @confirm_recommendation_form =
+        ConfirmRecommendationForm.new(
+          assessment:,
+          user: current_staff,
+          recommendation: assessment.recommendation,
+        )
     end
 
     def update
-      if UpdateAssessmentRecommendation.call(
-           assessment: @assessment,
-           user: current_staff,
-           new_recommendation: assessment_params[:recommendation],
-         )
+      @confirm_recommendation_form =
+        ConfirmRecommendationForm.new(
+          confirm_recommendation_form_params.merge(
+            assessment:,
+            user: current_staff,
+          ),
+        )
+
+      if @confirm_recommendation_form.save
         redirect_to post_update_redirect_path
       else
         render :edit, status: :unprocessable_entity
@@ -20,17 +30,23 @@ module AssessorInterface
     private
 
     def load_assessment_and_application_form
-      @assessment =
+      @assessment = assessment
+      @application_form = assessment.application_form
+    end
+
+    def assessment
+      @assessment ||=
         Assessment
           .includes(:application_form)
           .where(application_form_id: params[:application_form_id])
           .find(params[:id])
-
-      @application_form = @assessment.application_form
     end
 
-    def assessment_params
-      params.require(:assessment).permit(:recommendation)
+    def confirm_recommendation_form_params
+      params.require(:assessor_interface_confirm_recommendation_form).permit(
+        :recommendation,
+        :confirm,
+      )
     end
 
     def post_update_redirect_path

--- a/app/controllers/assessor_interface/assessments_controller.rb
+++ b/app/controllers/assessor_interface/assessments_controller.rb
@@ -11,6 +11,24 @@ module AssessorInterface
         )
     end
 
+    def confirm
+      @confirm_recommendation_form =
+        ConfirmRecommendationForm.new(
+          confirm_recommendation_form_params.merge(
+            assessment:,
+            user: current_staff,
+          ),
+        )
+
+      if @confirm_recommendation_form.needs_confirmation?
+        render :confirm
+      elsif @confirm_recommendation_form.save
+        redirect_to post_update_redirect_path
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
     def update
       @confirm_recommendation_form =
         ConfirmRecommendationForm.new(
@@ -23,7 +41,7 @@ module AssessorInterface
       if @confirm_recommendation_form.save
         redirect_to post_update_redirect_path
       else
-        render :edit, status: :unprocessable_entity
+        render :confirm, status: :unprocessable_entity
       end
     end
 

--- a/app/forms/assessor_interface/confirm_recommendation_form.rb
+++ b/app/forms/assessor_interface/confirm_recommendation_form.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AssessorInterface::ConfirmRecommendationForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :assessment, :user
+  attribute :recommendation, :string
+  attribute :confirm, :boolean
+
+  validates :assessment, :user, :recommendation, presence: true
+  validates :confirm, presence: true, if: :needs_confirmation?
+  validate :recommendation_allowed
+
+  def save
+    return false unless valid?
+
+    UpdateAssessmentRecommendation.call(
+      assessment:,
+      user:,
+      new_recommendation: recommendation,
+    )
+  end
+
+  def recommendation_allowed
+    return if assessment.blank? || recommendation.blank?
+
+    unless assessment.available_recommendations.include?(recommendation)
+      errors.add(:recommendation, :inclusion)
+    end
+  end
+
+  def needs_confirmation?
+    recommendation == "award"
+  end
+end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -6,6 +6,7 @@
 #  age_range_max       :integer
 #  age_range_min       :integer
 #  recommendation      :string           default("unknown"), not null
+#  recommended_at      :date
 #  subjects            :text             default([]), not null, is an Array
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/app/services/update_assessment_recommendation.rb
+++ b/app/services/update_assessment_recommendation.rb
@@ -13,7 +13,12 @@ class UpdateAssessmentRecommendation
     return true if assessment.recommendation == new_recommendation
 
     ActiveRecord::Base.transaction do
-      next false unless assessment.update(recommendation: new_recommendation)
+      unless assessment.update(
+               recommendation: new_recommendation,
+               recommended_at: Time.zone.now,
+             )
+        next false
+      end
 
       if (new_state = new_application_form_state)
         ChangeApplicationFormState.call(

--- a/app/views/assessor_interface/assessments/confirm.html.erb
+++ b/app/views/assessor_interface/assessments/confirm.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title, "You’re about to award QTS" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+
+<h1 class="govuk-heading-xl">You’re about to award QTS</h1>
+
+<p class="govuk-body-l">You’re about to award QTS to <%= application_form_full_name(@application_form) %>.</p>
+<p class="govuk-body">Read the declaration and if you’re happy to award QTS, select ‘Accept and award QTS’.</p>
+<p class="govuk-body">If you need to check something, use the ‘Back’ button.</p>
+
+<%= form_with model: @confirm_recommendation_form, url: [:assessor_interface, @application_form, @assessment], method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.hidden_field :recommendation %>
+
+  <%= f.govuk_check_boxes_fieldset :confirm, small: true do %>
+    <%= f.govuk_check_box :confirm,
+                          true,
+                          false,
+                          multiple: false,
+                          link_errors: true %>
+  <% end %>
+
+  <%= f.govuk_submit "Accept and award QTS", prevent_double_click: false do %>
+    <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
+  <% end %>
+<% end %>

--- a/app/views/assessor_interface/assessments/edit.html.erb
+++ b/app/views/assessor_interface/assessments/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t("helpers.legend.assessment.recommendation") %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
-<%= form_with model: [:assessor_interface, @application_form, @assessment] do |f| %>
+<%= form_with model: @confirm_recommendation_form, url: [:assessor_interface, @application_form, @assessment], method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :recommendation,

--- a/app/views/assessor_interface/assessments/edit.html.erb
+++ b/app/views/assessor_interface/assessments/edit.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, t("helpers.legend.assessment.recommendation") %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
-<%= form_with model: @confirm_recommendation_form, url: [:assessor_interface, @application_form, @assessment], method: :put do |f| %>
+<%= form_with model: @confirm_recommendation_form, url: [:confirm, :assessor_interface, @application_form, @assessment] do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :recommendation,

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -69,6 +69,7 @@
     - age_range_note_id
     - subjects
     - subjects_note_id
+    - recommended_at
   :countries:
     - id
     - code

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -129,3 +129,8 @@ en:
               blank: Enter the subject
             selected_failure_reasons:
               blank: Select the reasons for your recommendation
+        assessor_interface/confirm_recommendation_form:
+          attributes:
+            recommendation:
+              blank: Select your recommendation
+              inclusion: Select your recommendation

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -134,3 +134,5 @@ en:
             recommendation:
               blank: Select your recommendation
               inclusion: Select your recommendation
+            confirm:
+              blank: You must confirm that you have reviewed this QTS application

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -24,7 +24,7 @@ en:
       work_history:
         add_another: You can use the next section to tell us about additional work history.
     label:
-      assessment:
+      assessor_interface_confirm_recommendation_form:
         recommendation_options:
           award: Award QTS
           request_further_information: Request further information
@@ -78,10 +78,10 @@ en:
       assessor_interface_filter_form:
         reference: "Example: 210245"
     legend:
-      assessment:
-        recommendation: QTS review completed
       assessor_interface_assessment_section_form:
         selected_failure_reasons: What are the reasons for your recommendation?
+      assessor_interface_confirm_recommendation_form:
+        recommendation: QTS review completed
       assessor_interface_filter_form:
         assessor_ids: Assessor name
         states: Status of application

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -25,6 +25,8 @@ en:
         add_another: You can use the next section to tell us about additional work history.
     label:
       assessor_interface_confirm_recommendation_form:
+        confirm_options:
+          true: I’ve reviewed this QTS application and I’m satisfied that the applicant meets all the requirements. I understand that by continuing, the applicant will be awarded qualified teacher status.
         recommendation_options:
           award: Award QTS
           request_further_information: Request further information
@@ -81,6 +83,7 @@ en:
       assessor_interface_assessment_section_form:
         selected_failure_reasons: What are the reasons for your recommendation?
       assessor_interface_confirm_recommendation_form:
+        confirm: Declaration
         recommendation: QTS review completed
       assessor_interface_filter_form:
         assessor_ids: Assessor name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
       resources :timeline_events, only: :index
 
       resources :assessments, only: %i[edit update] do
+        post "confirm", to: "assessments#confirm", on: :member
+
         resources :assessment_sections,
                   path: "/sections",
                   param: :key,

--- a/db/migrate/20221020173812_add_recommended_at_date_to_assessments.rb
+++ b/db/migrate/20221020173812_add_recommended_at_date_to_assessments.rb
@@ -1,0 +1,5 @@
+class AddRecommendedAtDateToAssessments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :assessments, :recommended_at, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_12_140253) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_20_173812) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -101,6 +101,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_12_140253) do
     t.bigint "age_range_note_id"
     t.text "subjects", default: [], null: false, array: true
     t.bigint "subjects_note_id"
+    t.date "recommended_at"
     t.index ["age_range_note_id"], name: "index_assessments_on_age_range_note_id"
     t.index ["application_form_id"], name: "index_assessments_on_application_form_id"
     t.index ["subjects_note_id"], name: "index_assessments_on_subjects_note_id"

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -6,6 +6,7 @@
 #  age_range_max       :integer
 #  age_range_min       :integer
 #  recommendation      :string           default("unknown"), not null
+#  recommended_at      :date
 #  subjects            :text             default([]), not null, is an Array
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/spec/forms/assessor_interface/confirm_recommendation_form_spec.rb
+++ b/spec/forms/assessor_interface/confirm_recommendation_form_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::ConfirmRecommendationForm, type: :model do
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:assessment) { create(:assessment, application_form:) }
+  let(:user) { create(:staff, :confirmed) }
+  let(:attributes) { {} }
+
+  subject(:form) { described_class.new(assessment:, user:, **attributes) }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:assessment) }
+    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to validate_presence_of(:recommendation) }
+    it { is_expected.to_not validate_presence_of(:confirm) }
+
+    context "with an awarded recommendation" do
+      let(:attributes) { { recommendation: "award" } }
+
+      it { is_expected.to validate_presence_of(:confirm) }
+    end
+
+    context "with an award-able assessment" do
+      before { allow(assessment).to receive(:can_award?).and_return(true) }
+
+      it do
+        is_expected.to validate_inclusion_of(:recommendation).in_array(
+          %w[award],
+        )
+      end
+    end
+
+    context "with a decline-able assessment" do
+      before { allow(assessment).to receive(:can_decline?).and_return(true) }
+
+      it do
+        is_expected.to validate_inclusion_of(:recommendation).in_array(
+          %w[decline],
+        )
+      end
+    end
+
+    context "with can_request_further_information-able assessment" do
+      before do
+        allow(assessment).to receive(
+          :can_request_further_information?,
+        ).and_return(true)
+      end
+
+      it do
+        is_expected.to validate_inclusion_of(:recommendation).in_array(
+          %w[request_further_information],
+        )
+      end
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    describe "with invalid attributes" do
+      it { is_expected.to be false }
+    end
+
+    describe "with valid attributes" do
+      let(:attributes) { { confirm: "true", recommendation: "award" } }
+
+      before { allow(assessment).to receive(:can_award?).and_return(true) }
+
+      it { is_expected.to be true }
+
+      it "sets the recommendation" do
+        expect { save }.to change(assessment, :recommendation).to("award")
+      end
+    end
+  end
+end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -8,6 +8,7 @@
 #  age_range_max       :integer
 #  age_range_min       :integer
 #  recommendation      :string           default("unknown"), not null
+#  recommended_at      :date
 #  subjects            :text             default([]), not null, is an Array
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/spec/services/update_assessment_recommendation_spec.rb
+++ b/spec/services/update_assessment_recommendation_spec.rb
@@ -24,6 +24,18 @@ RSpec.describe UpdateAssessmentRecommendation do
     end
   end
 
+  describe "assessment recommendation date" do
+    subject(:recommended_at) { assessment.recommended_at }
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to_not be_nil }
+    end
+  end
+
   describe "application form status" do
     subject(:state) { application_form.state }
 

--- a/spec/support/autoload/page_objects/assessor_interface/confirm_assessment.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/confirm_assessment.rb
@@ -1,0 +1,14 @@
+module PageObjects
+  module AssessorInterface
+    class ConfirmAssessment < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/confirm"
+
+      element :heading, "h1"
+
+      section :form, "form" do
+        element :confirm_declaration, ".govuk-checkboxes__input", visible: false
+        element :submit_button, ".govuk-button"
+      end
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -54,6 +54,11 @@ module PageHelpers
       PageObjects::AssessorInterface::CompleteAssessment.new
   end
 
+  def confirm_assessment_page
+    @confirm_assessment_page ||=
+      PageObjects::AssessorInterface::ConfirmAssessment.new
+  end
+
   def country_page
     @country_page ||= PageObjects::EligibilityInterface::Country.new
   end


### PR DESCRIPTION
This adds a new page as part of submitting the recommendation of an assessment to include a confirmation declaration if the user chooses to award QTS.

[Trello Card](https://trello.com/c/TC0duusr/1046-award-confirmation-page)

## Screenshot

![Screenshot 2022-10-24 at 11 48 26](https://user-images.githubusercontent.com/510498/197514025-07f0db65-63fb-4bfa-b0d6-3f614f8d5e52.png)
