### PR TITLE
Ensure emails are recorded as timeline events

### DIFF
--- a/app/lib/teacher_mailer_observer.rb
+++ b/app/lib/teacher_mailer_observer.rb
@@ -15,3 +15,5 @@ class TeacherMailerObserver
     )
   end
 end
+
+ActionMailer::Base.register_observer(TeacherMailerObserver)

--- a/config/initializers/mail_observers.rb
+++ b/config/initializers/mail_observers.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-Rails.application.configure do
-  config.action_mailer.observers = %w[TeacherMailerObserver]
-end

--- a/spec/lib/teacher_mailer_observer_spec.rb
+++ b/spec/lib/teacher_mailer_observer_spec.rb
@@ -20,4 +20,14 @@ RSpec.describe TeacherMailerObserver do
     expect(timeline_event.application_form).to eq(application_form)
     expect(timeline_event.mailer_action_name).to eq("application_received")
   end
+
+  it "is called when an email is sent" do
+    application_form = create(:application_form, :submitted)
+    message =
+      TeacherMailer.with(teacher: application_form.teacher).application_received
+
+    expect(TeacherMailerObserver).to receive(:delivered_email).with(message)
+
+    message.deliver_now
+  end
 end


### PR DESCRIPTION
The observer wasn't being registered correctly so I've changed to a different approach which seems to work now. I've tested this by sending an email (both sync and async) in a Rails console and seeing that a timeline event is created for both of them.

## Screenshot

![Screenshot 2022-11-16 at 10 49 04](https://user-images.githubusercontent.com/510498/202161131-6e122e68-e3bd-427a-9f1d-7daeedb999c2.png)
