### PR TITLE
Add decline confirmation flow

### DIFF
--- a/app/forms/assessor_interface/confirm_recommendation_form.rb
+++ b/app/forms/assessor_interface/confirm_recommendation_form.rb
@@ -31,6 +31,6 @@ class AssessorInterface::ConfirmRecommendationForm
   end
 
   def needs_confirmation?
-    recommendation == "award"
+    %w[award decline].include?(recommendation)
   end
 end

--- a/app/views/assessor_interface/assessments/confirm.html.erb
+++ b/app/views/assessor_interface/assessments/confirm.html.erb
@@ -1,10 +1,34 @@
 <% content_for :page_title, "You’re about to award QTS" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
-<h1 class="govuk-heading-xl">You’re about to award QTS</h1>
+<h1 class="govuk-heading-xl"><%= t(".heading.#{@confirm_recommendation_form.recommendation}") %></h1>
 
-<p class="govuk-body-l">You’re about to award QTS to <%= application_form_full_name(@application_form) %>.</p>
-<p class="govuk-body">Read the declaration and if you’re happy to award QTS, select ‘Accept and award QTS’.</p>
+<% if @confirm_recommendation_form.recommendation == "award" %>
+  <p class="govuk-body-l">You’re about to award QTS to <%= application_form_full_name(@application_form) %>.</p>
+<% else %>
+  <p class="govuk-body-l">You’re about to decline this QTS application from <%= application_form_full_name(@application_form) %> for the following reasons:</p>
+
+  <h2 class="govuk-heading-l">Your decline reasons and notes</h2>
+
+  <% @assessment.sections.each do |section| %>
+    <% if section.selected_failure_reasons.present? %>
+      <h3 class="govuk-heading-m"><%= t(".assessment_section.#{section.key}") %></h3>
+      <ul class="govuk-list">
+        <% section.selected_failure_reasons.each do |key, note| %>
+          <li>
+            <h4 class="govuk-heading-s"><%= t("assessor_interface.assessment_sections.show.failure_reasons.#{key}") %></h4>
+            <p class="govuk-body govuk-!-margin-bottom-2">Your note to the applicant:</p>
+            <%= govuk_inset_text(text: note) %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+  <% end %>
+<% end %>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
+
+<p class="govuk-body"><%= t(".instruction.#{@confirm_recommendation_form.recommendation}") %></p>
 <p class="govuk-body">If you need to check something, use the ‘Back’ button.</p>
 
 <%= form_with model: @confirm_recommendation_form, url: [:assessor_interface, @application_form, @assessment], method: :put do |f| %>
@@ -17,10 +41,11 @@
                           true,
                           false,
                           multiple: false,
-                          link_errors: true %>
+                          link_errors: true,
+                          label: { text: t(".declaration.#{@confirm_recommendation_form.recommendation}") } %>
   <% end %>
 
-  <%= f.govuk_submit "Accept and award QTS", prevent_double_click: false do %>
+  <%= f.govuk_submit t(".button.#{@confirm_recommendation_form.recommendation}"), prevent_double_click: false do %>
     <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
   <% end %>
 <% end %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -29,6 +29,25 @@ en:
         hint:
           can_award: You’ve completed your review of this QTS application and marked all sections as complete to your satisfaction.
           cant_award: You’ve completed your review of this QTS application and marked 1 or more sections as not completed to your satisfaction.
+      confirm:
+        heading:
+          award: You’re about to award QTS
+          decline: You’re about to decline QTS
+        instruction:
+          award: Read the declaration and if you’re happy to award QTS, select ‘Accept and award QTS’.
+          decline: If you’re happy to proceed, read the declaration and if you want to decline, select ‘Continue’.
+        declaration:
+          award: I’ve reviewed this QTS application and I’m satisfied that the applicant meets all the requirements. I understand that by continuing, the applicant will be awarded qualified teacher status.
+          decline: I’ve reviewed this QTS application and the applicant does not meet all the requirements. I understand that by continuing, this application for qualified teacher status will be declined.
+        button:
+          award: Accept and award QTS
+          decline: Accept and decline QTS
+        assessment_section:
+          personal_information: Personal information
+          qualifications: Qualifications
+          age_range_subjects: Age range and subjects
+          work_history: Work history
+          professional_standing: Professional standing
 
     assessment_sections:
       show:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -25,8 +25,6 @@ en:
         add_another: You can use the next section to tell us about additional work history.
     label:
       assessor_interface_confirm_recommendation_form:
-        confirm_options:
-          true: I’ve reviewed this QTS application and I’m satisfied that the applicant meets all the requirements. I understand that by continuing, the applicant will be awarded qualified teacher status.
         recommendation_options:
           award: Award QTS
           request_further_information: Request further information

--- a/spec/support/autoload/page_objects/assessor_interface/confirm_assessment.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/confirm_assessment.rb
@@ -5,6 +5,13 @@ module PageObjects
 
       element :heading, "h1"
 
+      sections :failure_reason_lists, ".govuk-list" do
+        sections :items, "li" do
+          element :heading, ".govuk-heading-s"
+          element :note, ".govuk-inset-text"
+        end
+      end
+
       section :form, "form" do
         element :confirm_declaration, ".govuk-checkboxes__input", visible: false
         element :submit_button, ".govuk-button"

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -27,6 +27,10 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_select_decline_qts
     and_i_click_continue
+    then_i_see_the(:confirm_assessment_page, application_id:, assessment_id:)
+    and_i_see_failure_reasons
+
+    when_i_confirm_declaration
     then_the_application_form_is_declined
   end
 
@@ -70,6 +74,13 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
   def when_i_select_decline_qts
     complete_assessment_page.decline_qts.input.choose
+  end
+
+  def and_i_see_failure_reasons
+    failure_reason_item =
+      confirm_assessment_page.failure_reason_lists.first.items.first
+    expect(failure_reason_item.heading.text).to eq("Failure Reason")
+    expect(failure_reason_item.note.text).to eq("Notes.")
   end
 
   def when_i_confirm_declaration


### PR DESCRIPTION
This makes it possible for assessors to decline an application using the same declaration flow as they do when they accept, and it matches the designs we've got.

[Trello Card](https://trello.com/c/N1LhS5On/1051-decline-qts)

## Screenshot

<img width="618" alt="Screenshot 2022-10-27 at 12 07 37" src="https://user-images.githubusercontent.com/510498/198270860-f15d3a6e-9978-405e-808c-7cc0d811b202.png">

