### PR TITLE
Add user research link to submitted page

### DIFF
--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -157,5 +157,14 @@
 
   <h2 class="govuk-heading-s govuk-!-font-weight-regular">If you have any questions, contact:</h2>
   <p class="govuk-body"><a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.</p>
-  <p class="govuk-body"><a class="govuk-link" href="https://docs.google.com/forms/d/1OpMhXJ1blJu2qFqW7VWwKnfjIoU-5SmOLXdgI0Z_kZg/viewform?edit_requested=true">What did you think of this service?</a> (takes 30 seconds)</p>
+
+  <aside class="govuk-!-margin-top-6">
+    <h2 class="govuk-heading-s">Help us to improve this service</h2>
+
+    <p class="govuk-body">We’d like to talk to people about their experience of using this service. If you’d like to help, follow the link below. If you match our search criteria, we’ll invite you to a video call.</p>
+
+    <p class="govuk-body">
+      <%= govuk_link_to "I’d like to take part in the user research", "https://forms.gle/VmABLheeypwXJQy96" %>
+    </p>
+  </aside>
 <% end %>


### PR DESCRIPTION
We'd like to collect user research on the submitted page by sending users to a specific form link.

## Screenshot

![Screenshot 2022-11-08 at 10 37 10](https://user-images.githubusercontent.com/510498/200543159-50966ab7-624e-4f0a-ab3f-2d0f8dbe34c1.png)
