### PR TITLE
Show other information on registration number

### DIFF
--- a/app/controllers/teacher_interface/registration_number_controller.rb
+++ b/app/controllers/teacher_interface/registration_number_controller.rb
@@ -4,6 +4,7 @@ module TeacherInterface
 
     before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
+    before_action :load_teaching_authority_other
 
     def edit
       @registration_number_form =
@@ -36,6 +37,11 @@ module TeacherInterface
 
     def if_success_then_redirect
       params[:next].presence || %i[teacher_interface application_form]
+    end
+
+    def load_teaching_authority_other
+      @teaching_authority_other =
+        application_form.region.teaching_authority_other
     end
   end
 end

--- a/app/views/teacher_interface/registration_number/edit.html.erb
+++ b/app/views/teacher_interface/registration_number/edit.html.erb
@@ -13,6 +13,10 @@
       If we’re unable to find you using your registration number, we may need to
       contact you for more information as part of your application.
     </p>
+
+    <% if @teaching_authority_other.present? %>
+      <%= raw GovukMarkdown.render(@teaching_authority_other) %>
+    <% end %>
   <% end %>
 
   <%= render "shared/save_submit_buttons", f: %>

--- a/spec/support/autoload/page_objects/teacher_interface/registration_number_form.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/registration_number_form.rb
@@ -3,6 +3,11 @@ module PageObjects
     class RegistrationNumberForm < SitePrism::Page
       element :heading, "h1"
       element :input_number, ".govuk-input"
+
+      section :details, ".govuk-details" do
+        element :summary, ".govuk-details__summary"
+        element :text, ".govuk-details__text"
+      end
     end
   end
 end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -19,6 +19,7 @@ module SystemHelpers
       application_form_enabled: true,
       status_check: country_check,
       sanction_check: country_check,
+      teaching_authority_other: "Other teaching authority information.",
     )
 
     visit "/eligibility/start"

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -881,6 +881,11 @@ RSpec.describe "Teacher application", type: :system do
     expect(registration_number_form.heading.text).to eq(
       "What is your registration number?",
     )
+
+    registration_number_form.details.summary.click
+    expect(registration_number_form.details.text).to have_content(
+      "Other teaching authority information.",
+    )
   end
 
   def then_i_see_the_upload_written_statement_form


### PR DESCRIPTION
For online teaching authorities, we're currently using this field to store additional information about the online check, so we should show this to the user to reduce the number of declined applications.

## Screenshot

<img width="679" alt="Screenshot 2022-11-24 at 07 30 06" src="https://user-images.githubusercontent.com/510498/203723031-fee06410-ae42-4fd3-9284-e3bd680584e4.png">
