### PR TITLE
Add decline view for teachers

### DIFF
--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -42,7 +42,7 @@ class PersonasController < ApplicationController
     %w[online written none]
       .product(
         %w[online written none],
-        %w[draft submitted further_information_requested],
+        %w[draft submitted further_information_requested awarded declined],
       )
       .tap { |personas| personas.insert(2, *personas.slice!(8, 2)) }
       .map do |status_check, sanction_check, state|

--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -29,15 +29,14 @@ module TeacherInterface
         return
       end
 
-      if application_form.further_information_requested?
-        @further_information_request =
-          FurtherInformationRequest
-            .joins(:assessment)
-            .requested
-            .where(assessments: { application_form: })
-            .order(:created_at)
-            .first
-      end
+      @assessment = application_form.assessment
+
+      @further_information_request =
+        FurtherInformationRequest
+          .joins(:assessment)
+          .where(assessments: { application_form: })
+          .order(:created_at)
+          .first
     end
 
     def edit

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -62,6 +62,51 @@
   <p class="govuk-body">You must add all of the requested information, so the assessor can continue reviewing your QTS application.</p>
   <p class="govuk-body">The next screen will take you to the first section you need to complete.</p>
   <%= govuk_start_button(text: "Start now", href: teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
+<% elsif @application_form.declined? %>
+  <h2 class="govuk-heading-l">Your QTS application has been declined</h2>
+
+  <h3 class="govuk-heading-m">Notes from the assessor:</h3>
+
+  <% if @further_information_request.present? %>
+    <% @further_information_request.items.each do |item| %>
+      <h4 class="govuk-heading-s"><%= I18n.t("assessor_interface.assessment_sections.show.failure_reasons.#{item.failure_reason}") %></h4>
+      <%= govuk_inset_text(text: item.assessor_notes) %>
+    <% end %>
+  <% else %>
+    <% @assessment.sections.each do |section| %>
+      <% if section.selected_failure_reasons.present? %>
+        <h4 class="govuk-heading-s"><%= t(".assessment_section.#{section.key}") %></h4>
+        <ul class="govuk-list">
+          <% section.selected_failure_reasons.each do |key, note| %>
+            <li>
+              <h5 class="govuk-heading-s"><%= t("assessor_interface.assessment_sections.show.failure_reasons.#{key}") %></h5>
+              <%= govuk_inset_text(text: note) %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <h3 class="govuk-heading-m">What you can do next</h3>
+
+  <p class="govuk-body">While your QTS application was declined this time, you can make a new application in future, if you’re able to address the decline reasons we’ve set out.</p>
+  <p class="govuk-body">You may want to explore other routes to teaching in England. QTS is not a requirement to teach in independent (private) schools, academies, free schools and in the further education (FE) sector in England.</p>
+
+  <p class="govuk-body">You can find out more about working in these sectors from:</p>
+
+  <ul class="govuk-list">
+    <li><%= govuk_link_to "Independent Schools Council", "http://www.isc.co.uk/" %></li>
+    <li><%= govuk_link_to "The Education & Training Foundation", "http://www.et-foundation.co.uk/" %></li>
+    <li><%= govuk_link_to "Academies and Free Schools", "https://www.gov.uk/types-of-school" %></li>
+  </ul>
+
+  <p class="govuk-body">For further information on other routes to gaining QTS visit <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas" class="govuk-link">Get into teaching</a>.</p>
+  <p class="govuk-body">You can also learn more about <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student" class="govuk-link">training to teach in England</a>.</p>
+
+  <p class="govuk-body">You have the right of appeal to the Head of Teacher Qualifications and/or the County Court against this decision.</p>
+
+  <p class="govuk-body">If you want to appeal, you should inform QTS Enquiries and do so within 4 months of this notification.</p>
 <% else %>
   <%= govuk_panel(title_text: @application_form.further_information_received? ? "Further information successfully submitted" : "Application complete") do %>
     Your reference number

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe "teacher_interface/application_forms/show.html.erb",
+               type: :view do
+  before do
+    assign(:application_form, application_form)
+    assign(:assessment, assessment)
+    assign(:further_information_request, further_information_request)
+  end
+
+  let(:further_information_request) { nil }
+
+  subject { render }
+
+  context "when declined" do
+    let(:application_form) { create(:application_form, :declined) }
+    let(:assessment) { create(:assessment, application_form:) }
+
+    context "and an initial assessment" do
+      before do
+        create(
+          :assessment_section,
+          :failed,
+          key: :personal_information,
+          assessment:,
+        )
+      end
+
+      it { is_expected.to match(/Your QTS application has been declined/) }
+      it { is_expected.to match(/Notes/) }
+    end
+
+    context "and a further information request" do
+      let(:further_information_request) do
+        create(:further_information_request, assessment:)
+      end
+      before do
+        create(
+          :further_information_request_item,
+          further_information_request:,
+          assessor_notes: "A note",
+        )
+      end
+
+      it { is_expected.to match(/Your QTS application has been declined/) }
+      it { is_expected.to match(/A note/) }
+    end
+  end
+end


### PR DESCRIPTION
This adds a view for teachers to see when their application is declined containing all the information they need about their declined application.

## Screenshots

<img width="678" alt="Screenshot 2022-10-31 at 12 45 03" src="https://user-images.githubusercontent.com/510498/199012564-17f2f487-07a7-4bb4-95bc-224977e5a40f.png">
<img width="707" alt="Screenshot 2022-10-31 at 12 45 07" src="https://user-images.githubusercontent.com/510498/199012572-72491c55-c7ad-4771-91c5-daa1915a4df2.png">
