### PR TITLE
Update page titles when there's an error

### DIFF
--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -27,6 +27,7 @@ module TimelineEntry
               key: timeline_event.id,
               status: timeline_event.old_state,
               class_context: "timeline-event",
+              context: :assessor,
             ),
           ),
         new_state:
@@ -35,6 +36,7 @@ module TimelineEntry
               key: timeline_event.id,
               status: timeline_event.new_state,
               class_context: "timeline-event",
+              context: :assessor,
             ),
           ),
       }
@@ -60,6 +62,7 @@ module TimelineEntry
               key: timeline_event.id,
               status: timeline_event.new_state,
               class_context: "timeline-event",
+              context: :assessor,
             ),
           ),
       }

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t(".title.#{@assessment_section_view_object.assessment_section.key}") %>
+<% content_for :page_title, "#{"Error: " if @assessment_section_form.errors.any?}#{t(".title.#{@assessment_section_view_object.assessment_section.key}")}" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@assessment_section_view_object.application_form) %>
 
 <div class="app-inline-action">
@@ -7,7 +7,7 @@
 </div>
 
 <% case @assessment_section_view_object.assessment_section.key %>
-<% when "personal_information" %> 
+<% when "personal_information" %>
   <%= render "shared/application_form/personal_information_summary",
              application_form: @assessment_section_view_object.application_form,
              changeable: false %>

--- a/app/views/assessor_interface/assessments/confirm.html.erb
+++ b/app/views/assessor_interface/assessments/confirm.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t(".legend.#{@assessment_recommendation_form.recommendation}") %>
+<% content_for :page_title, "#{"Error: " if @assessment_recommendation_form.errors.any?}#{t(".legend.#{@assessment_recommendation_form.recommendation}")}" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
 <%= form_with model: @assessment_recommendation_form, url: [:assessor_interface, @application_form, @assessment], method: :put do |f| %>

--- a/app/views/assessor_interface/assessments/declare.html.erb
+++ b/app/views/assessor_interface/assessments/declare.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t(".heading.#{@assessment_recommendation_form.recommendation}") %>
+<% content_for :page_title, "#{"Error: " if @assessment_recommendation_form.errors.any?}#{t(".heading.#{@assessment_recommendation_form.recommendation}")}" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
 <h1 class="govuk-heading-xl"><%= t(".heading.#{@assessment_recommendation_form.recommendation}") %></h1>

--- a/app/views/assessor_interface/assessments/edit.html.erb
+++ b/app/views/assessor_interface/assessments/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t("helpers.legend.assessor_interface_assessment_recommendation_form.recommendation") %>
+<% content_for :page_title, "#{"Error: " if @assessment_recommendation_form.errors.any?}#{t("helpers.legend.assessor_interface_assessment_recommendation_form.recommendation")}" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
 <%= form_with model: @assessment_recommendation_form, url: [:declare, :assessor_interface, @application_form, @assessment] do |f| %>

--- a/app/views/assessor_interface/assessments/preview.html.erb
+++ b/app/views/assessor_interface/assessments/preview.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, t(".heading") %>
+<% content_for :page_title, "#{"Error: " if @assessment_recommendation_form.errors.any?}#{t(".heading")}" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
 <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>

--- a/app/views/assessor_interface/assessor_assignments/new.html.erb
+++ b/app/views/assessor_interface/assessor_assignments/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Select an assessor" %>
+<% content_for :page_title, "#{"Error: " if @assessor_assignment_form.errors.any?}Select an assessor" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
 <div class="app-inline-action">

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title, t(".title") %>
+<% content_for :page_title, "#{"Error: " if @further_information_request_form.errors.any?}#{t(".title")}" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@view_object.application_form) %>
 
 <h1 class="govuk-heading-xl"><%= t(".title") %></h1>

--- a/app/views/assessor_interface/notes/new.html.erb
+++ b/app/views/assessor_interface/notes/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Add a note" %>
+<% content_for :page_title, "#{"Error: " if @create_note_form.errors.any?}Add a note" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
 <%= form_with model: @create_note_form, url: assessor_interface_application_form_notes_path(@application_form) do |f| %>

--- a/app/views/assessor_interface/reviewer_assignments/new.html.erb
+++ b/app/views/assessor_interface/reviewer_assignments/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Select a reviewer" %>
+<% content_for :page_title, "#{"Error: " if @reviewer_assignment_form.errors.any?}Select a reviewer" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
 <div class="app-inline-action">

--- a/app/views/teacher_interface/age_range/edit.erb
+++ b/app/views/teacher_interface/age_range/edit.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, I18n.t("application_form.tasks.items.age_range") %>
+<% content_for :page_title, "#{"Error: " if @age_range_form.errors.any?}#{t("application_form.tasks.items.age_range")}" %>
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>

--- a/app/views/teacher_interface/documents/edit.html.erb
+++ b/app/views/teacher_interface/documents/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Check your uploaded files" %>
+<% content_for :page_title, "#{"Error: " if @add_another_upload_form.errors.any?}Check your uploaded files" %>
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
 <h1 class="govuk-heading-l">Check your uploaded files – <%= I18n.t("document.document_type.#{@document.document_type}") %> document</h1>

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Apply for qualified teacher status (QTS)" %>
+<% content_for :page_title, "#{"Error: " if @further_information_request_item_text_form&.errors&.any?}Further information required" %>
 <% content_for :back_link_url, back_link_url(teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
 
 <h1 class="govuk-heading-l">Further information required</h1>

--- a/app/views/teacher_interface/further_information_requests/edit.html.erb
+++ b/app/views/teacher_interface/further_information_requests/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Apply for qualified teacher status (QTS)" %>
+<% content_for :page_title, "Check your answers before submitting your application" %>
 <% content_for :back_link_url, teacher_interface_application_form_further_information_request_path(@view_object.further_information_request) %>
 
 <h1 class="govuk-heading-xl">

--- a/app/views/teacher_interface/personal_information/alternative_name.html.erb
+++ b/app/views/teacher_interface/personal_information/alternative_name.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, I18n.t("application_form.tasks.sections.about_you") %>
+<% content_for :page_title, "#{"Error: " if @alternative_name_form.errors.any?}#{t("application_form.tasks.sections.about_you")}" %>
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.about_you") %></span>

--- a/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
+++ b/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "About you" %>
+<% content_for :page_title, "#{"Error: " if @name_and_date_of_birth_form.errors.any?}About you" %>
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
 <span class="govuk-caption-l">About you</span>

--- a/app/views/teacher_interface/qualifications/edit.html.erb
+++ b/app/views/teacher_interface/qualifications/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, I18n.t("application_form.tasks.sections.qualifications") %>
+<% content_for :page_title, "#{"Error: " if @qualification_form.errors.any?}#{t("application_form.tasks.sections.qualifications")}" %>
 <% content_for :back_link_url, back_link_url(teacher_interface_application_form_path) %>
 
 <%= render "heading", qualification: @qualification %>

--- a/app/views/teacher_interface/qualifications/new.html.erb
+++ b/app/views/teacher_interface/qualifications/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, I18n.t("application_form.tasks.sections.qualifications") %>
+<% content_for :page_title, "#{"Error: " if @qualification_form.errors.any?}#{t("application_form.tasks.sections.qualifications")}" %>
 <% content_for :back_link_url, @application_form.qualifications.empty? ?
                                  teacher_interface_application_form_path :
                                  teacher_interface_application_form_qualifications_path %>

--- a/app/views/teacher_interface/registration_number/edit.html.erb
+++ b/app/views/teacher_interface/registration_number/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, I18n.t("application_form.tasks.items.registration_number") %>
+<% content_for :page_title, "#{"Error: " if @registration_number_form.errors.any?}#{t("application_form.tasks.items.registration_number")}" %>
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
 <%= form_with model: @registration_number_form, url: %i[registration_number teacher_interface application_form] do |f| %>

--- a/app/views/teacher_interface/subjects/edit.html.erb
+++ b/app/views/teacher_interface/subjects/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, I18n.t("application_form.tasks.items.subjects") %>
+<% content_for :page_title, "#{"Error: " if @subjects_form.errors.any?}#{t("application_form.tasks.items.subjects")}" %>
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>

--- a/app/views/teacher_interface/uploads/delete.html.erb
+++ b/app/views/teacher_interface/uploads/delete.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Delete file" %>
+<% content_for :page_title, "#{"Error: " if @delete_upload_form.errors.any?}Delete #{@upload.attachment.filename}" %>
 <% content_for :back_link_url, edit_teacher_interface_application_form_document_path(@document) %>
 
 <%= form_with model: @delete_upload_form, url: [:teacher_interface, :application_form, @document, @upload], method: :delete do |f| %>

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "Upload a document" %>
+<% content_for :page_title, "#{"Error: " if @upload_form.errors.any?}Upload a document" %>
 <% content_for :back_link_url, teacher_interface_application_form_path %>
 
 <% if @document.uploads.empty? %>

--- a/app/views/teacher_interface/work_histories/edit.html.erb
+++ b/app/views/teacher_interface/work_histories/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, I18n.t("application_form.tasks.sections.work_history") %>
+<% content_for :page_title, "#{"Error: " if @work_history_form.errors.any?}#{t("application_form.tasks.sections.work_history")}" %>
 <% content_for :back_link_url, teacher_interface_application_form_work_histories_path %>
 
 <%= render "heading" %>

--- a/app/views/teacher_interface/work_histories/edit_has_work_history.html.erb
+++ b/app/views/teacher_interface/work_histories/edit_has_work_history.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, I18n.t("application_form.tasks.sections.work_history") %>
+<% content_for :page_title, "#{"Error: " if @has_work_history_form.errors.any?}#{t("application_form.tasks.sections.work_history")}" %>
 <% content_for :back_link_url,  @application_form.work_histories.empty? ?
                                  teacher_interface_application_form_path :
                                  teacher_interface_application_form_work_histories_path %>

--- a/app/views/teacher_interface/work_histories/new.html.erb
+++ b/app/views/teacher_interface/work_histories/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, I18n.t("application_form.tasks.sections.work_history") %>
+<% content_for :page_title, "#{"Error: " if @work_history_form.errors.any?}#{t("application_form.tasks.sections.work_history")}" %>
 <% content_for :back_link_url, @application_form.work_histories.empty? ?
                                  teacher_interface_application_form_path :
                                  teacher_interface_application_form_work_histories_path %>

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -47,9 +47,16 @@ RSpec.describe TimelineEntry::Component, type: :component do
   end
 
   context "state changed" do
-    let(:timeline_event) { create(:timeline_event, :state_changed) }
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :state_changed,
+        old_state: "submitted",
+        new_state: "awarded",
+      )
+    end
     let(:old_state) do
-      I18n.t("application_form.status.#{timeline_event.old_state}")
+      I18n.t("application_form.status.#{timeline_event.old_state}.assessor")
     end
     let(:new_state) do
       I18n.t("application_form.status.#{timeline_event.new_state}")


### PR DESCRIPTION
For users of assistive technology it's helpful if the page title starts with the prefix "Error:" if the form has got errors.