### PR TITLE
Add application form status page

### DIFF
--- a/app/controllers/assessor_interface/application_forms_controller.rb
+++ b/app/controllers/assessor_interface/application_forms_controller.rb
@@ -8,5 +8,9 @@ module AssessorInterface
     def show
       @view_object = ApplicationFormsShowViewObject.new(params:)
     end
+
+    def status
+      @view_object = ApplicationFormsShowViewObject.new(params:)
+    end
   end
 end

--- a/app/controllers/assessor_interface/assessments_controller.rb
+++ b/app/controllers/assessor_interface/assessments_controller.rb
@@ -92,16 +92,16 @@ module AssessorInterface
 
     def post_update_redirect_path
       if @assessment.request_further_information?
-        return [
+        [
           :preview,
           :assessor_interface,
           @application_form,
           @assessment,
-          :further_information_requests
+          :further_information_requests,
         ]
+      else
+        [:status, :assessor_interface, @application_form]
       end
-
-      [:assessor_interface, @application_form]
     end
   end
 end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -98,6 +98,10 @@ class AssessorInterface::ApplicationFormsShowViewObject
     end
   end
 
+  def status
+    application_form.state.humanize
+  end
+
   private
 
   attr_reader :params

--- a/app/views/assessor_interface/application_forms/status.html.erb
+++ b/app/views/assessor_interface/application_forms/status.html.erb
@@ -1,0 +1,12 @@
+<% content_for :page_title, "Application" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@view_object.application_form) %>
+
+<%= govuk_panel(title_text: "QTS application #{@view_object.application_form.reference} has been #{@view_object.status.downcase}") %>
+
+<p class="govuk-body">The status of this application has been changed to ’<%= @view_object.status %>‘.</p>
+<p class="govuk-body">The application will be deleted after 90 days unless the applicant chooses to appeal.</p>
+
+<div class="govuk-button-group">
+  <%= govuk_button_link_to "Back to application list", assessor_interface_application_forms_path %>
+  <%= govuk_button_link_to "See application overview", assessor_interface_application_form_path(@view_object.application_form), secondary: true %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
     root to: redirect("/assessor/applications")
 
     resources :application_forms, path: "/applications", only: %i[index show] do
+      get "status", to: "application_forms#status", on: :member
+
       get "assign-assessor", to: "assessor_assignments#new"
       post "assign-assessor", to: "assessor_assignments#create"
       get "assign-reviewer", to: "reviewer_assignments#new"

--- a/spec/support/autoload/page_objects/assessor_interface/application_status.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application_status.rb
@@ -1,0 +1,16 @@
+module PageObjects
+  module AssessorInterface
+    class ApplicationStatus < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/status"
+
+      element :back_link, "a", text: "Back"
+
+      section :panel, GovukPanel, ".govuk-panel"
+
+      section :button_group, ".govuk-button-group" do
+        element :list_button, ".govuk-button:not(.govuk-button--secondary)"
+        element :overview_button, ".govuk-button.govuk-button--secondary"
+      end
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -12,6 +12,11 @@ module PageHelpers
       PageObjects::AssessorInterface::Application.new
   end
 
+  def assessor_application_status_page
+    @assessor_application_status_page ||=
+      PageObjects::AssessorInterface::ApplicationStatus.new
+  end
+
   def applications_page
     @applications_page ||= PageObjects::AssessorInterface::Applications.new
   end

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_check_declaration
     when_i_check_confirmation
+    then_i_see_the(:assessor_application_status_page, application_id:)
+
+    when_i_click_on_overview_button
     then_the_application_form_is_awarded
   end
 
@@ -42,6 +45,9 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_check_declaration
     when_i_check_confirmation
+    then_i_see_the(:assessor_application_status_page, application_id:)
+
+    when_i_click_on_overview_button
     then_the_application_form_is_declined
   end
 
@@ -124,6 +130,10 @@ RSpec.describe "Assessor completing assessment", type: :system do
   def when_i_check_confirmation
     confirm_assessment_recommendation_page.form.yes_radio_item.input.click
     confirm_assessment_recommendation_page.form.continue_button.click
+  end
+
+  def when_i_click_on_overview_button
+    assessor_application_status_page.button_group.overview_button.click
   end
 
   def then_the_application_form_is_awarded


### PR DESCRIPTION
We use this page after an assessor chooses a recommendation and we need to show them what the status of the application is.

[Trello Card](https://trello.com/c/Ub9tSDYs/1052-check-and-send-decline-email)

## Screenshot

<img width="700" alt="Screenshot 2022-10-31 at 12 21 37" src="https://user-images.githubusercontent.com/510498/199007910-d8437052-68fe-45dc-a144-cc6eab5e6419.png">
