### PR TITLE
Make sure assessors see right email preview

### DIFF
--- a/app/forms/assessor_interface/assessment_recommendation_form.rb
+++ b/app/forms/assessor_interface/assessment_recommendation_form.rb
@@ -34,6 +34,10 @@ class AssessorInterface::AssessmentRecommendationForm
     )
   end
 
+  def award?
+    recommendation == "award"
+  end
+
   def recommendation_allowed
     return if assessment.blank? || recommendation.blank?
 

--- a/app/views/assessor_interface/assessments/declare.html.erb
+++ b/app/views/assessor_interface/assessments/declare.html.erb
@@ -3,7 +3,7 @@
 
 <h1 class="govuk-heading-xl"><%= t(".heading.#{@assessment_recommendation_form.recommendation}") %></h1>
 
-<% if @assessment_recommendation_form.recommendation == "award" %>
+<% if @assessment_recommendation_form.award? %>
   <p class="govuk-body-l">You’re about to award QTS to <%= application_form_full_name(@application_form) %>.</p>
 <% else %>
   <p class="govuk-body-l">You’re about to decline this QTS application from <%= application_form_full_name(@application_form) %> for the following reasons:</p>

--- a/app/views/assessor_interface/assessments/preview.html.erb
+++ b/app/views/assessor_interface/assessments/preview.html.erb
@@ -6,7 +6,7 @@
 <p class="govuk-body-l"><%= t(".description") %></p>
 
 <%= render(PreviewTeacherMailer::Component.new(
-  name: :application_declined,
+  name: @assessment_recommendation_form.award? ? :application_awarded : :application_declined,
   teacher: @application_form.teacher,
 )) %>
 

--- a/spec/support/autoload/page_objects/assessor_interface/preview_assessment_recommendation.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/preview_assessment_recommendation.rb
@@ -5,6 +5,10 @@ module PageObjects
 
       element :heading, "h1"
 
+      section :email_preview, ".app-email-preview" do
+        element :content, ".app-email-preview__content"
+      end
+
       section :form, "form" do
         element :send_button, ".govuk-button"
       end


### PR DESCRIPTION
Previously we were hard coding the decline email, but we want to show assessors both kinds of emails.