### PR TITLE
Redirect user to previous page after creating a note

### DIFF
--- a/app/controllers/assessor_interface/notes_controller.rb
+++ b/app/controllers/assessor_interface/notes_controller.rb
@@ -13,7 +13,8 @@ module AssessorInterface
         )
 
       if @create_note_form.save!
-        redirect_to [:assessor_interface, application_form]
+        redirect_to params[:next].presence ||
+                      [:assessor_interface, application_form]
       else
         render :new, status: :unprocessable_entity
       end

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -1,10 +1,7 @@
 <% content_for :page_title, "Application" %>
 <% content_for :back_link_url, @view_object.back_link_path %>
 
-<div class="app-inline-action">
-  <h1 class="govuk-heading-xl">Application</h1>
-  <%= govuk_button_link_to "Add&nbsp;note".html_safe, new_assessor_interface_application_form_note_path(@view_object.application_form), secondary: true %>
-</div>
+<%= render "shared/assessor_header", title: "Application", application_form: @view_object.application_form %>
 
 <%= render(ApplicationFormOverview::Component.new(@view_object.application_form)) %>
 

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -1,10 +1,9 @@
 <% content_for :page_title, "#{"Error: " if @assessment_section_form.errors.any?}#{t(".title.#{@assessment_section_view_object.assessment_section.key}")}" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@assessment_section_view_object.application_form) %>
 
-<div class="app-inline-action">
-  <h1 class="govuk-heading-xl"><%= t(".title.#{@assessment_section_view_object.assessment_section.key}") %></h1>
-  <%= govuk_button_link_to "Add&nbsp;note".html_safe, new_assessor_interface_application_form_note_path(@assessment_section_view_object.application_form), secondary: true %>
-</div>
+<%= render "shared/assessor_header",
+           title: t(".title.#{@assessment_section_view_object.assessment_section.key}"),
+           application_form: @assessment_section_view_object.application_form %>
 
 <% case @assessment_section_view_object.assessment_section.key %>
 <% when "personal_information" %>

--- a/app/views/assessor_interface/assessor_assignments/new.html.erb
+++ b/app/views/assessor_interface/assessor_assignments/new.html.erb
@@ -1,10 +1,7 @@
 <% content_for :page_title, "#{"Error: " if @assessor_assignment_form.errors.any?}Select an assessor" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
-<div class="app-inline-action">
-  <h1 class="govuk-heading-xl">Select an assessor</h1>
-  <%= govuk_button_link_to "Add&nbsp;note".html_safe, new_assessor_interface_application_form_note_path(@application_form), secondary: true %>
-</div>
+<%= render "shared/assessor_header", title: "Select an assessor", application_form: @application_form %>
 
 <%= form_with model: @assessor_assignment_form, url: assessor_interface_application_form_assign_assessor_path(@application_form) do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/assessor_interface/notes/new.html.erb
+++ b/app/views/assessor_interface/notes/new.html.erb
@@ -2,6 +2,8 @@
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
 <%= form_with model: @create_note_form, url: assessor_interface_application_form_notes_path(@application_form) do |f| %>
+  <%= hidden_field_tag :next, params[:next] %>
+
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_text_area :text, label: { tag: "h1", size: "l" }, rows: 5 %>

--- a/app/views/assessor_interface/reviewer_assignments/new.html.erb
+++ b/app/views/assessor_interface/reviewer_assignments/new.html.erb
@@ -1,10 +1,7 @@
 <% content_for :page_title, "#{"Error: " if @reviewer_assignment_form.errors.any?}Select a reviewer" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
-<div class="app-inline-action">
-  <h1 class="govuk-heading-xl">Select a reviewer</h1>
-  <%= govuk_button_link_to "Add&nbsp;note".html_safe, new_assessor_interface_application_form_note_path(@application_form), secondary: true %>
-</div>
+<%= render "shared/assessor_header", title: "Select a reviewer", application_form: @application_form %>
 
 <%= form_with model: @reviewer_assignment_form, url: assessor_interface_application_form_assign_reviewer_path(@application_form) do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/shared/_assessor_header.html.erb
+++ b/app/views/shared/_assessor_header.html.erb
@@ -1,0 +1,7 @@
+<div class="app-inline-action">
+  <h1 class="govuk-heading-xl"><%= title %></h1>
+
+  <%= govuk_button_link_to "Add&nbsp;note".html_safe,
+                           new_assessor_interface_application_form_note_path(application_form),
+                           secondary: true %>
+</div>

--- a/app/views/shared/_assessor_header.html.erb
+++ b/app/views/shared/_assessor_header.html.erb
@@ -2,6 +2,6 @@
   <h1 class="govuk-heading-xl"><%= title %></h1>
 
   <%= govuk_button_link_to "Add&nbsp;note".html_safe,
-                           new_assessor_interface_application_form_note_path(application_form),
+                           new_assessor_interface_application_form_note_path(application_form, next: request.path),
                            secondary: true %>
 </div>


### PR DESCRIPTION
This avoids breaking the flow of assessors where they create a note and are sent back to the application page rather than the page they were previously on.

[Trello Card](https://trello.com/c/BhOAqcHM/1150-allow-assessor-notes-as-i-go)