### PR TITLE
[1063] Check validation on file upload pages

### DIFF
--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -50,6 +50,7 @@ module TeacherInterface
         teacher_interface_upload_form: %i[
           original_attachment
           translated_attachment
+          written_in_english
         ],
       )[
         :teacher_interface_upload_form

--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -5,6 +5,7 @@ module TeacherInterface
     attr_accessor :document
     attribute :original_attachment
     attribute :translated_attachment
+    attribute :written_in_english, type: :boolean
 
     validates :document, presence: true
     validates :original_attachment, file_upload: true
@@ -28,8 +29,9 @@ module TeacherInterface
     end
 
     def attachment_present
-      if original_attachment.blank? && translated_attachment.blank?
-        errors.add(:original_attachment, :blank)
+      errors.add(:original_attachment, :blank) if original_attachment.blank?
+      if written_in_english == "false" && translated_attachment.blank?
+        errors.add(:translated_attachment, :blank)
       end
     end
   end

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -101,9 +101,9 @@
 
   <% if @document.translatable? %>
     <%= f.govuk_radio_buttons_fieldset :written_in_english, legend: { size: "m", text: "Is your document written in English?" } do %>
-      <%= f.govuk_radio_button :written_in_english, :true, label: { text: "Yes" }, link_errors: true, checked: false %>
+      <%= f.govuk_radio_button :written_in_english, :true, label: { text: "Yes" }, link_errors: true %>
 
-      <%= f.govuk_radio_button :written_in_english, :false, label: { text: "No, I’ll upload a translation as well" }, checked: false do %>
+      <%= f.govuk_radio_button :written_in_english, :false, label: { text: "No, I’ll upload a translation as well" } do %>
         <%= f.govuk_file_field :translated_attachment,
                                label: { text: "Select a file to upload" },
                                hint: { text: "You can upload your files in PDF, JPG or DOC format. Each file must be no larger than 50MB." } %>

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -57,7 +57,7 @@
 
     <h1 class="govuk-heading-l">
       <% if @document.documentable.institution_name.present? %>
-        Upload your <%= I18n.t("document.document_type.qualification_certificate") %> for <%= @document.documentable.institution_name %>
+        Upload your <%= @document.documentable.institution_name %> <%= I18n.t("document.document_type.qualification_certificate") %> 
       <% elsif @document.documentable.is_teaching_qualification? %>
         Upload your teaching qualification certificate
       <% else %>
@@ -69,7 +69,7 @@
 
     <h1 class="govuk-heading-l">
       <% if @document.documentable.institution_name.present? %>
-        Upload your <%= I18n.t("document.document_type.qualification_transcript") %> for <%= @document.documentable.institution_name %>
+        Upload your <%= @document.documentable.institution_name %> <%= I18n.t("document.document_type.qualification_transcript") %>
       <% elsif @document.documentable.is_teaching_qualification? %>
         Upload your teaching qualification transcript
       <% else %>

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -38,7 +38,7 @@
       This is called <%= region_certificate_phrase(@application_form.region) %>.
     </p>
 
-    <div class="govuk-inset-text">If this document is not written in English, you’ll also need to upload a translation.</div>
+    <div class="govuk-body">Your documents must be written in English. If they are not written in English, you will need to upload a certified translation of each.</div>
 
     <p class="govuk-body">It must confirm:</p>
     <ul class="govuk-list govuk-list--bullet">
@@ -64,6 +64,8 @@
         Upload your university degree certificate
       <% end %>
     </h1>
+
+    <div class="govuk-body">Your documents must be written in English. If they are not written in English, you will need to upload a certified translation of each.</div>
   <% elsif @document.qualification_transcript? %>
     <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 
@@ -90,7 +92,7 @@
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_file_field :original_attachment,
-                         label: { text: "Select a file to upload" },
+                         label: { text: "Select a file to upload", class: "govuk-heading-m" },
                          hint: { text: "You can upload your files in PDF, JPG or DOC format. Each file must be no larger than 50MB." } %>
 
   <% if @document.qualification_transcript? %>

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -135,6 +135,13 @@ en:
           attributes:
             subject_1:
               blank: Enter your first subject
+        teacher_interface/upload_form:
+          attributes:
+            original_attachment:
+              blank: Select a file to upload
+            translated_attachment:
+              blank: Select a translation to upload
+
         teacher_interface/work_history_form:
           attributes:
             contact_name:

--- a/spec/forms/teacher_interface/upload_form_spec.rb
+++ b/spec/forms/teacher_interface/upload_form_spec.rb
@@ -2,12 +2,18 @@ require "rails_helper"
 
 RSpec.describe TeacherInterface::UploadForm, type: :model do
   subject(:upload_form) do
-    described_class.new(document:, original_attachment:, translated_attachment:)
+    described_class.new(
+      document:,
+      original_attachment:,
+      translated_attachment:,
+      written_in_english:,
+    )
   end
 
   let(:document) { create(:document) }
   let(:original_attachment) { nil }
   let(:translated_attachment) { nil }
+  let(:written_in_english) { nil }
 
   it { is_expected.to validate_presence_of(:document) }
 
@@ -30,6 +36,12 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
     end
 
     context "with an translated attachment" do
+      let(:original_attachment) do
+        ActionDispatch::Http::UploadedFile.new(
+          tempfile: file_fixture("upload.pdf"),
+          type: "application/pdf",
+        )
+      end
       let(:translated_attachment) do
         ActionDispatch::Http::UploadedFile.new(
           tempfile: file_fixture("upload.pdf"),
@@ -38,6 +50,18 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
       end
 
       it { is_expected.to be true }
+    end
+
+    context "written_in_english 'No'" do
+      let(:written_in_english) { "false" }
+      let(:original_attachment) do
+        ActionDispatch::Http::UploadedFile.new(
+          tempfile: file_fixture("upload.pdf"),
+          type: "application/pdf",
+        )
+      end
+
+      it { is_expected.to be false }
     end
 
     context "with an invalid content type" do
@@ -88,6 +112,14 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
     end
 
     context "with a translated attachment" do
+      let(:original_attachment) do
+        ActionDispatch::Http::UploadedFile.new(
+          tempfile: file_fixture("upload.pdf"),
+          filename: "upload.pdf",
+          type: "application/pdf",
+        )
+      end
+
       let(:translated_attachment) do
         ActionDispatch::Http::UploadedFile.new(
           tempfile: file_fixture("upload.pdf"),
@@ -96,9 +128,9 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
         )
       end
 
-      it "creates an upload" do
-        expect(document.uploads.count).to eq(1)
-        expect(document.uploads.first.translation).to be(true)
+      it "creates two uploads" do
+        expect(document.uploads.count).to eq(2)
+        expect(document.uploads.second.translation).to be(true)
       end
     end
   end

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -530,7 +530,7 @@ RSpec.describe "Teacher application", type: :system do
   def when_i_fill_in_qualifications
     fill_in "teacher-interface-qualification-form-title-field", with: "Title"
     fill_in "teacher-interface-qualification-form-institution-name-field",
-            with: "Name"
+            with: "Institution Name"
     fill_in "teacher-interface-qualification-form-institution-country-code-field",
             with: "France"
     fill_in "teacher_interface_qualification_form_start_date_2i", with: "1"
@@ -807,28 +807,28 @@ RSpec.describe "Teacher application", type: :system do
   def then_i_see_the_upload_certificate_form
     expect(upload_document_page).to have_title("Upload a document")
     expect(upload_document_page.heading.text).to eq(
-      "Upload your certificate for Name",
+      "Upload your Institution Name certificate",
     )
   end
 
   def then_i_see_the_upload_degree_certificate_form
     expect(upload_document_page).to have_title("Upload a document")
     expect(upload_document_page.heading.text).to eq(
-      "Upload your certificate for Name",
+      "Upload your Institution Name certificate",
     )
   end
 
   def then_i_see_the_upload_transcript_form
     expect(upload_document_page).to have_title("Upload a document")
     expect(upload_document_page.heading.text).to eq(
-      "Upload your transcript for Name",
+      "Upload your Institution Name transcript",
     )
   end
 
   def then_i_see_the_upload_degree_transcript_form
     expect(upload_document_page).to have_title("Upload a document")
     expect(upload_document_page.heading.text).to eq(
-      "Upload your transcript for Name",
+      "Upload your Institution Name transcript",
     )
   end
 
@@ -955,7 +955,7 @@ RSpec.describe "Teacher application", type: :system do
       "Qualification title\tTitle",
     )
     expect(qualification_summary_page.summary_card).to have_content(
-      "Name of institution\tName",
+      "Name of institution\tInstitution Name",
     )
     expect(qualification_summary_page.summary_card).to have_content(
       "Country of institution\tFrance",


### PR DESCRIPTION
* Fix validation to check for a translation file if the appropriate radio button is selected. This is working now but there's now another issue that if the original file is present but the translation isn't the original file is lost from the upload element when the page reloads. This is an improvement but needs some more work. We're going to review the file upload flow in any case.
* Update the titles that reference the awarding institution
* Add proper error messages to the locale file.