### PR TITLE
Don't suppress Faraday errors

### DIFF
--- a/app/services/create_dqt_trn_request.rb
+++ b/app/services/create_dqt_trn_request.rb
@@ -11,11 +11,9 @@ class CreateDQTTRNRequest
     request_id = SecureRandom.uuid
     dqt_trn_request = DQTTRNRequest.create!(request_id:, application_form:)
 
-    suppress(Faraday::Error) do
-      dqt_trn_request.update_from_dqt_response(
-        DQT::Client::CreateTRNRequest.call(request_id:, application_form:),
-      )
-    end
+    dqt_trn_request.update_from_dqt_response(
+      DQT::Client::CreateTRNRequest.call(request_id:, application_form:),
+    )
 
     dqt_trn_request
   end

--- a/app/services/update_dqt_trn_request.rb
+++ b/app/services/update_dqt_trn_request.rb
@@ -8,13 +8,9 @@ class UpdateDQTTRNRequest
   end
 
   def call
-    suppress(Faraday::Error) do
-      dqt_trn_request.update_from_dqt_response(
-        DQT::Client::ReadTRNRequest.call(
-          request_id: dqt_trn_request.request_id,
-        ),
-      )
-    end
+    dqt_trn_request.update_from_dqt_response(
+      DQT::Client::ReadTRNRequest.call(request_id: dqt_trn_request.request_id),
+    )
   end
 
   private

--- a/spec/services/create_dqt_trn_request_spec.rb
+++ b/spec/services/create_dqt_trn_request_spec.rb
@@ -36,17 +36,23 @@ RSpec.describe CreateDQTTRNRequest do
       )
     end
 
+    let(:call_rescue_exception) do
+      call
+    rescue StandardError
+      Faraday::BadRequestError
+    end
+
     it "creates a DQTTRNRequest" do
-      expect { call }.to change(DQTTRNRequest, :count).by(1)
+      expect { call_rescue_exception }.to change(DQTTRNRequest, :count).by(1)
     end
 
     it "marks the request as pending" do
-      call
+      call_rescue_exception
       expect(DQTTRNRequest.first.pending?).to be true
     end
 
     it "doesn't set the teacher TRN" do
-      expect { call }.to_not change(teacher, :trn)
+      expect { call_rescue_exception }.to_not change(teacher, :trn)
     end
   end
 end

--- a/spec/services/update_dqt_trn_request_spec.rb
+++ b/spec/services/update_dqt_trn_request_spec.rb
@@ -37,13 +37,19 @@ RSpec.describe UpdateDQTTRNRequest do
       )
     end
 
-    it "marks the request as pending" do
+    let(:call_rescue_exception) do
       call
+    rescue StandardError
+      Faraday::BadRequestError
+    end
+
+    it "marks the request as pending" do
+      call_rescue_exception
       expect(DQTTRNRequest.first.pending?).to be true
     end
 
     it "doesn't set the teacher TRN" do
-      expect { call }.to_not change(teacher, :trn)
+      expect { call_rescue_exception }.to_not change(teacher, :trn)
     end
   end
 end


### PR DESCRIPTION
If an error occurs when making a request to the DQT API we want to likely know about it as it means something was wrong with the syntax of our request, rather than our expected "failure" state of a duplicate TRN and manual intervention required.