### PR TITLE
Store assessment section states on timeline events

### DIFF
--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -54,7 +54,7 @@ module TimelineEntry
           render(
             ApplicationFormStatusTag::Component.new(
               key: timeline_event.id,
-              status: section.state,
+              status: timeline_event.new_state,
               class_context: "timeline-event",
             ),
           ),

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -64,8 +64,14 @@ class TimelineEvent < ApplicationRecord
             absence: true,
             unless: -> { assessor_assigned? || reviewer_assigned? }
 
-  validates :old_state, :new_state, presence: true, if: :state_changed?
-  validates :old_state, :new_state, absence: true, unless: :state_changed?
+  validates :old_state,
+            :new_state,
+            presence: true,
+            if: -> { state_changed? || assessment_section_recorded? }
+  validates :old_state,
+            :new_state,
+            absence: true,
+            unless: -> { state_changed? || assessment_section_recorded? }
 
   belongs_to :assessment_section, optional: true
   validates :assessment_section,

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -10,10 +10,12 @@ class UpdateAssessmentSection
   end
 
   def call
+    old_state = assessment_section.state
+
     ActiveRecord::Base.transaction do
       next false unless assessment_section.update(params)
 
-      create_timeline_event
+      create_timeline_event(old_state:)
       update_application_form_assessor
       update_application_form_state
 
@@ -25,12 +27,14 @@ class UpdateAssessmentSection
 
   attr_reader :assessment_section, :user, :params
 
-  def create_timeline_event
+  def create_timeline_event(old_state:)
     TimelineEvent.create!(
       creator: user,
       event_type: :assessment_section_recorded,
       assessment_section:,
       application_form:,
+      old_state:,
+      new_state: assessment_section.state,
     )
   end
 

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -68,7 +68,11 @@ RSpec.describe TimelineEntry::Component, type: :component do
 
   context "assessment section recorded" do
     let(:timeline_event) do
-      create(:timeline_event, :assessment_section_recorded)
+      create(
+        :timeline_event,
+        :assessment_section_recorded,
+        new_state: "completed",
+      )
     end
 
     it "describes the event" do

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -66,6 +66,8 @@ FactoryBot.define do
           assessment: build(:assessment, application_form:),
         )
       end
+      old_state { %i[not_started action_required completed].sample }
+      new_state { %i[not_started action_required completed].sample }
     end
 
     trait :note_created do

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -110,8 +110,8 @@ RSpec.describe TimelineEvent do
       before { timeline_event.event_type = :assessment_section_recorded }
 
       it { is_expected.to validate_absence_of(:assignee) }
-      it { is_expected.to validate_absence_of(:old_state) }
-      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_presence_of(:old_state) }
+      it { is_expected.to validate_presence_of(:new_state) }
       it { is_expected.to validate_presence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }


### PR DESCRIPTION
We want to store the states on the timeline event so we see the correct state as it was at the time, rather than the current state which may have changed.

[Trello Card](https://trello.com/c/QNLAp8oF/1076-full-journey-snags)