### PR TITLE
Change content on FI previews

### DIFF
--- a/app/views/assessor_interface/further_information_requests/preview.html.erb
+++ b/app/views/assessor_interface/further_information_requests/preview.html.erb
@@ -5,7 +5,7 @@
   Check the further information you’re asking the applicant for
 </h1>
 
-<p class="govuk-body">This screen shows your reasons for requesting further information, along with your notes to the applicant. They’ll see this information in the email they receive.</p>
+<p class="govuk-body">This screen shows your reasons for requesting further information, along with your notes to the applicant.</p>
 <p class="govuk-body">If you need to change your notes, you’ll need to go back to the relevant section.</p>
 
 <h2 class="govuk-heading-l">Your further information request reasons and notes</h2>
@@ -18,7 +18,7 @@
   </section>
 <% end %>
 
-<h2 class="govuk-heading-l">Compose and send your further information request email</h2>
+<h2 class="govuk-heading-l">Send the further information request email</h2>
 <p class="govuk-body">On the next screen, you’ll see a preview of the email.</p>
 
 <div class="govuk-button-group">


### PR DESCRIPTION
To remove a reference to the email containing the assessor notes as this isn't true.