### PR TITLE
[1062] 'Registration number' not 'reference number'

### DIFF
--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -40,7 +40,7 @@
       <% if region.status_check_online? %>
         <p class="govuk-body">
           As your education department or authority has an online register of teachers,
-          you’ll need to provide any reference numbers we need to check your record.
+          you’ll need to provide any registration numbers we need to check your record.
         </p>
       <% end %>
 

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -83,7 +83,7 @@ en:
           qualifications_dont_match_other_details: Uploaded qualifications do not match other details entered, for example, name of qualification, name of institution or dates.
           age_range: The age range the applicant is qualified to teach does not fall within the requirements of QTS.
           satisfactory_evidence_work_history: The information provided on work history is not sufficient to award QTS.
-          registration_number: We could not verify the reference number using the online checker.
+          registration_number: We could not verify the registration number using the online checker.
           written_statement_illegible: The letter from the country or state’s authority is illegible.
           written_statement_recent: The letter from the country or state’s authority was not issued within the last 3 months.
           authorisation_to_teach: Sanctions or restrictions were detected on professional record.

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -20,7 +20,7 @@ en:
       teacher_interface_new_session_form:
         email: Enter the email address you used to register, and we will send you a link to sign in.
       teacher_interface_registration_number_form:
-        registration_number: Your country has an online register of teachers. If you have a reference number, enter it on this screen. If you do not have one, just select ‘Continue’.
+        registration_number: Your country has an online register of teachers. If you have a registration number, enter it on this screen. If you do not have one, just select ‘Continue’.
       work_history:
         add_another: You can use the next section to tell us about additional work history.
     label:

--- a/spec/support/autoload/page_objects/assessor_interface/check_professional_standing.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_professional_standing.rb
@@ -2,7 +2,7 @@ module PageObjects
   module AssessorInterface
     class ProfessionalStandingCard < SitePrism::Section
       element :heading, "h2"
-      element :reference_number,
+      element :registration_number,
               "dl.govuk-summary-list > div:nth-of-type(1) > dd:nth-of-type(1)"
     end
 

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     expect(
       check_professional_standing_page
         .proof_of_recognition
-        .reference_number
+        .registration_number
         .text,
     ).to eq(application_form.registration_number)
   end


### PR DESCRIPTION
When we're referring to the number that is given to an applicant by the teaching authority in the country that they have worked we should use 'registration number' consistently. 

We do have legitimate uses of 'reference number' in the service where we're talking about the number we assign to the application.