### PR TITLE
Add training country code to TRN request params

### DIFF
--- a/app/lib/dqt/trn_request_params.rb
+++ b/app/lib/dqt/trn_request_params.rb
@@ -47,6 +47,8 @@ module DQT
         subject3: subjects.third,
         ageRangeFrom: assessment.age_range_min,
         ageRangeTo: assessment.age_range_max,
+        trainingCountryCode:
+          CountryCode.for_code(teaching_qualification.institution_country_code),
       }
     end
 

--- a/spec/lib/dqt/trn_request_params_spec.rb
+++ b/spec/lib/dqt/trn_request_params_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe DQT::TRNRequestParams do
             subject1: "100425",
             subject2: "100321",
             subject3: nil,
+            trainingCountryCode: "FR",
           },
           lastName: "Family",
           middleName: nil,


### PR DESCRIPTION
This was missed in e499cb2e7bb356418cef253d3c1c2159b4591b4a and the field is going to be renamed from `trainingCountry` to `trainingCountryCode` so it matches the `countryCode` field of the qualification.

https://github.com/DFE-Digital/qualified-teachers-api/pull/300/commits/6503a7ab11f15f17a2491a5059c48d14f48d096e