### PR TITLE
Allow timeline event creators to be strings

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -1,7 +1,7 @@
 <div class="moj-timeline__item">
   <div class="moj-timeline__header">
     <h2 class="moj-timeline__title"><%= t("components.timeline_entry.title.#{timeline_event.event_type}") %></h2>
-    <p class="moj-timeline__byline">by <%= timeline_event.creator.try(:name).presence || timeline_event.creator.email %></p>
+    <p class="moj-timeline__byline">by <%= creator %></p>
   </div>
 
   <p class="moj-timeline__date">

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -7,6 +7,12 @@ module TimelineEntry
 
     attr_reader :timeline_event
 
+    def creator
+      timeline_event.creator_name.presence ||
+        timeline_event.creator.try(:name).presence ||
+        timeline_event.creator.email
+    end
+
     def description_vars
       send("#{timeline_event.event_type}_vars")
     end

--- a/app/models/dqt_trn_request.rb
+++ b/app/models/dqt_trn_request.rb
@@ -3,7 +3,7 @@
 # Table name: dqt_trn_requests
 #
 #  id                  :bigint           not null, primary key
-#  state               :string           default("pending"), not null
+#  state               :string           default("initial"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  application_form_id :bigint           not null

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -6,6 +6,7 @@
 #
 #  id                             :bigint           not null, primary key
 #  annotation                     :string           default(""), not null
+#  creator_name                   :string           default(""), not null
 #  creator_type                   :string
 #  event_type                     :string           not null
 #  new_state                      :string           default(""), not null
@@ -37,7 +38,12 @@
 #
 class TimelineEvent < ApplicationRecord
   belongs_to :application_form
-  belongs_to :creator, polymorphic: true
+  belongs_to :creator, polymorphic: true, optional: true
+
+  validates :creator, presence: true, unless: -> { creator_name.present? }
+  validates :creator_name,
+            presence: true,
+            unless: -> { creator_id.present? && creator_type.present? }
 
   enum event_type: {
          assessor_assigned: "assessor_assigned",

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -221,6 +221,7 @@
     - annotation
     - creator_id
     - creator_type
+    - creator_name
     - created_at
     - updated_at
     - assignee_id

--- a/db/migrate/20221101134536_add_creator_name_to_timeline_events.rb
+++ b/db/migrate/20221101134536_add_creator_name_to_timeline_events.rb
@@ -1,0 +1,9 @@
+class AddCreatorNameToTimelineEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :timeline_events,
+               :creator_name,
+               :string,
+               null: false,
+               default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_26_143332) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_01_134536) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -303,6 +303,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_26_143332) do
     t.bigint "assessment_section_id"
     t.bigint "note_id"
     t.bigint "further_information_request_id"
+    t.string "creator_name", default: "", null: false
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
     t.index ["assessment_section_id"], name: "index_timeline_events_on_assessment_section_id"
     t.index ["assignee_id"], name: "index_timeline_events_on_assignee_id"

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe TimelineEntry::Component, type: :component do
   subject(:component) { render_inline(described_class.new(timeline_event:)) }
   let(:creator) { timeline_event.creator }
 
+  context "with a creator name" do
+    let(:timeline_event) do
+      create(:timeline_event, :state_changed, creator_name: "DQT", creator: nil)
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("by DQT")
+    end
+  end
+
   context "assessor assigned" do
     let(:timeline_event) { create(:timeline_event, :assessor_assigned) }
     let(:assignee) { timeline_event.assignee }

--- a/spec/factories/dqt_trn_requests.rb
+++ b/spec/factories/dqt_trn_requests.rb
@@ -3,7 +3,7 @@
 # Table name: dqt_trn_requests
 #
 #  id                  :bigint           not null, primary key
-#  state               :string           default("pending"), not null
+#  state               :string           default("initial"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  application_form_id :bigint           not null

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -4,6 +4,7 @@
 #
 #  id                             :bigint           not null, primary key
 #  annotation                     :string           default(""), not null
+#  creator_name                   :string           default(""), not null
 #  creator_type                   :string
 #  event_type                     :string           not null
 #  new_state                      :string           default(""), not null

--- a/spec/models/dqt_trn_request_spec.rb
+++ b/spec/models/dqt_trn_request_spec.rb
@@ -5,7 +5,7 @@
 # Table name: dqt_trn_requests
 #
 #  id                  :bigint           not null, primary key
-#  state               :string           default("pending"), not null
+#  state               :string           default("initial"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
 #  application_form_id :bigint           not null

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                             :bigint           not null, primary key
 #  annotation                     :string           default(""), not null
+#  creator_name                   :string           default(""), not null
 #  creator_type                   :string
 #  event_type                     :string           not null
 #  new_state                      :string           default(""), not null
@@ -45,6 +46,21 @@ RSpec.describe TimelineEvent do
   end
 
   describe "validations" do
+    it { is_expected.to validate_presence_of(:creator) }
+    it { is_expected.to validate_presence_of(:creator_name) }
+
+    context "with a creator reference" do
+      before { timeline_event.creator = create(:staff) }
+
+      it { is_expected.to_not validate_presence_of(:creator_name) }
+    end
+
+    context "with a creator name" do
+      before { timeline_event.creator_name = "DQT" }
+
+      it { is_expected.to_not validate_presence_of(:creator) }
+    end
+
     it do
       is_expected.to define_enum_for(:event_type).with_values(
         assessor_assigned: "assessor_assigned",


### PR DESCRIPTION
In the case where something happens due to a background job we don't have a user we can associate with a timeline event, instead we'll want to use a string.

This came up as we need to associate the "status change" timeline event when an application changes from "awarded pending checks" to "awarded", and this happens automatically in the background.