### PR TITLE
Change sign in link

### DIFF
--- a/app/views/teachers/sessions/signed_out.html.erb
+++ b/app/views/teachers/sessions/signed_out.html.erb
@@ -18,7 +18,7 @@
   The link will take you to the beginning of the service, but you can use your email address to sign in and continue your application.
 </p>
 
-<p class="govuk-body"><%= govuk_link_to request.host_with_port, "/" %></p>
+<p class="govuk-body"><%= govuk_link_to new_teacher_session_url, new_teacher_session_url %></p>
 
 <p class="govuk-body">
   If you do not continue your application within 60 days you’ll need to start a new application.


### PR DESCRIPTION
This changes the sign in link as shown on the sign out page to take users directly to the sign in page, rather than to the homepage.