### PR TITLE
Hide online checker if there's no registration number

### DIFF
--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -54,7 +54,8 @@ module AssessorInterface
     end
 
     def show_online_checker?
-      online_checker_url.present?
+      assessment_section.key == "professional_standing" &&
+        show_registration_number_summary && online_checker_url.present?
     end
 
     def online_checker_url

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -169,8 +169,39 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
 
     it { is_expected.to be false }
 
+    context "with a professional standing spoke" do
+      before do
+        params[:key] = "professional_standing"
+        assessment_section.update!(key: "professional_standing")
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "with a registration number" do
+      before { application_form.update!(registration_number: "abcdef") }
+
+      it { is_expected.to be false }
+    end
+
     context "with a checker URL" do
       before do
+        region.country.update!(
+          teaching_authority_online_checker_url:
+            "https://www.example.com/checks",
+        )
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "with a professional standing spoke and a registration number and a checker URL" do
+      before do
+        params[:key] = "professional_standing"
+        assessment_section.update!(key: "professional_standing")
+
+        application_form.update!(registration_number: "abcdef")
+
         region.country.update!(
           teaching_authority_online_checker_url:
             "https://www.example.com/checks",


### PR DESCRIPTION
We only want to show it to show in the relevant section, professional standing, and only if there's a registration number.