### PR TITLE
Update DQT TRN Requests in the background

### DIFF
--- a/app/jobs/update_dqt_trn_request_job.rb
+++ b/app/jobs/update_dqt_trn_request_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class UpdateDQTTRNRequestJob < ApplicationJob
+  class StillPending < StandardError
+  end
+
+  retry_on StillPending, wait: 30.minutes, attempts: 7 * 24 * 2 # 1 week
+
+  def perform(dqt_trn_request)
+    return unless dqt_trn_request.pending?
+
+    UpdateDQTTRNRequest.call(dqt_trn_request:)
+
+    raise StillPending if dqt_trn_request.pending?
+  end
+end

--- a/app/services/create_dqt_trn_request.rb
+++ b/app/services/create_dqt_trn_request.rb
@@ -15,6 +15,10 @@ class CreateDQTTRNRequest
       DQT::Client::CreateTRNRequest.call(request_id:, application_form:),
     )
 
+    if dqt_trn_request.pending?
+      UpdateDQTTRNRequestJob.set(wait: 1.hour).perform_later(dqt_trn_request)
+    end
+
     dqt_trn_request
   end
 

--- a/spec/jobs/update_dqt_trn_request_job_spec.rb
+++ b/spec/jobs/update_dqt_trn_request_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UpdateDQTTRNRequestJob, type: :job do
+  describe "#perform" do
+    subject(:perform) { described_class.new.perform(dqt_trn_request) }
+
+    let(:dqt_trn_request) { create(:dqt_trn_request) }
+
+    context "with an unsuccessful update" do
+      before { expect(UpdateDQTTRNRequest).to receive(:call) }
+
+      it "schedules a retry" do
+        expect { perform }.to raise_error(UpdateDQTTRNRequestJob::StillPending)
+      end
+    end
+
+    context "with a successful update" do
+      before do
+        expect(DQT::Client::ReadTRNRequest).to receive(:call).and_return(
+          { trn: "abcdef" },
+        )
+      end
+
+      it "runs without an error" do
+        expect { perform }.to_not raise_error
+      end
+    end
+  end
+end

--- a/spec/services/create_dqt_trn_request_spec.rb
+++ b/spec/services/create_dqt_trn_request_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe CreateDQTTRNRequest do
     it "sets the teacher TRN" do
       expect { call }.to change(teacher, :trn).from(nil).to("abcdef")
     end
+
+    it "doesn't schedule an update job" do
+      expect { call }.to_not have_enqueued_job(UpdateDQTTRNRequestJob)
+    end
   end
 
   context "with a failure response" do
@@ -53,6 +57,12 @@ RSpec.describe CreateDQTTRNRequest do
 
     it "doesn't set the teacher TRN" do
       expect { call_rescue_exception }.to_not change(teacher, :trn)
+    end
+
+    it "doesn't schedule an update job" do
+      expect { call_rescue_exception }.to_not have_enqueued_job(
+        UpdateDQTTRNRequestJob,
+      )
     end
   end
 end


### PR DESCRIPTION
This adds a job which updates DQT TRN requests in the background if they're still pending. For now it will run every 12 hours for up to 14 times, before giving up, and sending the `StillPending` error to Sentry.

Depends on #614 

[Trello Card](https://trello.com/c/2jWRWJQt/1047-poll-for-dqt-response)