### PR TITLE
[1155] Don't show reasons for FI decline

### DIFF
--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -65,14 +65,9 @@
 <% elsif @view_object.application_form.declined? %>
   <h2 class="govuk-heading-l">Your QTS application has been declined</h2>
 
-  <h3 class="govuk-heading-m">Notes from the assessor:</h3>
+  <% unless @view_object.further_information_request.present? %>
+    <h3 class="govuk-heading-m">Notes from the assessor:</h3>
 
-  <% if @view_object.further_information_request.present? %>
-    <% @view_object.further_information_request.items.each do |item| %>
-      <h4 class="govuk-heading-s"><%= I18n.t("assessor_interface.assessment_sections.show.failure_reasons.#{item.failure_reason}") %></h4>
-      <%= govuk_inset_text(text: item.assessor_notes) %>
-    <% end %>
-  <% else %>
     <% @view_object.assessment.sections.each do |section| %>
       <% if section.selected_failure_reasons.present? %>
         <h4 class="govuk-heading-s"><%= t(".assessment_section.#{section.key}") %></h4>

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -63,8 +63,11 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
       end
 
       it { is_expected.to match(/Your QTS application has been declined/) }
-      it { is_expected.to match(/A note/) }
       it { is_expected.to match(/you can make a new application in future/) }
+
+      it "does not show the assessor notes to the applicant" do
+        expect(subject).not_to match(/A note/)
+      end
     end
 
     context "and with sanctions" do


### PR DESCRIPTION
* Remove reasons and assessor notes from the teacher interface decline page if the decline follows an FI request

The notes are meant to belong on the assessment record. The user has already seen the original decline reasons and doesn't need them again here.