### PR TITLE
Fix received_at not being set

### DIFF
--- a/app/services/submit_further_information_request.rb
+++ b/app/services/submit_further_information_request.rb
@@ -12,7 +12,10 @@ class SubmitFurtherInformationRequest
     raise AlreadySubmitted if further_information_request.received?
 
     ActiveRecord::Base.transaction do
-      further_information_request.received!
+      further_information_request.update!(
+        state: "received",
+        received_at: Time.zone.now,
+      )
 
       ChangeApplicationFormState.call(
         application_form:,

--- a/spec/services/submit_further_information_request_spec.rb
+++ b/spec/services/submit_further_information_request_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe SubmitFurtherInformationRequest do
     ).from(false).to(true)
   end
 
+  it "changes the further information request received at" do
+    freeze_time do
+      expect { call }.to change(further_information_request, :received_at).from(
+        nil,
+      ).to(Time.current)
+    end
+  end
+
   it "sends an email" do
     expect { call }.to have_enqueued_mail(
       TeacherMailer,


### PR DESCRIPTION
This value should be set to the date/time of when the further information request changed from the requested state to the received state, but that wasn't previously working.