### PR TITLE
Prepopulate assessment age range

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -16,7 +16,12 @@ class AssessmentFactory
       professional_standing_section,
     ].compact
 
-    Assessment.create!(application_form:, sections:)
+    Assessment.create!(
+      application_form:,
+      sections:,
+      age_range_min: application_form.age_range_min,
+      age_range_max: application_form.age_range_max,
+    )
   end
 
   private

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe AssessmentFactory do
       needs_work_history: false,
       needs_written_statement: false,
       needs_registration_number: false,
+      age_range_min: 7,
+      age_range_max: 11,
     )
   end
 
@@ -23,6 +25,8 @@ RSpec.describe AssessmentFactory do
       assessment = call
       expect(assessment.unknown?).to be true
       expect(assessment.application_form).to eq(application_form)
+      expect(assessment.age_range_min).to eq(7)
+      expect(assessment.age_range_max).to eq(11)
     end
 
     describe "sections" do


### PR DESCRIPTION
We take this from the application form so assessors don't need to write it in each time if they agree with the age range provided by the users.

We could think about prepopulating the subjects in the future if there's an exact or similar enough match.

[Trello Card](https://trello.com/c/mJFRfgzr/1119-a-few-more-snags-%F0%9F%90%9F)