### PR TITLE
Update FI review flow

### DIFF
--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -49,7 +49,12 @@ module AssessorInterface
         )
 
       if @further_information_request_form.save
-        redirect_to [:assessor_interface, view_object.application_form]
+        redirect_to [
+                      :edit,
+                      :assessor_interface,
+                      view_object.application_form,
+                      view_object.assessment,
+                    ]
       else
         render :edit, status: :unprocessable_entity
       end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -28,9 +28,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
         professional_standing
       ].select { |key| assessment_section_keys.include?(key) }
 
-    recommendation =
-      %i[initial_assessment] +
-        further_information_requests.map { :second_assessment }
+    recommendation = %i[initial_assessment]
 
     further_information =
       further_information_requests.map { :review_requested_information }
@@ -49,11 +47,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
     when :recommendation
       return nil unless assessment.sections_finished?
 
-      if (item == :initial_assessment && assessment_editable?) ||
-           (
-             item == :second_assessment &&
-               assessment.request_further_information?
-           )
+      if item == :initial_assessment && assessment_editable?
         url_helpers.edit_assessor_interface_application_form_assessment_path(
           application_form,
           assessment,
@@ -63,7 +57,10 @@ class AssessorInterface::ApplicationFormsShowViewObject
       further_information_request = further_information_requests[index]
 
       if further_information_request.received? &&
-           further_information_request.passed.nil?
+           (
+             further_information_request.passed.nil? ||
+               assessment.request_further_information?
+           )
         url_helpers.edit_assessor_interface_application_form_assessment_further_information_request_path(
           application_form,
           assessment,
@@ -78,22 +75,15 @@ class AssessorInterface::ApplicationFormsShowViewObject
     when :submitted_details
       assessment.sections.find { |s| s.key == item.to_s }.state
     when :recommendation
-      case item
-      when :initial_assessment
-        return :cannot_start_yet unless assessment.sections_finished?
-        return :not_started if assessment.unknown?
-        return :in_progress if assessment_editable?
-        :completed
-      when :second_assessment
-        further_information_request = further_information_requests[index - 1]
-        return :cannot_start_yet if further_information_request.passed.nil?
-        return :not_started if assessment.request_further_information?
-        :completed
-      end
+      return :cannot_start_yet unless assessment.sections_finished?
+      return :not_started if assessment.unknown?
+      return :in_progress if assessment_editable?
+      :completed
     when :further_information
       further_information_request = further_information_requests[index]
       return :cannot_start_yet if further_information_request.requested?
       return :not_started if further_information_request.passed.nil?
+      return :in_progress if assessment.request_further_information?
       :completed
     end
   end

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -22,7 +22,6 @@ en:
             work_history: Check work history
             professional_standing: Check professional standing
             initial_assessment: Initial assessment recommendation
-            second_assessment: Second assessment recommendation
             review_requested_information: Review requested information from applicant
 
     assessments:

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     and_i_see_the_check_your_answers_items
 
     when_i_mark_the_section_as_complete
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:complete_assessment_page, application_id:)
+    and_i_see_an_award_qts_option
   end
 
   it "review incomplete" do
@@ -37,7 +38,8 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     and_i_see_the_check_your_answers_items
 
     when_i_mark_the_section_as_incomplete
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:complete_assessment_page, application_id:)
+    and_i_see_a_decline_qts_option
   end
 
   private
@@ -71,11 +73,19 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     review_further_information_request_page.form.continue_button.click
   end
 
+  def and_i_see_an_award_qts_option
+    expect(complete_assessment_page.award_qts).to_not be_nil
+  end
+
   def when_i_mark_the_section_as_incomplete
     review_further_information_request_page.form.no_radio_item.input.click
     review_further_information_request_page.form.failure_reason_textarea.fill_in with:
       "Failure reason"
     review_further_information_request_page.form.continue_button.click
+  end
+
+  def and_i_see_a_decline_qts_option
+    expect(complete_assessment_page.decline_qts).to_not be_nil
   end
 
   def application_form


### PR DESCRIPTION
This removes the "second assessment" option from the task list and instead moves it to be part of the "review further information" item.