### PR TITLE
[1076] Full journey snags - 1

### DIFF
--- a/app/components/application_form_overview/component.rb
+++ b/app/components/application_form_overview/component.rb
@@ -14,7 +14,6 @@ module ApplicationFormOverview
         application_form,
         include_name: true,
         include_reference: true,
-        include_notes: false,
       ) +
         [
           {

--- a/app/components/application_form_search_result/component.rb
+++ b/app/components/application_form_search_result/component.rb
@@ -22,6 +22,7 @@ module ApplicationFormSearchResult
         application_form,
         include_name: false,
         include_reference: false,
+        include_reviewer: application_form.reviewer.present?,
       )
     end
 

--- a/app/components/application_form_search_result/component.rb
+++ b/app/components/application_form_search_result/component.rb
@@ -22,7 +22,6 @@ module ApplicationFormSearchResult
         application_form,
         include_name: false,
         include_reference: false,
-        include_notes: true,
       )
     end
 

--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -6,7 +6,8 @@ module ApplicationFormHelper
   def application_form_summary_rows(
     application_form,
     include_name:,
-    include_reference:
+    include_reference:,
+    include_reviewer: true
   )
     [
       (
@@ -47,19 +48,23 @@ module ApplicationFormHelper
           },
         ],
       ],
-      [
-        I18n.t("application_form.summary.reviewer"),
-        application_form.reviewer&.name ||
-          I18n.t("application_form.summary.unassigned"),
-        [
-          {
-            href:
-              assessor_interface_application_form_assign_reviewer_path(
-                application_form,
-              ),
-          },
-        ],
-      ],
+      (
+       if include_reviewer
+         [
+           I18n.t("application_form.summary.reviewer"),
+           application_form.reviewer&.name ||
+           I18n.t("application_form.summary.unassigned"),
+           [
+             {
+               href:
+               assessor_interface_application_form_assign_reviewer_path(
+                 application_form,
+               ),
+             },
+           ],
+         ]
+       end
+      ),
       (
         if include_reference
           [

--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -39,8 +39,8 @@ module ApplicationFormHelper
         application_form.submitted_at.strftime("%e %B %Y"),
       ],
       [
-        I18n.t("application_form.summary.days_remaining_sla"),
-        "Not implemented",
+        I18n.t("application_form.summary.days_since_submission"),
+        pluralize(application_form.working_days_since_submission, "day"),
       ],
       [
         I18n.t("application_form.summary.assessor"),

--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -6,8 +6,7 @@ module ApplicationFormHelper
   def application_form_summary_rows(
     application_form,
     include_name:,
-    include_reference:,
-    include_notes:
+    include_reference:
   )
     [
       (
@@ -79,11 +78,6 @@ module ApplicationFormHelper
           ),
         ),
       ],
-      (
-        if include_notes
-          [I18n.t("application_form.summary.notes"), "Not implemented"]
-        end
-      ),
     ].compact.map do |key, value, actions|
       { key: { text: key }, value: { text: value }, actions: actions || [] }
     end

--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -26,7 +26,14 @@ module ApplicationFormHelper
         I18n.t("application_form.summary.email"),
         application_form.teacher.email,
       ],
-      [I18n.t("application_form.summary.region"), application_form.region.name],
+      (
+        if application_form.region.name.present?
+          [
+            I18n.t("application_form.summary.region"),
+            application_form.region.name,
+          ]
+        end
+      ),
       [
         I18n.t("application_form.summary.submitted_at"),
         application_form.submitted_at.strftime("%e %B %Y"),
@@ -49,21 +56,21 @@ module ApplicationFormHelper
         ],
       ],
       (
-       if include_reviewer
-         [
-           I18n.t("application_form.summary.reviewer"),
-           application_form.reviewer&.name ||
-           I18n.t("application_form.summary.unassigned"),
-           [
-             {
-               href:
-               assessor_interface_application_form_assign_reviewer_path(
-                 application_form,
-               ),
-             },
-           ],
-         ]
-       end
+        if include_reviewer
+          [
+            I18n.t("application_form.summary.reviewer"),
+            application_form.reviewer&.name ||
+              I18n.t("application_form.summary.unassigned"),
+            [
+              {
+                href:
+                  assessor_interface_application_form_assign_reviewer_path(
+                    application_form,
+                  ),
+              },
+            ],
+          ]
+        end
       ),
       (
         if include_reference

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -82,7 +82,7 @@ en:
       email: Email
       region: State/territory trained in
       submitted_at: Created on
-      days_remaining_sla: Days remaining in SLA
+      days_since_submission: Working days since submission
       assessor: Assigned to
       reviewer: Reviewer
       reference: Reference

--- a/spec/components/application_form_overview_component_spec.rb
+++ b/spec/components/application_form_overview_component_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ApplicationFormOverview::Component, type: :component do
       it { is_expected.to include("Country trained in") }
       it { is_expected.to include("State/territory trained in") }
       it { is_expected.to include("Created on") }
-      it { is_expected.to include("Days remaining in SLA") }
+      it { is_expected.to include("Working days since submission") }
       it { is_expected.to include("Assigned to") }
       it { is_expected.to include("Reviewer") }
       it { is_expected.to include("Reference") }

--- a/spec/components/application_form_search_result_component_spec.rb
+++ b/spec/components/application_form_search_result_component_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
     create(
       :application_form,
       :submitted,
+      :with_reviewer,
       given_names: "Given",
       family_name: "Family",
     )
@@ -56,6 +57,15 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
       it { is_expected.to include("Assigned to") }
       it { is_expected.to include("Reviewer") }
       it { is_expected.to include("Status") }
+
+      context "where there is no reviewer assigned" do
+        before do
+          application_form.update(reviewer: nil)
+        end
+
+        it { is_expected.not_to include("Reviewer") }
+      end
     end
+
   end
 end

--- a/spec/components/application_form_search_result_component_spec.rb
+++ b/spec/components/application_form_search_result_component_spec.rb
@@ -59,13 +59,10 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
       it { is_expected.to include("Status") }
 
       context "where there is no reviewer assigned" do
-        before do
-          application_form.update(reviewer: nil)
-        end
+        before { application_form.update(reviewer: nil) }
 
         it { is_expected.not_to include("Reviewer") }
       end
     end
-
   end
 end

--- a/spec/components/application_form_search_result_component_spec.rb
+++ b/spec/components/application_form_search_result_component_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
       it { is_expected.to include("Email") }
       it { is_expected.to include("State/territory trained in") }
       it { is_expected.to include("Created on") }
-      it { is_expected.to include("Days remaining in SLA") }
+      it { is_expected.to include("Working days since submission") }
       it { is_expected.to include("Assigned to") }
       it { is_expected.to include("Reviewer") }
       it { is_expected.to include("Status") }

--- a/spec/components/application_form_search_result_component_spec.rb
+++ b/spec/components/application_form_search_result_component_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
       it { is_expected.to include("Assigned to") }
       it { is_expected.to include("Reviewer") }
       it { is_expected.to include("Status") }
-      it { is_expected.to include("Notes") }
     end
   end
 end

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -60,7 +60,7 @@ FactoryBot.define do
     sequence(:reference) { |n| n.to_s.rjust(7, "0") }
     state { "draft" }
     association :teacher
-    association :region, :national
+    association :region
 
     needs_work_history do
       region.status_check_none? || region.sanction_check_none?

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -199,5 +199,9 @@ FactoryBot.define do
         create(:upload, document: application_form.written_statement_document)
       end
     end
+
+    trait :with_reviewer do
+      association :reviewer, factory: :staff
+    end
   end
 end

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -145,19 +145,35 @@ RSpec.describe ApplicationFormHelper do
         ],
       )
     end
-    context "include_reviewer false" do
 
+    context "include_reviewer false" do
       subject(:summary_rows_without_reviewer) do
         application_form_summary_rows(
           application_form,
           include_name: true,
           include_reference: true,
-          include_reviewer: false
+          include_reviewer: false,
         )
       end
 
       it "does not return the reviewer element" do
-        expect(summary_rows_without_reviewer.find {|row| row[:key][:text] == "Reviewer"}).to be_nil
+        expect(
+          summary_rows_without_reviewer.find do |row|
+            row[:key][:text] == "Reviewer"
+          end,
+        ).to be_nil
+      end
+    end
+
+    context "region has an empty name" do
+      before { application_form.region.update(name: "") }
+
+      it "does not return the region element" do
+        expect(
+          summary_rows.find do |row|
+            row[:key][:text] == "State/territory trained in"
+          end,
+        ).to be_nil
       end
     end
   end

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe ApplicationFormHelper do
         application_form,
         include_name: true,
         include_reference: true,
-        include_notes: true,
       )
     end
 
@@ -140,15 +139,6 @@ RSpec.describe ApplicationFormHelper do
             value: {
               text:
                 "<strong class=\"govuk-tag govuk-tag--grey app-search-result__item__tag\" id=\"application-form-#{application_form.id}-status\">Not started</strong>\n",
-            },
-            actions: [],
-          },
-          {
-            key: {
-              text: "Notes",
-            },
-            value: {
-              text: "Not implemented",
             },
             actions: [],
           },

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -145,5 +145,20 @@ RSpec.describe ApplicationFormHelper do
         ],
       )
     end
+    context "include_reviewer false" do
+
+      subject(:summary_rows_without_reviewer) do
+        application_form_summary_rows(
+          application_form,
+          include_name: true,
+          include_reference: true,
+          include_reviewer: false
+        )
+      end
+
+      it "does not return the reviewer element" do
+        expect(summary_rows_without_reviewer.find {|row| row[:key][:text] == "Reviewer"}).to be_nil
+      end
+    end
   end
 end

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -84,10 +84,10 @@ RSpec.describe ApplicationFormHelper do
           },
           {
             key: {
-              text: "Days remaining in SLA",
+              text: "Working days since submission",
             },
             value: {
-              text: "Not implemented",
+              text: "0 days",
             },
             actions: [],
           },


### PR DESCRIPTION
Some updates to the assessor interface to fix issues raised in the recent snagging session.

* Remove 'notes' from search results and the application overview page. We don't store notes as a single field anymore. They're available on the timeline view
* Hide the reviewer row from the search results if there isn't a reviewer assigned. The overview still shows it as we need to expose the link there to add one
* Hide 'state trained in' if the region is a 'National' region as they don't have a name
* Replace 'days remaining in SLA' with 'working days since submission'. We don't have the SLA logic in service as yet so display this instead.

### Search result

<img width="701" alt="Screenshot 2022-11-01 at 11 58 20" src="https://user-images.githubusercontent.com/5216/199227694-b30713ee-a848-4029-b7b1-c811031f167c.png">

### Overview

<img width="684" alt="Screenshot 2022-11-01 at 11 59 12" src="https://user-images.githubusercontent.com/5216/199227775-09de6d1b-b374-4624-ad69-dc2d616b8dbc.png">
