### PR TITLE
Show applicant email address to assessors

### DIFF
--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -22,6 +22,10 @@ module ApplicationFormHelper
         I18n.t("application_form.summary.country"),
         CountryName.from_country(application_form.region.country),
       ],
+      [
+        I18n.t("application_form.summary.email"),
+        application_form.teacher.email,
+      ],
       [I18n.t("application_form.summary.region"), application_form.region.name],
       [
         I18n.t("application_form.summary.submitted_at"),

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -79,6 +79,7 @@ en:
     summary:
       name: Name
       country: Country trained in
+      email: Email
       region: State/territory trained in
       submitted_at: Created on
       days_remaining_sla: Days remaining in SLA

--- a/spec/components/application_form_search_result_component_spec.rb
+++ b/spec/components/application_form_search_result_component_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
       subject(:text) { dl.text.strip }
 
       it { is_expected.to include("Country trained in") }
+      it { is_expected.to include("Email") }
       it { is_expected.to include("State/territory trained in") }
       it { is_expected.to include("Created on") }
       it { is_expected.to include("Days remaining in SLA") }

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -58,6 +58,15 @@ RSpec.describe ApplicationFormHelper do
           },
           {
             key: {
+              text: "Email",
+            },
+            value: {
+              text: application_form.teacher.email,
+            },
+            actions: [],
+          },
+          {
+            key: {
               text: "State/territory trained in",
             },
             value: {

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -7,9 +7,9 @@ module PageObjects
 
       section :overview, "#app-application-overview" do
         element :name, "div:nth-of-type(1) > dd:nth-of-type(1)"
-        element :assessor_name, "div:nth-of-type(6) > dd:nth-of-type(1)"
-        element :reviewer_name, "div:nth-of-type(7) > dd:nth-of-type(1)"
-        element :status, "div:nth-of-type(9) > dd:nth-of-type(1)"
+        element :assessor_name, "div:nth-of-type(7) > dd:nth-of-type(1)"
+        element :reviewer_name, "div:nth-of-type(8) > dd:nth-of-type(1)"
+        element :status, "div:nth-of-type(10) > dd:nth-of-type(1)"
       end
 
       section :task_list, TaskList, ".app-task-list"


### PR DESCRIPTION
Show the applicant's email address to assessors beneath 'country' in the overview component