### PR TITLE
Make delete links clearer

### DIFF
--- a/app/components/check_your_answers_summary/component.html.erb
+++ b/app/components/check_your_answers_summary/component.html.erb
@@ -6,7 +6,9 @@
       <div class="govuk-summary-list__card-actions">
         <ul class="govuk-summary-list__card-actions-list">
           <li class="govuk-summary-list__card-actions-list-item">
-            <%= govuk_link_to("Delete", delete_link_to) %>
+            <%= govuk_link_to(delete_link_to) do %>
+              Delete <span class="govuk-visually-hidden"><%= title.downcase %></span>
+            <% end %>
           </li>
         </ul>
       </div>

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
 
     it "renders a link" do
       a = component.at_css(".govuk-summary-list__card-actions a")
-      expect(a.text.strip).to eq("Delete")
+      expect(a.text.strip).to eq("Delete title")
       expect(a.attribute("href").value).to eq("/delete?next=%2F")
     end
   end


### PR DESCRIPTION
For users of assistive technology, we can include reference to what's being deleted in a similar way to the change links.