### PR TITLE
Hide re-apply content if teacher already has QTS

### DIFF
--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -26,12 +26,12 @@ class TeacherInterface::ApplicationFormShowViewObject
         .first
   end
 
-  def declined_due_to_sanctions?
+  def declined_cannot_reapply?
     return false if assessment.nil?
 
     assessment.sections.any? do |section|
       section.selected_failure_reasons.any? do |key, _|
-        key == "authorisation_to_teach"
+        %w[authorisation_to_teach applicant_already_qts].include?(key)
       end
     end
   end

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -90,7 +90,7 @@
 
   <h3 class="govuk-heading-m">What you can do next</h3>
 
-  <% unless @view_object.declined_due_to_sanctions? %>
+  <% unless @view_object.declined_cannot_reapply? %>
     <p class="govuk-body">While your QTS application was declined this time, you can make a new application in future, if you’re able to address the decline reasons we’ve set out.</p>
     <p class="govuk-body">You may want to explore other routes to teaching in England. QTS is not a requirement to teach in independent (private) schools, academies, free schools and in the further education (FE) sector in England.</p>
 

--- a/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
@@ -52,29 +52,38 @@ RSpec.describe TeacherInterface::ApplicationFormShowViewObject do
     end
   end
 
-  describe "#declined_due_to_sanctions?" do
-    subject(:declined_due_to_sanctions?) do
-      view_object.declined_due_to_sanctions?
-    end
+  describe "#declined_cannot_reapply?" do
+    subject(:declined_cannot_reapply?) { view_object.declined_cannot_reapply? }
 
     it { is_expected.to be false }
 
-    context "with sanctions" do
+    context "with failure reasons" do
+      let(:application_form) do
+        create(:application_form, teacher: current_teacher)
+      end
+      let(:assessment) { create(:assessment, application_form:) }
+
       before do
-        application_form = create(:application_form, teacher: current_teacher)
-        assessment = create(:assessment, application_form:)
         create(
           :assessment_section,
           :personal_information,
           :failed,
           selected_failure_reasons: {
-            authorisation_to_teach: "Sanctions found.",
+            failure_reason => "A note.",
           },
           assessment:,
         )
       end
 
-      it { is_expected.to be true }
+      context "with sanctions" do
+        let(:failure_reason) { "authorisation_to_teach" }
+        it { is_expected.to be true }
+      end
+
+      context "with already QTS" do
+        let(:failure_reason) { "applicant_already_qts" }
+        it { is_expected.to be true }
+      end
     end
   end
 end


### PR DESCRIPTION
We don't need to show them this content if they've already got QTS as there would be no reason for them to apply again.

[Trello Card](https://trello.com/c/mJFRfgzr/1119-a-few-more-snags-%F0%9F%90%9F)