### PR TITLE
Make email previews generic

### DIFF
--- a/app/components/preview_teacher_mailer/component.html.erb
+++ b/app/components/preview_teacher_mailer/component.html.erb
@@ -1,0 +1,11 @@
+<div class="app-email-preview govuk-body">
+  <div class="app-email-preview__header">
+    <div class="app-email-preview__header__logo">
+      GOV.UK
+    </div>
+  </div>
+
+  <div class="app-email-preview__content">
+    <%= preview.html_safe %>
+  </div>
+</div>

--- a/app/components/preview_teacher_mailer/component.rb
+++ b/app/components/preview_teacher_mailer/component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class PreviewTeacherMailer::Component < ViewComponent::Base
+  def initialize(name:, teacher:, **params)
+    super
+    @name = name
+    @teacher = teacher
+    @params = params
+  end
+
+  def preview
+    TeacherMailerPreview.with(teacher:, **params).send(name)
+  end
+
+  attr_reader :name, :teacher, :params
+end

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -9,11 +9,6 @@ module AssessorInterface
     end
 
     def new
-      @email_preview =
-        TeacherMailerPreview.with(
-          teacher:,
-          further_information_request: @further_information_request,
-        ).further_information_requested
     end
 
     def create

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -10,7 +10,7 @@ module AssessorInterface
 
     def new
       @email_preview =
-        FurtherInformationTemplatePreview.with(
+        TeacherMailerPreview.with(
           teacher:,
           further_information_request: @further_information_request,
         ).further_information_requested

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -13,7 +13,7 @@ module AssessorInterface
         FurtherInformationTemplatePreview.with(
           teacher:,
           further_information_request: @further_information_request,
-        ).render
+        ).further_information_requested
     end
 
     def create

--- a/app/lib/further_information_template_preview.rb
+++ b/app/lib/further_information_template_preview.rb
@@ -1,13 +1,13 @@
 class FurtherInformationTemplatePreview
   class << self
-    def with(teacher:, further_information_request:)
-      new(teacher:, further_information_request:)
+    def with(teacher:, **params)
+      new(teacher:, params:)
     end
   end
 
-  def initialize(teacher:, further_information_request:)
+  def initialize(teacher:, params:)
     @teacher = teacher
-    @further_information_request = further_information_request
+    @params = params
   end
 
   def render
@@ -23,16 +23,13 @@ class FurtherInformationTemplatePreview
 
   private
 
-  attr_reader :teacher, :further_information_request
+  attr_reader :teacher, :params
 
   def client
     @client ||= Notifications::Client.new(ENV.fetch("GOVUK_NOTIFY_API_KEY"))
   end
 
   def mail
-    TeacherMailer.with(
-      teacher:,
-      further_information_request:,
-    ).further_information_requested
+    TeacherMailer.with(teacher:, **params).further_information_requested
   end
 end

--- a/app/lib/further_information_template_preview.rb
+++ b/app/lib/further_information_template_preview.rb
@@ -1,10 +1,4 @@
 class FurtherInformationTemplatePreview
-  GOVUK_NOTIFY_TEMPLATE_ID =
-    ENV.fetch(
-      "GOVUK_NOTIFY_TEMPLATE_ID_MAILER",
-      "95adafaf-0920-4623-bddc-340853c047af",
-    )
-
   class << self
     def with(teacher:, further_information_request:)
       new(teacher:, further_information_request:)
@@ -18,7 +12,7 @@ class FurtherInformationTemplatePreview
 
   def render
     client.generate_template_preview(
-      GOVUK_NOTIFY_TEMPLATE_ID,
+      TeacherMailer::GOVUK_NOTIFY_TEMPLATE_ID,
       personalisation: {
         to: mail.to.first,
         subject: mail.subject,

--- a/app/lib/teacher_mailer_preview.rb
+++ b/app/lib/teacher_mailer_preview.rb
@@ -1,4 +1,4 @@
-class FurtherInformationTemplatePreview
+class TeacherMailerPreview
   class << self
     def with(teacher:, **params)
       new(teacher:, params:)

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -1,6 +1,12 @@
 class TeacherMailer < ApplicationMailer
   before_action :set_name
 
+  GOVUK_NOTIFY_TEMPLATE_ID =
+    ENV.fetch(
+      "GOVUK_NOTIFY_TEMPLATE_ID_TEACHER",
+      "95adafaf-0920-4623-bddc-340853c047af",
+    )
+
   def application_received
     teacher = params[:teacher]
 
@@ -26,12 +32,6 @@ class TeacherMailer < ApplicationMailer
   end
 
   private
-
-  GOVUK_NOTIFY_TEMPLATE_ID =
-    ENV.fetch(
-      "GOVUK_NOTIFY_TEMPLATE_ID_TEACHER",
-      "95adafaf-0920-4623-bddc-340853c047af",
-    )
 
   def set_name
     application_form = params[:teacher].application_form

--- a/app/views/assessor_interface/further_information_requests/new.html.erb
+++ b/app/views/assessor_interface/further_information_requests/new.html.erb
@@ -3,17 +3,11 @@
 
 <h1 class="govuk-heading-xl">Further information request email preview</h1>
 
-<div class="app-email-preview govuk-body">
-  <div class="app-email-preview__header">
-    <div class="app-email-preview__header__logo">
-      GOV.UK
-    </div>
-  </div>
-
-  <div class="app-email-preview__content">
-    <%= @email_preview.html_safe %>
-  </div>
-</div>
+<%= render(PreviewTeacherMailer::Component.new(
+  name: :further_information_requested,
+  teacher: @application_form.teacher,
+  further_information_request: @further_information_request
+)) %>
 
 <%= form_with model: [:assessor_interface, @application_form, @assessment, @further_information_request] do |f| %>
   <%= f.govuk_submit "Send email to applicant" do %>

--- a/spec/components/preview_teacher_mailer_component_spec.rb
+++ b/spec/components/preview_teacher_mailer_component_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PreviewTeacherMailer::Component, type: :component do
+  subject(:component) do
+    render_inline(described_class.new(name:, teacher:, param:))
+  end
+
+  let(:name) { :name }
+  let(:teacher) { create(:teacher) }
+  let(:param) { "param" }
+
+  let(:mailer) { double(name: "<p>Preview</p>") }
+
+  before do
+    expect(TeacherMailerPreview).to receive(:with).with(
+      teacher:,
+      param:,
+    ).and_return(mailer)
+  end
+
+  it "renders the header" do
+    expect(component.css(".app-email-preview__header").text.strip).to eq(
+      "GOV.UK",
+    )
+  end
+
+  it "renders the content" do
+    expect(component.css(".app-email-preview__content").text.strip).to eq(
+      "Preview",
+    )
+  end
+end

--- a/spec/lib/further_information_template_preview_spec.rb
+++ b/spec/lib/further_information_template_preview_spec.rb
@@ -23,7 +23,10 @@ RSpec.describe FurtherInformationTemplatePreview do
 
   describe "render" do
     subject do
-      described_class.with(teacher:, further_information_request:).render
+      described_class.with(
+        teacher:,
+        further_information_request:,
+      ).further_information_requested
     end
 
     it { is_expected.to eq("email html") }

--- a/spec/lib/teacher_mailer_preview_spec.rb
+++ b/spec/lib/teacher_mailer_preview_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe FurtherInformationTemplatePreview do
+RSpec.describe TeacherMailerPreview do
   let(:further_information_request) { create(:further_information_request) }
   let(:teacher) { create(:teacher, :with_application_form) }
   let(:notify_key) { "notify-key" }
@@ -21,7 +21,7 @@ RSpec.describe FurtherInformationTemplatePreview do
     )
   end
 
-  describe "render" do
+  describe "render preview" do
     subject do
       described_class.with(
         teacher:,


### PR DESCRIPTION
This changes how the email previews work so they're generic and can apply to any kind of email from the `TeacherMailer`. This is useful so we can preview the award and decline QTS emails.