### PR TITLE
Configure DQT API URLs

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -16,6 +16,8 @@ locals {
     AZURE_STORAGE_ACCOUNT_NAME = azurerm_storage_account.forms.name,
     AZURE_STORAGE_ACCESS_KEY   = azurerm_storage_account.forms.primary_access_key,
     AZURE_STORAGE_CONTAINER    = azurerm_storage_container.uploads.name
+
+    DQT_API_URL = var.dqt_api_url
   })
   logstash_endpoint = data.azurerm_key_vault_secret.secrets["LOGSTASH-ENDPOINT"].value
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -98,6 +98,10 @@ variable "region_name" {
   type    = string
 }
 
+variable "dqt_api_url" {
+  type = string
+}
+
 locals {
   apply_qts_routes = flatten([
     cloudfoundry_route.apply_qts_public,

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -5,5 +5,6 @@
   "paas_space": "tra-dev",
   "education_hostnames": ["dev"],
   "prometheus_app": "prometheus-tra-monitoring-dev",
-  "forms_storage_account_name": "s165d01afqtsformsdv"
+  "forms_storage_account_name": "s165d01afqtsformsdv",
+  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital"
 }

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -16,5 +16,6 @@
       "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"],
       "confirmations": 2
     }
-  }
+  },
+  "dqt_api_url": "https://preprod-teacher-qualifications-api.education.gov.uk"
 }

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -20,5 +20,6 @@
       "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"],
       "confirmations": 2
     }
-  }
+  },
+  "dqt_api_url": "https://teacher-qualifications-api.education.gov.uk"
 }

--- a/terraform/workspace_variables/review.tfvars.json
+++ b/terraform/workspace_variables/review.tfvars.json
@@ -2,5 +2,6 @@
   "environment_name": "review",
   "key_vault_name": "s165d01-afqts-dv-kv",
   "resource_group_name": "s165d01-afqts-dv-rg",
-  "paas_space": "tra-dev"
+  "paas_space": "tra-dev",
+  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital"
 }

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -16,5 +16,6 @@
       "node_locations": ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"],
       "confirmations": 2
     }
-  }
+  },
+  "dqt_api_url": "https://test-teacher-qualifications-api.education.gov.uk"
 }


### PR DESCRIPTION
This sets the approriate environment variables for each environment so we can start to communicate with the DQT API.