### PR TITLE
Show further information request while reviewing

### DIFF
--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -33,8 +33,8 @@ module AssessorInterface
           further_information_request: view_object.further_information_request,
           user: current_staff,
           passed: view_object.further_information_request.passed,
-          failure_reason:
-            view_object.further_information_request.failure_reason,
+          failure_assessor_note:
+            view_object.further_information_request.failure_assessor_note,
         )
     end
 
@@ -108,7 +108,7 @@ module AssessorInterface
     def further_information_request_form
       params.require(
         :assessor_interface_further_information_request_form,
-      ).permit(:passed, :failure_reason)
+      ).permit(:passed, :failure_assessor_note)
     end
   end
 end

--- a/app/forms/assessor_interface/further_information_request_form.rb
+++ b/app/forms/assessor_interface/further_information_request_form.rb
@@ -10,8 +10,8 @@ class AssessorInterface::FurtherInformationRequestForm
   attribute :passed, :boolean
   validates :passed, inclusion: [true, false]
 
-  attribute :failure_reason, :string
-  validates :failure_reason, presence: true, if: -> { passed == false }
+  attribute :failure_assessor_note, :string
+  validates :failure_assessor_note, presence: true, if: -> { passed == false }
 
   def save
     return false unless valid?
@@ -21,7 +21,7 @@ class AssessorInterface::FurtherInformationRequestForm
       user:,
       params: {
         passed:,
-        failure_reason:,
+        failure_assessor_note:,
       },
     )
 

--- a/app/lib/further_information_request_items_factory.rb
+++ b/app/lib/further_information_request_items_factory.rb
@@ -20,24 +20,30 @@ class FurtherInformationRequestItemsFactory
   def build_further_information_request_items(assessment_section)
     assessment_section
       .selected_failure_reasons
-      .map do |failure_reason, assessor_notes|
-      build_further_information_request_item(failure_reason, assessor_notes)
+      .map do |failure_reason_key, failure_reason_assessor_feedback|
+      build_further_information_request_item(
+        failure_reason_key,
+        failure_reason_assessor_feedback,
+      )
     end
   end
 
-  def build_further_information_request_item(failure_reason, assessor_notes)
-    if (document_type = DOCUMENT_FAILURE_REASONS[failure_reason]).present?
+  def build_further_information_request_item(
+    failure_reason_key,
+    failure_reason_assessor_feedback
+  )
+    if (document_type = DOCUMENT_FAILURE_REASONS[failure_reason_key]).present?
       FurtherInformationRequestItem.new(
         information_type: :document,
-        failure_reason:,
-        assessor_notes:,
+        failure_reason_key:,
+        failure_reason_assessor_feedback:,
         document: Document.new(document_type:),
       )
     else
       FurtherInformationRequestItem.new(
         information_type: :text,
-        failure_reason:,
-        assessor_notes:,
+        failure_reason_key:,
+        failure_reason_assessor_feedback:,
       )
     end
   end

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -2,14 +2,14 @@
 #
 # Table name: further_information_requests
 #
-#  id             :bigint           not null, primary key
-#  failure_reason :string           default(""), not null
-#  passed         :boolean
-#  received_at    :datetime
-#  state          :string           not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  assessment_id  :bigint
+#  id                    :bigint           not null, primary key
+#  failure_assessor_note :string           default(""), not null
+#  passed                :boolean
+#  received_at           :datetime
+#  state                 :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  assessment_id         :bigint
 #
 # Indexes
 #

--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -4,14 +4,14 @@
 #
 # Table name: further_information_request_items
 #
-#  id                             :bigint           not null, primary key
-#  assessor_notes                 :text
-#  failure_reason                 :string           default(""), not null
-#  information_type               :string
-#  response                       :text
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  further_information_request_id :bigint
+#  id                               :bigint           not null, primary key
+#  failure_reason_assessor_feedback :text
+#  failure_reason_key               :string           default(""), not null
+#  information_type                 :string
+#  response                         :text
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  further_information_request_id   :bigint
 #
 # Indexes
 #
@@ -33,7 +33,7 @@ class FurtherInformationRequestItem < ApplicationRecord
 
   def is_teaching_qualification?
     %w[teaching_certificate_illegible teaching_transcript_illegible].include?(
-      failure_reason,
+      failure_reason_key,
     )
   end
 end

--- a/app/view_objects/assessor_interface/further_information_request_view_object.rb
+++ b/app/view_objects/assessor_interface/further_information_request_view_object.rb
@@ -22,14 +22,31 @@ class AssessorInterface::FurtherInformationRequestViewObject
   delegate :assessment, to: :further_information_request
   delegate :application_form, to: :assessment
 
-  def check_your_answers_fields
+  def review_items
     further_information_request
       .items
       .order(:created_at)
-      .each_with_object({}) do |item, memo|
-        memo[item.id] = {
-          title: item_text(item),
-          value: item.text? ? item.response : item.document,
+      .map do |item|
+        {
+          heading:
+            I18n.t(
+              "assessor_interface.assessment_sections.show.failure_reasons.#{item.failure_reason_key}",
+            ),
+          description: item.failure_reason_assessor_feedback,
+          check_your_answers: {
+            id: "further-information-requested-#{item.id}",
+            model: item,
+            title:
+              I18n.t(
+                "assessor_interface.further_information_requests.edit.check_your_answers",
+              ),
+            fields: {
+              item.id => {
+                title: item_text(item),
+                value: item.text? ? item.response : item.document,
+              },
+            },
+          },
         }
       end
   end

--- a/app/view_objects/assessor_interface/further_information_request_view_object.rb
+++ b/app/view_objects/assessor_interface/further_information_request_view_object.rb
@@ -42,7 +42,7 @@ class AssessorInterface::FurtherInformationRequestViewObject
     case item.information_type
     when "text"
       I18n.t(
-        "teacher_interface.further_information_request.show.failure_reason.#{item.failure_reason}",
+        "teacher_interface.further_information_request.show.failure_reason.#{item.failure_reason_key}",
       )
     when "document"
       "Upload your #{I18n.t("document.document_type.#{item.document.document_type}")} document"

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -73,7 +73,7 @@ module TeacherInterface
       case item.information_type
       when "text"
         I18n.t(
-          "teacher_interface.further_information_request.show.failure_reason.#{item.failure_reason}",
+          "teacher_interface.further_information_request.show.failure_reason.#{item.failure_reason_key}",
         )
       when "document"
         "Upload your #{I18n.t("document.document_type.#{item.document.document_type}")} document"

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -3,12 +3,11 @@
 
 <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
 
-<%= render(CheckYourAnswersSummary::Component.new(
-  id: "further-information-requested",
-  model: @view_object.further_information_request,
-  title: t(".check_your_answers"),
-  fields: @view_object.check_your_answers_fields
-)) %>
+<% @view_object.review_items.each do |item| %>
+  <h2 class="govuk-heading-m"><%= item.fetch(:heading) %></h2>
+  <%= govuk_inset_text(text: item.fetch(:description)) %>
+  <%= render(CheckYourAnswersSummary::Component.new(**item.fetch(:check_your_answers))) %>
+<% end %>
 
 <%= form_with model: @further_information_request_form, url: [:assessor_interface, @view_object.application_form, @view_object.assessment, @view_object.further_information_request], method: :put do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -16,7 +16,7 @@
   <%= f.govuk_radio_buttons_fieldset :passed, legend: { size: "s" } do %>
     <%= f.govuk_radio_button :passed, :true, link_errors: true %>
     <%= f.govuk_radio_button :passed, :false do %>
-      <%= f.govuk_text_area :failure_reason %>
+      <%= f.govuk_text_area :failure_assessor_note %>
     <% end %>
   <% end %>
 

--- a/app/views/assessor_interface/further_information_requests/preview.html.erb
+++ b/app/views/assessor_interface/further_information_requests/preview.html.erb
@@ -12,9 +12,9 @@
 
 <% @further_information_request.items.each do |item| %>
   <section class="app-further-information-request-item">
-    <h3 class="govuk-heading-s"><%= I18n.t("assessor_interface.assessment_sections.show.failure_reasons.#{item.failure_reason}") %></h3>
+    <h3 class="govuk-heading-s"><%= I18n.t("assessor_interface.assessment_sections.show.failure_reasons.#{item.failure_reason_key}") %></h3>
     <p class="govuk-body govuk-!-margin-bottom-2">Your note to the applicant:</p>
-    <p class="govuk-inset-text"><%= item.assessor_notes %></p>
+    <p class="govuk-inset-text"><%= item.failure_reason_assessor_feedback %></p>
   </section>
 <% end %>
 

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -3,7 +3,7 @@
 
 <h1 class="govuk-heading-l">Further information required</h1>
 <h3 class="govuk-heading-s">Notes from the assessor</h3>
-<p class="govuk-inset-text"><%= @further_information_request_item.assessor_notes %></p>
+<p class="govuk-inset-text"><%= @further_information_request_item.failure_reason_assessor_feedback %></p>
 
 <%= form_with model: @further_information_request_item_text_form, url: teacher_interface_application_form_further_information_request_further_information_request_item_path, method: :put do |f| %>
   <%= hidden_field_tag :next, params[:next] %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -137,9 +137,9 @@
     - created_at
     - updated_at
     - further_information_request_id
-    - assessor_notes
+    - failure_reason_key
+    - failure_reason_assessor_feedback
     - response
-    - failure_reason
   :notes:
     - id
     - application_form_id

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -130,7 +130,7 @@
     - updated_at
     - assessment_id
     - passed
-    - failure_reason
+    - failure_assessor_note
   :further_information_request_items:
     - id
     - information_type

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -17,9 +17,9 @@
     - has_work_history
     - subjects
   :further_information_requests:
-    - failure_reason
+    - failure_assessor_note
   :further_information_request_items:
-    - assessor_notes
+    - failure_reason_assessor_feedback
     - response
   :notes:
     - text

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -215,5 +215,5 @@ en:
           attributes:
             passed:
               inclusion: Select whether the applicant completed this section to your satisfaction
-            failure_reason:
+            failure_assessor_note:
               blank: Enter why this section is not completed to your satisfaction

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -55,7 +55,7 @@ en:
         passed_options:
           true: "Yes"
           false: "No"
-        failure_reason: Explain why this section is not completed to your satisfaction
+        failure_assessor_note: Explain why this section is not completed to your satisfaction
       qualification:
         add_another_options:
           true: "Yes"

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -5,6 +5,7 @@ en:
         failure_reason:
           qualifications_dont_match_subjects: Tell us more about the subjects you can teach
           qualifications_dont_match_other_details: Tell us more about your qualifications
+          age_range: Tell us more about the age range you can teach
           satisfactory_evidence_work_history: Tell us more about your work history
           registration_number: Tell us your registration number
 

--- a/db/migrate/20221115234359_rename_further_information_request_failure_reason.rb
+++ b/db/migrate/20221115234359_rename_further_information_request_failure_reason.rb
@@ -1,0 +1,9 @@
+class RenameFurtherInformationRequestFailureReason < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    rename_column :further_information_requests,
+                  :failure_reason,
+                  :failure_assessor_note
+  end
+end

--- a/db/migrate/20221116002149_rename_further_information_request_item_assessor_notes.rb
+++ b/db/migrate/20221116002149_rename_further_information_request_item_assessor_notes.rb
@@ -1,0 +1,10 @@
+class RenameFurtherInformationRequestItemAssessorNotes < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    change_table :further_information_request_items, bulk: true do |t|
+      t.rename :failure_reason, :failure_reason_key
+      t.rename :assessor_notes, :failure_reason_assessor_feedback
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_15_234359) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_16_002149) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -169,12 +169,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_15_234359) do
 
   create_table "further_information_request_items", force: :cascade do |t|
     t.bigint "further_information_request_id"
-    t.text "assessor_notes"
+    t.text "failure_reason_assessor_feedback"
     t.string "information_type"
     t.text "response"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "failure_reason", default: "", null: false
+    t.string "failure_reason_key", default: "", null: false
     t.index ["further_information_request_id"], name: "index_fi_request_items_on_fi_request_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_15_154840) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_15_234359) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -185,7 +185,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_15_154840) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "passed"
-    t.string "failure_reason", default: "", null: false
+    t.string "failure_assessor_note", default: "", null: false
     t.index ["assessment_id"], name: "index_further_information_requests_on_assessment_id"
   end
 

--- a/spec/factories/further_information_request_items.rb
+++ b/spec/factories/further_information_request_items.rb
@@ -4,14 +4,14 @@
 #
 # Table name: further_information_request_items
 #
-#  id                             :bigint           not null, primary key
-#  assessor_notes                 :text
-#  failure_reason                 :string           default(""), not null
-#  information_type               :string
-#  response                       :text
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  further_information_request_id :bigint
+#  id                               :bigint           not null, primary key
+#  failure_reason_assessor_feedback :text
+#  failure_reason_key               :string           default(""), not null
+#  information_type                 :string
+#  response                         :text
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  further_information_request_id   :bigint
 #
 # Indexes
 #
@@ -20,15 +20,16 @@
 FactoryBot.define do
   factory :further_information_request_item do
     association :further_information_request
-    assessor_notes { Faker::Lorem.paragraph }
+    failure_reason_assessor_feedback { Faker::Lorem.paragraph }
 
     trait :with_text_response do
       information_type { "text" }
-      failure_reason { "qualifications_dont_match_subjects" }
+      failure_reason_key { "qualifications_dont_match_subjects" }
     end
 
     trait :with_document_response do
       information_type { "document" }
+      failure_reason_key { "identification_document_illegible" }
 
       after(:create) do |item|
         create(:document, :identification_document, documentable: item)

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -4,14 +4,14 @@
 #
 # Table name: further_information_requests
 #
-#  id             :bigint           not null, primary key
-#  failure_reason :string           default(""), not null
-#  passed         :boolean
-#  received_at    :datetime
-#  state          :string           not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  assessment_id  :bigint
+#  id                    :bigint           not null, primary key
+#  failure_assessor_note :string           default(""), not null
+#  passed                :boolean
+#  received_at           :datetime
+#  state                 :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  assessment_id         :bigint
 #
 # Indexes
 #
@@ -36,7 +36,7 @@ FactoryBot.define do
 
     trait :failed do
       passed { false }
-      failure_reason { "Notes." }
+      failure_assessor_note { "Notes." }
     end
 
     trait :with_items do

--- a/spec/forms/assessor_interface/further_information_request_form_spec.rb
+++ b/spec/forms/assessor_interface/further_information_request_form_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe AssessorInterface::FurtherInformationRequestForm, type: :model do
     context "when passed" do
       let(:attributes) { { passed: true } }
 
-      it { is_expected.to_not validate_presence_of(:failure_reason) }
+      it { is_expected.to_not validate_presence_of(:failure_assessor_note) }
     end
 
     context "when not passed" do
       let(:attributes) { { passed: false } }
 
-      it { is_expected.to validate_presence_of(:failure_reason) }
+      it { is_expected.to validate_presence_of(:failure_assessor_note) }
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.describe AssessorInterface::FurtherInformationRequestForm, type: :model do
     end
 
     context "with valid attributes" do
-      let(:attributes) { { passed: true, failure_reason: "" } }
+      let(:attributes) { { passed: true, failure_assessor_note: "" } }
 
       it "updates the application form" do
         expect { save }.to change(further_information_request, :passed).from(

--- a/spec/lib/further_information_request_items_factory_spec.rb
+++ b/spec/lib/further_information_request_items_factory_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe FurtherInformationRequestItemsFactory do
 
       it "has attributes" do
         expect(item).to be_document
-        expect(item.failure_reason).to eq("identification_document_expired")
-        expect(item.assessor_notes).to eq("Expired.")
+        expect(item.failure_reason_key).to eq("identification_document_expired")
+        expect(item.failure_reason_assessor_feedback).to eq("Expired.")
         expect(item.document.identification?).to be true
       end
     end
@@ -51,8 +51,10 @@ RSpec.describe FurtherInformationRequestItemsFactory do
 
       it "has attributes" do
         expect(item).to be_text
-        expect(item.failure_reason).to eq("qualifications_dont_match_subjects")
-        expect(item.assessor_notes).to eq("Subjects.")
+        expect(item.failure_reason_key).to eq(
+          "qualifications_dont_match_subjects",
+        )
+        expect(item.failure_reason_assessor_feedback).to eq("Subjects.")
       end
     end
   end

--- a/spec/models/further_information_request_item_spec.rb
+++ b/spec/models/further_information_request_item_spec.rb
@@ -2,14 +2,14 @@
 #
 # Table name: further_information_request_items
 #
-#  id                             :bigint           not null, primary key
-#  assessor_notes                 :text
-#  failure_reason                 :string           default(""), not null
-#  information_type               :string
-#  response                       :text
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  further_information_request_id :bigint
+#  id                               :bigint           not null, primary key
+#  failure_reason_assessor_feedback :text
+#  failure_reason_key               :string           default(""), not null
+#  information_type                 :string
+#  response                         :text
+#  created_at                       :datetime         not null
+#  updated_at                       :datetime         not null
+#  further_information_request_id   :bigint
 #
 # Indexes
 #
@@ -84,7 +84,7 @@ RSpec.describe FurtherInformationRequestItem do
     context "with a teaching failure reason" do
       before do
         further_information_request_item.update!(
-          failure_reason: "teaching_certificate_illegible",
+          failure_reason_key: "teaching_certificate_illegible",
         )
       end
 
@@ -94,7 +94,7 @@ RSpec.describe FurtherInformationRequestItem do
     context "with a degree failure reason" do
       before do
         further_information_request_item.update!(
-          failure_reason: "degree_certificate_illegible",
+          failure_reason_key: "degree_certificate_illegible",
         )
       end
 

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -4,14 +4,14 @@
 #
 # Table name: further_information_requests
 #
-#  id             :bigint           not null, primary key
-#  failure_reason :string           default(""), not null
-#  passed         :boolean
-#  received_at    :datetime
-#  state          :string           not null
-#  created_at     :datetime         not null
-#  updated_at     :datetime         not null
-#  assessment_id  :bigint
+#  id                    :bigint           not null, primary key
+#  failure_assessor_note :string           default(""), not null
+#  passed                :boolean
+#  received_at           :datetime
+#  state                 :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  assessment_id         :bigint
 #
 # Indexes
 #

--- a/spec/support/autoload/page_objects/assessor_interface/request_further_information.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/request_further_information.rb
@@ -5,7 +5,7 @@ module PageObjects
 
       sections :items, ".app-further-information-request-item" do
         element :heading, ".govuk-heading-s"
-        element :assessor_notes, ".govuk-inset-text"
+        element :feedback, ".govuk-inset-text"
       end
 
       element :continue_button, ".govuk-button:not(.govuk-button--secondary)"

--- a/spec/support/autoload/page_objects/assessor_interface/review_further_information_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/review_further_information_request.rb
@@ -5,7 +5,7 @@ module PageObjects
                 "/further-information-requests/{further_information_request_id}/edit"
 
       element :heading, ".govuk-heading-xl"
-      section :summary_list, GovukSummaryList, ".govuk-summary-list"
+      sections :summary_lists, GovukSummaryList, ".govuk-summary-list"
 
       section :form, "form" do
         section :yes_radio_item,

--- a/spec/support/autoload/page_objects/teacher_interface/further_information_required.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/further_information_required.rb
@@ -5,7 +5,7 @@ module PageObjects
 
       element :back_link, ".govuk-back-link"
       element :heading, ".govuk-heading-l"
-      element :assessor_notes, ".govuk-inset-text"
+      element :feedback, ".govuk-inset-text"
 
       section :form, "form" do
         element :response_textarea, ".govuk-textarea"

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -70,9 +70,9 @@ RSpec.describe "Assessor requesting further information", type: :system do
     expect(request_further_information_page.items.first.heading.text).to eq(
       "Subjects entered are acceptable for QTS, but the uploaded qualifications do not match them.",
     )
-    expect(
-      request_further_information_page.items.first.assessor_notes.text,
-    ).to eq("A note.")
+    expect(request_further_information_page.items.first.feedback.text).to eq(
+      "A note.",
+    )
   end
 
   def when_i_click_continue_to_email_button

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -57,7 +57,8 @@ RSpec.describe "Assessor reviewing further information", type: :system do
   end
 
   def and_i_see_the_check_your_answers_items
-    rows = review_further_information_request_page.summary_list.rows
+    rows =
+      review_further_information_request_page.summary_lists.flat_map(&:rows)
 
     expect(rows.count).to eq(2)
 

--- a/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
     }
   end
 
-  describe "#check_your_answers_fields" do
+  describe "#review_items" do
     let!(:text_item) do
       create(
         :further_information_request_item,
@@ -38,22 +38,44 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
       )
     end
 
-    subject(:check_your_answers_fields) do
-      view_object.check_your_answers_fields
-    end
+    subject(:review_items) { view_object.review_items }
 
     it do
       is_expected.to eq(
-        {
-          text_item.id => {
-            title: "Tell us more about the subjects you can teach",
-            value: text_item.response,
+        [
+          {
+            heading:
+              "Subjects entered are acceptable for QTS, but the uploaded qualifications do not match them.",
+            description: text_item.failure_reason_assessor_feedback,
+            check_your_answers: {
+              id: "further-information-requested-#{text_item.id}",
+              model: text_item,
+              title: "Further information requested",
+              fields: {
+                text_item.id => {
+                  title: "Tell us more about the subjects you can teach",
+                  value: text_item.response,
+                },
+              },
+            },
           },
-          document_item.id => {
-            title: "Upload your identity document",
-            value: document_item.document,
+          {
+            heading:
+              "The ID document is illegible or in a format that we cannot accept.",
+            description: document_item.failure_reason_assessor_feedback,
+            check_your_answers: {
+              id: "further-information-requested-#{document_item.id}",
+              model: document_item,
+              title: "Further information requested",
+              fields: {
+                document_item.id => {
+                  title: "Upload your identity document",
+                  value: document_item.document,
+                },
+              },
+            },
           },
-        },
+        ],
       )
     end
   end

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
         create(
           :further_information_request_item,
           further_information_request:,
-          assessor_notes: "A note",
+          failure_reason_assessor_feedback: "A note",
         )
       end
 


### PR DESCRIPTION
When an assessor is reviewing further information it would be useful if they could see the original request so they understand the context for the further information.

[Trello Card](https://trello.com/c/RqcGrHk7/1165-when-reviewing-returned-fi-show-the-text-of-the-fi-request)

## Screenshot

<img width="697" alt="Screenshot 2022-11-16 at 00 56 45" src="https://user-images.githubusercontent.com/510498/202143040-7de1b5a9-9ed5-4fe4-9471-4e4463373e09.png">
