### PR TITLE
Test that only one application form is deleted

### DIFF
--- a/spec/services/destroy_application_form_spec.rb
+++ b/spec/services/destroy_application_form_spec.rb
@@ -3,41 +3,41 @@
 require "rails_helper"
 
 RSpec.describe DestroyApplicationForm do
-  let(:teacher) { create(:teacher) }
-
-  let!(:application_form) do
-    create(
-      :application_form,
-      :submitted,
-      :with_identification_document,
-      teacher:,
-    )
-  end
-
   before do
-    create(:qualification, application_form:)
-    create(:work_history, application_form:)
-    create(:note, application_form:)
+    2.times do
+      application_form =
+        create(:application_form, :submitted, :with_identification_document)
 
-    assessment =
-      create(:assessment, :with_further_information_request, application_form:)
-    create(:assessment_section, :personal_information, assessment:)
+      create(:qualification, application_form:)
+      create(:work_history, application_form:)
+      create(:note, application_form:)
+
+      assessment =
+        create(
+          :assessment,
+          :with_further_information_request,
+          application_form:,
+        )
+      create(:assessment_section, :personal_information, assessment:)
+    end
   end
 
-  subject(:call) { described_class.call(application_form:) }
+  subject(:call) do
+    described_class.call(application_form: ApplicationForm.first)
+  end
 
-  shared_examples "deletes model" do |model|
+  shared_examples "deletes model" do |model, from, to|
     it "deletes all #{model}" do
-      expect { call }.to change(model, :count).to(0)
+      expect { call }.to change(model, :count).from(from || 2).to(to || 1)
     end
   end
 
   include_examples "deletes model", ApplicationForm
   include_examples "deletes model", Assessment
   include_examples "deletes model", AssessmentSection
-  include_examples "deletes model", Document
+  include_examples "deletes model", Document, 12, 6
   include_examples "deletes model", FurtherInformationRequest
-  include_examples "deletes model", FurtherInformationRequestItem
+  include_examples "deletes model", FurtherInformationRequestItem, 4, 2
   include_examples "deletes model", Note
   include_examples "deletes model", Qualification
   include_examples "deletes model", Teacher


### PR DESCRIPTION
The tests don't ensure that only the specified application form is deleted when calling this service, so we should make sure of that before using it.