### PR TITLE
[1107] Only show assessors in the filters and assign pages

### DIFF
--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -3,6 +3,7 @@
 # Table name: staff
 #
 #  id                     :bigint           not null, primary key
+#  assessor               :boolean          default(FALSE)
 #  confirmation_sent_at   :datetime
 #  confirmation_token     :string
 #  confirmed_at           :datetime
@@ -56,6 +57,8 @@ class Staff < ApplicationRecord
   self.timeout_in = 20.minutes
 
   validates :name, presence: true
+
+  scope :assessors, -> { where(assessor: true) }
 
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -21,7 +21,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
   end
 
   def assessor_filter_options
-    Staff.all
+    Staff.assessors
   end
 
   def country_filter_options

--- a/app/views/assessor_interface/assessor_assignments/new.html.erb
+++ b/app/views/assessor_interface/assessor_assignments/new.html.erb
@@ -10,7 +10,7 @@
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :assessor_id,
-                                       [OpenStruct.new(id: "", name: t("application_form.summary.unassigned"))] + Staff.all,
+                                       [OpenStruct.new(id: "", name: t("application_form.summary.unassigned"))] + Staff.assessors,
                                        :id,
                                        :name,
                                        legend: nil %>

--- a/app/views/assessor_interface/reviewer_assignments/new.html.erb
+++ b/app/views/assessor_interface/reviewer_assignments/new.html.erb
@@ -10,7 +10,7 @@
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :reviewer_id,
-                                       [OpenStruct.new(id: "", name: t("application_form.summary.unassigned"))] + Staff.all,
+                                       [OpenStruct.new(id: "", name: t("application_form.summary.unassigned"))] + Staff.assessors,
                                        :id,
                                        :name,
                                        legend: nil %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -200,6 +200,7 @@
     - invited_by_id
     - invitations_count
     - name
+    - assessor
   :teachers:
     - id
     - email

--- a/db/migrate/20221107115323_add_assessor_field_to_staff.rb
+++ b/db/migrate/20221107115323_add_assessor_field_to_staff.rb
@@ -1,0 +1,5 @@
+class AddAssessorFieldToStaff < ActiveRecord::Migration[7.0]
+  def change
+    add_column :staff, :assessor, :boolean, default: false, nullable: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_01_134536) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_07_115323) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -263,6 +263,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_01_134536) do
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
     t.text "name", default: "", null: false
+    t.boolean "assessor", default: false
     t.index ["confirmation_token"], name: "index_staff_on_confirmation_token", unique: true
     t.index ["email"], name: "index_staff_on_email", unique: true
     t.index ["invitation_token"], name: "index_staff_on_invitation_token", unique: true

--- a/spec/factories/staff.rb
+++ b/spec/factories/staff.rb
@@ -3,6 +3,7 @@
 # Table name: staff
 #
 #  id                     :bigint           not null, primary key
+#  assessor               :boolean          default(FALSE)
 #  confirmation_sent_at   :datetime
 #  confirmation_token     :string
 #  confirmed_at           :datetime
@@ -50,6 +51,10 @@ FactoryBot.define do
 
     trait :confirmed do
       confirmed_at { Time.zone.now }
+    end
+
+    trait :assessor do
+      assessor { true }
     end
   end
 end

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -3,6 +3,7 @@
 # Table name: staff
 #
 #  id                     :bigint           not null, primary key
+#  assessor               :boolean          default(FALSE)
 #  confirmation_sent_at   :datetime
 #  confirmation_token     :string
 #  confirmed_at           :datetime
@@ -58,5 +59,23 @@ RSpec.describe Staff, type: :model do
     it { is_expected.to validate_presence_of(:password) }
 
     it { is_expected.to validate_presence_of(:name) }
+  end
+
+  describe "scopes" do
+    describe ".assessors" do
+      subject { described_class.assessors }
+
+      context "when assessor == true" do
+        let(:assessor) { create(:staff, :assessor) }
+
+        it { is_expected.to include(assessor) }
+      end
+
+      context "when assessor == false" do
+        let(:non_assessor) { create(:staff) }
+
+        it { is_expected.not_to include(non_assessor) }
+      end
+    end
   end
 end

--- a/spec/system/assessor_interface/assigning_assessor_spec.rb
+++ b/spec/system/assessor_interface/assigning_assessor_spec.rb
@@ -80,6 +80,6 @@ RSpec.describe "Assigning an assessor", type: :system do
   end
 
   def assessor
-    @assessor ||= create(:staff, :confirmed)
+    @assessor ||= create(:staff, :assessor, :confirmed)
   end
 end

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -161,6 +161,6 @@ RSpec.describe "Assessor filtering application forms", type: :system do
   end
 
   def assessors
-    [create(:staff, name: "Wag Staff"), create(:staff, name: "Fal Staff")]
+    [create(:staff, :assessor, name: "Wag Staff"), create(:staff, :assessor, name: "Fal Staff")]
   end
 end

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -161,6 +161,9 @@ RSpec.describe "Assessor filtering application forms", type: :system do
   end
 
   def assessors
-    [create(:staff, :assessor, name: "Wag Staff"), create(:staff, :assessor, name: "Fal Staff")]
+    [
+      create(:staff, :assessor, name: "Wag Staff"),
+      create(:staff, :assessor, name: "Fal Staff"),
+    ]
   end
 end

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -116,10 +116,16 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
 
     it { is_expected.to be_empty }
 
-    context "with a staff user" do
-      let(:staff) { create(:staff) }
+    context "with an assessor user" do
+      let(:staff) { create(:staff, :assessor) }
 
       it { is_expected.to include(staff) }
+    end
+
+    context "with an non-assessor user" do
+      let(:staff) { create(:staff) }
+
+      it { is_expected.not_to include(staff) }
     end
   end
 


### PR DESCRIPTION
We currently show all staff users in the filters and assign assessor/reviewer pages. We need to be able to create support users that don't appear in this list.

### Changes

* Add a boolean `assessor?` field to the staff model. Default to false
* Add a scope `Staff.assessors` that returns assessor == true
* Use the scope on these pages

I've not validated that assignees are assessors as yet as we need to think that through but this will fix the UI for now.