### PR TITLE
Fix further information requests with no items

### DIFF
--- a/app/lib/further_information_request_items_factory.rb
+++ b/app/lib/further_information_request_items_factory.rb
@@ -20,35 +20,27 @@ class FurtherInformationRequestItemsFactory
   def build_further_information_request_items(assessment_section)
     assessment_section
       .selected_failure_reasons
-      .filter_map do |failure_reason, assessor_notes|
+      .map do |failure_reason, assessor_notes|
       build_further_information_request_item(failure_reason, assessor_notes)
     end
   end
 
   def build_further_information_request_item(failure_reason, assessor_notes)
-    if TEXT_FAILURE_REASONS.include?(failure_reason)
-      FurtherInformationRequestItem.new(
-        information_type: :text,
-        failure_reason:,
-        assessor_notes:,
-      )
-    elsif (document_type = DOCUMENT_FAILURE_REASONS[failure_reason]).present?
+    if (document_type = DOCUMENT_FAILURE_REASONS[failure_reason]).present?
       FurtherInformationRequestItem.new(
         information_type: :document,
         failure_reason:,
         assessor_notes:,
         document: Document.new(document_type:),
       )
+    else
+      FurtherInformationRequestItem.new(
+        information_type: :text,
+        failure_reason:,
+        assessor_notes:,
+      )
     end
   end
-
-  TEXT_FAILURE_REASONS = %w[
-    qualifications_dont_match_subjects
-    qualifications_dont_match_other_details
-    age_range
-    satisfactory_evidence_work_history
-    registration_number
-  ].freeze
 
   DOCUMENT_FAILURE_REASONS = {
     "identification_document_expired" => :identification,

--- a/app/lib/further_information_request_items_factory.rb
+++ b/app/lib/further_information_request_items_factory.rb
@@ -45,7 +45,9 @@ class FurtherInformationRequestItemsFactory
   TEXT_FAILURE_REASONS = %w[
     qualifications_dont_match_subjects
     qualifications_dont_match_other_details
+    age_range
     satisfactory_evidence_work_history
+    registration_number
   ].freeze
 
   DOCUMENT_FAILURE_REASONS = {

--- a/spec/lib/further_information_request_items_factory_spec.rb
+++ b/spec/lib/further_information_request_items_factory_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe FurtherInformationRequestItemsFactory do
           :failed,
           selected_failure_reasons: {
             qualifications_dont_match_subjects: "Subjects.",
-            unknown_reason: "Unknown.",
           },
         ),
       ]
@@ -55,12 +54,6 @@ RSpec.describe FurtherInformationRequestItemsFactory do
         expect(item.failure_reason).to eq("qualifications_dont_match_subjects")
         expect(item.assessor_notes).to eq("Subjects.")
       end
-    end
-
-    describe "third item" do
-      subject(:item) { items.third }
-
-      it { is_expected.to be_nil }
     end
   end
 end


### PR DESCRIPTION
With the current code it's possible to create a further information request without any items, this changes that so we default to a text item if it shouldn't be a document item.

[Trello Card](https://trello.com/c/M23VeDxY/1156-fi-prof-standing-no-field-or-upload-to-return-fi)