### PR TITLE
Decline email preview

### DIFF
--- a/app/controllers/assessor_interface/assessments_controller.rb
+++ b/app/controllers/assessor_interface/assessments_controller.rb
@@ -29,6 +29,26 @@ module AssessorInterface
       end
     end
 
+    def preview
+      @assessment_recommendation_form =
+        AssessmentRecommendationForm.new(
+          assessment_recommendation_form_params.merge(
+            assessment:,
+            user: current_staff,
+          ),
+        )
+
+      if @assessment_recommendation_form.needs_preview?
+        render :preview
+      elsif @assessment_recommendation_form.needs_confirmation?
+        render :confirm
+      elsif @assessment_recommendation_form.save
+        redirect_to post_update_redirect_path
+      else
+        render :declare, status: :unprocessable_entity
+      end
+    end
+
     def confirm
       @assessment_recommendation_form =
         AssessmentRecommendationForm.new(
@@ -60,6 +80,8 @@ module AssessorInterface
         redirect_to post_update_redirect_path
       elsif @assessment_recommendation_form.needs_confirmation?
         render :confirm, status: :unprocessable_entity
+      elsif @assessment_recommendation_form.needs_preview?
+        render :preview, status: :unprocessable_entity
       elsif @assessment_recommendation_form.needs_declaration?
         render :declare, status: :unprocessable_entity
       else

--- a/app/forms/assessor_interface/assessment_recommendation_form.rb
+++ b/app/forms/assessor_interface/assessment_recommendation_form.rb
@@ -46,6 +46,10 @@ class AssessorInterface::AssessmentRecommendationForm
     %w[award decline].include?(recommendation)
   end
 
+  def needs_preview?
+    recommendation == "decline"
+  end
+
   def needs_confirmation?
     needs_declaration? && declaration
   end

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -1,5 +1,7 @@
 class TeacherMailer < ApplicationMailer
   before_action :set_name
+  before_action :set_reference,
+                only: %i[application_declined application_received]
 
   GOVUK_NOTIFY_TEMPLATE_ID =
     ENV.fetch(
@@ -7,14 +9,18 @@ class TeacherMailer < ApplicationMailer
       "95adafaf-0920-4623-bddc-340853c047af",
     )
 
-  def application_received
-    teacher = params[:teacher]
-
-    @reference = teacher.application_form.reference
-
+  def application_declined
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
-      to: teacher.email,
+      to: params[:teacher].email,
+      subject: I18n.t("mailer.teacher.application_declined.subject"),
+    )
+  end
+
+  def application_received
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: params[:teacher].email,
       subject: I18n.t("mailer.teacher.application_received.subject"),
     )
   end
@@ -36,5 +42,9 @@ class TeacherMailer < ApplicationMailer
   def set_name
     application_form = params[:teacher].application_form
     @name = "#{application_form.given_names} #{application_form.family_name}"
+  end
+
+  def set_reference
+    @reference = params[:teacher].application_form.reference
   end
 end

--- a/app/services/update_assessment_recommendation.rb
+++ b/app/services/update_assessment_recommendation.rb
@@ -24,6 +24,10 @@ class UpdateAssessmentRecommendation
         ChangeApplicationFormState.call(application_form:, user:, new_state:)
       end
 
+      if assessment.decline?
+        TeacherMailer.with(teacher:).application_declined.deliver_later
+      end
+
       CreateDQTTRNRequest.call(application_form:) if assessment.award?
 
       true
@@ -35,6 +39,7 @@ class UpdateAssessmentRecommendation
   attr_reader :assessment, :user, :new_recommendation
 
   delegate :application_form, to: :assessment
+  delegate :teacher, to: :application_form
 
   def new_application_form_state
     return "awarded" if assessment.award?

--- a/app/views/assessor_interface/assessments/declare.html.erb
+++ b/app/views/assessor_interface/assessments/declare.html.erb
@@ -31,7 +31,7 @@
 <p class="govuk-body"><%= t(".instruction.#{@assessment_recommendation_form.recommendation}") %></p>
 <p class="govuk-body">If you need to check something, use the ‘Back’ button.</p>
 
-<%= form_with model: @assessment_recommendation_form, url: [:confirm, :assessor_interface, @application_form, @assessment] do |f| %>
+<%= form_with model: @assessment_recommendation_form, url: [:preview, :assessor_interface, @application_form, @assessment] do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.hidden_field :recommendation %>

--- a/app/views/assessor_interface/assessments/preview.html.erb
+++ b/app/views/assessor_interface/assessments/preview.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, t(".heading") %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+
+<h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
+<p class="govuk-body-l"><%= t(".subheading") %></p>
+<p class="govuk-body-l"><%= t(".description") %></p>
+
+<%= render(PreviewTeacherMailer::Component.new(
+  name: :application_declined,
+  teacher: @application_form.teacher
+)) %>
+
+<%= form_with model: @assessment_recommendation_form, url: [:confirm, :assessor_interface, @application_form, @assessment] do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.hidden_field :recommendation %>
+  <%= f.hidden_field :declaration %>
+
+  <%= f.govuk_submit t(".button"), prevent_double_click: false do %>
+    <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
+  <% end %>
+<% end %>

--- a/app/views/teacher_mailer/application_declined.text.erb
+++ b/app/views/teacher_mailer/application_declined.text.erb
@@ -1,0 +1,20 @@
+Dear <%= @name %>
+
+# Your QTS application has been declined
+
+Your reference number is:
+
+<%= @reference %>
+
+Thank you for applying for qualified teacher status (QTS) and for your patience while we reviewed your application.
+
+Unfortunately, we’re unable to award QTS status.
+
+# Why your QTS application was declined
+
+You can sign in to view the reason why your application was declined:
+
+<%= new_teacher_session_url %>
+
+Kind regards,
+The Teacher Qualifications Team

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -49,6 +49,11 @@ en:
           age_range_subjects: Age range and subjects
           work_history: Work history
           professional_standing: Professional standing
+      preview:
+        heading: Check and send the email
+        subheading: This screen shows how the email to the applicant will look.
+        description: Make sure you’re happy with the content, then select ‘Send email to applicant’, or select ‘Cancel’ to return to the application.
+        button: Send email to applicant
       confirm:
         legend:
           award: Award this QTS application?

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -1,6 +1,8 @@
 en:
   mailer:
     teacher:
+      application_declined:
+        subject: Your QTS application has been declined
       application_received:
         subject: We’ve received your application for qualified teacher status (QTS)
       further_information_requested:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
       resources :assessments, only: %i[edit update] do
         member do
           post "declare", to: "assessments#declare"
+          post "preview", to: "assessments#preview"
           post "confirm", to: "assessments#confirm"
         end
 

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -12,7 +12,30 @@ RSpec.describe TeacherMailer, type: :mailer do
     )
   end
 
-  describe "application_received" do
+  describe "#application_declined" do
+    subject(:mail) { described_class.with(teacher:).application_declined }
+
+    describe "#subject" do
+      subject(:subject) { mail.subject }
+
+      it { is_expected.to eq("Your QTS application has been declined") }
+    end
+
+    describe "#to" do
+      subject(:to) { mail.to }
+
+      it { is_expected.to eq(["teacher@example.com"]) }
+    end
+
+    describe "#body" do
+      subject(:body) { mail.body.encoded }
+
+      it { is_expected.to include("Dear First Last") }
+      it { is_expected.to include("abc") }
+    end
+  end
+
+  describe "#application_received" do
     subject(:mail) { described_class.with(teacher:).application_received }
 
     describe "#subject" do

--- a/spec/services/update_assessment_recommendation_spec.rb
+++ b/spec/services/update_assessment_recommendation_spec.rb
@@ -52,15 +52,37 @@ RSpec.describe UpdateAssessmentRecommendation do
     end
   end
 
-  describe "DQT TRN request job" do
-    it "creates a DQT TRN request" do
-      expect(CreateDQTTRNRequest).to receive(:call)
-      call
+  context "award recommendation" do
+    let(:new_recommendation) { "award" }
+
+    describe "application declined email" do
+      it "doesn't send an email" do
+        expect { call }.to_not have_enqueued_mail(
+          TeacherMailer,
+          :application_declined,
+        )
+      end
+    end
+
+    describe "DQT TRN request job" do
+      it "creates a DQT TRN request" do
+        expect(CreateDQTTRNRequest).to receive(:call)
+        call
+      end
     end
   end
 
-  context "decline recommendataion" do
+  context "decline recommendation" do
     let(:new_recommendation) { "decline" }
+
+    describe "application declined email" do
+      it "sends an email" do
+        expect { call }.to have_enqueued_mail(
+          TeacherMailer,
+          :application_declined,
+        )
+      end
+    end
 
     describe "DQT TRN request job" do
       it "doesn't create a DQT TRN request" do
@@ -88,6 +110,15 @@ RSpec.describe UpdateAssessmentRecommendation do
     describe "application form status" do
       it "doesn't change the state" do
         expect { call }.to_not change(application_form, :state)
+      end
+    end
+
+    describe "application declined email" do
+      it "doesn't send an email" do
+        expect { call }.to_not have_enqueued_mail(
+          TeacherMailer,
+          :application_declined,
+        )
       end
     end
 

--- a/spec/support/autoload/page_objects/assessor_interface/preview_assessment_recommendation.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/preview_assessment_recommendation.rb
@@ -1,0 +1,13 @@
+module PageObjects
+  module AssessorInterface
+    class PreviewAssessmentRecommendation < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/preview"
+
+      element :heading, "h1"
+
+      section :form, "form" do
+        element :send_button, ".govuk-button"
+      end
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -120,6 +120,11 @@ module PageHelpers
     @personas_page ||= PageObjects::Personas.new
   end
 
+  def preview_assessment_recommendation_page
+    @preview_assessment_recommendation_page ||=
+      PageObjects::AssessorInterface::PreviewAssessmentRecommendation.new
+  end
+
   def qualification_page
     @qualification_page ||= PageObjects::EligibilityInterface::Qualification.new
   end


### PR DESCRIPTION
This adds a preview step to the assessment recommendation flow such that they get to see a preview of the decline email before it's sent to the user.

Depends on #643

[Trello Card](https://trello.com/c/Ub9tSDYs/1052-check-and-send-decline-email)
