### PR TITLE
Remove autofocus on fields

### DIFF
--- a/app/views/staff/confirmations/new.html.erb
+++ b/app/views/staff/confirmations/new.html.erb
@@ -3,7 +3,7 @@
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), label: { text: "Email" } %>
+  <%= f.govuk_email_field :email, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email), label: { text: "Email" } %>
   <%= f.govuk_submit "Resend confirmation instructions" %>
 <% end %>
 

--- a/app/views/staff/passwords/new.html.erb
+++ b/app/views/staff/passwords/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
   <%= f.govuk_error_summary %>
-  <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
+  <%= f.govuk_email_field :email, autocomplete: "email", label: { text: "Email" } %>
   <%= f.govuk_submit "Send me reset password instructions" %>
 <% end %>
 

--- a/app/views/staff/sessions/new.html.erb
+++ b/app/views/staff/sessions/new.html.erb
@@ -3,7 +3,7 @@
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
+  <%= f.govuk_email_field :email, autocomplete: "email", label: { text: "Email" } %>
   <%= f.govuk_password_field :password, autocomplete: "current-password", label: { text: "Password" } %>
 
   <% if devise_mapping.rememberable? %>

--- a/app/views/staff/unlocks/new.html.erb
+++ b/app/views/staff/unlocks/new.html.erb
@@ -2,7 +2,7 @@
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= f.govuk_error_summary %>
-  <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { text: "Email" } %>
+  <%= f.govuk_email_field :email, autocomplete: "email", label: { text: "Email" } %>
   <%= f.govuk_submit "Resend unlock instructions" %>
 <% end %>
 

--- a/app/views/teachers/registrations/new.html.erb
+++ b/app/views/teachers/registrations/new.html.erb
@@ -7,6 +7,6 @@
 
 <%= form_with model: resource, url: registration_path(resource_name) do |f| %>
   <%= f.govuk_error_summary %>
-  <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { size: "m" } %>
+  <%= f.govuk_email_field :email, autocomplete: "email", label: { size: "m" } %>
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teachers/sessions/new.html.erb
+++ b/app/views/teachers/sessions/new.html.erb
@@ -6,7 +6,7 @@
   <%= f.govuk_error_summary %>
 
   <%= f.hidden_field :create_or_sign_in %>
-  <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email", label: { size: "m" } %>
+  <%= f.govuk_email_field :email, autocomplete: "email", label: { size: "m" } %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teachers/sessions/new_or_create.html.erb
+++ b/app/views/teachers/sessions/new_or_create.html.erb
@@ -7,7 +7,7 @@
 
   <%= f.govuk_radio_buttons_fieldset :create_or_sign_in, legend: { size: "m", text: "Have you used the service before?" } do %>
     <%= f.govuk_radio_button :create_or_sign_in, "sign_in", label: { text: "Yes, sign in and continue application" }, link_errors: true do %>
-      <%= f.govuk_email_field :email, autofocus: true, autocomplete: "email" %>
+      <%= f.govuk_email_field :email, autocomplete: "email" %>
     <% end %>
 
     <%= f.govuk_radio_button :create_or_sign_in, "create", label: { text: "No, I need to check my eligibility" } %>


### PR DESCRIPTION
Although this can be useful, it makes it harder for users of assistive technologies to use the page as they lose the context of the rest of the page.