### PR TITLE
Fix flaky assessor filter test

### DIFF
--- a/spec/lib/filters/assessor_spec.rb
+++ b/spec/lib/filters/assessor_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Filters::Assessor do
     end
 
     it "returns a filtered scope" do
-      expect(subject).to eq(included)
+      expect(subject).to match_array(included)
     end
   end
 


### PR DESCRIPTION
This was checking the array matches exactly which isn't important as we only care that the contents are the same.