### PR TITLE
Hide content if declined due to sanctions

### DIFF
--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -24,19 +24,11 @@ module TeacherInterface
     end
 
     def show
-      unless application_form
+      @view_object = ApplicationFormShowViewObject.new(current_teacher:)
+
+      if @view_object.application_form.nil?
         redirect_to %i[new teacher_interface application_form]
-        return
       end
-
-      @assessment = application_form.assessment
-
-      @further_information_request =
-        FurtherInformationRequest
-          .joins(:assessment)
-          .where(assessments: { application_form: })
-          .order(:created_at)
-          .first
     end
 
     def edit

--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -22,6 +22,16 @@ class TeacherInterface::ApplicationFormShowViewObject
         .first
   end
 
+  def declined_due_to_sanctions?
+    return false if assessment.nil?
+
+    assessment.sections.any? do |section|
+      section.selected_failure_reasons.any? do |key, _|
+        key == "authorisation_to_teach"
+      end
+    end
+  end
+
   private
 
   attr_reader :current_teacher

--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class TeacherInterface::ApplicationFormShowViewObject
+  def initialize(current_teacher:)
+    @current_teacher = current_teacher
+  end
+
+  def application_form
+    @application_form ||= current_teacher.application_form
+  end
+
+  def assessment
+    @assessment ||= application_form&.assessment
+  end
+
+  def further_information_request
+    @further_information_request ||=
+      FurtherInformationRequest
+        .joins(:assessment)
+        .where(assessments: { application_form: })
+        .order(:created_at)
+        .first
+  end
+
+  private
+
+  attr_reader :current_teacher
+end

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -2,9 +2,9 @@
 
 <h1 class="govuk-heading-xl">Apply for qualified teacher status (QTS)</h1>
 
-<% if @application_form.draft? %>
+<% if @view_object.application_form.draft? %>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
-    <% if @application_form.can_submit? %>
+    <% if @view_object.application_form.can_submit? %>
       Application complete
     <% else %>
       Application incomplete
@@ -12,11 +12,11 @@
   </h2>
 
   <p class="govuk-body govuk-!-margin-bottom-7">
-    You have completed <%= @application_form.completed_task_sections.count %> of <%= @application_form.tasks.count %> sections.
+    You have completed <%= @view_object.application_form.completed_task_sections.count %> of <%= @view_object.application_form.tasks.count %> sections.
   </p>
 
   <ol class="app-task-list">
-    <% @application_form.tasks.each_with_index do |(section, items), index| %>
+    <% @view_object.application_form.tasks.each_with_index do |(section, items), index| %>
       <li>
         <h2 class="app-task-list__section">
           <span class="app-task-list__section-number"><%= index + 1 %>. </span>
@@ -28,13 +28,13 @@
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
                 <%= link_to I18n.t("application_form.tasks.items.#{item}"),
-                            @application_form.path_for_task_item(item),
+                            @view_object.application_form.path_for_task_item(item),
                             aria: { describedby: "#{item}-status" } %>
               </span>
 
               <%= render(ApplicationFormStatusTag::Component.new(
                 key: item,
-                status: @application_form.task_statuses.dig(section, item),
+                status: @view_object.application_form.task_statuses.dig(section, item),
                 class_context: "app-task-list"
               )) %>
             </li>
@@ -45,15 +45,15 @@
   </ol>
 
   <div class="govuk-button-group">
-    <%- if @application_form.can_submit? -%>
+    <%- if @view_object.application_form.can_submit? -%>
       <%= govuk_button_link_to "Check your answers", edit_teacher_interface_application_form_path %>
     <%- end -%>
     <%= govuk_button_link_to "Save and sign out", destroy_teacher_session_path, secondary: true %>
   </div>
-<% elsif @application_form.further_information_requested? %>
+<% elsif @view_object.application_form.further_information_requested? %>
   <h2 class="govuk-heading-m">We need some more information</h2>
   <p class="govuk-body">The status of your qualified teacher status application is currently:</p>
-  <p class="govuk-body"><%= render(ApplicationFormStatusTag::Component.new(key: "state", status: @application_form.state)) %></p>
+  <p class="govuk-body"><%= render(ApplicationFormStatusTag::Component.new(key: "state", status: @view_object.application_form.state)) %></p>
   <h3 class="govuk-heading-m">What you need to do</h3>
   <p class="govuk-body">The assessor needs you to provide some additional information so they can continue reviewing your application.</p>
   <div class="govuk-inset-text">
@@ -61,19 +61,19 @@
   </div>
   <p class="govuk-body">You must add all of the requested information, so the assessor can continue reviewing your QTS application.</p>
   <p class="govuk-body">The next screen will take you to the first section you need to complete.</p>
-  <%= govuk_start_button(text: "Start now", href: teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
-<% elsif @application_form.declined? %>
+  <%= govuk_start_button(text: "Start now", href: teacher_interface_application_form_further_information_request_path(@view_object.further_information_request)) %>
+<% elsif @view_object.application_form.declined? %>
   <h2 class="govuk-heading-l">Your QTS application has been declined</h2>
 
   <h3 class="govuk-heading-m">Notes from the assessor:</h3>
 
-  <% if @further_information_request.present? %>
-    <% @further_information_request.items.each do |item| %>
+  <% if @view_object.further_information_request.present? %>
+    <% @view_object.further_information_request.items.each do |item| %>
       <h4 class="govuk-heading-s"><%= I18n.t("assessor_interface.assessment_sections.show.failure_reasons.#{item.failure_reason}") %></h4>
       <%= govuk_inset_text(text: item.assessor_notes) %>
     <% end %>
   <% else %>
-    <% @assessment.sections.each do |section| %>
+    <% @view_object.assessment.sections.each do |section| %>
       <% if section.selected_failure_reasons.present? %>
         <h4 class="govuk-heading-s"><%= t(".assessment_section.#{section.key}") %></h4>
         <ul class="govuk-list">
@@ -108,13 +108,13 @@
 
   <p class="govuk-body">If you want to appeal, you should inform QTS Enquiries and do so within 4 months of this notification.</p>
 <% else %>
-  <%= govuk_panel(title_text: @application_form.further_information_received? ? "Further information successfully submitted" : "Application complete") do %>
+  <%= govuk_panel(title_text: @view_object.application_form.further_information_received? ? "Further information successfully submitted" : "Application complete") do %>
     Your reference number
     <br />
-    <strong><%= @application_form.reference %></strong>
+    <strong><%= @view_object.application_form.reference %></strong>
   <% end %>
 
-  <% if @application_form.further_information_received? %>
+  <% if @view_object.application_form.further_information_received? %>
     <h3 class="govuk-heading-m">You’ve successfully submitted your further information</h3>
     <p class="govuk-body">We’ve sent you an email to confirm that we’ve received it.</p>
     <p class="govuk-body">Once the assessor has checked the documents to make sure you’ve provided all of the requested information, they’ll continue reviewing your QTS application.</p>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -90,21 +90,23 @@
 
   <h3 class="govuk-heading-m">What you can do next</h3>
 
-  <p class="govuk-body">While your QTS application was declined this time, you can make a new application in future, if you’re able to address the decline reasons we’ve set out.</p>
-  <p class="govuk-body">You may want to explore other routes to teaching in England. QTS is not a requirement to teach in independent (private) schools, academies, free schools and in the further education (FE) sector in England.</p>
+  <% unless @view_object.declined_due_to_sanctions? %>
+    <p class="govuk-body">While your QTS application was declined this time, you can make a new application in future, if you’re able to address the decline reasons we’ve set out.</p>
+    <p class="govuk-body">You may want to explore other routes to teaching in England. QTS is not a requirement to teach in independent (private) schools, academies, free schools and in the further education (FE) sector in England.</p>
 
-  <p class="govuk-body">You can find out more about working in these sectors from:</p>
+    <p class="govuk-body">You can find out more about working in these sectors from:</p>
 
-  <ul class="govuk-list">
-    <li><%= govuk_link_to "Independent Schools Council", "http://www.isc.co.uk/" %></li>
-    <li><%= govuk_link_to "The Education & Training Foundation", "http://www.et-foundation.co.uk/" %></li>
-    <li><%= govuk_link_to "Academies and Free Schools", "https://www.gov.uk/types-of-school" %></li>
-  </ul>
+    <ul class="govuk-list">
+      <li><%= govuk_link_to "Independent Schools Council", "http://www.isc.co.uk/" %></li>
+      <li><%= govuk_link_to "The Education & Training Foundation", "http://www.et-foundation.co.uk/" %></li>
+      <li><%= govuk_link_to "Academies and Free Schools", "https://www.gov.uk/types-of-school" %></li>
+    </ul>
 
-  <p class="govuk-body">For further information on other routes to gaining QTS visit <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas" class="govuk-link">Get into teaching</a>.</p>
-  <p class="govuk-body">You can also learn more about <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student" class="govuk-link">training to teach in England</a>.</p>
+    <p class="govuk-body">For further information on other routes to gaining QTS visit <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas" class="govuk-link">Get into teaching</a>.</p>
+    <p class="govuk-body">You can also learn more about <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student" class="govuk-link">training to teach in England</a>.</p>
 
-  <p class="govuk-body">You have the right of appeal to the Head of Teacher Qualifications and/or the County Court against this decision.</p>
+    <p class="govuk-body">You have the right of appeal to the Head of Teacher Qualifications and/or the County Court against this decision.</p>
+  <% end %>
 
   <p class="govuk-body">If you want to appeal, you should inform QTS Enquiries and do so within 4 months of this notification.</p>
 <% else %>

--- a/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::ApplicationFormShowViewObject do
+  subject(:view_object) { described_class.new(current_teacher:) }
+
+  let(:current_teacher) { create(:teacher, :confirmed) }
+
+  describe "#application_form" do
+    subject(:application_form) { view_object.application_form }
+
+    it { is_expected.to be_nil }
+
+    context "with an application form" do
+      before { create(:application_form, teacher: current_teacher) }
+
+      it { is_expected.to_not be_nil }
+    end
+  end
+
+  describe "#assessment" do
+    subject(:assessment) { view_object.assessment }
+
+    it { is_expected.to be_nil }
+
+    context "with an assessment form" do
+      before do
+        application_form = create(:application_form, teacher: current_teacher)
+        create(:assessment, application_form:)
+      end
+
+      it { is_expected.to_not be_nil }
+    end
+  end
+
+  describe "#further_information_request" do
+    subject(:further_information_request) do
+      view_object.further_information_request
+    end
+
+    it { is_expected.to be_nil }
+
+    context "with an application form" do
+      before do
+        application_form = create(:application_form, teacher: current_teacher)
+        assessment = create(:assessment, application_form:)
+        create(:further_information_request, assessment:)
+      end
+
+      it { is_expected.to_not be_nil }
+    end
+  end
+end

--- a/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
@@ -51,4 +51,30 @@ RSpec.describe TeacherInterface::ApplicationFormShowViewObject do
       it { is_expected.to_not be_nil }
     end
   end
+
+  describe "#declined_due_to_sanctions?" do
+    subject(:declined_due_to_sanctions?) do
+      view_object.declined_due_to_sanctions?
+    end
+
+    it { is_expected.to be false }
+
+    context "with sanctions" do
+      before do
+        application_form = create(:application_form, teacher: current_teacher)
+        assessment = create(:assessment, application_form:)
+        create(
+          :assessment_section,
+          :personal_information,
+          :failed,
+          selected_failure_reasons: {
+            authorisation_to_teach: "Sanctions found.",
+          },
+          assessment:,
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -3,12 +3,13 @@ require "rails_helper"
 RSpec.describe "teacher_interface/application_forms/show.html.erb",
                type: :view do
   before do
-    assign(:application_form, application_form)
-    assign(:assessment, assessment)
-    assign(:further_information_request, further_information_request)
+    assign(
+      :view_object,
+      TeacherInterface::ApplicationFormShowViewObject.new(
+        current_teacher: application_form.teacher,
+      ),
+    )
   end
-
-  let(:further_information_request) { nil }
 
   subject { render }
 
@@ -34,6 +35,7 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
       let(:further_information_request) do
         create(:further_information_request, assessment:)
       end
+
       before do
         create(
           :further_information_request_item,

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
 
       it { is_expected.to match(/Your QTS application has been declined/) }
       it { is_expected.to match(/Notes/) }
+      it { is_expected.to match(/you can make a new application in future/) }
     end
 
     context "and a further information request" do
@@ -46,6 +47,25 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
 
       it { is_expected.to match(/Your QTS application has been declined/) }
       it { is_expected.to match(/A note/) }
+      it { is_expected.to match(/you can make a new application in future/) }
+    end
+
+    context "and with sanctions" do
+      before do
+        create(
+          :assessment_section,
+          :failed,
+          key: :personal_information,
+          selected_failure_reasons: {
+            authorisation_to_teach: "Sanctions.",
+          },
+          assessment:,
+        )
+      end
+
+      it do
+        is_expected.to_not match(/you can make a new application in future/)
+      end
     end
   end
 end


### PR DESCRIPTION
If a teacher has been declined due to sanctions then we don't want to point them to other ways of getting QTS since it's unlikely they would be successful.