### PR TITLE
Build award flow

### DIFF
--- a/app/components/application_form_status_tag/component.rb
+++ b/app/components/application_form_status_tag/component.rb
@@ -28,6 +28,7 @@ module ApplicationFormStatusTag
       initial_assessment: "blue",
       further_information_requested: "yellow",
       further_information_received: "purple",
+      awarded_pending_checks: "green",
       awarded: "green",
       declined: "red",
       draft: "grey",

--- a/app/forms/assessor_interface/assessment_recommendation_form.rb
+++ b/app/forms/assessor_interface/assessment_recommendation_form.rb
@@ -47,10 +47,8 @@ class AssessorInterface::AssessmentRecommendationForm
   end
 
   def needs_preview?
-    recommendation == "decline"
-  end
-
-  def needs_confirmation?
     needs_declaration? && declaration
   end
+
+  alias_method :needs_confirmation?, :needs_preview?
 end

--- a/app/jobs/update_dqt_trn_request_job.rb
+++ b/app/jobs/update_dqt_trn_request_job.rb
@@ -10,51 +10,28 @@ class UpdateDQTTRNRequestJob < ApplicationJob
   def perform(dqt_trn_request)
     return if dqt_trn_request.complete?
 
-    response = fetch_response(dqt_trn_request)
+    response =
+      if dqt_trn_request.initial?
+        DQT::Client::CreateTRNRequest.call(
+          request_id: dqt_trn_request.request_id,
+          application_form: dqt_trn_request.application_form,
+        )
+      else
+        DQT::Client::ReadTRNRequest.call(request_id: dqt_trn_request.request_id)
+      end
 
     dqt_trn_request.pending! if dqt_trn_request.initial?
 
     if (trn = response[:trn]).present?
-      update_teacher_trn(dqt_trn_request, trn)
-      send_award_email(dqt_trn_request)
-      update_application_form(dqt_trn_request)
+      AwardQTS.call(
+        application_form: dqt_trn_request.application_form,
+        user: "DQT",
+        trn:,
+      )
+
       dqt_trn_request.complete!
     end
 
     raise StillPending if dqt_trn_request.pending?
-  end
-
-  private
-
-  def fetch_response(dqt_trn_request)
-    if dqt_trn_request.initial?
-      DQT::Client::CreateTRNRequest.call(
-        request_id: dqt_trn_request.request_id,
-        application_form: dqt_trn_request.application_form,
-      )
-    else
-      DQT::Client::ReadTRNRequest.call(request_id: dqt_trn_request.request_id)
-    end
-  end
-
-  def update_teacher_trn(dqt_trn_request, trn)
-    dqt_trn_request.application_form.teacher.update!(trn:)
-  end
-
-  def send_award_email(dqt_trn_request)
-    return if dqt_trn_request.application_form.awarded?
-
-    TeacherMailer
-      .with(teacher: dqt_trn_request.application_form.teacher)
-      .application_awarded
-      .deliver_later
-  end
-
-  def update_application_form(dqt_trn_request)
-    ChangeApplicationFormState.call(
-      application_form: dqt_trn_request.application_form,
-      user: "DQT",
-      new_state: "awarded",
-    )
   end
 end

--- a/app/jobs/update_dqt_trn_request_job.rb
+++ b/app/jobs/update_dqt_trn_request_job.rb
@@ -10,30 +10,40 @@ class UpdateDQTTRNRequestJob < ApplicationJob
   def perform(dqt_trn_request)
     return if dqt_trn_request.complete?
 
-    response =
-      if dqt_trn_request.initial?
-        DQT::Client::CreateTRNRequest.call(
-          request_id: dqt_trn_request.request_id,
-          application_form: dqt_trn_request.application_form,
-        )
-      else
-        DQT::Client::ReadTRNRequest.call(request_id: dqt_trn_request.request_id)
-      end
+    response = fetch_response(dqt_trn_request)
 
     dqt_trn_request.pending! if dqt_trn_request.initial?
 
     if (trn = response[:trn]).present?
-      ActiveRecord::Base.transaction do
-        dqt_trn_request.application_form.teacher.update!(trn:)
-        dqt_trn_request.complete!
-      end
-
-      TeacherMailer
-        .with(teacher: dqt_trn_request.application_form.teacher)
-        .application_awarded
-        .deliver_later
+      update_teacher_trn(dqt_trn_request, trn)
+      send_award_email(dqt_trn_request)
+      dqt_trn_request.complete!
     end
 
     raise StillPending if dqt_trn_request.pending?
+  end
+
+  private
+
+  def fetch_response(dqt_trn_request)
+    if dqt_trn_request.initial?
+      DQT::Client::CreateTRNRequest.call(
+        request_id: dqt_trn_request.request_id,
+        application_form: dqt_trn_request.application_form,
+      )
+    else
+      DQT::Client::ReadTRNRequest.call(request_id: dqt_trn_request.request_id)
+    end
+  end
+
+  def update_teacher_trn(dqt_trn_request, trn)
+    dqt_trn_request.application_form.teacher.update!(trn:)
+  end
+
+  def send_award_email(dqt_trn_request)
+    TeacherMailer
+      .with(teacher: dqt_trn_request.application_form.teacher)
+      .application_awarded
+      .deliver_later
   end
 end

--- a/app/jobs/update_dqt_trn_request_job.rb
+++ b/app/jobs/update_dqt_trn_request_job.rb
@@ -27,6 +27,11 @@ class UpdateDQTTRNRequestJob < ApplicationJob
         dqt_trn_request.application_form.teacher.update!(trn:)
         dqt_trn_request.complete!
       end
+
+      TeacherMailer
+        .with(teacher: dqt_trn_request.application_form.teacher)
+        .application_awarded
+        .deliver_later
     end
 
     raise StillPending if dqt_trn_request.pending?

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -1,13 +1,25 @@
 class TeacherMailer < ApplicationMailer
   before_action :set_name
   before_action :set_reference,
-                only: %i[application_declined application_received]
+                only: %i[
+                  application_awarded
+                  application_declined
+                  application_received
+                ]
 
   GOVUK_NOTIFY_TEMPLATE_ID =
     ENV.fetch(
       "GOVUK_NOTIFY_TEMPLATE_ID_TEACHER",
       "95adafaf-0920-4623-bddc-340853c047af",
     )
+
+  def application_awarded
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: params[:teacher].email,
+      subject: I18n.t("mailer.teacher.application_awarded.subject"),
+    )
+  end
 
   def application_declined
     view_mail(

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -82,6 +82,7 @@ class ApplicationForm < ApplicationRecord
          initial_assessment: "initial_assessment",
          further_information_requested: "further_information_requested",
          further_information_received: "further_information_received",
+         awarded_pending_checks: "awarded_pending_checks",
          awarded: "awarded",
          declined: "declined",
        }

--- a/app/services/award_qts.rb
+++ b/app/services/award_qts.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class AwardQTS
+  include ServicePattern
+
+  def initialize(application_form:, user:, trn:)
+    @application_form = application_form
+    @user = user
+    @trn = trn
+  end
+
+  def call
+    return if application_form.awarded?
+    raise MustBePendingChecks unless application_form.awarded_pending_checks?
+
+    ActiveRecord::Base.transaction do
+      teacher.update!(trn:)
+
+      ChangeApplicationFormState.call(
+        application_form:,
+        user:,
+        new_state: "awarded",
+      )
+    end
+
+    TeacherMailer.with(teacher:).application_awarded.deliver_later
+  end
+
+  class MustBePendingChecks < StandardError
+  end
+
+  private
+
+  attr_reader :application_form, :user, :trn
+
+  delegate :teacher, to: :application_form
+end

--- a/app/services/change_application_form_state.rb
+++ b/app/services/change_application_form_state.rb
@@ -16,18 +16,25 @@ class ChangeApplicationFormState
 
     ActiveRecord::Base.transaction do
       application_form.update!(state: new_state)
-
-      TimelineEvent.create!(
-        application_form:,
-        event_type: "state_changed",
-        creator: user,
-        new_state:,
-        old_state:,
-      )
+      create_timeline_event(old_state:)
     end
   end
 
   private
 
   attr_reader :application_form, :user, :new_state
+
+  def create_timeline_event(old_state:)
+    creator = user.is_a?(String) ? nil : user
+    creator_name = user.is_a?(String) ? user : ""
+
+    TimelineEvent.create!(
+      application_form:,
+      event_type: "state_changed",
+      creator:,
+      creator_name:,
+      new_state:,
+      old_state:,
+    )
+  end
 end

--- a/app/services/update_assessment_recommendation.rb
+++ b/app/services/update_assessment_recommendation.rb
@@ -42,7 +42,7 @@ class UpdateAssessmentRecommendation
   delegate :teacher, to: :application_form
 
   def new_application_form_state
-    return "awarded" if assessment.award?
+    return "awarded_pending_checks" if assessment.award?
     return "declined" if assessment.decline?
     nil
   end

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -38,6 +38,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
       initial_assessment
       further_information_requested
       further_information_received
+      awarded_pending_checks
       awarded
       declined
     ]

--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -5,8 +5,12 @@ class TeacherInterface::ApplicationFormShowViewObject
     @current_teacher = current_teacher
   end
 
+  def teacher
+    @current_teacher
+  end
+
   def application_form
-    @application_form ||= current_teacher.application_form
+    @application_form ||= teacher.application_form
   end
 
   def assessment
@@ -31,8 +35,4 @@ class TeacherInterface::ApplicationFormShowViewObject
       end
     end
   end
-
-  private
-
-  attr_reader :current_teacher
 end

--- a/app/views/assessor_interface/application_forms/status.html.erb
+++ b/app/views/assessor_interface/application_forms/status.html.erb
@@ -4,7 +4,13 @@
 <%= govuk_panel(title_text: "QTS application #{@view_object.application_form.reference} has been #{@view_object.status.downcase}") %>
 
 <p class="govuk-body">The status of this application has been changed to ’<%= @view_object.status %>‘.</p>
-<p class="govuk-body">The application will be deleted after 90 days unless the applicant chooses to appeal.</p>
+
+<% if @view_object.application_form.declined? %>
+  <p class="govuk-body">The application will be deleted after 90 days unless the applicant chooses to appeal.</p>
+<% elsif @view_object.application_form.awarded_pending_checks? %>
+  <p class="govuk-body">This status will appear while the award is reconciled with the information in the Database of Qualified Teachers (DQT).</p>
+  <p class="govuk-body">Once these checks are complete, the status will change to ‘Awarded’ and the applicant will receive the email telling them they’ve been awarded QTS.</p>
+<% end %>
 
 <div class="govuk-button-group">
   <%= govuk_button_link_to "Back to application list", assessor_interface_application_forms_path %>

--- a/app/views/assessor_interface/assessments/preview.html.erb
+++ b/app/views/assessor_interface/assessments/preview.html.erb
@@ -16,7 +16,7 @@
   <%= f.hidden_field :recommendation %>
   <%= f.hidden_field :declaration %>
 
-  <%= f.govuk_submit t(".button"), prevent_double_click: false do %>
-    <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
+  <%= f.govuk_submit prevent_double_click: false do %>
+    <%= govuk_link_to t(".cancel"), assessor_interface_application_form_path(@application_form) %>
   <% end %>
 <% end %>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -109,6 +109,31 @@
   <% end %>
 
   <p class="govuk-body">If you want to appeal, you should inform QTS Enquiries and do so within 4 months of this notification.</p>
+<% elsif @view_object.application_form.awarded? %>
+  <h2 class="govuk-heading-l">Your QTS application was successful</h2>
+
+  <p class="govuk-body">As someone with qualified teacher status, you’ve been assigned a teacher reference number (TRN).</p>
+
+  <p class="govuk-body">Your TRN is:</p>
+  <%= govuk_inset_text(text: @view_object.teacher.trn) %>
+
+  <h3 class="govuk-heading-m">Next steps</h3>
+
+  <p class="govuk-body">To download a PDF of your QTS certificate and find your date of recognition, visit:</p>
+  <p class="govuk-body"><%= govuk_link_to "https://www.gov.uk/guidance/teacher-self-service-portal", "https://www.gov.uk/guidance/teacher-self-service-portal" %></p>
+
+  <h3 class="govuk-heading-m">Find out more about teaching in England</h3>
+
+  <p class="govuk-body">There’s more information about coming to teach in England, including details about visas and immigration, in the <a href="https://www.gov.uk/government/publications/teach-in-england-if-you-qualified-outside-the-uk/teach-in-england-if-you-qualified-outside-the-uk" class="govuk-link">Department for Education’s guidance for teachers who qualified outside the UK</a>.</p>
+
+  <h3 class="govuk-heading-m">Search for a job in teaching</h3>
+
+  <p class="govuk-body">You can search for a teaching job using <a href="https://teaching-vacancies.service.gov.uk" class="govuk-link">Teaching Vacancies</a>. It’s the official government service that schools use to list their teaching roles. You can also sign up to alerts for the latest jobs matching your key search criteria.</p>
+
+  <h3 class="govuk-heading-m">Get support with your application</h3>
+
+  <p class="govuk-body">If you’re applying for a secondary school maths, physics or modern foreign languages teaching role in England, use the Get into Teaching service for one-to-one support with your application through <a href="https://adviser-getintoteaching.education.gov.uk" class="govuk-link">Get an advisor</a>.</p>
+  <p class="govuk-body">Your adviser can help with writing a personal statement, preparing for an interview and accessing courses to enhance your subject knowledge.</p>
 <% else %>
   <%= govuk_panel(title_text: @view_object.application_form.further_information_received? ? "Further information successfully submitted" : "Application complete") do %>
     Your reference number

--- a/app/views/teacher_mailer/application_awarded.text.erb
+++ b/app/views/teacher_mailer/application_awarded.text.erb
@@ -1,0 +1,18 @@
+Dear <%= @name %>
+
+# Your QTS application was successful
+
+Your reference number is:
+
+<%= @reference %>
+
+We’re pleased to tell you that the assessor has now completed their review of your application and you’ve been awarded qualified teacher status (QTS).
+
+# What happens next
+
+You can sign in to get your Teacher Reference Number (TRN) and get some guidance about your next steps:
+
+<%= new_teacher_session_url %>
+
+Kind regards,
+The Teacher Qualifications Team

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -3,6 +3,7 @@
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "DfE"
   inflect.acronym "DQT"
+  inflect.acronym "QTS"
   inflect.acronym "TRN"
   inflect.uncountable %w[staff]
 end

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -52,8 +52,8 @@ en:
       preview:
         heading: Check and send the email
         subheading: This screen shows how the email to the applicant will look.
-        description: Make sure you’re happy with the content, then select ‘Send email to applicant’, or select ‘Cancel’ to return to the application.
-        button: Send email to applicant
+        description: Make sure you’re happy with the content, then select ‘Continue’, or select ‘Cancel’ to return to the application.
+        cancel: Cancel
       confirm:
         legend:
           award: Award this QTS application?

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -1,6 +1,8 @@
 en:
   mailer:
     teacher:
+      application_awarded:
+        subject: Your QTS application was successful
       application_declined:
         subject: Your QTS application has been declined
       application_received:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -15,6 +15,7 @@ en:
       initial_assessment: Initial assessment
       further_information_requested: Further information requested
       further_information_received: Further information received
+      awarded_pending_checks: Awarded pending checks
       awarded: Awarded
       declined: Declined
       draft: Draft

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -114,6 +114,11 @@ FactoryBot.define do
       submitted_at { Time.zone.now }
     end
 
+    trait :awarded_pending_checks do
+      state { "awarded_pending_checks" }
+      submitted_at { Time.zone.now }
+    end
+
     trait :awarded do
       state { "awarded" }
       submitted_at { Time.zone.now }

--- a/spec/factories/dqt_trn_requests.rb
+++ b/spec/factories/dqt_trn_requests.rb
@@ -19,7 +19,7 @@
 #
 FactoryBot.define do
   factory :dqt_trn_request do
-    association :application_form, :submitted
+    association :application_form, :awarded_pending_checks
 
     request_id { SecureRandom.uuid }
   end

--- a/spec/factories/dqt_trn_requests.rb
+++ b/spec/factories/dqt_trn_requests.rb
@@ -19,7 +19,7 @@
 #
 FactoryBot.define do
   factory :dqt_trn_request do
-    association :application_form
+    association :application_form, :submitted
 
     request_id { SecureRandom.uuid }
   end

--- a/spec/jobs/update_dqt_trn_request_job_spec.rb
+++ b/spec/jobs/update_dqt_trn_request_job_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
   describe "#perform" do
     subject(:perform) { described_class.new.perform(dqt_trn_request) }
 
-    let(:teacher) { dqt_trn_request.application_form.teacher }
+    let(:application_form) { dqt_trn_request.application_form }
+    let(:teacher) { application_form.teacher }
 
     let(:perform_rescue_exception) do
       perform
@@ -39,6 +40,15 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           )
         end
 
+        it "changes the application form status" do
+          expect(ChangeApplicationFormState).to receive(:call).with(
+            application_form:,
+            user: "DQT",
+            new_state: "awarded",
+          )
+          perform
+        end
+
         it "doesn't raise an error" do
           expect { perform }.to_not raise_error
         end
@@ -67,6 +77,11 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           )
         end
 
+        it "doesn't change the application form status" do
+          expect(ChangeApplicationFormState).to_not receive(:call)
+          perform_rescue_exception
+        end
+
         it "raises the error" do
           expect { perform }.to raise_error(Faraday::BadRequestError)
         end
@@ -91,6 +106,11 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
             TeacherMailer,
             :application_awarded,
           )
+        end
+
+        it "doesn't change the application form status" do
+          expect(ChangeApplicationFormState).to_not receive(:call)
+          perform_rescue_exception
         end
 
         it "raises a still pending error" do
@@ -127,6 +147,15 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           )
         end
 
+        it "changes the application form status" do
+          expect(ChangeApplicationFormState).to receive(:call).with(
+            application_form:,
+            user: "DQT",
+            new_state: "awarded",
+          )
+          perform
+        end
+
         it "doesn't raise an error" do
           expect { perform }.to_not raise_error
         end
@@ -155,6 +184,11 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           )
         end
 
+        it "doesn't change the application form status" do
+          expect(ChangeApplicationFormState).to_not receive(:call)
+          perform_rescue_exception
+        end
+
         it "raises the error" do
           expect { perform }.to raise_error(Faraday::BadRequestError)
         end
@@ -179,6 +213,11 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
             TeacherMailer,
             :application_awarded,
           )
+        end
+
+        it "doesn't change the application form status" do
+          expect(ChangeApplicationFormState).to_not receive(:call)
+          perform_rescue_exception
         end
 
         it "raises a still pending error" do
@@ -206,6 +245,11 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           TeacherMailer,
           :application_awarded,
         )
+      end
+
+      it "doesn't change the application form status" do
+        expect(ChangeApplicationFormState).to_not receive(:call)
+        perform
       end
 
       it "doesn't raise an error" do

--- a/spec/jobs/update_dqt_trn_request_job_spec.rb
+++ b/spec/jobs/update_dqt_trn_request_job_spec.rb
@@ -29,22 +29,11 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           expect(dqt_trn_request.reload.state).to eq("complete")
         end
 
-        it "sets the TRN on the teacher" do
-          expect { perform }.to change(teacher, :trn).to("abcdef")
-        end
-
-        it "sends an email" do
-          expect { perform }.to have_enqueued_mail(
-            TeacherMailer,
-            :application_awarded,
-          )
-        end
-
-        it "changes the application form status" do
-          expect(ChangeApplicationFormState).to receive(:call).with(
+        it "awards QTS" do
+          expect(AwardQTS).to receive(:call).with(
             application_form:,
             user: "DQT",
-            new_state: "awarded",
+            trn: "abcdef",
           )
           perform
         end
@@ -66,19 +55,8 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           expect(dqt_trn_request.reload.state).to eq("initial")
         end
 
-        it "doesn't change the TRN on the teacher" do
-          expect { perform_rescue_exception }.to_not change(teacher, :trn)
-        end
-
-        it "doesn't send an email" do
-          expect { perform_rescue_exception }.to_not have_enqueued_mail(
-            TeacherMailer,
-            :application_awarded,
-          )
-        end
-
-        it "doesn't change the application form status" do
-          expect(ChangeApplicationFormState).to_not receive(:call)
+        it "doesn't award QTS" do
+          expect(AwardQTS).to_not receive(:call)
           perform_rescue_exception
         end
 
@@ -97,19 +75,8 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           expect(dqt_trn_request.reload.state).to eq("pending")
         end
 
-        it "doesn't change the TRN on the teacher" do
-          expect { perform_rescue_exception }.to_not change(teacher, :trn)
-        end
-
-        it "doesn't send an email" do
-          expect { perform_rescue_exception }.to_not have_enqueued_mail(
-            TeacherMailer,
-            :application_awarded,
-          )
-        end
-
-        it "doesn't change the application form status" do
-          expect(ChangeApplicationFormState).to_not receive(:call)
+        it "doesn't award QTS" do
+          expect(AwardQTS).to_not receive(:call)
           perform_rescue_exception
         end
 
@@ -136,22 +103,11 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           expect(dqt_trn_request.reload.state).to eq("complete")
         end
 
-        it "sets the TRN on the teacher" do
-          expect { perform }.to change(teacher, :trn).to("abcdef")
-        end
-
-        it "sends an email" do
-          expect { perform }.to have_enqueued_mail(
-            TeacherMailer,
-            :application_awarded,
-          )
-        end
-
-        it "changes the application form status" do
-          expect(ChangeApplicationFormState).to receive(:call).with(
+        it "awards QTS" do
+          expect(AwardQTS).to receive(:call).with(
             application_form:,
             user: "DQT",
-            new_state: "awarded",
+            trn: "abcdef",
           )
           perform
         end
@@ -173,19 +129,8 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           expect(dqt_trn_request.reload.state).to eq("pending")
         end
 
-        it "doesn't change the TRN on the teacher" do
-          expect { perform_rescue_exception }.to_not change(teacher, :trn)
-        end
-
-        it "doesn't send an email" do
-          expect { perform_rescue_exception }.to_not have_enqueued_mail(
-            TeacherMailer,
-            :application_awarded,
-          )
-        end
-
-        it "doesn't change the application form status" do
-          expect(ChangeApplicationFormState).to_not receive(:call)
+        it "doesn't award QTS" do
+          expect(AwardQTS).to_not receive(:call)
           perform_rescue_exception
         end
 
@@ -204,19 +149,8 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           expect(dqt_trn_request.reload.state).to eq("pending")
         end
 
-        it "doesn't change the TRN on the teacher" do
-          expect { perform_rescue_exception }.to_not change(teacher, :trn)
-        end
-
-        it "doesn't send an email" do
-          expect { perform_rescue_exception }.to_not have_enqueued_mail(
-            TeacherMailer,
-            :application_awarded,
-          )
-        end
-
-        it "doesn't change the application form status" do
-          expect(ChangeApplicationFormState).to_not receive(:call)
+        it "doesn't award QTS" do
+          expect(AwardQTS).to_not receive(:call)
           perform_rescue_exception
         end
 
@@ -236,19 +170,8 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
         expect(dqt_trn_request.reload.state).to eq("complete")
       end
 
-      it "doesn't change the TRN on the teacher" do
-        expect { perform }.to_not change(teacher, :trn)
-      end
-
-      it "doesn't send an email" do
-        expect { perform }.to_not have_enqueued_mail(
-          TeacherMailer,
-          :application_awarded,
-        )
-      end
-
-      it "doesn't change the application form status" do
-        expect(ChangeApplicationFormState).to_not receive(:call)
+      it "doesn't award QTS" do
+        expect(AwardQTS).to_not receive(:call)
         perform
       end
 

--- a/spec/jobs/update_dqt_trn_request_job_spec.rb
+++ b/spec/jobs/update_dqt_trn_request_job_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           expect { perform }.to change(teacher, :trn).to("abcdef")
         end
 
+        it "sends an email" do
+          expect { perform }.to have_enqueued_mail(
+            TeacherMailer,
+            :application_awarded,
+          )
+        end
+
         it "doesn't raise an error" do
           expect { perform }.to_not raise_error
         end
@@ -53,6 +60,13 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           expect { perform_rescue_exception }.to_not change(teacher, :trn)
         end
 
+        it "doesn't send an email" do
+          expect { perform_rescue_exception }.to_not have_enqueued_mail(
+            TeacherMailer,
+            :application_awarded,
+          )
+        end
+
         it "raises the error" do
           expect { perform }.to raise_error(Faraday::BadRequestError)
         end
@@ -70,6 +84,13 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
 
         it "doesn't change the TRN on the teacher" do
           expect { perform_rescue_exception }.to_not change(teacher, :trn)
+        end
+
+        it "doesn't send an email" do
+          expect { perform_rescue_exception }.to_not have_enqueued_mail(
+            TeacherMailer,
+            :application_awarded,
+          )
         end
 
         it "raises a still pending error" do
@@ -99,6 +120,13 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           expect { perform }.to change(teacher, :trn).to("abcdef")
         end
 
+        it "sends an email" do
+          expect { perform }.to have_enqueued_mail(
+            TeacherMailer,
+            :application_awarded,
+          )
+        end
+
         it "doesn't raise an error" do
           expect { perform }.to_not raise_error
         end
@@ -120,6 +148,13 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           expect { perform_rescue_exception }.to_not change(teacher, :trn)
         end
 
+        it "doesn't send an email" do
+          expect { perform_rescue_exception }.to_not have_enqueued_mail(
+            TeacherMailer,
+            :application_awarded,
+          )
+        end
+
         it "raises the error" do
           expect { perform }.to raise_error(Faraday::BadRequestError)
         end
@@ -137,6 +172,13 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
 
         it "doesn't change the TRN on the teacher" do
           expect { perform_rescue_exception }.to_not change(teacher, :trn)
+        end
+
+        it "doesn't send an email" do
+          expect { perform_rescue_exception }.to_not have_enqueued_mail(
+            TeacherMailer,
+            :application_awarded,
+          )
         end
 
         it "raises a still pending error" do
@@ -157,6 +199,13 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
 
       it "doesn't change the TRN on the teacher" do
         expect { perform }.to_not change(teacher, :trn)
+      end
+
+      it "doesn't send an email" do
+        expect { perform }.to_not have_enqueued_mail(
+          TeacherMailer,
+          :application_awarded,
+        )
       end
 
       it "doesn't raise an error" do

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -12,6 +12,29 @@ RSpec.describe TeacherMailer, type: :mailer do
     )
   end
 
+  describe "#application_awarded" do
+    subject(:mail) { described_class.with(teacher:).application_awarded }
+
+    describe "#subject" do
+      subject(:subject) { mail.subject }
+
+      it { is_expected.to eq("Your QTS application was successful") }
+    end
+
+    describe "#to" do
+      subject(:to) { mail.to }
+
+      it { is_expected.to eq(["teacher@example.com"]) }
+    end
+
+    describe "#body" do
+      subject(:body) { mail.body.encoded }
+
+      it { is_expected.to include("Dear First Last") }
+      it { is_expected.to include("abc") }
+    end
+  end
+
   describe "#application_declined" do
     subject(:mail) { described_class.with(teacher:).application_declined }
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe ApplicationForm, type: :model do
         further_information_requested: "further_information_requested",
         further_information_received: "further_information_received",
         awarded: "awarded",
+        awarded_pending_checks: "awarded_pending_checks",
         declined: "declined",
       ).backed_by_column_of_type(:string)
     end

--- a/spec/services/award_qts_spec.rb
+++ b/spec/services/award_qts_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AwardQTS do
+  let(:teacher) { create(:teacher, :confirmed) }
+  let(:user) { create(:staff, :confirmed) }
+  let(:trn) { "abcdef" }
+
+  subject(:call) { described_class.call(application_form:, user:, trn:) }
+
+  context "with a submitted application form" do
+    let(:application_form) { create(:application_form, :submitted, teacher:) }
+
+    it "raises an error" do
+      expect { call }.to raise_error(AwardQTS::MustBePendingChecks)
+    end
+  end
+
+  context "with an awarded pending checks application form" do
+    let(:application_form) do
+      create(:application_form, :awarded_pending_checks, teacher:)
+    end
+
+    it "sets the TRN" do
+      expect { call }.to change(teacher, :trn).to("abcdef")
+    end
+
+    it "sends an email" do
+      expect { call }.to have_enqueued_mail(
+        TeacherMailer,
+        :application_awarded,
+      ).with(params: { teacher: }, args: [])
+    end
+
+    it "changes the status" do
+      expect(ChangeApplicationFormState).to receive(:call).with(
+        application_form:,
+        user:,
+        new_state: "awarded",
+      )
+      call
+    end
+  end
+
+  context "with an awarded application form" do
+    let(:application_form) { create(:application_form, :awarded, teacher:) }
+
+    it "doesn't set the TRN" do
+      expect { call }.to_not change(teacher, :trn)
+    end
+
+    it "doesn't send an email" do
+      expect { call }.to_not have_enqueued_mail(
+        TeacherMailer,
+        :application_awarded,
+      )
+    end
+
+    it "doesn't change the status" do
+      expect(ChangeApplicationFormState).to_not receive(:call)
+      call
+    end
+  end
+end

--- a/spec/services/update_assessment_recommendation_spec.rb
+++ b/spec/services/update_assessment_recommendation_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe UpdateAssessmentRecommendation do
     context "after calling the service" do
       before { call }
 
-      it { is_expected.to eq("awarded") }
+      it { is_expected.to eq("awarded_pending_checks") }
     end
   end
 

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe "Assessor completing assessment", type: :system do
     )
 
     when_i_check_declaration
+    then_i_see_the(
+      :preview_assessment_recommendation_page,
+      application_id:,
+      assessment_id:,
+    )
+
+    when_i_send_the_email
+    then_i_see_the(
+      :confirm_assessment_recommendation_page,
+      application_id:,
+      assessment_id:,
+    )
+
     when_i_check_confirmation
     then_i_see_the(:assessor_application_status_page, application_id:)
 
@@ -69,6 +82,11 @@ RSpec.describe "Assessor completing assessment", type: :system do
     )
 
     when_i_send_the_email
+    then_i_see_the(
+      :confirm_assessment_recommendation_page,
+      application_id:,
+      assessment_id:,
+    )
 
     when_i_check_confirmation
     then_i_see_the(:assessor_application_status_page, application_id:)

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -198,6 +198,10 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
             id: "further_information_received",
             label: "Further information received (0)",
           ),
+          OpenStruct.new(
+            id: "awarded_pending_checks",
+            label: "Awarded pending checks (0)",
+          ),
           OpenStruct.new(id: "awarded", label: "Awarded (0)"),
           OpenStruct.new(id: "declined", label: "Declined (0)"),
         ],
@@ -210,8 +214,9 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
         create_list(:application_form, 2, :initial_assessment)
         create_list(:application_form, 3, :further_information_requested)
         create_list(:application_form, 4, :further_information_received)
-        create_list(:application_form, 5, :awarded)
-        create_list(:application_form, 6, :declined)
+        create_list(:application_form, 5, :awarded_pending_checks)
+        create_list(:application_form, 6, :awarded)
+        create_list(:application_form, 7, :declined)
       end
 
       it do
@@ -230,8 +235,12 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
               id: "further_information_received",
               label: "Further information received (4)",
             ),
-            OpenStruct.new(id: "awarded", label: "Awarded (5)"),
-            OpenStruct.new(id: "declined", label: "Declined (6)"),
+            OpenStruct.new(
+              id: "awarded_pending_checks",
+              label: "Awarded pending checks (5)",
+            ),
+            OpenStruct.new(id: "awarded", label: "Awarded (6)"),
+            OpenStruct.new(id: "declined", label: "Declined (7)"),
           ],
         )
       end

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -13,6 +13,23 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
 
   subject { render }
 
+  context "when awarded pending checks" do
+    let(:application_form) do
+      create(:application_form, :awarded_pending_checks)
+    end
+
+    it { is_expected.to match(/Application complete/) }
+    it { is_expected.to match(/We’ve received your application for QTS/) }
+  end
+
+  context "when awarded" do
+    let(:teacher) { create(:teacher, trn: "ABCDEF") }
+    let(:application_form) { create(:application_form, :awarded, teacher:) }
+
+    it { is_expected.to match(/Your QTS application was successful/) }
+    it { is_expected.to match(/ABCDEF/) }
+  end
+
   context "when declined" do
     let(:application_form) { create(:application_form, :declined) }
     let(:assessment) { create(:assessment, application_form:) }


### PR DESCRIPTION
This builds the award flow to allow assessors to award QTS to an application and then have the teacher automatically receive an email once their details have been recorded in DQT. It required added a new state to the application form, "awarded pending checks" which we can use in the future for any other checks that need to happen before an application is awarded.

Depends on #662 

[Trello Card](https://trello.com/c/lkvfY3JA/1091-awarded-application-form-view)