### PR TITLE
[1183] Further information request reminder emails

### DIFF
--- a/app/jobs/send_further_information_request_reminder_job.rb
+++ b/app/jobs/send_further_information_request_reminder_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SendFurtherInformationRequestReminderJob < ApplicationJob
+  def perform(further_information_request:)
+    FurtherInformationRequestReminder.call(further_information_request:)
+  end
+end

--- a/app/jobs/send_further_information_request_reminders_job.rb
+++ b/app/jobs/send_further_information_request_reminders_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class SendFurtherInformationRequestRemindersJob < ApplicationJob
+  def perform
+    FurtherInformationRequest
+      .requested
+      .find_each do |further_information_request|
+      SendFurtherInformationRequestReminderJob.perform_later(
+        further_information_request:,
+      )
+    end
+  end
+end

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -6,8 +6,10 @@ class TeacherMailer < ApplicationMailer
                   application_declined
                   application_received
                   further_information_received
+                  further_information_reminder
                 ]
   before_action :set_further_information_requested, only: :application_declined
+  before_action :set_due_date, only: :further_information_reminder
   after_action :store_observer_metadata
 
   GOVUK_NOTIFY_TEMPLATE_ID =
@@ -56,6 +58,14 @@ class TeacherMailer < ApplicationMailer
     )
   end
 
+  def further_information_reminder
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: params[:teacher].email,
+      subject: I18n.t("mailer.teacher.further_information_reminder.subject"),
+    )
+  end
+
   private
 
   def set_name
@@ -64,6 +74,10 @@ class TeacherMailer < ApplicationMailer
 
   def set_reference
     @reference = params[:teacher].application_form.reference
+  end
+
+  def set_due_date
+    @due_date = params[:due_date]
   end
 
   def set_further_information_requested

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -23,6 +23,8 @@ class FurtherInformationRequest < ApplicationRecord
            inverse_of: :further_information_request,
            dependent: :destroy
 
+  has_many :reminder_emails
+
   enum :state,
        { requested: "requested", received: "received", expired: "expired" },
        default: :requested

--- a/app/models/reminder_email.rb
+++ b/app/models/reminder_email.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reminder_emails
+#
+#  id                             :bigint           not null, primary key
+#  created_at                     :datetime         not null
+#  updated_at                     :datetime         not null
+#  further_information_request_id :bigint           not null
+#
+# Indexes
+#
+#  index_reminder_emails_on_further_information_request_id  (further_information_request_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (further_information_request_id => further_information_requests.id)
+#
+class ReminderEmail < ApplicationRecord
+  belongs_to :further_information_request, inverse_of: :reminder_emails
+end

--- a/app/services/concerns/further_information_request_expirable.rb
+++ b/app/services/concerns/further_information_request_expirable.rb
@@ -1,0 +1,21 @@
+module FurtherInformationRequestExpirable
+  FOUR_WEEK_COUNTRY_CODES = %w[AU CA GI NZ US].freeze
+
+  delegate :assessment, to: :further_information_request
+  delegate :application_form, to: :assessment
+  delegate :region, to: :application_form
+  delegate :country, to: :region
+
+  def days_until_expiry
+    today = Time.zone.now.to_date
+    date_due = (further_information_request.created_at + time_allowed).to_date
+
+    (date_due - today).to_i
+  end
+
+  def time_allowed
+    return 4.weeks if FOUR_WEEK_COUNTRY_CODES.include?(country.code)
+
+    6.weeks
+  end
+end

--- a/app/services/concerns/further_information_request_expirable.rb
+++ b/app/services/concerns/further_information_request_expirable.rb
@@ -5,17 +5,21 @@ module FurtherInformationRequestExpirable
   delegate :application_form, to: :assessment
   delegate :region, to: :application_form
   delegate :country, to: :region
+  delegate :teacher, to: :application_form
 
   def days_until_expiry
     today = Time.zone.now.to_date
-    date_due = (further_information_request.created_at + time_allowed).to_date
 
-    (date_due - today).to_i
+    (due_date - today).to_i
   end
 
   def time_allowed
     return 4.weeks if FOUR_WEEK_COUNTRY_CODES.include?(country.code)
 
     6.weeks
+  end
+
+  def due_date
+    (further_information_request.created_at + time_allowed).to_date
   end
 end

--- a/app/services/further_information_request_expirer.rb
+++ b/app/services/further_information_request_expirer.rb
@@ -2,7 +2,7 @@
 
 class FurtherInformationRequestExpirer
   include ServicePattern
-  FOUR_WEEK_COUNTRY_CODES = %w[AU CA GI NZ US].freeze
+  include FurtherInformationRequestExpirable
 
   def initialize(further_information_request:)
     @further_information_request = further_information_request
@@ -26,10 +26,6 @@ class FurtherInformationRequestExpirer
   private
 
   attr_reader :further_information_request
-  delegate :assessment, to: :further_information_request
-  delegate :application_form, to: :assessment
-  delegate :region, to: :application_form
-  delegate :country, to: :region
 
   def expire_request?
     further_information_request.requested? &&
@@ -37,9 +33,7 @@ class FurtherInformationRequestExpirer
   end
 
   def expire_if_older_than
-    return 4.weeks.ago if FOUR_WEEK_COUNTRY_CODES.include?(country.code)
-
-    6.weeks.ago
+    time_allowed.ago
   end
 
   def decline_application

--- a/app/services/further_information_request_reminder.rb
+++ b/app/services/further_information_request_reminder.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+#
+class FurtherInformationRequestReminder
+  include ServicePattern
+  include FurtherInformationRequestExpirable
+
+  def initialize(further_information_request:)
+    @further_information_request = further_information_request
+  end
+
+  def call
+    further_information_request.reminder_emails.create! if send_reminder?
+  end
+
+  private
+
+  attr_reader :further_information_request
+
+  def send_reminder?
+    two_weeks? || one_week? || two_days?
+  end
+
+  def number_of_reminders_sent
+    further_information_request.reminder_emails.count
+  end
+
+  def two_weeks?
+    days_until_expiry <= 14 && number_of_reminders_sent.zero?
+  end
+
+  def one_week?
+    days_until_expiry <= 7 && number_of_reminders_sent == 1
+  end
+
+  def two_days?
+    days_until_expiry <= 2 && number_of_reminders_sent == 2
+  end
+end

--- a/app/services/further_information_request_reminder.rb
+++ b/app/services/further_information_request_reminder.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-#
+
 class FurtherInformationRequestReminder
   include ServicePattern
   include FurtherInformationRequestExpirable
@@ -9,7 +9,10 @@ class FurtherInformationRequestReminder
   end
 
   def call
-    further_information_request.reminder_emails.create! if send_reminder?
+    if send_reminder?
+      send_email
+      record_reminder
+    end
   end
 
   private
@@ -34,5 +37,16 @@ class FurtherInformationRequestReminder
 
   def two_days?
     days_until_expiry <= 2 && number_of_reminders_sent == 2
+  end
+
+  def send_email
+    TeacherMailer
+      .with(teacher:, further_information_request:, due_date:)
+      .further_information_reminder
+      .deliver_later
+  end
+
+  def record_reminder
+    further_information_request.reminder_emails.create!
   end
 end

--- a/app/views/teacher_mailer/further_information_reminder.text.erb
+++ b/app/views/teacher_mailer/further_information_reminder.text.erb
@@ -1,0 +1,23 @@
+Dear <%= @name %>
+
+# The assessor reviewing your QTS application needs more information
+
+Your reference number is:
+
+<%= @reference %>
+
+# What happens next
+
+You must respond to this request by <%= @due_date.strftime("%e %B %Y") %> otherwise your QTS application will be declined..
+
+Once you respond with all of the information we’ve requested, the assessor will be able to continue reviewing your application.
+
+You can sign in to add the requested information to your application at:
+
+<%= new_teacher_session_url %>
+
+If you have any questions, contact:
+qts.enquiries@education.gov.uk
+
+Kind regards,
+The Teacher Qualifications Team

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -189,6 +189,11 @@
     - teaching_authority_certificate
     - teaching_authority_online_checker_url
     - application_form_enabled
+  :reminder_emails:
+    - id
+    - created_at
+    - updated_at
+    - further_information_request_id
   :staff:
     - id
     - email

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -11,3 +11,5 @@ en:
         subject: We’ve received the additional information you sent us
       further_information_requested:
         subject: We need some more information to progress your QTS application
+      further_information_reminder:
+        subject: We still need some more information to progress your QTS application

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,11 +1,12 @@
 trim_sessions_job:
-  cron: "0 2 * * *"
+  cron: "0 1 * * *"
   class: TrimSessionsJob
-
-update_working_days_since_submission:
-  cron: "0 3 * * *"
-  class: UpdateWorkingDaysJob
-
 expire_further_information_requests:
   cron: "0 2 * * *"
   class: ExpireFurtherInformationRequestsJob
+update_working_days_since_submission:
+  cron: "0 3 * * *"
+  class: UpdateWorkingDaysJob
+send_further_information_request_reminders:
+  cron: "0 4 * * *"
+  class: SendFurtherInformationRequestRemindersJob

--- a/db/migrate/20221122162438_create_reminder_emails.rb
+++ b/db/migrate/20221122162438_create_reminder_emails.rb
@@ -1,0 +1,8 @@
+class CreateReminderEmails < ActiveRecord::Migration[7.0]
+  def change
+    create_table :reminder_emails do |t|
+      t.references :further_information_request, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -248,6 +248,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_02_110957) do
     t.index ["country_id"], name: "index_regions_on_country_id"
   end
 
+  create_table "reminder_emails", force: :cascade do |t|
+    t.bigint "further_information_request_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["further_information_request_id"], name: "index_reminder_emails_on_further_information_request_id"
+  end
+
   create_table "sessions", force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data"
@@ -378,6 +385,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_02_110957) do
   add_foreign_key "notes", "staff", column: "author_id"
   add_foreign_key "qualifications", "application_forms"
   add_foreign_key "regions", "countries"
+  add_foreign_key "reminder_emails", "further_information_requests"
   add_foreign_key "timeline_events", "application_forms"
   add_foreign_key "timeline_events", "assessment_sections"
   add_foreign_key "timeline_events", "assessments"

--- a/spec/jobs/send_further_information_request_reminder_job_spec.rb
+++ b/spec/jobs/send_further_information_request_reminder_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SendFurtherInformationRequestReminderJob do
+  describe "#perform" do
+    subject { described_class.new.perform(further_information_request:) }
+
+    let(:further_information_request) { build(:further_information_request) }
+
+    it "calls the FurtherInformationRequestReminder" do
+      expect(FurtherInformationRequestReminder).to receive(:call).with(
+        further_information_request:,
+      )
+      subject
+    end
+  end
+end

--- a/spec/jobs/send_further_information_request_reminders_job_spec.rb
+++ b/spec/jobs/send_further_information_request_reminders_job_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SendFurtherInformationRequestRemindersJob do
+  describe "#perform" do
+    subject { described_class.new.perform }
+
+    let!(:received_fi_request) do
+      create(:further_information_request, :received)
+    end
+    let!(:requested_fi_request) do
+      create(:further_information_request, :requested)
+    end
+    let!(:expired_fi_request) { create(:further_information_request, :expired) }
+
+    it "enqueues a job for each 'requested' FI request" do
+      expect(SendFurtherInformationRequestReminderJob).to receive(
+        :perform_later,
+      ).with(further_information_request: requested_fi_request)
+      subject
+    end
+
+    it "doesn't enqueue a job for 'received' FI requests" do
+      expect(SendFurtherInformationRequestReminderJob).not_to receive(
+        :perform_later,
+      ).with(further_information_request: received_fi_request)
+      subject
+    end
+
+    it "doesn't enqueue a job for 'expired' FI requests" do
+      expect(SendFurtherInformationRequestReminderJob).not_to receive(
+        :perform_later,
+      ).with(further_information_request: received_fi_request)
+      subject
+    end
+  end
+end

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -200,4 +200,49 @@ RSpec.describe TeacherMailer, type: :mailer do
 
     include_examples "observer metadata", "further_information_requested"
   end
+
+  describe "#further_information_reminder" do
+    subject(:mail) do
+      described_class.with(
+        teacher:,
+        further_information_request:,
+        due_date:,
+      ).further_information_reminder
+    end
+
+    let(:further_information_request) { create(:further_information_request) }
+    let(:due_date) { 10.days.from_now }
+
+    describe "#subject" do
+      subject(:subject) { mail.subject }
+
+      it do
+        is_expected.to eq(
+          "We still need some more information to progress your QTS application",
+        )
+      end
+    end
+
+    describe "#to" do
+      subject(:to) { mail.to }
+
+      it { is_expected.to eq(["teacher@example.com"]) }
+    end
+
+    describe "#body" do
+      subject(:body) { mail.body.encoded }
+
+      it { is_expected.to include("Dear First Last") }
+      it do
+        is_expected.to include(
+          "You must respond to this request by #{due_date.strftime("%e %B %Y")} " \
+            "otherwise your QTS application will be declined.",
+        )
+      end
+      it { is_expected.to include("abc") }
+      it { is_expected.to include("http://localhost:3000/teacher/sign_in") }
+    end
+
+    include_examples "observer metadata", "further_information_reminder"
+  end
 end

--- a/spec/services/further_information_request_reminder_spec.rb
+++ b/spec/services/further_information_request_reminder_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FurtherInformationRequestReminder do
+  describe ".call" do
+    subject { described_class.call(further_information_request:) }
+
+    shared_examples_for "an ignored FI request" do
+      it "doesn't log any email" do
+        expect { subject }.not_to(change { ReminderEmail.count })
+      end
+
+      it "doesn't send any email" do
+        expect { subject }.to_not have_enqueued_mail(
+          TeacherMailer,
+          :further_information_request_reminder,
+        )
+      end
+    end
+
+    shared_examples_for "an FI request that triggers a reminder" do
+      it "logs an email" do
+        expect { subject }.to change {
+          ReminderEmail.where(further_information_request:).count
+        }.by(1)
+      end
+    end
+
+    shared_examples_for "an FI request with less than two weeks remaining" do
+      context "when no previous reminder has been sent" do
+        it_behaves_like "an FI request that triggers a reminder"
+      end
+
+      context "when a previous reminder has been sent" do
+        before { further_information_request.reminder_emails.create }
+
+        it_behaves_like "an ignored FI request"
+      end
+    end
+
+    shared_examples_for "an FI request with less than one week remaining" do
+      context "when no previous reminder has been sent" do
+        it_behaves_like "an FI request that triggers a reminder"
+      end
+
+      context "when one previous reminder has been sent" do
+        before { further_information_request.reminder_emails.create }
+
+        it_behaves_like "an FI request that triggers a reminder"
+      end
+
+      context "when two previous reminders have been sent" do
+        before do
+          2.times { further_information_request.reminder_emails.create }
+        end
+
+        it_behaves_like "an ignored FI request"
+      end
+    end
+
+    shared_examples_for "an FI request with less than two days remaining" do
+      context "when no previous reminder has been sent" do
+        it_behaves_like "an FI request that triggers a reminder"
+      end
+
+      context "when one previous reminder has been sent" do
+        before { further_information_request.reminder_emails.create }
+
+        it_behaves_like "an FI request that triggers a reminder"
+      end
+
+      context "when two previous reminders have been sent" do
+        before do
+          2.times { further_information_request.reminder_emails.create }
+        end
+
+        it_behaves_like "an FI request that triggers a reminder"
+      end
+    end
+
+    shared_examples_for "a request that is allowed 4 weeks to complete" do
+      context "with less than two weeks remaining" do
+        let(:further_information_requested_at) { (4.weeks - 13.days).ago }
+
+        it_behaves_like "an FI request with less than two weeks remaining"
+      end
+
+      context "with less than one week remaining" do
+        let(:further_information_requested_at) { (4.weeks - 5.days).ago }
+
+        it_behaves_like "an FI request with less than one week remaining"
+      end
+
+      context "with one day remaining" do
+        let(:further_information_requested_at) { (4.weeks - 47.hours).ago }
+
+        it_behaves_like "an FI request with less than two days remaining"
+      end
+    end
+
+    context "with a requested FI request" do
+      let(:application_form) { create(:application_form, :submitted, region:) }
+      let(:assessment) { create(:assessment, application_form:) }
+      let(:region) { create(:region, :in_country, country_code: "FR") }
+
+      let(:further_information_request) do
+        create(
+          :further_information_request,
+          created_at: further_information_requested_at,
+          assessment:,
+        )
+      end
+
+      context "that allows 6 weeks to complete" do
+        context "with less than two weeks remaining" do
+          let(:further_information_requested_at) { (6.weeks - 13.days).ago }
+
+          it_behaves_like "an FI request with less than two weeks remaining"
+        end
+
+        context "with less than one week remaining" do
+          let(:further_information_requested_at) { (6.weeks - 5.days).ago }
+
+          it_behaves_like "an FI request with less than one week remaining"
+        end
+
+        context "with one day remaining" do
+          let(:further_information_requested_at) { (6.weeks - 47.hours).ago }
+
+          it_behaves_like "an FI request with less than two days remaining"
+        end
+      end
+
+      context "when the applicant is from a country with a 4 week expiry" do
+        # Australia, Canada, Gibraltar, New Zealand, US
+        %w[AU CA GI NZ US].each do |country_code|
+          context "from country_code #{country_code}" do
+            let(:region) { create(:region, :in_country, country_code:) }
+
+            it_behaves_like "a request that is allowed 4 weeks to complete"
+          end
+        end
+      end
+    end
+
+    context "with a received FI request" do
+      let(:further_information_request) do
+        create(:further_information_request, :received)
+      end
+
+      it_behaves_like "an ignored FI request"
+    end
+
+    context "with an expired FI request" do
+      let(:further_information_request) do
+        create(:further_information_request, :expired)
+      end
+
+      it_behaves_like "an ignored FI request"
+    end
+  end
+end


### PR DESCRIPTION
Send a reminder email at 2 weeks, 1 week and 2 days before the expiry date. Expiry can be 6 weeks from request or 4 weeks for `FOUR_WEEK_COUNTRY_CODES` countries.

NB: this is currently on top of the expiry PR. I'll sort that out when I merge the other one.

* Add the `SendFurtherInformationRequestReminder` service
* Add `ReminderEmail` to allow us to check what emails have already been sent
* Add timeline support
* Job to call that ^ and job to queue up those <
* Refactor the expired service as it also needs the FI expiry logic so I've extracted it into a concern