### PR TITLE
Allow customising sanction requirements

### DIFF
--- a/app/controllers/support_interface/countries_controller.rb
+++ b/app/controllers/support_interface/countries_controller.rb
@@ -67,6 +67,7 @@ class SupportInterface::CountriesController < SupportInterface::BaseController
       :teaching_authority_websites_string,
       :teaching_authority_certificate,
       :teaching_authority_other,
+      :teaching_authority_checks_sanctions,
     )
   end
 end

--- a/app/helpers/proof_of_recognition_helper.rb
+++ b/app/helpers/proof_of_recognition_helper.rb
@@ -2,13 +2,13 @@ module ProofOfRecognitionHelper
   def proof_of_recognition_requirements_for(region:)
     if region.status_check_written? && region.sanction_check_written?
       return(
-        written_status_reasons.insert(2, *written_sanction_reasons) +
+        written_status_reasons.insert(2, *written_sanction_reasons(region)) +
           ["that you’re qualified to teach at state or government schools"]
       )
     end
 
     return written_status_reasons if region.status_check_written?
-    return written_sanction_reasons if region.sanction_check_written?
+    return written_sanction_reasons(region) if region.sanction_check_written?
     []
   end
 
@@ -34,10 +34,14 @@ module ProofOfRecognitionHelper
     ]
   end
 
-  def written_sanction_reasons
-    [
-      "that your authorisation to teach has never been suspended, barred, " \
-        "cancelled, revoked or restricted, and that you have no sanctions against you",
-    ]
+  def written_sanction_reasons(region)
+    if region.country.teaching_authority_checks_sanctions?
+      [
+        "that your authorisation to teach has never been suspended, barred, " \
+          "cancelled, revoked or restricted, and that you have no sanctions against you",
+      ]
+    else
+      []
+    end
   end
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -2,16 +2,17 @@
 #
 # Table name: countries
 #
-#  id                             :bigint           not null, primary key
-#  code                           :string           not null
-#  teaching_authority_address     :text             default(""), not null
-#  teaching_authority_certificate :text             default(""), not null
-#  teaching_authority_emails      :text             default([]), not null, is an Array
-#  teaching_authority_name        :text             default(""), not null
-#  teaching_authority_other       :text             default(""), not null
-#  teaching_authority_websites    :text             default([]), not null, is an Array
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
+#  id                                  :bigint           not null, primary key
+#  code                                :string           not null
+#  teaching_authority_address          :text             default(""), not null
+#  teaching_authority_certificate      :text             default(""), not null
+#  teaching_authority_checks_sanctions :boolean          default(TRUE), not null
+#  teaching_authority_emails           :text             default([]), not null, is an Array
+#  teaching_authority_name             :text             default(""), not null
+#  teaching_authority_other            :text             default(""), not null
+#  teaching_authority_websites         :text             default([]), not null, is an Array
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
 #
 # Indexes
 #

--- a/app/views/support_interface/countries/confirm_edit.html.erb
+++ b/app/views/support_interface/countries/confirm_edit.html.erb
@@ -54,5 +54,6 @@
   <%= f.hidden_field :teaching_authority_websites_string, value: @country.teaching_authority_websites_string %>
   <%= f.hidden_field :teaching_authority_certificate, value: @country.teaching_authority_certificate %>
   <%= f.hidden_field :teaching_authority_other, value: @country.teaching_authority_other %>
+  <%= f.hidden_field :teaching_authority_checks_sanctions, value: @country.teaching_authority_checks_sanctions %>
   <%= f.govuk_submit "Confirm save", prevent_double_click: false %>
 <% end %>

--- a/app/views/support_interface/countries/edit.html.erb
+++ b/app/views/support_interface/countries/edit.html.erb
@@ -9,6 +9,8 @@
 
   <%= f.govuk_text_field :teaching_authority_certificate, label: { text: "Teaching authority certificate" } %>
 
+  <%= f.govuk_check_box :teaching_authority_checks_sanctions, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Teaching authority checks sanctions" } %>
+
   <%= f.govuk_text_area :all_regions,
                         value: @all_regions,
                         label: { text: "Regions" },

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -42,7 +42,7 @@
 
     <p class="govuk-body">It must confirm:</p>
     <ul class="govuk-list govuk-list--bullet">
-      <%- proof_of_recognition_requirements_for(region: @application_form.region ).each do |requirement| %>
+      <%- proof_of_recognition_requirements_for(region: @application_form.region).each do |requirement| %>
         <li><%= requirement %></li>
       <%- end -%>
     </ul>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -81,6 +81,7 @@
     - teaching_authority_certificate
     - teaching_authority_other
     - teaching_authority_name
+    - teaching_authority_checks_sanctions
   :documents:
     - id
     - document_type

--- a/db/migrate/20221024123047_add_teaching_authority_checks_sanctions_to_countries.rb
+++ b/db/migrate/20221024123047_add_teaching_authority_checks_sanctions_to_countries.rb
@@ -1,0 +1,11 @@
+class AddTeachingAuthorityChecksSanctionsToCountries < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    add_column :countries,
+               :teaching_authority_checks_sanctions,
+               :boolean,
+               null: false,
+               default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_23_123629) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_24_123047) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -117,6 +117,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_23_123629) do
     t.text "teaching_authority_certificate", default: "", null: false
     t.text "teaching_authority_other", default: "", null: false
     t.text "teaching_authority_name", default: "", null: false
+    t.boolean "teaching_authority_checks_sanctions", default: true, null: false
     t.index ["code"], name: "index_countries_on_code", unique: true
   end
 

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -2,16 +2,17 @@
 #
 # Table name: countries
 #
-#  id                             :bigint           not null, primary key
-#  code                           :string           not null
-#  teaching_authority_address     :text             default(""), not null
-#  teaching_authority_certificate :text             default(""), not null
-#  teaching_authority_emails      :text             default([]), not null, is an Array
-#  teaching_authority_name        :text             default(""), not null
-#  teaching_authority_other       :text             default(""), not null
-#  teaching_authority_websites    :text             default([]), not null, is an Array
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
+#  id                                  :bigint           not null, primary key
+#  code                                :string           not null
+#  teaching_authority_address          :text             default(""), not null
+#  teaching_authority_certificate      :text             default(""), not null
+#  teaching_authority_checks_sanctions :boolean          default(TRUE), not null
+#  teaching_authority_emails           :text             default([]), not null, is an Array
+#  teaching_authority_name             :text             default(""), not null
+#  teaching_authority_other            :text             default(""), not null
+#  teaching_authority_websites         :text             default([]), not null, is an Array
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
 #
 # Indexes
 #
@@ -20,6 +21,8 @@
 FactoryBot.define do
   factory :country do
     sequence :code, Country::CODES.cycle
+
+    teaching_authority_checks_sanctions { true }
 
     trait :with_national_region do
       after(:create) do |country, _evaluator|

--- a/spec/helpers/proof_of_recognition_helper_spec.rb
+++ b/spec/helpers/proof_of_recognition_helper_spec.rb
@@ -2,10 +2,19 @@ require "rails_helper"
 
 RSpec.describe ProofOfRecognitionHelper do
   let(:region) do
-    double(status_check_written?: status, sanction_check_written?: sanction)
+    double(
+      status_check_written?: status,
+      sanction_check_written?: sanction,
+      country:
+        double(
+          teaching_authority_checks_sanctions?:
+            teaching_authority_checks_sanctions,
+        ),
+    )
   end
   let(:status) { false }
   let(:sanction) { false }
+  let(:teaching_authority_checks_sanctions) { true }
 
   describe "proof_of_recognition_requirements_for" do
     subject { proof_of_recognition_requirements_for(region:) }
@@ -55,6 +64,13 @@ RSpec.describe ProofOfRecognitionHelper do
           ],
         )
       end
+    end
+
+    context "with a country where authority doesn't change sanctions" do
+      let(:sanction) { true }
+      let(:teaching_authority_checks_sanctions) { false }
+
+      it { is_expected.to be_empty }
     end
   end
 

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -2,16 +2,17 @@
 #
 # Table name: countries
 #
-#  id                             :bigint           not null, primary key
-#  code                           :string           not null
-#  teaching_authority_address     :text             default(""), not null
-#  teaching_authority_certificate :text             default(""), not null
-#  teaching_authority_emails      :text             default([]), not null, is an Array
-#  teaching_authority_name        :text             default(""), not null
-#  teaching_authority_other       :text             default(""), not null
-#  teaching_authority_websites    :text             default([]), not null, is an Array
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
+#  id                                  :bigint           not null, primary key
+#  code                                :string           not null
+#  teaching_authority_address          :text             default(""), not null
+#  teaching_authority_certificate      :text             default(""), not null
+#  teaching_authority_checks_sanctions :boolean          default(TRUE), not null
+#  teaching_authority_emails           :text             default([]), not null, is an Array
+#  teaching_authority_name             :text             default(""), not null
+#  teaching_authority_other            :text             default(""), not null
+#  teaching_authority_websites         :text             default([]), not null, is an Array
+#  created_at                          :datetime         not null
+#  updated_at                          :datetime         not null
 #
 # Indexes
 #

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_websites
     when_i_fill_teaching_authority_other
     when_i_fill_teaching_authority_certificate
+    when_i_fill_teaching_authority_checks_sanctions
     when_i_fill_regions
     and_i_save
     then_i_see_country_contact_preview
@@ -171,6 +172,10 @@ RSpec.describe "Countries support", type: :system do
     fill_in "region-teaching-authority-certificate-field", with: "Certificate"
   rescue Capybara::ElementNotFound
     fill_in "country-teaching-authority-certificate-field", with: "Certificate"
+  end
+
+  def when_i_fill_teaching_authority_checks_sanctions
+    check "country-teaching-authority-checks-sanctions-1-field", visible: false
   end
 
   def and_i_save


### PR DESCRIPTION
This allows the proof of recognition requirements for sanctions to be customised, if the country's teaching authority doesn't check the sanctions. This is currently only a requirement for France, but it allows us to customise this in the future for other countries as necessary (rather than hard coding the content for France).

[Trello Card](https://trello.com/c/bEEr6qGE/1056-fix-issue-when-displaying-standard-bucket-2-sanctions-for-france)