### PR TITLE
Add service class for deleting application forms

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -58,12 +58,12 @@
 class ApplicationForm < ApplicationRecord
   belongs_to :teacher
   belongs_to :region
-  has_many :work_histories
-  has_many :qualifications
-  has_many :documents, as: :documentable
+  has_many :work_histories, dependent: :destroy
+  has_many :qualifications, dependent: :destroy
+  has_many :documents, as: :documentable, dependent: :destroy
   has_many :timeline_events
   has_one :assessment
-  has_many :notes
+  has_many :notes, dependent: :destroy
 
   before_save :build_documents, if: :new_record?
 

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -29,8 +29,8 @@
 class Assessment < ApplicationRecord
   belongs_to :application_form
 
-  has_many :sections, class_name: "AssessmentSection"
-  has_many :further_information_requests
+  has_many :sections, class_name: "AssessmentSection", dependent: :destroy
+  has_many :further_information_requests, dependent: :destroy
 
   belongs_to :age_range_note, class_name: "Note", optional: true
   belongs_to :subjects_note, class_name: "Note", optional: true

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -17,7 +17,7 @@
 class Document < ApplicationRecord
   belongs_to :documentable, polymorphic: true
 
-  has_many :uploads
+  has_many :uploads, dependent: :destroy
 
   has_many :original_uploads,
            -> { where(translation: false) },

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -19,7 +19,8 @@ class FurtherInformationRequest < ApplicationRecord
   belongs_to :assessment
   has_many :items,
            class_name: "FurtherInformationRequestItem",
-           inverse_of: :further_information_request
+           inverse_of: :further_information_request,
+           dependent: :destroy
 
   enum :state,
        { requested: "requested", received: "received" },

--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -19,7 +19,7 @@
 #
 class FurtherInformationRequestItem < ApplicationRecord
   belongs_to :further_information_request, inverse_of: :items
-  has_one :document, as: :documentable
+  has_one :document, as: :documentable, dependent: :destroy
 
   enum :information_type, { text: "text", document: "document" }
 

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -26,7 +26,7 @@ class Qualification < ApplicationRecord
   include ApplicationFormStatusUpdatable
 
   belongs_to :application_form
-  has_many :documents, as: :documentable
+  has_many :documents, as: :documentable, dependent: :destroy
 
   scope :ordered, -> { order(created_at: :asc) }
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -21,7 +21,7 @@ class Upload < ApplicationRecord
 
   belongs_to :document
 
-  has_one_attached :attachment
+  has_one_attached :attachment, dependent: :purge_later
   validates :attachment, presence: true
 
   def original?

--- a/app/services/destroy_application_form.rb
+++ b/app/services/destroy_application_form.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class DestroyApplicationForm
+  include ServicePattern
+
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      timeline_events.destroy_all
+      assessment.destroy!
+      application_form.destroy!
+      teacher.destroy!
+    end
+  end
+
+  private
+
+  attr_reader :application_form
+
+  delegate :assessment, :teacher, :timeline_events, to: :application_form
+end

--- a/spec/services/destroy_application_form_spec.rb
+++ b/spec/services/destroy_application_form_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DestroyApplicationForm do
+  let(:teacher) { create(:teacher) }
+
+  let!(:application_form) do
+    create(
+      :application_form,
+      :submitted,
+      :with_identification_document,
+      teacher:,
+    )
+  end
+
+  before do
+    create(:qualification, application_form:)
+    create(:work_history, application_form:)
+    create(:note, application_form:)
+
+    assessment =
+      create(:assessment, :with_further_information_request, application_form:)
+    create(:assessment_section, :personal_information, assessment:)
+  end
+
+  subject(:call) { described_class.call(application_form:) }
+
+  shared_examples "deletes model" do |model|
+    it "deletes all #{model}" do
+      expect { call }.to change(model, :count).to(0)
+    end
+  end
+
+  include_examples "deletes model", ApplicationForm
+  include_examples "deletes model", Assessment
+  include_examples "deletes model", AssessmentSection
+  include_examples "deletes model", Document
+  include_examples "deletes model", FurtherInformationRequest
+  include_examples "deletes model", FurtherInformationRequestItem
+  include_examples "deletes model", Note
+  include_examples "deletes model", Qualification
+  include_examples "deletes model", Teacher
+  include_examples "deletes model", TimelineEvent
+  include_examples "deletes model", Upload
+  include_examples "deletes model", WorkHistory
+end


### PR DESCRIPTION
This performs the steps necessary to delete everything associated with an application form, including the assessment and teacher.

I've set dependencies according to what I think would be useful to be able to delete directly without needing to delete the children first. I've explicitly left some dependencies to protect against accidental deletion (for example, if an application form has an assessment, it would be worth explicitly deleting that first).

[Trello Card](https://trello.com/c/MrrTlset/1134-delete-application-form-service)