### PR TITLE
Fix FI document uploads for certificates or transcripts

### DIFF
--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -30,4 +30,10 @@ class FurtherInformationRequestItem < ApplicationRecord
   def completed?
     (text? && response.present?) || (document? && document.uploaded?)
   end
+
+  def is_teaching_qualification?
+    %w[teaching_certificate_illegible teaching_transcript_illegible].include?(
+      failure_reason,
+    )
+  end
 end

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -56,7 +56,7 @@
     <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 
     <h1 class="govuk-heading-l">
-      <% if @document.documentable.institution_name.present? %>
+      <% if @document.documentable.try(:institution_name).present? %>
         Upload your <%= @document.documentable.institution_name %> <%= I18n.t("document.document_type.qualification_certificate") %>
       <% elsif @document.documentable.is_teaching_qualification? %>
         Upload your teaching qualification certificate
@@ -70,7 +70,7 @@
     <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 
     <h1 class="govuk-heading-l">
-      <% if @document.documentable.institution_name.present? %>
+      <% if @document.documentable.try(:institution_name).present? %>
         Upload your <%= @document.documentable.institution_name %> <%= I18n.t("document.document_type.qualification_transcript") %>
       <% elsif @document.documentable.is_teaching_qualification? %>
         Upload your teaching qualification transcript

--- a/spec/models/further_information_request_item_spec.rb
+++ b/spec/models/further_information_request_item_spec.rb
@@ -75,4 +75,30 @@ RSpec.describe FurtherInformationRequestItem do
       end
     end
   end
+
+  describe "#is_teaching_qualification?" do
+    subject(:is_teaching_qualification?) do
+      further_information_request_item.is_teaching_qualification?
+    end
+
+    context "with a teaching failure reason" do
+      before do
+        further_information_request_item.update!(
+          failure_reason: "teaching_certificate_illegible",
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "with a degree failure reason" do
+      before do
+        further_information_request_item.update!(
+          failure_reason: "degree_certificate_illegible",
+        )
+      end
+
+      it { is_expected.to be false }
+    end
+  end
 end


### PR DESCRIPTION
We need to make sure users can upload documents for certificates or transcripts and at the moment users see an error related to a missing method.

This PR should fix: https://sentry.io/organizations/dfe-teacher-services/issues/3727383001/?project=6426061&query=is%3Aunresolved&referrer=issue-stream