### PR TITLE
Add missing error messages

### DIFF
--- a/app/assets/stylesheets/_teacher_application_form.scss
+++ b/app/assets/stylesheets/_teacher_application_form.scss
@@ -1,3 +1,0 @@
-label.app-application-form__confirmed-no-sanctions {
-  margin-top: -2%;
-}

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -16,7 +16,6 @@ $moj-images-path: "/";
 @import "_summary_list_card";
 @import "_support";
 @import "_task_list";
-@import "_teacher_application_form";
 
 ul.autocomplete__menu {
   li {

--- a/app/views/teacher_interface/application_forms/edit.html.erb
+++ b/app/views/teacher_interface/application_forms/edit.html.erb
@@ -43,18 +43,16 @@
       <h2 class="govuk-heading-m">How we handle your data</h2>
       <p class="govuk-body">You can read about the data we collect from you, how we use it and how it’s stored, in our <%= govuk_link_to "privacy policy", privacy_path %>.</p>
 
-      <h2 class="govuk-heading-m">About sanctions and restrictions</h2>
-      <p class="govuk-body">
+      <%= f.govuk_check_boxes_fieldset :confirmed_no_sanctions, legend: { text: "About sanctions and restrictions", tag: "h2", size: "m" }, small: true do %>
         <%= f.govuk_check_box :confirmed_no_sanctions,
                               true,
                               false,
                               multiple: false,
                               link_errors: true,
                               label: {
-                                class: "govuk-label govuk-checkboxes__label app-application-form__confirmed-no-sanctions",
                                 text: "Tick the box to confirm your employment record does not contain any sanctions, restrictions, penalties or instances of misconduct."
                               } %>
-      </p>
+      <% end %>
 
       <h2 class="govuk-heading-m">Submitting your application</h2>
       <p class="govuk-body">By selecting the ‘Submit application button’ you confirm that, to the best of your knowledge, the details you’ve provided are correct.</p>

--- a/app/views/teacher_interface/work_histories/edit_has_work_history.html.erb
+++ b/app/views/teacher_interface/work_histories/edit_has_work_history.html.erb
@@ -9,11 +9,9 @@
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :has_work_history,
-                                       [OpenStruct.new(label: "Yes", value: true), OpenStruct.new(label: "No", value: false)],
+                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
                                        :value,
-                                       :label,
-                                       legend: { text: "Have you worked professionally as a teacher?", size: "l", tag: "h1" },
-                                       hint: { text: "If you’re a recent university graduate, or you've just completed your teaching qualification, you may not have held a professional teaching position yet." } %>
+                                       legend: { size: "l", tag: "h1" } %>
 
   <%= f.govuk_submit name: "button", value: "save_and_continue", prevent_double_click: false%>
 <% end %>

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -17,6 +17,8 @@ en:
         alternative_family_name: Enter just your family name
       teacher_interface_further_information_request_item_text_form:
         response: Use the text box below to respond to the assessor’s question.
+      teacher_interface_has_work_history_form:
+        has_work_history: If you’re a recent university graduate, or you've just completed your teaching qualification, you may not have held a professional teaching position yet.
       teacher_interface_new_session_form:
         email: Enter the email address you used to register, and we will send you a link to sign in.
       teacher_interface_registration_number_form:
@@ -69,6 +71,10 @@ en:
         maximum: To
       teacher_interface_further_information_request_item_text_form:
         response: Enter your response
+      teacher_interface_has_work_history_form:
+        has_work_history_options:
+          true: "Yes"
+          false: "No"
       teacher_interface_new_session_form:
         email: Email address
       teacher_interface_registration_number_form:
@@ -107,5 +113,7 @@ en:
         add_another: Add another qualification?
       teacher_interface_alternative_name_form:
         has_alternative_name: Does your name appear differently on your ID documents or qualifications?
+      teacher_interface_has_work_history_form:
+        has_work_history: Have you worked professionally as a teacher?
       work_history:
         add_another: Add another workplace?

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -127,6 +127,10 @@ en:
           attributes:
             confirm:
               inclusion: Select whether you want to delete this file
+        teacher_interface/has_work_history_form:
+          attributes:
+            has_work_history:
+              inclusion: Select whether you have worked professionally as a teacher
         teacher_interface/name_and_date_of_birth_form:
           attributes:
             date_of_birth:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -149,6 +149,12 @@ en:
               blank: Enter your email address
         teacher_interface/qualification_form:
           attributes:
+            title:
+              blank: Enter the qualification title
+            institution_name:
+              blank: Enter the name of the institution
+            institution_country_code:
+              blank: Enter the country of the institution
             start_date:
               blank: Enter the start date in the format 27 3 1980
               invalid: Enter the start date in the format 27 3 1980


### PR DESCRIPTION
This adds missing error messages from the work history and qualification form that were previously missed.

[Trello Card](https://trello.com/c/QNLAp8oF/1076-full-journey-snags)

## Screenshots

<img width="627" alt="Screenshot 2022-11-02 at 12 09 52" src="https://user-images.githubusercontent.com/510498/199488252-c7128c5f-3179-4ee4-9e7c-351bdef6112f.png">
<img width="672" alt="Screenshot 2022-11-02 at 12 18 19" src="https://user-images.githubusercontent.com/510498/199488255-5973851e-c38c-44dc-a958-d10cf3605e85.png">
<img width="667" alt="Screenshot 2022-11-02 at 12 20 04" src="https://user-images.githubusercontent.com/510498/199488257-9864058e-db14-48ce-b4bd-2319564187b9.png">
