### PR TITLE
Allow unassigning assessor/reviewer

### DIFF
--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -41,7 +41,11 @@ module TimelineEntry
     end
 
     def assessor_assigned_vars
-      { assignee_name: timeline_event.assignee.name }
+      {
+        assignee_name:
+          timeline_event.assignee&.name.presence ||
+            I18n.t("application_form.summary.unassigned"),
+      }
     end
 
     alias_method :reviewer_assigned_vars, :assessor_assigned_vars

--- a/app/controllers/assessor_interface/assessor_assignments_controller.rb
+++ b/app/controllers/assessor_interface/assessor_assignments_controller.rb
@@ -16,7 +16,7 @@ module AssessorInterface
           assessor_id: assessor_params[:assessor_id],
         )
 
-      if @assessor_assignment_form.save!
+      if @assessor_assignment_form.save
         redirect_to assessor_interface_application_form_path(application_form)
       else
         render :new

--- a/app/controllers/assessor_interface/reviewer_assignments_controller.rb
+++ b/app/controllers/assessor_interface/reviewer_assignments_controller.rb
@@ -16,7 +16,7 @@ module AssessorInterface
           reviewer_id: reviewer_params[:reviewer_id],
         )
 
-      if @reviewer_assignment_form.save!
+      if @reviewer_assignment_form.save
         redirect_to assessor_interface_application_form_path(application_form)
       else
         render :new

--- a/app/forms/assessor_interface/assessor_assignment_form.rb
+++ b/app/forms/assessor_interface/assessor_assignment_form.rb
@@ -1,20 +1,27 @@
+# frozen_string_literal: true
+
 class AssessorInterface::AssessorAssignmentForm
   include ActiveModel::Model
   include ActiveModel::Attributes
-  include ActiveRecord::AttributeAssignment
 
   attr_accessor :application_form, :staff
   attribute :assessor_id, :string
 
-  validates :application_form, :staff, :assessor_id, presence: true
+  validates :application_form, :staff, presence: true
 
-  def save!
+  def save
     return false unless valid?
 
     AssignApplicationFormAssessor.call(
       application_form:,
       user: staff,
-      assessor: Staff.find(assessor_id),
+      assessor:,
     )
+  end
+
+  private
+
+  def assessor
+    assessor_id.present? ? Staff.find(assessor_id) : nil
   end
 end

--- a/app/forms/assessor_interface/reviewer_assignment_form.rb
+++ b/app/forms/assessor_interface/reviewer_assignment_form.rb
@@ -1,27 +1,27 @@
+# frozen_string_literal: true
+
 class AssessorInterface::ReviewerAssignmentForm
   include ActiveModel::Model
   include ActiveModel::Attributes
-  include ActiveRecord::AttributeAssignment
 
   attr_accessor :application_form, :staff
   attribute :reviewer_id, :string
 
-  validates :application_form, :staff, :reviewer_id, presence: true
-  def save!
+  validates :application_form, :staff, presence: true
+
+  def save
     return false unless valid?
 
-    application_form.update!(reviewer_id:)
-    create_timeline_event!
+    AssignApplicationFormReviewer.call(
+      application_form:,
+      user: staff,
+      reviewer:,
+    )
   end
 
   private
 
-  def create_timeline_event!
-    TimelineEvent.create!(
-      application_form:,
-      event_type: "reviewer_assigned",
-      creator: staff,
-      assignee_id: reviewer_id,
-    )
+  def reviewer
+    reviewer_id.present? ? Staff.find(reviewer_id) : nil
   end
 end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -58,9 +58,6 @@ class TimelineEvent < ApplicationRecord
 
   belongs_to :assignee, class_name: "Staff", optional: true
   validates :assignee,
-            presence: true,
-            if: -> { assessor_assigned? || reviewer_assigned? }
-  validates :assignee,
             absence: true,
             unless: -> { assessor_assigned? || reviewer_assigned? }
 

--- a/app/services/assign_application_form_reviewer.rb
+++ b/app/services/assign_application_form_reviewer.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class AssignApplicationFormReviewer
+  include ServicePattern
+
+  def initialize(application_form:, user:, reviewer:)
+    @application_form = application_form
+    @user = user
+    @reviewer = reviewer
+  end
+
+  def call
+    return if application_form.reviewer == reviewer
+
+    ActiveRecord::Base.transaction do
+      application_form.update!(reviewer:)
+
+      TimelineEvent.create!(
+        application_form:,
+        event_type: "reviewer_assigned",
+        creator: user,
+        assignee: reviewer,
+      )
+    end
+  end
+
+  private
+
+  attr_reader :application_form, :user, :reviewer
+end

--- a/app/views/assessor_interface/assessor_assignments/new.html.erb
+++ b/app/views/assessor_interface/assessor_assignments/new.html.erb
@@ -9,7 +9,11 @@
 <%= form_with model: @assessor_assignment_form, url: assessor_interface_application_form_assign_assessor_path(@application_form) do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_collection_radio_buttons :assessor_id, Staff.all, :id, :name, legend: nil %>
+  <%= f.govuk_collection_radio_buttons :assessor_id,
+                                       [OpenStruct.new(id: "", name: t("application_form.summary.unassigned"))] + Staff.all,
+                                       :id,
+                                       :name,
+                                       legend: nil %>
 
   <%= f.govuk_submit do %>
     <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>

--- a/app/views/assessor_interface/reviewer_assignments/new.html.erb
+++ b/app/views/assessor_interface/reviewer_assignments/new.html.erb
@@ -1,18 +1,21 @@
-<h1 class="govuk-heading-l">
-  Select a reviewer
-</h1>
+<% content_for :page_title, "Select a reviewer" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
-<%= form_for @reviewer_assignment_form, url: assessor_interface_application_form_assign_reviewer_path(@application_form) do |form| %>
-    <%= form.govuk_error_summary %>
+<div class="app-inline-action">
+  <h1 class="govuk-heading-xl">Select a reviewer</h1>
+  <%= govuk_button_link_to "Add&nbsp;note".html_safe, new_assessor_interface_application_form_note_path(@application_form), secondary: true %>
+</div>
 
-    <%= form.govuk_collection_radio_buttons :reviewer_id,
-      Staff.all,
-      :id,
-      :name,
-      legend: nil
-    %>
-    <%= form.govuk_submit "Continue" do %>
-      <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
-    <%- end -%>
-<%- end -%>
+<%= form_with model: @reviewer_assignment_form, url: assessor_interface_application_form_assign_reviewer_path(@application_form) do |f| %>
+  <%= f.govuk_error_summary %>
 
+  <%= f.govuk_collection_radio_buttons :reviewer_id,
+                                       [OpenStruct.new(id: "", name: t("application_form.summary.unassigned"))] + Staff.all,
+                                       :id,
+                                       :name,
+                                       legend: nil %>
+
+  <%= f.govuk_submit do %>
+    <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
+  <% end %>
+<% end %>

--- a/spec/forms/assessor_interface/assessor_assignment_form_spec.rb
+++ b/spec/forms/assessor_interface/assessor_assignment_form_spec.rb
@@ -7,25 +7,27 @@ RSpec.describe AssessorInterface::AssessorAssignmentForm, type: :model do
   let(:staff) { create(:staff, :confirmed) }
   let(:assessor_id) { create(:staff, :confirmed).id }
 
-  subject { described_class.new(application_form:, staff:, assessor_id:) }
+  subject(:form) do
+    described_class.new(application_form:, staff:, assessor_id:)
+  end
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:application_form) }
     it { is_expected.to validate_presence_of(:staff) }
-    it { is_expected.to validate_presence_of(:assessor_id) }
+    it { is_expected.to_not validate_presence_of(:assessor_id) }
   end
 
   describe "#save" do
+    subject(:save) { form.save }
+
     it "updates the application form" do
-      subject.save!
-      application_form.reload
-      expect(application_form.assessor_id).to eq(assessor_id)
+      expect { save }.to change(application_form, :assessor_id).to(assessor_id)
     end
 
     it "creates a timeline event" do
-      expect { subject.save! }.to change { TimelineEvent.count }.by(1)
-      created_event = TimelineEvent.last
+      expect { save }.to change { TimelineEvent.count }.by(1)
 
+      created_event = TimelineEvent.last
       expect(created_event.creator).to eq(staff)
       expect(created_event).to be_assessor_assigned
     end

--- a/spec/forms/assessor_interface/reviewer_assignment_form_spec.rb
+++ b/spec/forms/assessor_interface/reviewer_assignment_form_spec.rb
@@ -7,25 +7,27 @@ RSpec.describe AssessorInterface::ReviewerAssignmentForm, type: :model do
   let(:staff) { create(:staff, :confirmed) }
   let(:reviewer_id) { create(:staff, :confirmed).id }
 
-  subject { described_class.new(application_form:, staff:, reviewer_id:) }
+  subject(:form) do
+    described_class.new(application_form:, staff:, reviewer_id:)
+  end
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:application_form) }
     it { is_expected.to validate_presence_of(:staff) }
-    it { is_expected.to validate_presence_of(:reviewer_id) }
+    it { is_expected.to_not validate_presence_of(:reviewer_id) }
   end
 
   describe "#save" do
+    subject(:save) { form.save }
+
     it "updates the application form" do
-      subject.save!
-      application_form.reload
-      expect(application_form.reviewer_id).to eq(reviewer_id)
+      expect { save }.to change(application_form, :reviewer_id).to(reviewer_id)
     end
 
     it "creates a timeline event" do
-      expect { subject.save! }.to change { TimelineEvent.count }.by(1)
-      created_event = TimelineEvent.last
+      expect { save }.to change { TimelineEvent.count }.by(1)
 
+      created_event = TimelineEvent.last
       expect(created_event.creator).to eq(staff)
       expect(created_event).to be_reviewer_assigned
     end

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe TimelineEvent do
     context "with an assessor assigned event type" do
       before { timeline_event.event_type = :assessor_assigned }
 
-      it { is_expected.to validate_presence_of(:assignee) }
+      it { is_expected.to_not validate_presence_of(:assignee) }
       it { is_expected.to validate_absence_of(:old_state) }
       it { is_expected.to validate_absence_of(:new_state) }
       it { is_expected.to validate_absence_of(:assessment_section) }
@@ -87,7 +87,7 @@ RSpec.describe TimelineEvent do
     context "with an reviewer assigned event type" do
       before { timeline_event.event_type = :reviewer_assigned }
 
-      it { is_expected.to validate_presence_of(:assignee) }
+      it { is_expected.to_not validate_presence_of(:assignee) }
       it { is_expected.to validate_absence_of(:old_state) }
       it { is_expected.to validate_absence_of(:new_state) }
       it { is_expected.to validate_absence_of(:assessment_section) }

--- a/spec/services/assign_application_form_reviewer_spec.rb
+++ b/spec/services/assign_application_form_reviewer_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssignApplicationFormReviewer do
+  let!(:application_form) { create(:application_form, :submitted) }
+  let(:user) { create(:staff) }
+  let(:reviewer) { create(:staff) }
+
+  subject(:call) { described_class.call(application_form:, user:, reviewer:) }
+
+  describe "application form reviewer" do
+    subject(:reviewer) { application_form.reviewer }
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to be(reviewer) }
+    end
+  end
+
+  describe "record timeline event" do
+    subject(:timeline_event) do
+      TimelineEvent.reviewer_assigned.find_by(application_form:)
+    end
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to_not be_nil }
+
+      it "sets the attributes correctly" do
+        expect(timeline_event.creator).to eq(user)
+        expect(timeline_event.assignee).to eq(reviewer)
+      end
+    end
+  end
+end

--- a/spec/system/assessor_interface/assigning_assessor_spec.rb
+++ b/spec/system/assessor_interface/assigning_assessor_spec.rb
@@ -11,7 +11,11 @@ RSpec.describe "Assigning an assessor", type: :system do
 
     when_i_visit_the(:assign_assessor_page, application_id: application_form.id)
     and_i_select_an_assessor
-    then_the_assessor_is_assigned_to_the_application_form
+    then_i_see_the(
+      :assessor_application_page,
+      application_id: application_form.id,
+    )
+    and_the_assessor_is_assigned_to_the_application_form
   end
 
   it "assigns a reviewer" do
@@ -22,7 +26,11 @@ RSpec.describe "Assigning an assessor", type: :system do
 
     when_i_visit_the(:assign_reviewer_page, application_id: application_form.id)
     and_i_select_a_reviewer
-    then_the_assessor_is_assigned_as_reviewer_to_the_application_form
+    then_i_see_the(
+      :assessor_application_page,
+      application_id: application_form.id,
+    )
+    and_the_assessor_is_assigned_as_reviewer_to_the_application_form
   end
 
   private
@@ -36,11 +44,11 @@ RSpec.describe "Assigning an assessor", type: :system do
   end
 
   def and_i_select_an_assessor
-    assign_assessor_page.assessors.first.input.click
+    assign_assessor_page.assessors.second.input.click
     assign_assessor_page.continue_button.click
   end
 
-  def then_the_assessor_is_assigned_to_the_application_form
+  def and_the_assessor_is_assigned_to_the_application_form
     expect(assessor_application_page.overview.assessor_name.text).to eq(
       assessor.name,
     )
@@ -51,11 +59,11 @@ RSpec.describe "Assigning an assessor", type: :system do
   end
 
   def and_i_select_a_reviewer
-    assign_reviewer_page.reviewers.first.input.click
+    assign_reviewer_page.reviewers.second.input.click
     assign_reviewer_page.continue_button.click
   end
 
-  def then_the_assessor_is_assigned_as_reviewer_to_the_application_form
+  def and_the_assessor_is_assigned_as_reviewer_to_the_application_form
     expect(assessor_application_page.overview.reviewer_name.text).to eq(
       assessor.name,
     )


### PR DESCRIPTION
This adds the ability to unassign an assessor or a reviewer by selecting the "Not assigned" option in the list of choices.

[Trello Card](https://trello.com/c/QNLAp8oF/1076-full-journey-snags)

## Screenshot

![Screenshot 2022-11-02 at 17 24 59](https://user-images.githubusercontent.com/510498/199559269-ee9f7a05-dd2f-4fb3-abd9-37c2b1a7a091.png)
