### PR TITLE
Hide header links if not signed in

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,34 +6,36 @@
     ) do |header| %>
   <% case current_namespace %>
   <% when "assessor" %>
-    <% header.navigation_item(
+    <% if current_staff %>
+      <% header.navigation_item(
          text: "Search",
          href: assessor_interface_application_forms_path,
          active: current_page?(assessor_interface_application_forms_path)
        ) %>
-    <% header.navigation_item(text: "Support console", href: support_interface_root_path) %>
-    <% if current_staff %>
+      <% header.navigation_item(text: "Support console", href: support_interface_root_path) %>
       <% header.navigation_item(text: "Sign out", href: destroy_staff_session_path) %>
     <% end %>
   <% when "support" %>
-    <% header.navigation_item(
+    <% if current_staff %>
+      <% header.navigation_item(
          text: "Features",
          href: support_interface_features_path,
          active: current_page?(support_interface_features_path)
        ) %>
-    <% header.navigation_item(
+      <% header.navigation_item(
          text: "Countries",
          href: support_interface_countries_path,
          active: request.path.start_with?("/support/countries") || request.path.start_with?("/support/regions")
        ) %>
-    <% header.navigation_item(
+      <% header.navigation_item(
          text: "Staff",
          href: support_interface_staff_index_path,
          active: request.path.start_with?("/support/staff")
        ) %>
-    <% header.navigation_item(text: "Sidekiq", href: support_interface_sidekiq_web_path) %>
-    <% header.navigation_item(text: "Assessor case management", href: assessor_interface_root_path) %>
-    <% header.navigation_item(text: "Sign out", href: destroy_staff_session_path) %>
+      <% header.navigation_item(text: "Sidekiq", href: support_interface_sidekiq_web_path) %>
+      <% header.navigation_item(text: "Assessor case management", href: assessor_interface_root_path) %>
+      <% header.navigation_item(text: "Sign out", href: destroy_staff_session_path) %>
+    <% end %>
   <% when "teacher" %>
     <% if current_teacher %>
       <% header.navigation_item(text: "Sign out", href: destroy_teacher_session_path) %>


### PR DESCRIPTION
There's no need to show the links since if a user who's not signed in clicks on them, they'll be taken back to the sign in page.