### PR TITLE
Show all errors on upload form if one file is missed

### DIFF
--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -10,7 +10,7 @@ module TeacherInterface
     validates :document, presence: true
     validates :original_attachment, file_upload: true
     validates :translated_attachment, file_upload: true
-    validate :attachment_present
+    validate :attachments_present
 
     def update_model
       if original_attachment.present?
@@ -28,10 +28,20 @@ module TeacherInterface
       end
     end
 
-    def attachment_present
-      errors.add(:original_attachment, :blank) if original_attachment.blank?
-      if written_in_english == "false" && translated_attachment.blank?
-        errors.add(:translated_attachment, :blank)
+    def attachments_present
+      has_errors =
+        original_attachment.blank? ||
+          (written_in_english == "false" && translated_attachment.blank?)
+
+      # We lose any uploaded documents if the form isn't valid - the user has to upload both again,
+      # so we should show both errors even if there was only one.
+
+      if has_errors
+        errors.add(:original_attachment, :blank)
+
+        if written_in_english == "false"
+          errors.add(:translated_attachment, :blank)
+        end
       end
     end
   end

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -57,7 +57,7 @@
 
     <h1 class="govuk-heading-l">
       <% if @document.documentable.institution_name.present? %>
-        Upload your <%= @document.documentable.institution_name %> <%= I18n.t("document.document_type.qualification_certificate") %> 
+        Upload your <%= @document.documentable.institution_name %> <%= I18n.t("document.document_type.qualification_certificate") %>
       <% elsif @document.documentable.is_teaching_qualification? %>
         Upload your teaching qualification certificate
       <% else %>


### PR DESCRIPTION
We lose any uploaded files when re-rendering the form (without using JavaScript) so users may not notice that they've got to re-upload their file. For that reason, although confusing, showing to the user both error messages should avoid that.

[Trello Card](https://trello.com/c/QNLAp8oF/1076-full-journey-snags)

## Screenshot

![Screenshot 2022-11-02 at 11 31 56](https://user-images.githubusercontent.com/510498/199480433-22e7ddc3-1fc8-4bc8-b900-27a6a75bc020.png)
