### PR TITLE
[1143] Expire further information requests

### DIFF
--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -74,6 +74,16 @@ module TimelineEntry
       }
     end
 
+    def further_information_request_expired_vars
+      {
+        further_information_request: timeline_event.further_information_request,
+        date_requested:
+          timeline_event.further_information_request.created_at.strftime(
+            "%e %B %Y at %l:%M %P",
+          ),
+      }
+    end
+
     def email_sent_vars
       {
         subject:

--- a/app/jobs/expire_further_information_request_job.rb
+++ b/app/jobs/expire_further_information_request_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ExpireFurtherInformationRequestJob < ApplicationJob
+  def perform(further_information_request:)
+    FurtherInformationRequestExpirer.call(further_information_request:)
+  end
+end

--- a/app/jobs/expire_further_information_requests_job.rb
+++ b/app/jobs/expire_further_information_requests_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ExpireFurtherInformationRequestsJob < ApplicationJob
+  def perform
+    FurtherInformationRequest
+      .requested
+      .find_each do |further_information_request|
+      ExpireFurtherInformationRequestJob.perform_later(
+        further_information_request:,
+      )
+    end
+  end
+end

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -23,7 +23,7 @@ class FurtherInformationRequest < ApplicationRecord
            dependent: :destroy
 
   enum :state,
-       { requested: "requested", received: "received" },
+       { requested: "requested", received: "received", expired: "expired" },
        default: :requested
 
   def failed

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -59,6 +59,8 @@ class TimelineEvent < ApplicationRecord
            "further_information_request_assessed",
          email_sent: "email_sent",
          age_range_subjects_verified: "age_range_subjects_verified",
+         further_information_request_expired:
+           "further_information_request_expired",
        }
   validates :event_type, inclusion: { in: event_types.values }
 
@@ -91,10 +93,17 @@ class TimelineEvent < ApplicationRecord
   belongs_to :further_information_request, optional: true
   validates :further_information_request,
             presence: true,
-            if: :further_information_request_assessed?
+            if: -> {
+              further_information_request_assessed? ||
+                further_information_request_expired?
+            }
+
   validates :further_information_request,
             absence: true,
-            unless: :further_information_request_assessed?
+            unless: -> {
+              further_information_request_assessed? ||
+                further_information_request_expired?
+            }
 
   validates :mailer_action_name, presence: true, if: :email_sent?
   validates :mailer_action_name, absence: true, unless: :email_sent?

--- a/app/services/further_information_request_expirer.rb
+++ b/app/services/further_information_request_expirer.rb
@@ -11,8 +11,10 @@ class FurtherInformationRequestExpirer
   def call
     if expire_request?
       ActiveRecord::Base.transaction do
-        decline_application
+        further_information_request.failure_assessor_note =
+          "Further information not supplied by deadline"
         further_information_request.expired!
+        decline_application
       end
     end
 

--- a/app/services/further_information_request_expirer.rb
+++ b/app/services/further_information_request_expirer.rb
@@ -14,6 +14,7 @@ class FurtherInformationRequestExpirer
         further_information_request.failure_assessor_note =
           "Further information not supplied by deadline"
         further_information_request.expired!
+        create_timeline_event
         decline_application
       end
     end
@@ -45,6 +46,15 @@ class FurtherInformationRequestExpirer
       assessment:,
       user: "Expirer",
       new_recommendation: "decline",
+    )
+  end
+
+  def create_timeline_event
+    TimelineEvent.create!(
+      application_form:,
+      creator_name: "Expirer",
+      further_information_request:,
+      event_type: "further_information_request_expired",
     )
   end
 end

--- a/app/services/further_information_request_expirer.rb
+++ b/app/services/further_information_request_expirer.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class FurtherInformationRequestExpirer
+  include ServicePattern
+  FOUR_WEEK_COUNTRY_CODES = %w[AU CA GI NZ US].freeze
+
+  def initialize(further_information_request:)
+    @further_information_request = further_information_request
+  end
+
+  def call
+    further_information_request.expired! if expire_request?
+
+    further_information_request
+  end
+
+  private
+
+  attr_reader :further_information_request
+  delegate :assessment, to: :further_information_request
+  delegate :application_form, to: :assessment
+  delegate :region, to: :application_form
+  delegate :country, to: :region
+
+  def expire_request?
+    further_information_request.requested? &&
+      further_information_request.created_at < expire_if_older_than
+  end
+
+  def expire_if_older_than
+    return 4.weeks.ago if FOUR_WEEK_COUNTRY_CODES.include?(country.code)
+
+    6.weeks.ago
+  end
+end

--- a/app/services/further_information_request_expirer.rb
+++ b/app/services/further_information_request_expirer.rb
@@ -13,6 +13,7 @@ class FurtherInformationRequestExpirer
       ActiveRecord::Base.transaction do
         further_information_request.failure_assessor_note =
           "Further information not supplied by deadline"
+        further_information_request.passed = false
         further_information_request.expired!
         create_timeline_event
         decline_application

--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -59,4 +59,8 @@ class TeacherInterface::ApplicationFormShowViewObject
       end
     end
   end
+
+  def show_further_information_request_expired_content?
+    further_information_request.present? && further_information_request.expired?
+  end
 end

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -65,6 +65,10 @@
 <% elsif @view_object.application_form.declined? %>
   <h2 class="govuk-heading-l">Your QTS application has been declined</h2>
 
+  <%- if @view_object.show_further_information_request_expired_content? -%>
+    <%= govuk_inset_text(text:t(".further_information_request_expired")) %>
+  <%- end -%>
+  
   <% if (sections = @view_object.notes_from_assessors).present? %>
     <h3 class="govuk-heading-m">Notes from the assessor:</h3>
 

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -25,6 +25,7 @@ en:
         assessment_section_completed: Section completed
         note_created: Note created
         further_information_request_assessed: Further information assessed
+        further_information_request_expired: Further information expired
         email_sent: Email sent
         age_range_subjects_verified: Age range and subjects verified
       description:
@@ -32,4 +33,6 @@ en:
         reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
         state_changed: Status changed from %{old_state} to %{new_state}
         note_created: "%{text}"
+        further_information_request_assessed: Further information request has been assessed.
+        further_information_request_expired: "Further information requested on %{date_requested} has expired. Application has been declined."
         email_sent: "%{subject}"

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -9,6 +9,9 @@ en:
           age_range: Tell us more about the age range you can teach
           satisfactory_evidence_work_history: Tell us more about your work history
           registration_number: Tell us your registration number
+    application_forms:
+      show:
+        further_information_request_expired: Your application has been declined as you did not respond to the assessor’s request for further information within the specified time.
 
   application_form:
     tasks:

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -5,3 +5,6 @@ trim_sessions_job:
 update_working_days_since_submission:
   cron: "0 3 * * *"
   class: UpdateWorkingDaysSinceSubmissionJob
+expire_further_information_requests:
+  cron: "0 2 * * *"
+  class: ExpireFurtherInformationRequestsJob

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -145,6 +145,24 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
   end
 
+  context "further information request expired" do
+    let(:timeline_event) do
+      create(:timeline_event, :further_information_request_expired)
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "Further information requested on " \
+          "#{timeline_event.further_information_request.created_at.strftime("%e %B %Y at %l:%M %P")} has expired. " \
+          "Application has been declined.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
   context "email sent" do
     let(:timeline_event) do
       create(

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -39,6 +39,10 @@ FactoryBot.define do
       failure_assessor_note { "Notes." }
     end
 
+    trait :expired do
+      state { "expired" }
+    end
+
     trait :with_items do
       after(:create) do |further_information_request, _evaluator|
         create(

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -67,5 +67,10 @@ FactoryBot.define do
       teaching_authority_emails { [Faker::Internet.email] }
       teaching_authority_websites { [Faker::Internet.url] }
     end
+
+    trait :in_country do
+      transient { country_code { "" } }
+      country { Country.find_or_create_by(code: country_code) }
+    end
   end
 end

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -84,6 +84,11 @@ FactoryBot.define do
       association :further_information_request
     end
 
+    trait :further_information_request_expired do
+      event_type { "further_information_request_expired" }
+      association :further_information_request
+    end
+
     trait :email_sent do
       event_type { "email_sent" }
       mailer_action_name { "application_received" }

--- a/spec/jobs/expire_further_information_request_job_spec.rb
+++ b/spec/jobs/expire_further_information_request_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ExpireFurtherInformationRequestJob do
+  describe "#perform" do
+    subject { described_class.new.perform(further_information_request:) }
+
+    let(:further_information_request) { build(:further_information_request) }
+
+    it "calls the FurtherInformationRequestExpirer" do
+      expect(FurtherInformationRequestExpirer).to receive(:call).with(
+        further_information_request:,
+      )
+      subject
+    end
+  end
+end

--- a/spec/jobs/expire_further_information_requests_job_spec.rb
+++ b/spec/jobs/expire_further_information_requests_job_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ExpireFurtherInformationRequestsJob do
+  describe "#perform" do
+    subject { described_class.new.perform }
+
+    let!(:received_fi_request) do
+      create(:further_information_request, :received)
+    end
+    let!(:requested_fi_request) do
+      create(:further_information_request, :requested)
+    end
+    let!(:expired_fi_request) { create(:further_information_request, :expired) }
+
+    it "enqueues a job for each 'requested' FI request" do
+      expect(ExpireFurtherInformationRequestJob).to receive(
+        :perform_later,
+      ).with(further_information_request: requested_fi_request)
+      subject
+    end
+
+    it "doesn't enqueue a job for 'received' FI requests" do
+      expect(ExpireFurtherInformationRequestJob).not_to receive(
+        :perform_later,
+      ).with(further_information_request: received_fi_request)
+      subject
+    end
+
+    it "doesn't enqueue a job for 'expired' FI requests" do
+      expect(ExpireFurtherInformationRequestJob).not_to receive(
+        :perform_later,
+      ).with(further_information_request: received_fi_request)
+      subject
+    end
+  end
+end

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe FurtherInformationRequest do
     is_expected.to define_enum_for(:state).with_values(
       requested: "requested",
       received: "received",
+      expired: "expired",
     ).backed_by_column_of_type(:string)
   end
 end

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -77,6 +77,8 @@ RSpec.describe TimelineEvent do
           "further_information_request_assessed",
         email_sent: "email_sent",
         age_range_subjects_verified: "age_range_subjects_verified",
+        further_information_request_expired:
+          "further_information_request_expired",
       ).backed_by_column_of_type(:string)
     end
 
@@ -148,6 +150,21 @@ RSpec.describe TimelineEvent do
     context "with a further information request assessed event type" do
       before do
         timeline_event.event_type = :further_information_request_assessed
+      end
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
+      it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_presence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:assessment) }
+    end
+
+    context "with a further information request expired event type" do
+      before do
+        timeline_event.event_type = :further_information_request_expired
       end
 
       it { is_expected.to validate_absence_of(:assignee) }

--- a/spec/services/further_information_request_expirer_spec.rb
+++ b/spec/services/further_information_request_expirer_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe FurtherInformationRequestExpirer do
         expect(subject.failure_assessor_note).to eq(expected_assessor_note)
       end
 
+      it "sets the passed to false" do
+        expect(subject.passed).to eq(false)
+      end
+
       it "creates the expiry timeline event" do
         expect { subject }.to change {
           TimelineEvent.where(further_information_request:).count

--- a/spec/services/further_information_request_expirer_spec.rb
+++ b/spec/services/further_information_request_expirer_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe FurtherInformationRequestExpirer do
       it "sets the failure_assessor_note" do
         expect(subject.failure_assessor_note).to eq(expected_assessor_note)
       end
+
+      it "creates the expiry timeline event" do
+        expect { subject }.to change {
+          TimelineEvent.where(further_information_request:).count
+        }.by(1)
+      end
     end
 
     context "with requested FI request" do

--- a/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
@@ -106,6 +106,37 @@ RSpec.describe TeacherInterface::ApplicationFormShowViewObject do
     end
   end
 
+  describe "#show_further_information_request_expired_content?" do
+    let(:application_form) do
+      create(:application_form, teacher: current_teacher)
+    end
+    let(:assessment) { create(:assessment, application_form:) }
+
+    subject(:show_fi_expired) do
+      view_object.show_further_information_request_expired_content?
+    end
+
+    context "when further_information_request is present" do
+      context "and it has expired" do
+        let!(:further_information_request) do
+          create(:further_information_request, :expired, assessment:)
+        end
+        it { is_expected.to eq(true) }
+      end
+
+      context "and it hasn't expired" do
+        let!(:further_information_request) do
+          create(:further_information_request, assessment:)
+        end
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    context "when further_information_request is nil" do
+      it { is_expected.to eq(false) }
+    end
+  end
+
   describe "#declined_cannot_reapply?" do
     subject(:declined_cannot_reapply?) { view_object.declined_cannot_reapply? }
 


### PR DESCRIPTION
Further information requests have a time limit after which they expire and the application is automatically declined. For most regions this is 6 weeks from application submission but for some it is 4 weeks.

* Add an expired state to FurtherInformationRequest (and a factory trait for this)
* Add a timeline event type and support for it on the timeline component
* Add `FurtherInformationRequestExpirer` service. This checks the date on the FI request and if it should be expired it:
  * updates the assessment state to declined (which creates an timeline entry and emails the user)
  * updates the application form state
  * creates a specific timeline entry for the expiry
  * sets the FI request to 'expired'
  * sets the FI request assessor note accordingly
* Add two jobs to retrieve FI requests to check and then run them through the service
* Schedule the 'outer' job to run daily at 2am
* Slight tweak to the decline email, we're going to just use the standard content but the 'thank you' bit has been moved so as it is in both versions
* Update the teacher interface application show to include a note from the assessor if they FI request has expired

There is also work on the ticket for reminder emails but I've split this off and opened another ticket for that.