### PR TITLE
Allow registration number to be optional

### DIFF
--- a/app/forms/teacher_interface/registration_number_form.rb
+++ b/app/forms/teacher_interface/registration_number_form.rb
@@ -6,10 +6,11 @@ module TeacherInterface
     attribute :registration_number, :string
 
     validates :application_form, presence: true
-    validates :registration_number, presence: true
 
     def update_model
-      application_form.update!(registration_number:)
+      application_form.update!(
+        registration_number: registration_number.presence || "",
+      )
     end
   end
 end

--- a/spec/forms/teacher_interface/registration_number_form_spec.rb
+++ b/spec/forms/teacher_interface/registration_number_form_spec.rb
@@ -11,16 +11,36 @@ RSpec.describe TeacherInterface::RegistrationNumberForm, type: :model do
     let(:registration_number) { "" }
 
     it { is_expected.to validate_presence_of(:application_form) }
-    it { is_expected.to validate_presence_of(:registration_number) }
+    it { is_expected.to_not validate_presence_of(:registration_number) }
   end
 
   describe "#save" do
-    let(:registration_number) { "ABC" }
+    subject(:save) { form.save(validate: true) }
 
-    before { form.save(validate: true) }
+    context "with a present registration number" do
+      let(:registration_number) { "ABC" }
 
-    it "saves the application form" do
-      expect(application_form.registration_number).to eq("ABC")
+      it "sets the registration number to the string" do
+        expect { save }.to change(application_form, :registration_number).to(
+          "ABC",
+        )
+      end
+    end
+
+    context "with a blank registration number" do
+      let(:registration_number) { "" }
+
+      it "sets the registration number to blank" do
+        expect { save }.to change(application_form, :registration_number).to("")
+      end
+    end
+
+    context "with a nil registration number" do
+      let(:registration_number) { nil }
+
+      it "sets the registration number to blank" do
+        expect { save }.to change(application_form, :registration_number).to("")
+      end
     end
   end
 end


### PR DESCRIPTION
This number is optional as some users will not have a registration number, and need to progress through the form without one.

[Trello Card](https://trello.com/c/NjLDC2Ff/1115-registration-number-not-mandatory)