### PR TITLE
Fix bug 'Back link on "qualification" page goes to itself'

### DIFF
--- a/app/views/teacher_interface/qualifications/edit.html.erb
+++ b/app/views/teacher_interface/qualifications/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, I18n.t("application_form.tasks.sections.qualifications") %>
-<% content_for :back_link_url, teacher_interface_application_form_qualifications_path %>
+<% content_for :back_link_url, back_link_url(teacher_interface_application_form_path) %>
 
 <%= render "heading", qualification: @qualification %>
 


### PR DESCRIPTION
Back link on qualification page now goes back to the task list