### PR TITLE
Set explicit timeout options

### DIFF
--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -53,6 +53,8 @@ class Staff < ApplicationRecord
          :lockable,
          :invitable
 
+  self.timeout_in = 20.minutes
+
   validates :name, presence: true
 
   def send_devise_notification(notification, *args)

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -28,6 +28,8 @@ class Teacher < ApplicationRecord
          :timeoutable,
          :trackable
 
+  self.timeout_in = 1.hour
+
   has_one :application_form
 
   validates :email,


### PR DESCRIPTION
For staff we want a shorter timeout as they're dealing with a lot of personal information. For teachers it's okay to be a little longer, and it helps with our accessibility.