### PR TITLE
Use assessor context in case management

### DIFF
--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -87,6 +87,7 @@ module ApplicationFormHelper
             key: "application-form-#{application_form.id}",
             status: application_form.state,
             class_context: "app-search-result__item",
+            context: :assessor,
           ),
         ),
       ],

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe ApplicationFormHelper do
             },
             value: {
               text:
-                "<strong class=\"govuk-tag govuk-tag--grey app-search-result__item__tag\" id=\"application-form-#{application_form.id}-status\">Submitted</strong>\n",
+                "<strong class=\"govuk-tag govuk-tag--grey app-search-result__item__tag\" id=\"application-form-#{application_form.id}-status\">Not started</strong>\n",
             },
             actions: [],
           },


### PR DESCRIPTION
This ensures that assessor see the status as "Not started" rather than "Submitted", and it's the correct colour.