### PR TITLE
Allow deleting qualifications

### DIFF
--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -52,7 +52,7 @@ class Qualification < ApplicationRecord
       application_form.teaching_qualification&.part_of_university_degree
     return true if part_of_university_degree.nil? || part_of_university_degree
 
-    application_form.qualifications.ordered.second != self
+    application_form.qualifications.count > 2
   end
 
   def institution_country_name

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -85,16 +85,27 @@ RSpec.describe Qualification, type: :model do
         create(:qualification, application_form: qualification.application_form)
       end
 
-      context "with qualification part of degree" do
+      context "and qualification part of degree" do
         before { qualification.update!(part_of_university_degree: true) }
 
         it { is_expected.to be true }
       end
 
-      context "with qualification not part of degree" do
+      context "and qualification not part of degree" do
         before { qualification.update!(part_of_university_degree: false) }
 
         it { is_expected.to be false }
+
+        context "and more than 2 degree qualifications" do
+          before do
+            create(
+              :qualification,
+              application_form: qualification.application_form,
+            )
+          end
+
+          it { is_expected.to be true }
+        end
       end
     end
   end


### PR DESCRIPTION
This changes the behaviour related to which qualifications are allowed to be deleted to make it possible to delete any degree qualifications if there are more than two degree qualifications, as we only need one of them to be valid.