### PR TITLE
Disable Sidekiq retries for DQT TRN request job

### DIFF
--- a/app/jobs/update_dqt_trn_request_job.rb
+++ b/app/jobs/update_dqt_trn_request_job.rb
@@ -4,6 +4,7 @@ class UpdateDQTTRNRequestJob < ApplicationJob
   class StillPending < StandardError
   end
 
+  sidekiq_options retry: false
   retry_on Faraday::Error, wait: :exponentially_longer, attempts: 3
   retry_on StillPending, wait: 30.minutes, attempts: 7 * 24 * 2 # 1 week
 


### PR DESCRIPTION
We don't want to use Sidekiq for retries as we're using ActiveJob directly which reschedules the jobs manually. This will prevent the jobs from staying around in Sidekiq after the duration we've specified in the `retry_on` blocks.

More information on this approach:

- https://github.com/mperham/sidekiq/wiki/Active-Job#customizing-error-handling
- https://stackoverflow.com/a/59754115