### PR TITLE
Don't send programme type to DQT

### DIFF
--- a/app/lib/dqt/trn_request_params.rb
+++ b/app/lib/dqt/trn_request_params.rb
@@ -41,7 +41,6 @@ module DQT
         providerUkprn: nil,
         programmeStartDate: teaching_qualification.start_date.iso8601,
         programmeEndDate: teaching_qualification.complete_date.iso8601,
-        programmeType: "OverseasTrainedTeacherProgramme",
         subject1: subjects.first,
         subject2: subjects.second,
         subject3: subjects.third,

--- a/spec/lib/dqt/trn_request_params_spec.rb
+++ b/spec/lib/dqt/trn_request_params_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe DQT::TRNRequestParams do
             ageRangeTo: 11,
             programmeStartDate: "1990-01-01",
             programmeEndDate: "1995-01-01",
-            programmeType: "OverseasTrainedTeacherProgramme",
             providerUkprn: nil,
             subject1: "100425",
             subject2: "100321",


### PR DESCRIPTION
This route relates to a historic QTS pathway and is usually left blank.