### PR TITLE
Update rules for which assessments can be declined

### DIFF
--- a/spec/factories/assessment_sections.rb
+++ b/spec/factories/assessment_sections.rb
@@ -34,6 +34,12 @@ FactoryBot.define do
       selected_failure_reasons { { failure_reason: "Notes." } }
     end
 
+    trait :declines_assessment do
+      selected_failure_reasons do
+        { AssessmentSection::DECLINE_FAILURE_REASONS.first => "Notes." }
+      end
+    end
+
     trait :personal_information do
       key { "personal_information" }
       checks { %w[identification_document_present] }

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -151,41 +151,74 @@ RSpec.describe Assessment, type: :model do
   describe "#can_decline?" do
     subject(:can_decline?) { assessment.can_decline? }
 
-    context "with an unfinished assessment" do
+    context "with an unfinished section" do
       before { create(:assessment_section, :personal_information, assessment:) }
 
       it { is_expected.to be false }
     end
 
-    context "with a passed assessment" do
+    context "with a passed section" do
       before do
         create(:assessment_section, :personal_information, :passed, assessment:)
       end
       it { is_expected.to be false }
     end
 
-    context "with a failed assessment" do
+    context "with a failed section" do
       before do
         create(:assessment_section, :personal_information, :failed, assessment:)
+      end
+      it { is_expected.to be false }
+    end
+
+    context "with a failed section which declines the assessment" do
+      before do
+        create(
+          :assessment_section,
+          :personal_information,
+          :failed,
+          :declines_assessment,
+          assessment:,
+        )
       end
       it { is_expected.to be true }
     end
 
-    context "with a mixture of assessments" do
+    context "with a mixture of sections" do
       before do
         create(:assessment_section, :personal_information, :passed, assessment:)
         create(:assessment_section, :qualifications, :failed, assessment:)
+      end
+      it { is_expected.to be false }
+    end
+
+    context "with a mixture of sections which declines the assessment" do
+      before do
+        create(:assessment_section, :personal_information, :passed, assessment:)
+        create(
+          :assessment_section,
+          :qualifications,
+          :failed,
+          :declines_assessment,
+          assessment:,
+        )
       end
       it { is_expected.to be true }
     end
 
     context "with a passed further information request" do
-      before { create(:further_information_request, :passed, assessment:) }
+      before do
+        create(:assessment_section, :personal_information, :failed, assessment:)
+        create(:further_information_request, :passed, assessment:)
+      end
       it { is_expected.to be false }
     end
 
     context "with a failed further information request" do
-      before { create(:further_information_request, :failed, assessment:) }
+      before do
+        create(:assessment_section, :personal_information, :failed, assessment:)
+        create(:further_information_request, :failed, assessment:)
+      end
       it { is_expected.to be true }
     end
   end
@@ -220,13 +253,10 @@ RSpec.describe Assessment, type: :model do
           :assessment_section,
           :qualifications,
           :failed,
+          :declines_assessment,
           assessment:,
-          selected_failure_reasons: {
-            duplicate_application: "Notes.",
-          },
         )
       end
-
       it { is_expected.to be false }
     end
 

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -104,7 +104,13 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     assessment = create(:assessment, application_form:)
 
-    create(:assessment_section, :personal_information, :failed, assessment:)
+    create(
+      :assessment_section,
+      :personal_information,
+      :failed,
+      :declines_assessment,
+      assessment:,
+    )
   end
 
   def given_i_can_request_dqt_api
@@ -144,7 +150,9 @@ RSpec.describe "Assessor completing assessment", type: :system do
         .first
         .items
         .first
-    expect(failure_reason_item.heading.text).to eq("Failure Reason")
+    expect(failure_reason_item.heading.text).to eq(
+      "There’s already another in-flight application for this applicant.",
+    )
     expect(failure_reason_item.note.text).to eq("Notes.")
   end
 


### PR DESCRIPTION
If it's possible to request further information, we don't want to give users the option to decline the assessment early.

[Trello Card](https://trello.com/c/QNLAp8oF/1076-full-journey-snags)