### PR TITLE
Ensure file extension matches content type

### DIFF
--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -1,12 +1,14 @@
 class FileUploadValidator < ActiveModel::EachValidator
   MAX_FILE_SIZE = 50.megabytes
-  CONTENT_TYPES = %w[
-    image/png
-    image/jpeg
-    application/pdf
-    application/msword
-    application/vnd.openxmlformats-officedocument.wordprocessingml.document
-  ].freeze
+
+  CONTENT_TYPES = {
+    ".png" => "image/png",
+    ".jpg" => "image/jpeg",
+    ".pdf" => "application/pdf",
+    ".doc" => "application/msword",
+    ".docx" =>
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  }.freeze
 
   def validate_each(record, attribute, value)
     return if value.nil?
@@ -15,8 +17,14 @@ class FileUploadValidator < ActiveModel::EachValidator
       record.errors.add attribute, :file_size_too_big
     end
 
-    unless CONTENT_TYPES.include?(value.content_type)
+    content_type = value.content_type
+    extension = File.extname(value.original_filename)
+
+    if !CONTENT_TYPES.values.include?(content_type) ||
+         !CONTENT_TYPES.keys.include?(extension)
       record.errors.add attribute, :invalid_content_type
+    elsif CONTENT_TYPES[extension] != content_type
+      record.errors.add attribute, :mismatch_content_type
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
   errors:
     messages:
       invalid_content_type: is not in the correct format
+      mismatch_content_type: file format doesn't match extension
       file_size_too_big: file size is too large
       future: can't be in the future
       comparison: can't be before start date

--- a/spec/forms/teacher_interface/upload_form_spec.rb
+++ b/spec/forms/teacher_interface/upload_form_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
         ActionDispatch::Http::UploadedFile.new(
           tempfile: file_fixture("upload.pdf"),
           type: "application/pdf",
+          filename: "upload.pdf",
         )
       end
 
@@ -40,12 +41,14 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
         ActionDispatch::Http::UploadedFile.new(
           tempfile: file_fixture("upload.pdf"),
           type: "application/pdf",
+          filename: "upload.pdf",
         )
       end
       let(:translated_attachment) do
         ActionDispatch::Http::UploadedFile.new(
           tempfile: file_fixture("upload.pdf"),
           type: "application/pdf",
+          filename: "upload.pdf",
         )
       end
 
@@ -58,6 +61,7 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
         ActionDispatch::Http::UploadedFile.new(
           tempfile: file_fixture("upload.pdf"),
           type: "application/pdf",
+          filename: "upload.pdf",
         )
       end
 
@@ -69,6 +73,19 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
         ActionDispatch::Http::UploadedFile.new(
           tempfile: file_fixture("upload.txt"),
           type: "text/plain",
+          filename: "upload.txt",
+        )
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "with an invalid extension" do
+      let(:original_attachment) do
+        ActionDispatch::Http::UploadedFile.new(
+          tempfile: file_fixture("upload.txt"),
+          type: "application/pdf",
+          filename: "upload.txt",
         )
       end
 
@@ -80,6 +97,7 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
         ActionDispatch::Http::UploadedFile.new(
           tempfile: file_fixture("upload.pdf"),
           type: "application/pdf",
+          filename: "upload.pdf",
         )
       end
 
@@ -100,8 +118,8 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
       let(:original_attachment) do
         ActionDispatch::Http::UploadedFile.new(
           tempfile: file_fixture("upload.pdf"),
-          filename: "upload.pdf",
           type: "application/pdf",
+          filename: "upload.pdf",
         )
       end
 

--- a/spec/validators/file_upload_validator_spec.rb
+++ b/spec/validators/file_upload_validator_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe FileUploadValidator do
       ActionDispatch::Http::UploadedFile.new(
         tempfile: file_fixture("upload.pdf"),
         type: "application/pdf",
+        filename: "upload.pdf",
       )
     end
 
@@ -29,6 +30,19 @@ RSpec.describe FileUploadValidator do
       ActionDispatch::Http::UploadedFile.new(
         tempfile: file_fixture("upload.txt"),
         type: "text/plain",
+        filename: "upload.txt",
+      )
+    end
+
+    it { is_expected.to_not be_valid }
+  end
+
+  context "with an invalid extension" do
+    let(:file) do
+      ActionDispatch::Http::UploadedFile.new(
+        tempfile: file_fixture("upload.txt"),
+        type: "application/pdf",
+        filename: "upload.txt",
       )
     end
 
@@ -40,6 +54,7 @@ RSpec.describe FileUploadValidator do
       ActionDispatch::Http::UploadedFile.new(
         tempfile: file_fixture("upload.pdf"),
         type: "application/pdf",
+        filename: "upload.pdf",
       )
     end
 


### PR DESCRIPTION
This is some extra validation that checks the file extension matches the file type provided. This was spotted as part of our ITHC.

[Trello Card](https://trello.com/c/JBagEpHA/1092-ithc-remedial-work)