### PR TITLE
Uploaded docs open in new tab

### DIFF
--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -116,9 +116,13 @@ module CheckYourAnswersSummary
       scope
         .order(:created_at)
         .select { |upload| upload.attachment.present? }
-        .map { |upload| link_to(upload.name, upload.url) }
+        .map { |upload| uploaded_document_link(upload) }
         .join(", ")
         .html_safe
+    end
+
+    def uploaded_document_link(upload)
+      link_to(upload.name, upload.url, target: :_blank, rel: :noopener)
     end
   end
 end


### PR DESCRIPTION
Update document url to force open a new tab
so that the assessors can review information side by side