### PR TITLE
Suppress FI notes when an application is declined

### DIFF
--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -34,11 +34,16 @@ class TeacherInterface::ApplicationFormShowViewObject
 
       failure_reasons =
         section.selected_failure_reasons.map do |key, assessor_feedback|
-          unless AssessmentSection.decline_failure_reason?(failure_reason: key)
-            assessor_feedback = ""
-          end
+          is_decline =
+            AssessmentSection.decline_failure_reason?(failure_reason: key)
+          assessor_feedback = "" unless is_decline
 
-          { key:, assessor_feedback: }
+          { key:, is_decline:, assessor_feedback: }
+        end
+
+      failure_reasons =
+        failure_reasons.sort_by do |failure_reason|
+          [failure_reason[:is_decline] ? 0 : 1, failure_reason[:key]]
         end
 
       { assessment_section_key: section.key, failure_reasons: }

--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -26,6 +26,21 @@ class TeacherInterface::ApplicationFormShowViewObject
         .first
   end
 
+  def notes_from_assessors
+    return [] if assessment.nil? || further_information_request.present?
+
+    assessment.sections.filter_map do |section|
+      next nil if section.selected_failure_reasons.blank?
+
+      failure_reasons =
+        section.selected_failure_reasons.map do |key, assessor_feedback|
+          { key:, assessor_feedback: }
+        end
+
+      { assessment_section_key: section.key, failure_reasons: }
+    end
+  end
+
   def declined_cannot_reapply?
     return false if assessment.nil?
 

--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -34,6 +34,10 @@ class TeacherInterface::ApplicationFormShowViewObject
 
       failure_reasons =
         section.selected_failure_reasons.map do |key, assessor_feedback|
+          unless AssessmentSection.decline_failure_reason?(failure_reason: key)
+            assessor_feedback = ""
+          end
+
           { key:, assessor_feedback: }
         end
 

--- a/app/views/assessor_interface/assessments/declare.html.erb
+++ b/app/views/assessor_interface/assessments/declare.html.erb
@@ -17,7 +17,13 @@
         <% section.selected_failure_reasons.each do |key, note| %>
           <li>
             <h4 class="govuk-heading-s"><%= t("assessor_interface.assessment_sections.show.failure_reasons.#{key}") %></h4>
-            <p class="govuk-body govuk-!-margin-bottom-2">Your note to the applicant:</p>
+
+            <% if AssessmentSection.decline_failure_reason?(failure_reason: key) %>
+              <p class="govuk-body govuk-!-margin-bottom-2">Your note to the applicant:</p>
+            <% else %>
+              <p class="govuk-body govuk-!-margin-bottom-2">Your note (the applicant won’t see this):</p>
+            <% end %>
+
             <%= govuk_inset_text(text: note) %>
           </li>
         <% end %>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -77,7 +77,9 @@
               <%= t("assessor_interface.assessment_sections.show.failure_reasons.#{failure_reason[:key]}") %>
             </h5>
 
-            <%= govuk_inset_text(text: failure_reason[:assessor_feedback]) %>
+            <% if (text = failure_reason[:assessor_feedback]).present? %>
+              <%= govuk_inset_text(text:) %>
+            <% end %>
           </li>
         <% end %>
       </ul>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -65,21 +65,22 @@
 <% elsif @view_object.application_form.declined? %>
   <h2 class="govuk-heading-l">Your QTS application has been declined</h2>
 
-  <% unless @view_object.further_information_request.present? %>
+  <% if (sections = @view_object.notes_from_assessors).present? %>
     <h3 class="govuk-heading-m">Notes from the assessor:</h3>
 
-    <% @view_object.assessment.sections.each do |section| %>
-      <% if section.selected_failure_reasons.present? %>
-        <h4 class="govuk-heading-s"><%= t(".assessment_section.#{section.key}") %></h4>
-        <ul class="govuk-list">
-          <% section.selected_failure_reasons.each do |key, note| %>
-            <li>
-              <h5 class="govuk-heading-s"><%= t("assessor_interface.assessment_sections.show.failure_reasons.#{key}") %></h5>
-              <%= govuk_inset_text(text: note) %>
-            </li>
-          <% end %>
-        </ul>
-      <% end %>
+    <% sections.each do |section| %>
+      <h4 class="govuk-heading-s"><%= t(".assessment_section.#{section[:assessment_section_key]}") %></h4>
+      <ul class="govuk-list">
+        <% section[:failure_reasons].each do |failure_reason| %>
+          <li>
+            <h5 class="govuk-body">
+              <%= t("assessor_interface.assessment_sections.show.failure_reasons.#{failure_reason[:key]}") %>
+            </h5>
+
+            <%= govuk_inset_text(text: failure_reason[:assessor_feedback]) %>
+          </li>
+        <% end %>
+      </ul>
     <% end %>
   <% end %>
 

--- a/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe TeacherInterface::ApplicationFormShowViewObject do
               assessment_section_key: "personal_information",
               failure_reasons: [
                 { assessor_feedback: "A note.", key: "applicant_already_qts" },
-                { assessor_feedback: "A note.", key: "identification_document_expired" },
+                { assessor_feedback: "", key: "identification_document_expired" },
               ],
             },
           ],

--- a/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe TeacherInterface::ApplicationFormShowViewObject do
           :personal_information,
           :failed,
           selected_failure_reasons: {
+            duplicate_application: "A note.",
             identification_document_expired: "A note.",
             applicant_already_qts: "A note.",
           },
@@ -82,8 +83,21 @@ RSpec.describe TeacherInterface::ApplicationFormShowViewObject do
             {
               assessment_section_key: "personal_information",
               failure_reasons: [
-                { assessor_feedback: "A note.", key: "applicant_already_qts" },
-                { assessor_feedback: "", key: "identification_document_expired" },
+                {
+                  assessor_feedback: "A note.",
+                  is_decline: true,
+                  key: "applicant_already_qts",
+                },
+                {
+                  assessor_feedback: "A note.",
+                  is_decline: true,
+                  key: "duplicate_application",
+                },
+                {
+                  assessor_feedback: "",
+                  is_decline: false,
+                  key: "identification_document_expired",
+                },
               ],
             },
           ],

--- a/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
@@ -52,6 +52,46 @@ RSpec.describe TeacherInterface::ApplicationFormShowViewObject do
     end
   end
 
+  describe "#notes_from_assessors" do
+    subject(:notes_from_assessors) { view_object.notes_from_assessors }
+
+    it { is_expected.to be_empty }
+
+    context "with failure reasons" do
+      let(:application_form) do
+        create(:application_form, teacher: current_teacher)
+      end
+      let(:assessment) { create(:assessment, application_form:) }
+
+      before do
+        create(
+          :assessment_section,
+          :personal_information,
+          :failed,
+          selected_failure_reasons: {
+            identification_document_expired: "A note.",
+            applicant_already_qts: "A note.",
+          },
+          assessment:,
+        )
+      end
+
+      it do
+        is_expected.to eq(
+          [
+            {
+              assessment_section_key: "personal_information",
+              failure_reasons: [
+                { assessor_feedback: "A note.", key: "applicant_already_qts" },
+                { assessor_feedback: "A note.", key: "identification_document_expired" },
+              ],
+            },
+          ],
+        )
+      end
+    end
+  end
+
   describe "#declined_cannot_reapply?" do
     subject(:declined_cannot_reapply?) { view_object.declined_cannot_reapply? }
 


### PR DESCRIPTION
We only want to show the assessor feedback notes for declined failure reasons if the application form is declined, since there's nothing the applicant can do for the further information failure reasons.

[Trello Card](https://trello.com/c/P0WTEmQ8/1178-supress-fi-notes-in-notification-when-an-application-is-declined)