### PR TITLE
Add ability to assess further information

### DIFF
--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -58,5 +58,11 @@ module TimelineEntry
     def note_created_vars
       { text: timeline_event.note.text }
     end
+
+    def further_information_request_assessed_vars
+      {
+        further_information_request: timeline_event.further_information_request,
+      }
+    end
   end
 end

--- a/app/forms/assessor_interface/further_information_request_form.rb
+++ b/app/forms/assessor_interface/further_information_request_form.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AssessorInterface::FurtherInformationRequestForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :further_information_request, :user
+  validates :further_information_request, :user, presence: true
+
+  attribute :passed, :boolean
+  validates :passed, inclusion: [true, false]
+
+  attribute :failure_reason, :string
+  validates :failure_reason, presence: true, if: -> { passed == false }
+
+  def save
+    return false unless valid?
+
+    UpdateFurtherInformationRequest.call(
+      further_information_request:,
+      user:,
+      params: {
+        passed:,
+        failure_reason:,
+      },
+    )
+
+    true
+  end
+end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -59,15 +59,19 @@ class Assessment < ApplicationRecord
   end
 
   def can_award?
-    sections.all? { |section| section.state == :completed }
+    sections.all? { |section| section.state == :completed } ||
+      (
+        further_information_requests.present? &&
+          further_information_requests.all?(&:passed)
+      )
   end
 
   def can_decline?
-    action_required?
+    action_required? || further_information_requests.any?(&:failed)
   end
 
   def can_request_further_information?
-    action_required? && !must_decline?
+    action_required? && !must_decline? && further_information_requests.empty?
   end
 
   def available_recommendations

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -2,12 +2,14 @@
 #
 # Table name: further_information_requests
 #
-#  id            :bigint           not null, primary key
-#  received_at   :datetime
-#  state         :string           not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  assessment_id :bigint
+#  id             :bigint           not null, primary key
+#  failure_reason :string           default(""), not null
+#  passed         :boolean
+#  received_at    :datetime
+#  state          :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  assessment_id  :bigint
 #
 # Indexes
 #

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -24,4 +24,8 @@ class FurtherInformationRequest < ApplicationRecord
   enum :state,
        { requested: "requested", received: "received" },
        default: :requested
+
+  def failed
+    passed == false
+  end
 end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -4,32 +4,35 @@
 #
 # Table name: timeline_events
 #
-#  id                    :bigint           not null, primary key
-#  annotation            :string           default(""), not null
-#  creator_type          :string
-#  event_type            :string           not null
-#  new_state             :string           default(""), not null
-#  old_state             :string           default(""), not null
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  application_form_id   :bigint           not null
-#  assessment_section_id :bigint
-#  assignee_id           :bigint
-#  creator_id            :integer
-#  note_id               :bigint
+#  id                             :bigint           not null, primary key
+#  annotation                     :string           default(""), not null
+#  creator_type                   :string
+#  event_type                     :string           not null
+#  new_state                      :string           default(""), not null
+#  old_state                      :string           default(""), not null
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  application_form_id            :bigint           not null
+#  assessment_section_id          :bigint
+#  assignee_id                    :bigint
+#  creator_id                     :integer
+#  further_information_request_id :bigint
+#  note_id                        :bigint
 #
 # Indexes
 #
-#  index_timeline_events_on_application_form_id    (application_form_id)
-#  index_timeline_events_on_assessment_section_id  (assessment_section_id)
-#  index_timeline_events_on_assignee_id            (assignee_id)
-#  index_timeline_events_on_note_id                (note_id)
+#  index_timeline_events_on_application_form_id             (application_form_id)
+#  index_timeline_events_on_assessment_section_id           (assessment_section_id)
+#  index_timeline_events_on_assignee_id                     (assignee_id)
+#  index_timeline_events_on_further_information_request_id  (further_information_request_id)
+#  index_timeline_events_on_note_id                         (note_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (application_form_id => application_forms.id)
 #  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #  fk_rails_...  (assignee_id => staff.id)
+#  fk_rails_...  (further_information_request_id => further_information_requests.id)
 #  fk_rails_...  (note_id => notes.id)
 #
 class TimelineEvent < ApplicationRecord
@@ -42,6 +45,8 @@ class TimelineEvent < ApplicationRecord
          state_changed: "state_changed",
          assessment_section_recorded: "assessment_section_recorded",
          note_created: "note_created",
+         further_information_request_assessed:
+           "further_information_request_assessed",
        }
   validates :event_type, inclusion: { in: event_types.values }
 
@@ -67,4 +72,12 @@ class TimelineEvent < ApplicationRecord
   belongs_to :note, optional: true
   validates :note, presence: true, if: :note_created?
   validates :note, absence: true, unless: :note_created?
+
+  belongs_to :further_information_request, optional: true
+  validates :further_information_request,
+            presence: true,
+            if: :further_information_request_assessed?
+  validates :further_information_request,
+            absence: true,
+            unless: :further_information_request_assessed?
 end

--- a/app/services/update_further_information_request.rb
+++ b/app/services/update_further_information_request.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class UpdateFurtherInformationRequest
+  include ServicePattern
+
+  def initialize(further_information_request:, user:, params:)
+    @further_information_request = further_information_request
+    @user = user
+    @params = params
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      further_information_request.update!(params)
+      create_timeline_event
+    end
+  end
+
+  private
+
+  attr_reader :further_information_request, :user, :params
+
+  def create_timeline_event
+    unless further_information_request.passed.nil?
+      TimelineEvent.create!(
+        creator: user,
+        event_type: :further_information_request_assessed,
+        further_information_request:,
+        application_form:,
+      )
+    end
+  end
+
+  def application_form
+    further_information_request.assessment.application_form
+  end
+end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -58,7 +58,8 @@ class AssessorInterface::ApplicationFormsShowViewObject
     when :further_information
       further_information_request = further_information_requests[index]
 
-      if further_information_request.received?
+      if further_information_request.received? &&
+           further_information_request.passed.nil?
         url_helpers.edit_assessor_interface_application_form_assessment_further_information_request_path(
           application_form,
           assessment,
@@ -80,7 +81,8 @@ class AssessorInterface::ApplicationFormsShowViewObject
     when :further_information
       further_information_request = further_information_requests[index]
       return :cannot_start_yet if further_information_request.requested?
-      :not_started
+      return :not_started if further_information_request.passed.nil?
+      :completed
     end
   end
 

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -28,14 +28,14 @@ class AssessorInterface::ApplicationFormsShowViewObject
         professional_standing
       ].select { |key| assessment_section_keys.include?(key) }
 
+    recommendation =
+      %i[initial_assessment] +
+        further_information_requests.map { :second_assessment }
+
     further_information =
       further_information_requests.map { :review_requested_information }
 
-    {
-      submitted_details:,
-      recommendation: %i[initial_assessment],
-      further_information:,
-    }.compact_blank
+    { submitted_details:, recommendation:, further_information: }.compact_blank
   end
 
   def assessment_task_path(section, item, index)
@@ -49,7 +49,11 @@ class AssessorInterface::ApplicationFormsShowViewObject
     when :recommendation
       return nil unless assessment.sections_finished?
 
-      if assessment_editable?
+      if (item == :initial_assessment && assessment_editable?) ||
+           (
+             item == :second_assessment &&
+               assessment.request_further_information?
+           )
         url_helpers.edit_assessor_interface_application_form_assessment_path(
           application_form,
           assessment,
@@ -74,10 +78,18 @@ class AssessorInterface::ApplicationFormsShowViewObject
     when :submitted_details
       assessment.sections.find { |s| s.key == item.to_s }.state
     when :recommendation
-      return :cannot_start_yet unless assessment.sections_finished?
-      return :not_started if assessment.unknown?
-      return :in_progress if assessment_editable?
-      :completed
+      case item
+      when :initial_assessment
+        return :cannot_start_yet unless assessment.sections_finished?
+        return :not_started if assessment.unknown?
+        return :in_progress if assessment_editable?
+        :completed
+      when :second_assessment
+        further_information_request = further_information_requests[index - 1]
+        return :cannot_start_yet if further_information_request.passed.nil?
+        return :not_started if assessment.request_further_information?
+        :completed
+      end
     when :further_information
       further_information_request = further_information_requests[index]
       return :cannot_start_yet if further_information_request.requested?

--- a/app/view_objects/assessor_interface/further_information_request_view_object.rb
+++ b/app/view_objects/assessor_interface/further_information_request_view_object.rb
@@ -19,9 +19,8 @@ class AssessorInterface::FurtherInformationRequestViewObject
         .find(params[:id])
   end
 
-  def application_form
-    further_information_request.assessment.application_form
-  end
+  delegate :assessment, to: :further_information_request
+  delegate :application_form, to: :assessment
 
   def check_your_answers_fields
     further_information_request

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -9,3 +9,18 @@
   title: t(".check_your_answers"),
   fields: @view_object.check_your_answers_fields
 )) %>
+
+<%= form_with model: @further_information_request_form, url: [:assessor_interface, @view_object.application_form, @view_object.assessment, @view_object.further_information_request], method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_radio_buttons_fieldset :passed, legend: { size: "s" } do %>
+    <%= f.govuk_radio_button :passed, :true, link_errors: true %>
+    <%= f.govuk_radio_button :passed, :false do %>
+      <%= f.govuk_text_area :failure_reason %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit prevent_double_click: false do %>
+    <%= govuk_link_to "Cancel", [:assessor_interface, @view_object.application_form] %>
+  <% end %>
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -228,6 +228,7 @@
     - new_state
     - assessment_section_id
     - note_id
+    - further_information_request_id
   :uploads:
     - id
     - document_id

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -129,6 +129,8 @@
     - created_at
     - updated_at
     - assessment_id
+    - passed
+    - failure_reason
   :further_information_request_items:
     - id
     - information_type

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -16,6 +16,8 @@
     - registration_number
     - has_work_history
     - subjects
+  :further_information_requests:
+    - failure_reason
   :further_information_request_items:
     - assessor_notes
     - response

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -124,12 +124,14 @@ en:
         state_changed: Status changed
         assessment_section_completed: Section completed
         note_created: Note created
+        further_information_request_assessed: Further information assessed
       description:
         assessor_assigned: "%{assignee_name} is assigned as the assessor."
         reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
         state_changed: Status changed from %{old_state} to %{new_state}
         assessment_section_recorded: "%{section_name}: %{section_state}"
         note_created: "%{text}"
+        further_information_request_assessed: Further information request has been assessed.
 
   activemodel:
     errors:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -157,3 +157,9 @@ en:
               inclusion: Select your recommendation
             confirm:
               blank: You must confirm that you have reviewed this QTS application
+        assessor_interface/further_information_request_form:
+          attributes:
+            passed:
+              inclusion: Choose whether the applicant completed this section to your satisfaction
+            failure_reason:
+              blank: Enter why this section is not completed to your satisfaction

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -22,6 +22,7 @@ en:
             work_history: Check work history
             professional_standing: Check professional standing
             initial_assessment: Initial assessment recommendation
+            second_assessment: Second assessment recommendation
             review_requested_information: Review requested information from applicant
 
     assessments:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -44,6 +44,11 @@ en:
         location: Country trained in
         name: Applicant name
         reference: Application reference number
+      assessor_interface_further_information_request_form:
+        passed_options:
+          true: "Yes"
+          false: "No"
+        failure_reason: Explain why this section is not completed to your satisfaction
       qualification:
         add_another_options:
           true: "Yes"
@@ -93,6 +98,8 @@ en:
         submitted_at: Created date
         submitted_at_after: Start date
         submitted_at_before: End date
+      assessor_interface_further_information_request_form:
+        passed: Has the applicant completed this section to your satisfaction?
       qualification:
         add_another: Add another qualification?
       teacher_interface_alternative_name_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
                   only: %i[show update]
         resources :further_information_requests,
                   path: "/further-information-requests",
-                  only: %i[new create show edit] do
+                  only: %i[new create show edit update] do
           get "preview",
               to: "further_information_requests#preview",
               on: :collection

--- a/db/migrate/20221026094905_add_passed_to_further_information_requests.rb
+++ b/db/migrate/20221026094905_add_passed_to_further_information_requests.rb
@@ -1,0 +1,8 @@
+class AddPassedToFurtherInformationRequests < ActiveRecord::Migration[7.0]
+  def change
+    change_table :further_information_requests, bulk: true do |t|
+      t.boolean :passed
+      t.string :failure_reason, null: false, default: ""
+    end
+  end
+end

--- a/db/migrate/20221026143332_add_further_information_request_to_timeline_events.rb
+++ b/db/migrate/20221026143332_add_further_information_request_to_timeline_events.rb
@@ -1,0 +1,9 @@
+class AddFurtherInformationRequestToTimelineEvents < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    change_table :timeline_events, bulk: true do |t|
+      t.references :further_information_request, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_26_094905) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_26_143332) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -302,9 +302,11 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_26_094905) do
     t.string "new_state", default: "", null: false
     t.bigint "assessment_section_id"
     t.bigint "note_id"
+    t.bigint "further_information_request_id"
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
     t.index ["assessment_section_id"], name: "index_timeline_events_on_assessment_section_id"
     t.index ["assignee_id"], name: "index_timeline_events_on_assignee_id"
+    t.index ["further_information_request_id"], name: "index_timeline_events_on_further_information_request_id"
     t.index ["note_id"], name: "index_timeline_events_on_note_id"
   end
 
@@ -350,6 +352,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_26_094905) do
   add_foreign_key "regions", "countries"
   add_foreign_key "timeline_events", "application_forms"
   add_foreign_key "timeline_events", "assessment_sections"
+  add_foreign_key "timeline_events", "further_information_requests"
   add_foreign_key "timeline_events", "notes"
   add_foreign_key "timeline_events", "staff", column: "assignee_id"
   add_foreign_key "uploads", "documents"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_25_095046) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_26_094905) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -186,6 +186,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_25_095046) do
     t.datetime "received_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "passed"
+    t.string "failure_reason", default: "", null: false
     t.index ["assessment_id"], name: "index_further_information_requests_on_assessment_id"
   end
 

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -82,4 +82,20 @@ RSpec.describe TimelineEntry::Component, type: :component do
       expect(component.text).to include(creator.name)
     end
   end
+
+  context "further information request assessed" do
+    let(:timeline_event) do
+      create(:timeline_event, :further_information_request_assessed)
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "Further information request has been assessed.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
 end

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -4,12 +4,14 @@
 #
 # Table name: further_information_requests
 #
-#  id            :bigint           not null, primary key
-#  received_at   :datetime
-#  state         :string           not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  assessment_id :bigint
+#  id             :bigint           not null, primary key
+#  failure_reason :string           default(""), not null
+#  passed         :boolean
+#  received_at    :datetime
+#  state          :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  assessment_id  :bigint
 #
 # Indexes
 #

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -30,6 +30,15 @@ FactoryBot.define do
       received_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end
 
+    trait :passed do
+      passed { true }
+    end
+
+    trait :failed do
+      passed { false }
+      failure_reason { "Notes." }
+    end
+
     trait :with_items do
       after(:create) do |further_information_request, _evaluator|
         create(

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -2,32 +2,35 @@
 #
 # Table name: timeline_events
 #
-#  id                    :bigint           not null, primary key
-#  annotation            :string           default(""), not null
-#  creator_type          :string
-#  event_type            :string           not null
-#  new_state             :string           default(""), not null
-#  old_state             :string           default(""), not null
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  application_form_id   :bigint           not null
-#  assessment_section_id :bigint
-#  assignee_id           :bigint
-#  creator_id            :integer
-#  note_id               :bigint
+#  id                             :bigint           not null, primary key
+#  annotation                     :string           default(""), not null
+#  creator_type                   :string
+#  event_type                     :string           not null
+#  new_state                      :string           default(""), not null
+#  old_state                      :string           default(""), not null
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  application_form_id            :bigint           not null
+#  assessment_section_id          :bigint
+#  assignee_id                    :bigint
+#  creator_id                     :integer
+#  further_information_request_id :bigint
+#  note_id                        :bigint
 #
 # Indexes
 #
-#  index_timeline_events_on_application_form_id    (application_form_id)
-#  index_timeline_events_on_assessment_section_id  (assessment_section_id)
-#  index_timeline_events_on_assignee_id            (assignee_id)
-#  index_timeline_events_on_note_id                (note_id)
+#  index_timeline_events_on_application_form_id             (application_form_id)
+#  index_timeline_events_on_assessment_section_id           (assessment_section_id)
+#  index_timeline_events_on_assignee_id                     (assignee_id)
+#  index_timeline_events_on_further_information_request_id  (further_information_request_id)
+#  index_timeline_events_on_note_id                         (note_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (application_form_id => application_forms.id)
 #  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #  fk_rails_...  (assignee_id => staff.id)
+#  fk_rails_...  (further_information_request_id => further_information_requests.id)
 #  fk_rails_...  (note_id => notes.id)
 #
 FactoryBot.define do
@@ -67,6 +70,11 @@ FactoryBot.define do
     trait :note_created do
       event_type { "note_created" }
       association :note
+    end
+
+    trait :further_information_request_assessed do
+      event_type { "further_information_request_assessed" }
+      association :further_information_request
     end
   end
 end

--- a/spec/forms/assessor_interface/further_information_request_form_spec.rb
+++ b/spec/forms/assessor_interface/further_information_request_form_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe AssessorInterface::FurtherInformationRequestForm, type: :model do
+  let(:further_information_request) { create(:further_information_request) }
+  let(:user) { create(:staff, :confirmed) }
+  let(:attributes) { {} }
+
+  subject(:form) do
+    described_class.new(further_information_request:, user:, **attributes)
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:further_information_request) }
+    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to allow_values(true, false).for(:passed) }
+
+    context "when passed" do
+      let(:attributes) { { passed: true } }
+
+      it { is_expected.to_not validate_presence_of(:failure_reason) }
+    end
+
+    context "when not passed" do
+      let(:attributes) { { passed: false } }
+
+      it { is_expected.to validate_presence_of(:failure_reason) }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    context "with invalid attributes" do
+      it { is_expected.to be false }
+    end
+
+    context "with valid attributes" do
+      let(:attributes) { { passed: true, failure_reason: "" } }
+
+      it "updates the application form" do
+        expect { save }.to change(further_information_request, :passed).from(
+          nil,
+        ).to(true)
+      end
+
+      it "creates a timeline event" do
+        expect { save }.to change { TimelineEvent.count }.by(1)
+      end
+    end
+  end
+end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -127,6 +127,16 @@ RSpec.describe Assessment, type: :model do
         create(:assessment_section, :personal_information, :failed, assessment:)
       end
       it { is_expected.to be false }
+
+      context "with a passed further information request" do
+        before { create(:further_information_request, :passed, assessment:) }
+        it { is_expected.to be true }
+      end
+
+      context "with a failed further information request" do
+        before { create(:further_information_request, :failed, assessment:) }
+        it { is_expected.to be false }
+      end
     end
 
     context "with a mixture of assessments" do
@@ -168,6 +178,16 @@ RSpec.describe Assessment, type: :model do
       end
       it { is_expected.to be true }
     end
+
+    context "with a passed further information request" do
+      before { create(:further_information_request, :passed, assessment:) }
+      it { is_expected.to be false }
+    end
+
+    context "with a failed further information request" do
+      before { create(:further_information_request, :failed, assessment:) }
+      it { is_expected.to be true }
+    end
   end
 
   describe "#can_request_further_information?" do
@@ -207,6 +227,11 @@ RSpec.describe Assessment, type: :model do
         )
       end
 
+      it { is_expected.to be false }
+    end
+
+    context "with an existing further information request" do
+      before { create(:further_information_request, assessment:) }
       it { is_expected.to be false }
     end
   end

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -4,12 +4,14 @@
 #
 # Table name: further_information_requests
 #
-#  id            :bigint           not null, primary key
-#  received_at   :datetime
-#  state         :string           not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  assessment_id :bigint
+#  id             :bigint           not null, primary key
+#  failure_reason :string           default(""), not null
+#  passed         :boolean
+#  received_at    :datetime
+#  state          :string           not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  assessment_id  :bigint
 #
 # Indexes
 #

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -2,32 +2,35 @@
 #
 # Table name: timeline_events
 #
-#  id                    :bigint           not null, primary key
-#  annotation            :string           default(""), not null
-#  creator_type          :string
-#  event_type            :string           not null
-#  new_state             :string           default(""), not null
-#  old_state             :string           default(""), not null
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  application_form_id   :bigint           not null
-#  assessment_section_id :bigint
-#  assignee_id           :bigint
-#  creator_id            :integer
-#  note_id               :bigint
+#  id                             :bigint           not null, primary key
+#  annotation                     :string           default(""), not null
+#  creator_type                   :string
+#  event_type                     :string           not null
+#  new_state                      :string           default(""), not null
+#  old_state                      :string           default(""), not null
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  application_form_id            :bigint           not null
+#  assessment_section_id          :bigint
+#  assignee_id                    :bigint
+#  creator_id                     :integer
+#  further_information_request_id :bigint
+#  note_id                        :bigint
 #
 # Indexes
 #
-#  index_timeline_events_on_application_form_id    (application_form_id)
-#  index_timeline_events_on_assessment_section_id  (assessment_section_id)
-#  index_timeline_events_on_assignee_id            (assignee_id)
-#  index_timeline_events_on_note_id                (note_id)
+#  index_timeline_events_on_application_form_id             (application_form_id)
+#  index_timeline_events_on_assessment_section_id           (assessment_section_id)
+#  index_timeline_events_on_assignee_id                     (assignee_id)
+#  index_timeline_events_on_further_information_request_id  (further_information_request_id)
+#  index_timeline_events_on_note_id                         (note_id)
 #
 # Foreign Keys
 #
 #  fk_rails_...  (application_form_id => application_forms.id)
 #  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #  fk_rails_...  (assignee_id => staff.id)
+#  fk_rails_...  (further_information_request_id => further_information_requests.id)
 #  fk_rails_...  (note_id => notes.id)
 #
 require "rails_helper"
@@ -38,6 +41,7 @@ RSpec.describe TimelineEvent do
   describe "associations" do
     it { is_expected.to belong_to(:assessment_section).optional }
     it { is_expected.to belong_to(:note).optional }
+    it { is_expected.to belong_to(:further_information_request).optional }
   end
 
   describe "validations" do
@@ -48,6 +52,8 @@ RSpec.describe TimelineEvent do
         state_changed: "state_changed",
         assessment_section_recorded: "assessment_section_recorded",
         note_created: "note_created",
+        further_information_request_assessed:
+          "further_information_request_assessed",
       ).backed_by_column_of_type(:string)
     end
 
@@ -59,6 +65,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:new_state) }
       it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:further_information_request) }
     end
 
     context "with an reviewer assigned event type" do
@@ -69,6 +76,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:new_state) }
       it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:further_information_request) }
     end
 
     context "with a state changed event type" do
@@ -79,6 +87,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:new_state) }
       it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:further_information_request) }
     end
 
     context "with an assessment section recorded event type" do
@@ -89,6 +98,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:new_state) }
       it { is_expected.to validate_presence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:further_information_request) }
     end
 
     context "with a note created event type" do
@@ -99,6 +109,20 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:new_state) }
       it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_presence_of(:note) }
+      it { is_expected.to validate_absence_of(:further_information_request) }
+    end
+
+    context "with a further information request assessed event type" do
+      before do
+        timeline_event.event_type = :further_information_request_assessed
+      end
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
+      it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_presence_of(:further_information_request) }
     end
   end
 end

--- a/spec/services/update_further_information_request_spec.rb
+++ b/spec/services/update_further_information_request_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UpdateFurtherInformationRequest do
+  let(:further_information_request) { create(:further_information_request) }
+  let(:user) { create(:staff) }
+  let(:params) { { passed: true } }
+
+  subject(:call) do
+    described_class.call(further_information_request:, user:, params:)
+  end
+
+  describe "further information request attributes" do
+    subject(:passed) { further_information_request.passed }
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "record timeline event" do
+    subject(:timeline_event) do
+      TimelineEvent.further_information_request_assessed.find_by(
+        further_information_request:,
+      )
+    end
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to_not be_nil }
+
+      it "sets the attributes correctly" do
+        expect(timeline_event.creator).to eq(user)
+        expect(timeline_event.further_information_request).to eq(
+          further_information_request,
+        )
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/review_further_information_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/review_further_information_request.rb
@@ -6,6 +6,17 @@ module PageObjects
 
       element :heading, ".govuk-heading-xl"
       section :summary_list, GovukSummaryList, ".govuk-summary-list"
+
+      section :form, "form" do
+        section :yes_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(1)"
+        section :no_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(2)"
+        element :failure_reason_textarea, ".govuk-textarea"
+        element :continue_button, "button"
+      end
     end
   end
 end

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -3,12 +3,14 @@
 require "rails_helper"
 
 RSpec.describe "Assessor reviewing further information", type: :system do
-  it "reviewing further information" do
+  before do
     given_the_service_is_open
     given_i_am_authorized_as_a_user(assessor)
     given_there_is_an_application_form_with_failure_reasons
     given_there_is_further_information_received
+  end
 
+  it "review complete" do
     when_i_visit_the(:assessor_application_page, application_id:)
     and_i_click_review_requested_information
     then_i_see_the(
@@ -18,6 +20,24 @@ RSpec.describe "Assessor reviewing further information", type: :system do
       further_information_request_id:,
     )
     and_i_see_the_check_your_answers_items
+
+    when_i_mark_the_section_as_complete
+    then_i_see_the(:assessor_application_page, application_id:)
+  end
+
+  it "review incomplete" do
+    when_i_visit_the(:assessor_application_page, application_id:)
+    and_i_click_review_requested_information
+    then_i_see_the(
+      :review_further_information_request_page,
+      application_id:,
+      assessment_id:,
+      further_information_request_id:,
+    )
+    and_i_see_the_check_your_answers_items
+
+    when_i_mark_the_section_as_incomplete
+    then_i_see_the(:assessor_application_page, application_id:)
   end
 
   private
@@ -44,6 +64,18 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     )
 
     expect(rows.second.key.text).to eq("Upload your identity document")
+  end
+
+  def when_i_mark_the_section_as_complete
+    review_further_information_request_page.form.yes_radio_item.input.click
+    review_further_information_request_page.form.continue_button.click
+  end
+
+  def when_i_mark_the_section_as_incomplete
+    review_further_information_request_page.form.no_radio_item.input.click
+    review_further_information_request_page.form.failure_reason_textarea.fill_in with:
+      "Failure reason"
+    review_further_information_request_page.form.continue_button.click
   end
 
   def application_form

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -148,6 +148,20 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           )
         end
       end
+
+      context "and a passed further information request" do
+        let!(:further_information_request) do
+          create(:further_information_request, :received, :passed, assessment:)
+        end
+        it { is_expected.to be_nil }
+      end
+
+      context "and a failed further information request" do
+        let!(:further_information_request) do
+          create(:further_information_request, :received, :failed, assessment:)
+        end
+        it { is_expected.to be_nil }
+      end
     end
   end
 
@@ -219,6 +233,20 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       context "and a received further information request" do
         before { create(:further_information_request, :received, assessment:) }
         it { is_expected.to eq(:not_started) }
+      end
+
+      context "and a passed further information request" do
+        before do
+          create(:further_information_request, :received, :passed, assessment:)
+        end
+        it { is_expected.to eq(:completed) }
+      end
+
+      context "and a failed further information request" do
+        before do
+          create(:further_information_request, :received, :failed, assessment:)
+        end
+        it { is_expected.to eq(:completed) }
       end
     end
   end


### PR DESCRIPTION
This adds the functionality required to make it possible for an assessor to review further information and submit the assessment.

[Trello Card](https://trello.com/c/9gVBM9UN/1050-after-fi-review)

## Screenshots

![Screenshot 2022-10-26 at 16 19 41](https://user-images.githubusercontent.com/510498/198071478-e584a8b0-cbdd-4418-9cf5-3ca840de4c3a.png)
![Screenshot 2022-10-26 at 16 19 50](https://user-images.githubusercontent.com/510498/198071488-8848329b-0476-45c8-a645-6a53fca8dad2.png)
![Screenshot 2022-10-26 at 16 34 14](https://user-images.githubusercontent.com/510498/198071490-e7250ddb-118a-4855-a7ad-a3df9baee6a0.png)
![Screenshot 2022-10-26 at 16 37 30](https://user-images.githubusercontent.com/510498/198071493-a700a6d7-ea66-45a4-a487-5c4f2697cb64.png)
