### PR TITLE
Add assessor notes to timeline events

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -41,6 +41,12 @@
           <% end %>
         </ul>
       <% end %>
+    <% elsif timeline_event.further_information_request_assessed? %>
+      <p class="govuk-body">Further information request has been assessed.</p>
+
+      <% if (failure_assessor_note = description_vars[:failure_assessor_note]).present? %>
+        <%= govuk_inset_text(text: failure_assessor_note) %>
+      <% end %>
     <% else %>
       <p class="govuk-body">
         <%= t("components.timeline_entry.description.#{timeline_event.event_type}", **description_vars).html_safe %>

--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -20,6 +20,27 @@
       <% if (text = description_vars[:subjects_note]).present? %>
         <p class="govuk-body"><%= text %></p>
       <% end %>
+    <% elsif timeline_event.assessment_section_recorded? %>
+      <p class="govuk-body">
+        <%= description_vars[:section_name] %>:
+        <%= render(ApplicationFormStatusTag::Component.new(
+          key: timeline_event.id,
+          status: description_vars[:section_state],
+          class_context: "timeline-event",
+          context: :assessor,
+          )) %>
+      </p>
+
+      <%= govuk_inset_text do %>
+        <ul class="govuk-list--bullet">
+          <% description_vars[:failure_reasons].each do |failure_reason_key, failure_reason_assessor_note| %>
+            <li>
+              <%= t("assessor_interface.assessment_sections.show.failure_reasons.#{failure_reason_key}") %><br />
+              <%= failure_reason_assessor_note %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
     <% else %>
       <p class="govuk-body">
         <%= t("components.timeline_entry.description.#{timeline_event.event_type}", **description_vars).html_safe %>

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -66,8 +66,11 @@ module TimelineEntry
     end
 
     def further_information_request_assessed_vars
+      further_information_request = timeline_event.further_information_request
       {
-        further_information_request: timeline_event.further_information_request,
+        passed: further_information_request.passed,
+        failure_assessor_note:
+          further_information_request.failure_assessor_note,
       }
     end
 

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -56,15 +56,8 @@ module TimelineEntry
       section = timeline_event.assessment_section
       {
         section_name: section.key.titleize,
-        section_state:
-          render(
-            ApplicationFormStatusTag::Component.new(
-              key: timeline_event.id,
-              status: timeline_event.new_state,
-              class_context: "timeline-event",
-              context: :assessor,
-            ),
-          ),
+        section_state: timeline_event.new_state,
+        failure_reasons: section.selected_failure_reasons,
       }
     end
 

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -15,5 +15,4 @@ en:
         reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
         state_changed: Status changed from %{old_state} to %{new_state}
         note_created: "%{text}"
-        further_information_request_assessed: Further information request has been assessed.
         email_sent: "%{subject}"

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -14,7 +14,6 @@ en:
         assessor_assigned: "%{assignee_name} is assigned as the assessor."
         reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
         state_changed: Status changed from %{old_state} to %{new_state}
-        assessment_section_recorded: "%{section_name}: %{section_state}"
         note_created: "%{text}"
         further_information_request_assessed: Further information request has been assessed.
         email_sent: "%{subject}"

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -74,16 +74,30 @@ RSpec.describe TimelineEntry::Component, type: :component do
   end
 
   context "assessment section recorded" do
+    let(:assessment_section) do
+      create(
+        :assessment_section,
+        :personal_information,
+        :failed,
+        selected_failure_reasons: {
+          identification_document_expired: "A note.",
+        },
+      )
+    end
     let(:timeline_event) do
       create(
         :timeline_event,
         :assessment_section_recorded,
         new_state: "completed",
+        assessment_section:,
       )
     end
 
     it "describes the event" do
-      expect(component.text).to include("Personal Information: Completed")
+      expect(component.text).to include("Personal Information:")
+      expect(component.text).to include("Completed")
+      expect(component.text).to include("The ID document has expired.")
+      expect(component.text).to include("A note.")
     end
 
     it "attributes to the creator" do

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -119,14 +119,25 @@ RSpec.describe TimelineEntry::Component, type: :component do
   end
 
   context "further information request assessed" do
+    let(:further_information_request) do
+      create(
+        :further_information_request,
+        failure_assessor_note: "For this reason.",
+      )
+    end
     let(:timeline_event) do
-      create(:timeline_event, :further_information_request_assessed)
+      create(
+        :timeline_event,
+        :further_information_request_assessed,
+        further_information_request:,
+      )
     end
 
     it "describes the event" do
       expect(component.text).to include(
         "Further information request has been assessed.",
       )
+      expect(component.text).to include("For this reason.")
     end
 
     it "attributes to the creator" do


### PR DESCRIPTION
This adds more detail to the timeline events for assessment section and further information reviews, so the assessor can see all the information they provided in one place.

Depends on #740 

[Trello Card](https://trello.com/c/9EpqkFbe/1147-write-fi-reasons-applicant-notification-to-case-history)

## Screenshot

![Screenshot 2022-11-16 at 11 13 58](https://user-images.githubusercontent.com/510498/202168007-215b582c-2bbd-412b-a9ac-d1330dff1c11.png)
