### PR TITLE
Add "Add note" button to multiple pages

### DIFF
--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -1,6 +1,11 @@
 <% content_for :page_title, "Application" %>
 <% content_for :back_link_url, @view_object.back_link_path %>
 
+<div class="app-inline-action">
+  <h1 class="govuk-heading-xl">Application</h1>
+  <%= govuk_button_link_to "Add&nbsp;note".html_safe, new_assessor_interface_application_form_note_path(@view_object.application_form), secondary: true %>
+</div>
+
 <%= render(ApplicationFormOverview::Component.new(@view_object.application_form)) %>
 
 <h2 class="govuk-heading-l govuk-!-margin-top-9">Assessment</h2>

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -1,7 +1,10 @@
 <% content_for :page_title, t(".title.#{@assessment_section_view_object.assessment_section.key}") %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@assessment_section_view_object.application_form) %>
 
-<h1 class="govuk-heading-xl"><%= t(".title.#{@assessment_section_view_object.assessment_section.key}") %></h1>
+<div class="app-inline-action">
+  <h1 class="govuk-heading-xl"><%= t(".title.#{@assessment_section_view_object.assessment_section.key}") %></h1>
+  <%= govuk_button_link_to "Add&nbsp;note".html_safe, new_assessor_interface_application_form_note_path(@assessment_section_view_object.application_form), secondary: true %>
+</div>
 
 <% case @assessment_section_view_object.assessment_section.key %>
 <% when "personal_information" %>

--- a/app/views/assessor_interface/assessor_assignments/new.html.erb
+++ b/app/views/assessor_interface/assessor_assignments/new.html.erb
@@ -1,18 +1,17 @@
-<h1 class="govuk-heading-l">
-  Select an assessor
-</h1>
+<% content_for :page_title, "Select an assessor" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
-<%= form_for @assessor_assignment_form, url: assessor_interface_application_form_assign_assessor_path(@application_form) do |form| %>
-    <%= form.govuk_error_summary %>
+<div class="app-inline-action">
+  <h1 class="govuk-heading-xl">Select an assessor</h1>
+  <%= govuk_button_link_to "Add&nbsp;note".html_safe, new_assessor_interface_application_form_note_path(@application_form), secondary: true %>
+</div>
 
-    <%= form.govuk_collection_radio_buttons :assessor_id,
-      Staff.all,
-      :id,
-      :name,
-      legend: nil
-    %>
-    <%= form.govuk_submit "Continue" do %>
-      <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
-    <%- end -%>
-<%- end -%>
+<%= form_with model: @assessor_assignment_form, url: assessor_interface_application_form_assign_assessor_path(@application_form) do |f| %>
+  <%= f.govuk_error_summary %>
 
+  <%= f.govuk_collection_radio_buttons :assessor_id, Staff.all, :id, :name, legend: nil %>
+
+  <%= f.govuk_submit do %>
+    <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
+  <% end %>
+<% end %>

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -5,6 +5,8 @@ module PageObjects
 
       element :back_link, "a", text: "Back"
 
+      element :add_note_button, ".app-inline-action .govuk-button"
+
       section :overview, "#app-application-overview" do
         element :name, "div:nth-of-type(1) > dd:nth-of-type(1)"
         element :assessor_name, "div:nth-of-type(7) > dd:nth-of-type(1)"

--- a/spec/system/assessor_interface/creating_note_spec.rb
+++ b/spec/system/assessor_interface/creating_note_spec.rb
@@ -9,8 +9,14 @@ RSpec.describe "Creating a note", type: :system do
     given_there_is_an_application_form
     given_an_assessor_exists
 
-    when_i_visit_the(:create_note_page, application_id: application_form.id)
-    and_i_create_a_note
+    when_i_visit_the(
+      :assessor_application_page,
+      application_id: application_form.id,
+    )
+    and_i_click_add_note
+    then_i_see_the(:create_note_page, application_id: application_form.id)
+
+    when_i_create_a_note
     then_i_see_the(
       :assessor_application_page,
       application_id: application_form.id,
@@ -31,7 +37,11 @@ RSpec.describe "Creating a note", type: :system do
     assessor
   end
 
-  def and_i_create_a_note
+  def and_i_click_add_note
+    assessor_application_page.add_note_button.click
+  end
+
+  def when_i_create_a_note
     create_note_page.form.text_textarea.fill_in with: "A note."
     create_note_page.form.submit_button.click
   end


### PR DESCRIPTION
This partially reverts https://github.com/DFE-Digital/apply-for-qualified-teacher-status/commit/89a21ecaa05023754f1666fd9bbabe7e685ac302 which accidentally removed the button, and then adds the missing button to various pages.

[Trello Card](https://trello.com/c/RkVMM75t/1049-add-note-button)