### PR TITLE
Add teaching authority online checker URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem "sidekiq"
 gem "sidekiq-cron"
 gem "sitemap_generator"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby] # Windows
+gem "validate_url"
 
 gem "dfe-analytics", github: "DFE-Digital/dfe-analytics"
 gem "dfe-autocomplete", github: "DFE-Digital/dfe-autocomplete"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -467,6 +467,9 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.3.0)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
     view_component (2.74.1)
       activesupport (>= 5.0.0, < 8.0)
       concurrent-ruby (~> 1.0)
@@ -544,6 +547,7 @@ DEPENDENCIES
   syntax_tree-haml
   syntax_tree-rbs
   tzinfo-data
+  validate_url
   web-console
   webmock
 

--- a/app/controllers/support_interface/countries_controller.rb
+++ b/app/controllers/support_interface/countries_controller.rb
@@ -68,6 +68,7 @@ class SupportInterface::CountriesController < SupportInterface::BaseController
       :teaching_authority_certificate,
       :teaching_authority_other,
       :teaching_authority_checks_sanctions,
+      :teaching_authority_online_checker_url,
     )
   end
 end

--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -43,6 +43,7 @@ module SupportInterface
         :teaching_authority_websites_string,
         :teaching_authority_certificate,
         :teaching_authority_other,
+        :teaching_authority_online_checker_url,
       )
     end
   end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -37,5 +37,7 @@ class Country < ApplicationRecord
 
   validates :code, inclusion: { in: CODES }
 
+  validates :teaching_authority_online_checker_url, url: { allow_blank: true }
+
   alias_method :country, :itself
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -2,17 +2,18 @@
 #
 # Table name: countries
 #
-#  id                                  :bigint           not null, primary key
-#  code                                :string           not null
-#  teaching_authority_address          :text             default(""), not null
-#  teaching_authority_certificate      :text             default(""), not null
-#  teaching_authority_checks_sanctions :boolean          default(TRUE), not null
-#  teaching_authority_emails           :text             default([]), not null, is an Array
-#  teaching_authority_name             :text             default(""), not null
-#  teaching_authority_other            :text             default(""), not null
-#  teaching_authority_websites         :text             default([]), not null, is an Array
-#  created_at                          :datetime         not null
-#  updated_at                          :datetime         not null
+#  id                                    :bigint           not null, primary key
+#  code                                  :string           not null
+#  teaching_authority_address            :text             default(""), not null
+#  teaching_authority_certificate        :text             default(""), not null
+#  teaching_authority_checks_sanctions   :boolean          default(TRUE), not null
+#  teaching_authority_emails             :text             default([]), not null, is an Array
+#  teaching_authority_name               :text             default(""), not null
+#  teaching_authority_online_checker_url :string           default(""), not null
+#  teaching_authority_other              :text             default(""), not null
+#  teaching_authority_websites           :text             default([]), not null, is an Array
+#  created_at                            :datetime         not null
+#  updated_at                            :datetime         not null
 #
 # Indexes
 #

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -2,21 +2,22 @@
 #
 # Table name: regions
 #
-#  id                             :bigint           not null, primary key
-#  application_form_enabled       :boolean          default(FALSE)
-#  legacy                         :boolean          default(TRUE), not null
-#  name                           :string           default(""), not null
-#  sanction_check                 :string           default("none"), not null
-#  status_check                   :string           default("none"), not null
-#  teaching_authority_address     :text             default(""), not null
-#  teaching_authority_certificate :text             default(""), not null
-#  teaching_authority_emails      :text             default([]), not null, is an Array
-#  teaching_authority_name        :text             default(""), not null
-#  teaching_authority_other       :text             default(""), not null
-#  teaching_authority_websites    :text             default([]), not null, is an Array
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  country_id                     :bigint           not null
+#  id                                    :bigint           not null, primary key
+#  application_form_enabled              :boolean          default(FALSE)
+#  legacy                                :boolean          default(TRUE), not null
+#  name                                  :string           default(""), not null
+#  sanction_check                        :string           default("none"), not null
+#  status_check                          :string           default("none"), not null
+#  teaching_authority_address            :text             default(""), not null
+#  teaching_authority_certificate        :text             default(""), not null
+#  teaching_authority_emails             :text             default([]), not null, is an Array
+#  teaching_authority_name               :text             default(""), not null
+#  teaching_authority_online_checker_url :string           default(""), not null
+#  teaching_authority_other              :text             default(""), not null
+#  teaching_authority_websites           :text             default([]), not null, is an Array
+#  created_at                            :datetime         not null
+#  updated_at                            :datetime         not null
+#  country_id                            :bigint           not null
 #
 # Indexes
 #

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -44,6 +44,9 @@ class Region < ApplicationRecord
        prefix: true
 
   validates :name, uniqueness: { scope: :country_id }
+
   validates :sanction_check, inclusion: { in: sanction_checks.values }
   validates :status_check, inclusion: { in: status_checks.values }
+
+  validates :teaching_authority_online_checker_url, url: { allow_blank: true }
 end

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -9,7 +9,7 @@ module AssessorInterface
     def assessment_section
       @assessment_section ||=
         AssessmentSection
-          .includes(assessment: :application_form)
+          .includes(assessment: { application_form: { region: :country } })
           .where(
             assessment_id: params[:assessment_id],
             assessment: {
@@ -23,6 +23,7 @@ module AssessorInterface
     delegate :application_form, to: :assessment
     delegate :registration_number, to: :application_form
     delegate :checks, to: :assessment_section
+    delegate :region, to: :application_form
 
     def qualifications
       application_form.qualifications.ordered
@@ -50,6 +51,16 @@ module AssessorInterface
 
     def notes_placeholder_key_for(failure_reason:)
       build_key(failure_reason, "placeholder")
+    end
+
+    def show_online_checker?
+      online_checker_url.present?
+    end
+
+    def online_checker_url
+      @online_checker_url ||=
+        region.teaching_authority_online_checker_url.presence ||
+          region.country.teaching_authority_online_checker_url
     end
 
     private

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -46,6 +46,12 @@
   <% end %>
 <% end %>
 
+<% if @assessment_section_view_object.show_online_checker? %>
+  <h2 class="govuk-heading-s">Online checker</h2>
+  <p class="govuk-body">This authority has an online checker for validating the supplied reference number:</p>
+  <p class="govuk-body"><%= govuk_link_to @assessment_section_view_object.online_checker_url, @assessment_section_view_object.online_checker_url, target: "_blank" %></p>
+<% end %>
+
 <h2 class="govuk-heading-s">Check:</h2>
 <ul class="govuk-list govuk-list--bullet">
   <% @assessment_section_view_object.checks.each do |check| %>

--- a/app/views/shared/_teaching_authority_form_fields.html.erb
+++ b/app/views/shared/_teaching_authority_form_fields.html.erb
@@ -7,3 +7,7 @@
 <%= f.govuk_text_area :teaching_authority_websites_string, label: { text: "Teaching authority websites" }, hint: { text: "One on each line." } %>
 
 <%= f.govuk_text_area :teaching_authority_other, label: { text: "Teaching authority other" } %>
+
+<%= f.govuk_text_field :teaching_authority_certificate, label: { text: "Teaching authority certificate" } %>
+
+<%= f.govuk_text_field :teaching_authority_online_checker_url, label: { text: "Teaching authority online checker URL" } %>

--- a/app/views/support_interface/countries/confirm_edit.html.erb
+++ b/app/views/support_interface/countries/confirm_edit.html.erb
@@ -14,6 +14,8 @@
   <% end %>
 
   <p class="govuk-body"><%= @country.teaching_authority_certificate %></p>
+
+  <p class="govuk-body"><%= @country.teaching_authority_online_checker_url %></p>
 <% end %>
 
 <% if @diff_actions.present? %>
@@ -54,6 +56,7 @@
   <%= f.hidden_field :teaching_authority_websites_string, value: @country.teaching_authority_websites_string %>
   <%= f.hidden_field :teaching_authority_certificate, value: @country.teaching_authority_certificate %>
   <%= f.hidden_field :teaching_authority_other, value: @country.teaching_authority_other %>
+  <%= f.hidden_field :teaching_authority_online_checker_url, value: @country.teaching_authority_online_checker_url %>
   <%= f.hidden_field :teaching_authority_checks_sanctions, value: @country.teaching_authority_checks_sanctions %>
   <%= f.govuk_submit "Confirm save", prevent_double_click: false %>
 <% end %>

--- a/app/views/support_interface/countries/edit.html.erb
+++ b/app/views/support_interface/countries/edit.html.erb
@@ -5,9 +5,7 @@
 <%= form_with model: @country, url: confirm_edit_support_interface_country_path(@country), method: "POST" do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= render "shared/teaching_authority_contactable_fields", f: %>
-
-  <%= f.govuk_text_field :teaching_authority_certificate, label: { text: "Teaching authority certificate" } %>
+  <%= render "shared/teaching_authority_form_fields", f: %>
 
   <%= f.govuk_check_box :teaching_authority_checks_sanctions, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Teaching authority checks sanctions" } %>
 

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -21,9 +21,7 @@
     OpenStruct.new(id: 'none', name: 'None')
   ], :id, :name, label: { text: "Status check" } %>
 
-  <%= render "shared/teaching_authority_contactable_fields", f: %>
-
-  <%= f.govuk_text_field :teaching_authority_certificate, label: { text: "Teaching authority certificate" } %>
+  <%= render "shared/teaching_authority_form_fields", f: %>
 
   <%= f.govuk_submit "Save", prevent_double_click: false do %>
     <%= f.govuk_submit "Save and preview", prevent_double_click: false, name: "preview", value: "preview" %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -90,6 +90,7 @@
     - teaching_authority_other
     - teaching_authority_name
     - teaching_authority_checks_sanctions
+    - teaching_authority_online_checker_url
   :documents:
     - id
     - document_type
@@ -174,6 +175,7 @@
     - teaching_authority_name
     - teaching_authority_other
     - teaching_authority_certificate
+    - teaching_authority_online_checker_url
     - application_form_enabled
   :staff:
     - id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,6 +38,14 @@ en:
           attributes:
             selected_failure_reasons:
               blank: Select the reasons for your recommendation.
+        country:
+          attributes:
+            teaching_authority_online_checker_url:
+              url: Enter a valid teaching authority online checker URL
+        region:
+          attributes:
+            teaching_authority_online_checker_url:
+              url: Enter a valid teaching authority online checker URL
         teacher:
           attributes:
             email:

--- a/db/migrate/20221122093227_add_teaching_authority_online_checker_url_to_countries_and_regions.rb
+++ b/db/migrate/20221122093227_add_teaching_authority_online_checker_url_to_countries_and_regions.rb
@@ -1,0 +1,17 @@
+class AddTeachingAuthorityOnlineCheckerUrlToCountriesAndRegions < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    add_column :countries,
+               :teaching_authority_online_checker_url,
+               :string,
+               default: "",
+               null: false
+
+    add_column :regions,
+               :teaching_authority_online_checker_url,
+               :string,
+               default: "",
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_16_160408) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_22_093227) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -124,6 +124,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_16_160408) do
     t.text "teaching_authority_other", default: "", null: false
     t.text "teaching_authority_name", default: "", null: false
     t.boolean "teaching_authority_checks_sanctions", default: true, null: false
+    t.string "teaching_authority_online_checker_url", default: "", null: false
     t.index ["code"], name: "index_countries_on_code", unique: true
   end
 
@@ -228,6 +229,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_16_160408) do
     t.text "teaching_authority_other", default: "", null: false
     t.boolean "application_form_enabled", default: false
     t.text "teaching_authority_certificate", default: "", null: false
+    t.string "teaching_authority_online_checker_url", default: "", null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
     t.index ["country_id"], name: "index_regions_on_country_id"
   end

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -2,17 +2,18 @@
 #
 # Table name: countries
 #
-#  id                                  :bigint           not null, primary key
-#  code                                :string           not null
-#  teaching_authority_address          :text             default(""), not null
-#  teaching_authority_certificate      :text             default(""), not null
-#  teaching_authority_checks_sanctions :boolean          default(TRUE), not null
-#  teaching_authority_emails           :text             default([]), not null, is an Array
-#  teaching_authority_name             :text             default(""), not null
-#  teaching_authority_other            :text             default(""), not null
-#  teaching_authority_websites         :text             default([]), not null, is an Array
-#  created_at                          :datetime         not null
-#  updated_at                          :datetime         not null
+#  id                                    :bigint           not null, primary key
+#  code                                  :string           not null
+#  teaching_authority_address            :text             default(""), not null
+#  teaching_authority_certificate        :text             default(""), not null
+#  teaching_authority_checks_sanctions   :boolean          default(TRUE), not null
+#  teaching_authority_emails             :text             default([]), not null, is an Array
+#  teaching_authority_name               :text             default(""), not null
+#  teaching_authority_online_checker_url :string           default(""), not null
+#  teaching_authority_other              :text             default(""), not null
+#  teaching_authority_websites           :text             default([]), not null, is an Array
+#  created_at                            :datetime         not null
+#  updated_at                            :datetime         not null
 #
 # Indexes
 #

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -2,21 +2,22 @@
 #
 # Table name: regions
 #
-#  id                             :bigint           not null, primary key
-#  application_form_enabled       :boolean          default(FALSE)
-#  legacy                         :boolean          default(TRUE), not null
-#  name                           :string           default(""), not null
-#  sanction_check                 :string           default("none"), not null
-#  status_check                   :string           default("none"), not null
-#  teaching_authority_address     :text             default(""), not null
-#  teaching_authority_certificate :text             default(""), not null
-#  teaching_authority_emails      :text             default([]), not null, is an Array
-#  teaching_authority_name        :text             default(""), not null
-#  teaching_authority_other       :text             default(""), not null
-#  teaching_authority_websites    :text             default([]), not null, is an Array
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  country_id                     :bigint           not null
+#  id                                    :bigint           not null, primary key
+#  application_form_enabled              :boolean          default(FALSE)
+#  legacy                                :boolean          default(TRUE), not null
+#  name                                  :string           default(""), not null
+#  sanction_check                        :string           default("none"), not null
+#  status_check                          :string           default("none"), not null
+#  teaching_authority_address            :text             default(""), not null
+#  teaching_authority_certificate        :text             default(""), not null
+#  teaching_authority_emails             :text             default([]), not null, is an Array
+#  teaching_authority_name               :text             default(""), not null
+#  teaching_authority_online_checker_url :string           default(""), not null
+#  teaching_authority_other              :text             default(""), not null
+#  teaching_authority_websites           :text             default([]), not null, is an Array
+#  created_at                            :datetime         not null
+#  updated_at                            :datetime         not null
+#  country_id                            :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe Country, type: :model do
   describe "validations" do
     it { is_expected.to validate_inclusion_of(:code).in_array(%w[GB-SCT FR]) }
     it { is_expected.to_not validate_inclusion_of(:code).in_array(%w[ABC]) }
+    it do
+      is_expected.to validate_url_of(
+        :teaching_authority_online_checker_url,
+      ).with_message("Enter a valid teaching authority online checker URL")
+    end
   end
 
   describe "#teaching_authority_emails_string" do

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -2,17 +2,18 @@
 #
 # Table name: countries
 #
-#  id                                  :bigint           not null, primary key
-#  code                                :string           not null
-#  teaching_authority_address          :text             default(""), not null
-#  teaching_authority_certificate      :text             default(""), not null
-#  teaching_authority_checks_sanctions :boolean          default(TRUE), not null
-#  teaching_authority_emails           :text             default([]), not null, is an Array
-#  teaching_authority_name             :text             default(""), not null
-#  teaching_authority_other            :text             default(""), not null
-#  teaching_authority_websites         :text             default([]), not null, is an Array
-#  created_at                          :datetime         not null
-#  updated_at                          :datetime         not null
+#  id                                    :bigint           not null, primary key
+#  code                                  :string           not null
+#  teaching_authority_address            :text             default(""), not null
+#  teaching_authority_certificate        :text             default(""), not null
+#  teaching_authority_checks_sanctions   :boolean          default(TRUE), not null
+#  teaching_authority_emails             :text             default([]), not null, is an Array
+#  teaching_authority_name               :text             default(""), not null
+#  teaching_authority_online_checker_url :string           default(""), not null
+#  teaching_authority_other              :text             default(""), not null
+#  teaching_authority_websites           :text             default([]), not null, is an Array
+#  created_at                            :datetime         not null
+#  updated_at                            :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -2,21 +2,22 @@
 #
 # Table name: regions
 #
-#  id                             :bigint           not null, primary key
-#  application_form_enabled       :boolean          default(FALSE)
-#  legacy                         :boolean          default(TRUE), not null
-#  name                           :string           default(""), not null
-#  sanction_check                 :string           default("none"), not null
-#  status_check                   :string           default("none"), not null
-#  teaching_authority_address     :text             default(""), not null
-#  teaching_authority_certificate :text             default(""), not null
-#  teaching_authority_emails      :text             default([]), not null, is an Array
-#  teaching_authority_name        :text             default(""), not null
-#  teaching_authority_other       :text             default(""), not null
-#  teaching_authority_websites    :text             default([]), not null, is an Array
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  country_id                     :bigint           not null
+#  id                                    :bigint           not null, primary key
+#  application_form_enabled              :boolean          default(FALSE)
+#  legacy                                :boolean          default(TRUE), not null
+#  name                                  :string           default(""), not null
+#  sanction_check                        :string           default("none"), not null
+#  status_check                          :string           default("none"), not null
+#  teaching_authority_address            :text             default(""), not null
+#  teaching_authority_certificate        :text             default(""), not null
+#  teaching_authority_emails             :text             default([]), not null, is an Array
+#  teaching_authority_name               :text             default(""), not null
+#  teaching_authority_online_checker_url :string           default(""), not null
+#  teaching_authority_other              :text             default(""), not null
+#  teaching_authority_websites           :text             default([]), not null, is an Array
+#  created_at                            :datetime         not null
+#  updated_at                            :datetime         not null
+#  country_id                            :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -47,6 +47,11 @@ RSpec.describe Region, type: :model do
         .with_prefix(:status_check)
         .backed_by_column_of_type(:string)
     end
+    it do
+      is_expected.to validate_url_of(
+        :teaching_authority_online_checker_url,
+      ).with_message("Enter a valid teaching authority online checker URL")
+    end
   end
 
   describe "#teaching_authority_emails_string" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,7 @@ require "dfe/analytics/testing"
 require "support/page_helpers"
 require "site_prism"
 require "site_prism/all_there"
+require "validate_url/rspec_matcher"
 require "view_component/test_helpers"
 require "webmock/rspec"
 

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_websites
     when_i_fill_teaching_authority_other
     when_i_fill_teaching_authority_certificate
+    when_i_fill_teaching_authority_online_checker_url
     when_i_fill_teaching_authority_checks_sanctions
     when_i_fill_regions
     and_i_save
@@ -39,6 +40,7 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_websites
     when_i_fill_teaching_authority_other
     when_i_fill_teaching_authority_certificate
+    when_i_fill_teaching_authority_online_checker_url
     and_i_save_and_preview
     then_i_see_the_preview
     and_i_see_a_success_banner
@@ -172,6 +174,14 @@ RSpec.describe "Countries support", type: :system do
     fill_in "region-teaching-authority-certificate-field", with: "Certificate"
   rescue Capybara::ElementNotFound
     fill_in "country-teaching-authority-certificate-field", with: "Certificate"
+  end
+
+  def when_i_fill_teaching_authority_online_checker_url
+    fill_in "region-teaching-authority-online-checker-url-field",
+            with: "https://www.example.com/checks"
+  rescue Capybara::ElementNotFound
+    fill_in "country-teaching-authority-online-checker-url-field",
+            with: "https://www.example.com/checks"
   end
 
   def when_i_fill_teaching_authority_checks_sanctions

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -2,12 +2,14 @@
 
 require "rails_helper"
 RSpec.describe AssessorInterface::AssessmentSectionViewObject do
-  subject { described_class.new(params:) }
+  subject(:view_object) { described_class.new(params:) }
+
   let(:assessment_section) do
     create(:assessment_section, :personal_information, assessment:)
   end
   let(:assessment) { create(:assessment, application_form:) }
-  let(:application_form) { create(:application_form) }
+  let(:region) { create(:region) }
+  let(:application_form) { create(:application_form, region:) }
 
   let(:params) do
     {
@@ -159,6 +161,66 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
           "helpers.placeholder.assessor_interface_assessment_section_form.failure_reason_notes",
         )
       end
+    end
+  end
+
+  describe "#show_online_checker?" do
+    subject(:show_online_checker?) { view_object.show_online_checker? }
+
+    it { is_expected.to be false }
+
+    context "with a checker URL" do
+      before do
+        region.country.update!(
+          teaching_authority_online_checker_url:
+            "https://www.example.com/checks",
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "#online_checker_url" do
+    subject(:online_checker_url) { view_object.online_checker_url }
+
+    it { is_expected.to eq("") }
+
+    context "with a country value set" do
+      before do
+        region.country.update!(
+          teaching_authority_online_checker_url:
+            "https://www.example.com/checks",
+        )
+      end
+
+      it { is_expected.to eq("https://www.example.com/checks") }
+    end
+
+    context "with a region value set" do
+      before do
+        region.update!(
+          teaching_authority_online_checker_url:
+            "https://www.example.com/checks",
+        )
+      end
+
+      it { is_expected.to eq("https://www.example.com/checks") }
+    end
+
+    context "with a country and a region value set" do
+      before do
+        region.country.update!(
+          teaching_authority_online_checker_url:
+            "https://www.example.com/country-checks",
+        )
+        region.update!(
+          teaching_authority_online_checker_url:
+            "https://www.example.com/region-checks",
+        )
+      end
+
+      it { is_expected.to eq("https://www.example.com/region-checks") }
     end
   end
 end


### PR DESCRIPTION
This adds a new field to regions and countries which we can use the set the online checker URL, relevant if the teaching authority has an online checker for teachers.

[Trello Card](https://trello.com/c/nDtRrHHk/1135-add-online-checker-url-field-to-case-management-via-support-console)

## Screenshots

![Screenshot 2022-11-22 at 10 44 19](https://user-images.githubusercontent.com/510498/203297174-c6236495-f55e-433e-a953-380425705b49.png)

<img width="999" alt="Screenshot 2022-11-23 at 08 13 52" src="https://user-images.githubusercontent.com/510498/203498581-2c94b4ea-4b3e-4441-b033-f0060a93303a.png">

![Screenshot 2022-11-22 at 10 56 06](https://user-images.githubusercontent.com/510498/203297196-dd099b4b-d11e-4c42-ad07-a6df342bc3e4.png)
