### PR TITLE
Ensure uploaded files have preview links

### DIFF
--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -97,7 +97,7 @@ module CheckYourAnswersSummary
       when Date
         format_date(value, field)
       when Upload
-        format_upload(value)
+        helpers.upload_link_to(value)
       when Document
         format_document(value, field)
       when Array
@@ -130,15 +130,6 @@ module CheckYourAnswersSummary
         scope.order(:created_at).select { |upload| upload.attachment.present? }
 
       format_array(uploads, field)
-    end
-
-    def format_upload(upload)
-      link_to(
-        "#{upload.name} (opens in a new tab)",
-        upload.url,
-        target: :_blank,
-        rel: :noopener,
-      )
     end
 
     def format_array(list, field)

--- a/app/helpers/upload_helper.rb
+++ b/app/helpers/upload_helper.rb
@@ -1,0 +1,10 @@
+module UploadHelper
+  def upload_link_to(upload)
+    govuk_link_to(
+      "#{upload.name} (opens in a new tab)",
+      upload.url,
+      target: :_blank,
+      rel: :noopener,
+    )
+  end
+end

--- a/app/views/teacher_interface/documents/edit.html.erb
+++ b/app/views/teacher_interface/documents/edit.html.erb
@@ -9,7 +9,7 @@
   @document.uploads.order(:created_at).each_with_index do |upload, index|
     summary_list.row do |row|
       row.key(text: "File #{index + 1}")
-      row.value(text: upload.attachment.filename)
+      row.value { upload_link_to(upload) }
       row.action(
         text: "Delete",
         href: delete_teacher_interface_application_form_document_upload_path(@document, upload, next: params[:next]),

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -740,7 +740,7 @@ RSpec.describe "Teacher application", type: :system do
       "Check your uploaded files – identity document",
     )
     expect(check_your_uploads_page.summary_list_row).to have_content(
-      "File 1\tupload.pdf\tDelete",
+      "File 1\tupload.pdf (opens in a new tab)\tDelete",
     )
   end
 
@@ -750,7 +750,7 @@ RSpec.describe "Teacher application", type: :system do
       "Check your uploaded files – name change document",
     )
     expect(check_your_uploads_page.summary_list_row).to have_content(
-      "File 1\tupload.pdf\tDelete",
+      "File 1\tupload.pdf (opens in a new tab)\tDelete",
     )
   end
 
@@ -760,7 +760,7 @@ RSpec.describe "Teacher application", type: :system do
       "Check your uploaded files – certificate document",
     )
     expect(check_your_uploads_page.summary_list_row).to have_content(
-      "File 1\tupload.pdf\tDelete",
+      "File 1\tupload.pdf (opens in a new tab)\tDelete",
     )
   end
 
@@ -770,7 +770,7 @@ RSpec.describe "Teacher application", type: :system do
       "Check your uploaded files – transcript document",
     )
     expect(check_your_uploads_page.summary_list_row).to have_content(
-      "File 1\tupload.pdf\tDelete",
+      "File 1\tupload.pdf (opens in a new tab)\tDelete",
     )
   end
 
@@ -780,7 +780,7 @@ RSpec.describe "Teacher application", type: :system do
       "Check your uploaded files – written statement document",
     )
     expect(check_your_uploads_page.summary_list_row).to have_content(
-      "File 1\tupload.pdf\tDelete",
+      "File 1\tupload.pdf (opens in a new tab)\tDelete",
     )
   end
 

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -76,17 +76,17 @@ RSpec.describe "Teacher documents", type: :system do
       "Check your uploaded files – written statement document",
     )
     expect(check_uploaded_files_page.files).to have_content(
-      "File 1\tupload.pdf\tDelete",
+      "File 1\tupload.pdf (opens in a new tab)\tDelete",
     )
     expect(check_uploaded_files_page.files).to have_content(
-      "File 2\tupload.pdf\tDelete",
+      "File 2\tupload.pdf (opens in a new tab)\tDelete",
     )
   end
 
   def then_i_see_the_check_your_uploaded_files_page_with_three_files
     then_i_see_the_check_your_uploaded_files_page
     expect(check_uploaded_files_page.files).to have_content(
-      "File 3\tupload.pdf\tDelete",
+      "File 3\tupload.pdf (opens in a new tab)\tDelete",
     )
   end
 end


### PR DESCRIPTION
At the moment we only link to the documents on the "Check your answers" pages, whereas we should also be linking to them on the "Check your uploaded files" page.

## Screenshot

![Screenshot 2022-11-08 at 14 35 49](https://user-images.githubusercontent.com/510498/200593376-b95359ea-d40b-4503-bb91-6666ed58837f.png)
