### PR TITLE
[1076] Display 'Reference' in search results

### DIFF
--- a/app/components/application_form_search_result/component.rb
+++ b/app/components/application_form_search_result/component.rb
@@ -21,7 +21,7 @@ module ApplicationFormSearchResult
       application_form_summary_rows(
         application_form,
         include_name: false,
-        include_reference: false,
+        include_reference: true,
         include_reviewer: application_form.reviewer.present?,
       )
     end

--- a/spec/components/application_form_search_result_component_spec.rb
+++ b/spec/components/application_form_search_result_component_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
       it { is_expected.to include("Assigned to") }
       it { is_expected.to include("Reviewer") }
       it { is_expected.to include("Status") }
+      it { is_expected.to include("Reference") }
 
       context "where there is no reviewer assigned" do
         before { application_form.update(reviewer: nil) }


### PR DESCRIPTION
* Include the application form reference in the search results

<img width="648" alt="Screenshot 2022-11-01 at 16 33 00" src="https://user-images.githubusercontent.com/5216/199286483-f8a42354-f55a-42d7-ab21-1e21d5c93800.png">
