### PR TITLE
Send users to the first incomplete qualification

### DIFF
--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -11,11 +11,17 @@ module TeacherInterface
       elsif application_form.qualifications.empty?
         redirect_to %i[new teacher_interface application_form qualification]
       else
+        ordered_qualifications = application_form.qualifications.ordered
+
+        qualification =
+          ordered_qualifications.find(&:incomplete?) ||
+            ordered_qualifications.first
+
         redirect_to [
                       :edit,
                       :teacher_interface,
                       :application_form,
-                      application_form.qualifications.ordered.first,
+                      qualification,
                     ]
       end
     end

--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -73,32 +73,7 @@ class ApplicationFormStatusUpdater
       return :in_progress
     end
 
-    all_complete =
-      qualifications.all? do |qualification|
-        qualification_complete?(qualification)
-      end
-
-    all_complete ? :completed : :in_progress
-  end
-
-  def qualification_complete?(qualification)
-    values = [
-      qualification.title,
-      qualification.institution_name,
-      qualification.institution_country_code,
-      qualification.start_date,
-      qualification.complete_date,
-      qualification.certificate_date,
-      qualification.certificate_document.uploaded?,
-      qualification.transcript_document.uploaded?,
-    ]
-
-    if qualification.is_teaching_qualification? &&
-         qualification.part_of_university_degree != false
-      values.push(qualification.part_of_university_degree)
-    end
-
-    values.all?(&:present?)
+    qualifications.all?(&:complete?) ? :completed : :in_progress
   end
 
   def age_range_status

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -55,6 +55,29 @@ class Qualification < ApplicationRecord
     application_form.qualifications.count > 2
   end
 
+  def complete?
+    values = [
+      title,
+      institution_name,
+      institution_country_code,
+      start_date,
+      complete_date,
+      certificate_date,
+      certificate_document.uploaded?,
+      transcript_document.uploaded?,
+    ]
+
+    if is_teaching_qualification? && part_of_university_degree != false
+      values.push(part_of_university_degree)
+    end
+
+    values.all?(&:present?)
+  end
+
+  def incomplete?
+    !complete?
+  end
+
   def institution_country_name
     CountryName.from_code(institution_country_code)
   end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -110,6 +110,37 @@ RSpec.describe Qualification, type: :model do
     end
   end
 
+  describe "#complete?" do
+    subject(:complete?) { qualification.complete? }
+
+    it { is_expected.to be false }
+
+    context "with a partially complete qualification" do
+      before { qualification.update!(title: "Title") }
+
+      it { is_expected.to be false }
+    end
+
+    context "with a complete qualification" do
+      before do
+        qualification.update!(
+          title: "Title",
+          institution_name: "Institution name",
+          institution_country_code: "FR",
+          start_date: Date.new(2020, 1, 1),
+          complete_date: Date.new(2021, 1, 1),
+          certificate_date: Date.new(2021, 1, 1),
+          part_of_university_degree: true,
+        )
+
+        create(:upload, document: qualification.certificate_document)
+        create(:upload, document: qualification.transcript_document)
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
   describe "#institution_country_location" do
     subject(:institution_country_location) do
       qualification.institution_country_location


### PR DESCRIPTION
If a user goes from the task list to the qualifications section, rather than taking them to the first qualification, we should take them to the first incomplete qualification so they can continue from where they left off.

[Trello Card](https://trello.com/c/QNLAp8oF/1076-full-journey-snags)