### PR TITLE
Update DQT retry attempts

### DIFF
--- a/app/jobs/update_dqt_trn_request_job.rb
+++ b/app/jobs/update_dqt_trn_request_job.rb
@@ -4,7 +4,7 @@ class UpdateDQTTRNRequestJob < ApplicationJob
   class StillPending < StandardError
   end
 
-  retry_on Faraday::Error, wait: :exponentially_longer, attempts: 10
+  retry_on Faraday::Error, wait: :exponentially_longer, attempts: 3
   retry_on StillPending, wait: 30.minutes, attempts: 7 * 24 * 2 # 1 week
 
   def perform(dqt_trn_request)


### PR DESCRIPTION
* Only retry 3 times for `Faraday::Error`

While these retries are happening any error isn't reported to Sentry. 10 times backed off exponentially leaves us with too long of a delay before we see unrecoverable errors. While we learn how the integration is going to behave and understand enough to be more granular reduce the retries so as we can intervene.