### PR TITLE
Improve eligible page content

### DIFF
--- a/app/views/eligibility_interface/finish/eligible.html.erb
+++ b/app/views/eligibility_interface/finish/eligible.html.erb
@@ -3,9 +3,8 @@
 
 <%= render "shared/eligible_region_content", region: @region %>
 
-<p class="govuk-body">Once you start your application, we’ll sign you out if you’re inactive for 60 minutes.</p>
-
 <% if FeatureFlag.active?(:teacher_applications) && @region && @region.application_form_enabled %>
+  <p class="govuk-body">Use our new application form to apply for QTS.</p>
   <%= govuk_start_button(text: "Apply for QTS", href: new_teacher_registration_path) %>
 <% else %>
   <p class="govuk-body">You’ll make your application on the Teaching Regulation Agency website.</p>

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -5,11 +5,16 @@
 <h2 class="govuk-heading-m">Preparing to apply</h2>
 
 <p class="govuk-body">
-  If you decide to apply, you'll need to provide a range of evidence. We'll ask you
-  to upload some scans, photos, or original files.
+  If you decide to apply, you'll need to provide a range of evidence. We'll ask you to upload some scans, photos, or original files.
 </p>
 
-<%= govuk_inset_text(text: "You may want to spend some time gathering all the documents you need before you begin your application.") %>
+<%= govuk_inset_text do %>
+  <% if FeatureFlag.active?(:teacher_applications) && region && region.application_form_enabled %>
+    You may want to spend some time gathering all the documents you need before you begin your application. Once you start your application, we’ll sign you out if you’re inactive for 60 minutes.
+  <% else %>
+    You may want to spend some time gathering all the documents you need before you begin your application.
+  <% end %>
+<% end %>
 
 <% if region && !region.legacy %>
   <h2 class="govuk-heading-m">What we’ll ask for</h2>

--- a/app/views/shared/_help_us_to_improve_this_service.html.erb
+++ b/app/views/shared/_help_us_to_improve_this_service.html.erb
@@ -1,15 +1,15 @@
 <aside class="govuk-!-margin-top-6">
   <h2 class="govuk-heading-s">Help us to improve this service</h2>
 
-  <p class="govuk-body">We’re redesigning this service as part of the government’s plan to boost teacher recruitment from overseas, so we’d like to talk to people who want to come to England to teach.</p>
-
-  <p class="govuk-body">Throughout 2022 we’re inviting people to chat on video calls – it’ll take no more than 60 minutes.</p>
-
-  <p class="govuk-body">If you’d like to help, follow the link below. If you match our search criteria, we’ll be in touch.</p>
+  <p class="govuk-body">
+    We're always trying to improve this service and boost teacher recruitment from overseas. So we'd like to talk to people about their experience of using this service.
+  </p>
 
   <p class="govuk-body">
-    <%= govuk_link_to "https://docs.google.com/forms/d/e/1FAIpQLSfjsMHqaiNP2cUUpmbeOkHRM96afrsj1TmTIEs-k4yit0JqBA/viewform?usp=sharing" do %>
-      I’d like to take part in the user research
-    <% end %>
+    If you’d like to help, please <a class="govuk-link" href="https://docs.google.com/forms/d/e/1FAIpQLSdH_nfDnt9OUolI25fLs27uitWWn63KibNWsGFOYT-Os14PRg/viewform">complete this form</a>.
+  </p>
+
+  <p class="govuk-body">
+    If you match our search criteria, we'll invite you to take part in research.
   </p>
 </aside>


### PR DESCRIPTION
These changes should help to make the service clearer for users who have used the eligibility checker before, but not since the new application form was launched.

[Trello Card](https://trello.com/c/GdhB53f8/1167-content-changes-eligible-pages)

## Screenshots

<img width="673" alt="Screenshot 2022-11-22 at 14 27 09" src="https://user-images.githubusercontent.com/510498/203339385-72e9c8e5-aa62-42ad-b468-2e7af1cb18d4.png">

<img width="432" alt="Screenshot 2022-11-22 at 14 27 20" src="https://user-images.githubusercontent.com/510498/203339394-76676621-0745-4736-bfc8-21aefa2c0b8c.png">
