### PR TITLE
Don't send qualification subject to DQT

### DIFF
--- a/app/lib/dqt/trn_request_params.rb
+++ b/app/lib/dqt/trn_request_params.rb
@@ -57,7 +57,6 @@ module DQT
         providerUkprn: nil,
         countryCode:
           CountryCode.for_code(degree_qualification.institution_country_code),
-        subject: degree_qualification.title,
         class: "NotKnown",
         date: degree_qualification.certificate_date.iso8601,
         heQualificationType: "Unknown",

--- a/spec/lib/dqt/trn_request_params_spec.rb
+++ b/spec/lib/dqt/trn_request_params_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe DQT::TRNRequestParams do
             date: "1996-01-01",
             heQualificationType: "Unknown",
             providerUkprn: nil,
-            subject: "Master of Physics and French",
           },
           recognitionRoute: "OverseasTrainedTeachers",
           teacherType: "OverseasQualifiedTeacher",


### PR DESCRIPTION
We've realised that this is an optional field and as we don't capture it as a HECOS code it's not valid if we send it.