### PR TITLE
Order assessors by name in filter

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -21,7 +21,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
   end
 
   def assessor_filter_options
-    Staff.assessors
+    Staff.assessors.order(:name)
   end
 
   def country_filter_options

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -60,7 +60,12 @@ module SystemHelpers
 
   def when_i_am_authorized_as_an_assessor_user
     sign_in @assessor_user =
-              create(:staff, :with_award_decline_permission, :confirmed)
+              create(
+                :staff,
+                :with_award_decline_permission,
+                :confirmed,
+                name: "Authorized User",
+              )
   end
 
   def when_i_am_authorized_as_a_support_user

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -5,8 +5,6 @@ require "rails_helper"
 RSpec.describe "Assessor filtering application forms", type: :system do
   it "applies the filters" do
     given_the_service_is_open
-    when_i_am_authorized_as_an_assessor_user
-
     given_there_are_application_forms
 
     when_i_am_authorized_as_an_assessor_user

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe "Assessor filtering application forms", type: :system do
   end
 
   def and_i_apply_the_assessor_filter
-    applications_page.assessor_filter.assessors.first.checkbox.click
+    expect(applications_page.assessor_filter.assessors.count).to eq(3)
+    applications_page.assessor_filter.assessors.second.checkbox.click
     applications_page.apply_filters.click
   end
 
@@ -127,6 +128,7 @@ RSpec.describe "Assessor filtering application forms", type: :system do
         region: create(:region, country: create(:country, code: "US")),
         given_names: "Cher",
         family_name: "Bert",
+        assessor: assessors.second,
         submitted_at: Date.new(2019, 12, 1),
         reference: "CHERBERT",
       ),
@@ -136,6 +138,7 @@ RSpec.describe "Assessor filtering application forms", type: :system do
         region: create(:region, country: create(:country, code: "FR")),
         given_names: "Emma",
         family_name: "Dubois",
+        assessor: assessors.second,
         submitted_at: Date.new(2019, 12, 1),
       ),
       create(
@@ -151,15 +154,16 @@ RSpec.describe "Assessor filtering application forms", type: :system do
         :awarded,
         given_names: "John",
         family_name: "Smith",
+        assessor: assessors.second,
         submitted_at: Date.new(2020, 1, 1),
       ),
     ]
   end
 
   def assessors
-    [
-      create(:staff, :with_award_decline_permission, name: "Wag Staff"),
+    @assessors ||= [
       create(:staff, :with_award_decline_permission, name: "Fal Staff"),
+      create(:staff, :with_award_decline_permission, name: "Wag Staff"),
     ]
   end
 end


### PR DESCRIPTION
This means the assessors won't jump around in the list, but also helps to fix a flaky test.