### PR TITLE
Store filter parameters in session

### DIFF
--- a/app/components/application_form_search_result/component.rb
+++ b/app/components/application_form_search_result/component.rb
@@ -1,9 +1,8 @@
 module ApplicationFormSearchResult
   class Component < ViewComponent::Base
-    def initialize(application_form:, search_params:)
+    def initialize(application_form:)
       super
       @application_form = application_form
-      @search_params = search_params
     end
 
     def full_name
@@ -11,10 +10,7 @@ module ApplicationFormSearchResult
     end
 
     def href
-      assessor_interface_application_form_path(
-        application_form,
-        search: search_params,
-      )
+      assessor_interface_application_form_path(application_form)
     end
 
     def summary_rows
@@ -28,7 +24,7 @@ module ApplicationFormSearchResult
 
     private
 
-    attr_reader :application_form, :search_params
+    attr_reader :application_form
 
     delegate :application_form_full_name, to: :helpers
     delegate :application_form_summary_rows, to: :helpers

--- a/app/controllers/assessor_interface/application_forms_controller.rb
+++ b/app/controllers/assessor_interface/application_forms_controller.rb
@@ -1,7 +1,7 @@
 module AssessorInterface
   class ApplicationFormsController < BaseController
     def index
-      @view_object = ApplicationFormsIndexViewObject.new(params:)
+      @view_object = ApplicationFormsIndexViewObject.new(params:, session:)
       render layout: "full_from_desktop"
     end
 

--- a/app/controllers/assessor_interface/application_forms_controller.rb
+++ b/app/controllers/assessor_interface/application_forms_controller.rb
@@ -5,12 +5,39 @@ module AssessorInterface
       render layout: "full_from_desktop"
     end
 
+    def apply_filters
+      session[:filter_params] = extract_filter_params(
+        remove_cleared_autocomplete_values(params),
+      )
+      redirect_to assessor_interface_application_forms_path(page: params[:page])
+    end
+
+    def clear_filters
+      session[:filter_params] = {}
+      redirect_to assessor_interface_application_forms_path(page: params[:page])
+    end
+
     def show
       @view_object = ApplicationFormsShowViewObject.new(params:)
     end
 
     def status
       @view_object = ApplicationFormsShowViewObject.new(params:)
+    end
+
+    private
+
+    def extract_filter_params(params)
+      params[:assessor_interface_filter_form].permit!
+    end
+
+    def remove_cleared_autocomplete_values(params)
+      if params.include?(:location_autocomplete) &&
+           params[:location_autocomplete].blank?
+        params[:assessor_interface_filter_form]&.delete(:location)
+      end
+
+      params
     end
   end
 end

--- a/app/forms/assessor_interface/filter_form.rb
+++ b/app/forms/assessor_interface/filter_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AssessorInterface::FilterForm
   include ActiveModel::Model
   include ActiveRecord::AttributeAssignment

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -4,8 +4,9 @@ class AssessorInterface::ApplicationFormsIndexViewObject
   include ActionView::Helpers::FormOptionsHelper
   include Pagy::Backend
 
-  def initialize(params:)
-    @params = remove_cleared_autocomplete_values(params)
+  def initialize(params:, session:)
+    @params = params
+    @session = session
   end
 
   def application_forms_pagy
@@ -51,25 +52,10 @@ class AssessorInterface::ApplicationFormsIndexViewObject
     end
   end
 
-  def permitted_params
-    params.permit(
-      :location_autocomplete,
-      :page,
-      assessor_interface_filter_form: [
-        :location,
-        :name,
-        :reference,
-        :submitted_at_before,
-        :submitted_at_after,
-        { assessor_ids: [], states: [] },
-      ],
-    )
-  end
-
   private
 
   def filter_params
-    permitted_params[:assessor_interface_filter_form] || {}
+    (session[:filter_params] || {}).with_indifferent_access
   end
 
   def application_forms_with_pagy
@@ -98,14 +84,5 @@ class AssessorInterface::ApplicationFormsIndexViewObject
       end
   end
 
-  def remove_cleared_autocomplete_values(params)
-    if params.include?(:location_autocomplete) &&
-         params[:location_autocomplete].blank?
-      params[:assessor_interface_filter_form]&.delete(:location)
-    end
-
-    params
-  end
-
-  attr_reader :params
+  attr_reader :params, :session
 end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -10,12 +10,6 @@ class AssessorInterface::ApplicationFormsShowViewObject
       ApplicationForm.includes(assessment: :sections).find(params[:id])
   end
 
-  def back_link_path
-    url_helpers.assessor_interface_application_forms_path(
-      params[:search]&.permit!,
-    )
-  end
-
   def assessment_tasks
     assessment_section_keys = assessment.sections.map(&:key).map(&:to_sym)
 

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -52,7 +52,7 @@
   <% if @view_object.application_forms_records.any? %>
     <ul class="app-search-results">
       <%- @view_object.application_forms_records.each do |application_form| -%>
-        <%= render(ApplicationFormSearchResult::Component.new(application_form:, search_params: @view_object.permitted_params)) %>
+        <%= render(ApplicationFormSearchResult::Component.new(application_form:)) %>
       <%- end -%>
     </ul>
 

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -5,9 +5,11 @@
 <div class="govuk-grid-column-one-third app-application-forms__filters">
   <h2 class="govuk-heading-m"><%= t(".filters.title") %></h2>
 
-  <%= form_with model: @view_object.filter_form, method: :get, url: assessor_interface_application_forms_path, class: "app-application-forms__filter-form" do |f| %>
+  <%= form_with model: @view_object.filter_form, url: filters_apply_assessor_interface_application_forms_path, method: :post, class: "app-application-forms__filter-form" do |f| %>
+    <%= hidden_field_tag :page, params[:page] %>
+
     <%= f.govuk_submit t(".filters.apply") do %>
-      <%= govuk_link_to t(".filters.clear") %>
+      <%= govuk_link_to t(".filters.clear"), filters_clear_assessor_interface_application_forms_path(page: params[:page]) %>
     <%- end -%>
 
     <section id="app-applications-filters-assessor">

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Application" %>
-<% content_for :back_link_url, @view_object.back_link_path %>
+<% content_for :back_link_url, assessor_interface_application_forms_path %>
 
 <%= render "shared/assessor_header", title: "Application", application_form: @view_object.application_form %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,11 @@ Rails.application.routes.draw do
     root to: redirect("/assessor/applications")
 
     resources :application_forms, path: "/applications", only: %i[index show] do
+      collection do
+        post "filters/apply", to: "application_forms#apply_filters"
+        get "filters/clear", to: "application_forms#clear_filters"
+      end
+
       get "status", to: "application_forms#status", on: :member
 
       get "assign-assessor", to: "assessor_assignments#new"

--- a/spec/components/application_form_search_result_component_spec.rb
+++ b/spec/components/application_form_search_result_component_spec.rb
@@ -3,9 +3,7 @@
 require "rails_helper"
 
 RSpec.describe ApplicationFormSearchResult::Component, type: :component do
-  subject(:component) do
-    render_inline(described_class.new(application_form:, search_params:))
-  end
+  subject(:component) { render_inline(described_class.new(application_form:)) }
 
   let(:application_form) do
     create(
@@ -17,8 +15,6 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
     )
   end
 
-  let(:search_params) { {} }
-
   describe "heading text" do
     subject(:text) { component.at_css("h2").text.strip }
 
@@ -29,16 +25,6 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
     subject(:href) { component.at_css("h2 > a")["href"] }
 
     it { is_expected.to eq("/assessor/applications/#{application_form.id}") }
-
-    context "with search params" do
-      let(:search_params) { { states: %w[awarded] } }
-
-      it do
-        is_expected.to eq(
-          "/assessor/applications/#{application_form.id}?search%5Bstates%5D%5B%5D=awarded",
-        )
-      end
-    end
   end
 
   describe "description list" do

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -3,11 +3,10 @@
 require "rails_helper"
 
 RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
-  subject(:view_object) do
-    described_class.new(params: ActionController::Parameters.new(params))
-  end
+  subject(:view_object) { described_class.new(params:, session:) }
 
   let(:params) { {} }
+  let(:session) { {} }
 
   describe "#application_forms_pagy" do
     subject(:application_forms_pagy) { view_object.application_forms_pagy }
@@ -139,43 +138,7 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
     end
 
     context "when the filter is set" do
-      let(:params) do
-        {
-          assessor_interface_filter_form: {
-            location: "country:US",
-          },
-          location_autocomplete: "United States",
-        }
-      end
-
-      it do
-        is_expected.to include(
-          '<option selected="selected" value="country:US">United States</option>',
-        )
-      end
-    end
-
-    context "when the autocomplete input is cleared" do
-      let(:params) do
-        {
-          assessor_interface_filter_form: {
-            location: "country:US",
-          },
-          location_autocomplete: "",
-        }
-      end
-
-      it do
-        is_expected.to include(
-          '<option value="country:US">United States</option>',
-        )
-      end
-    end
-
-    context "when the autocomplete input isn't being used" do
-      let(:params) do
-        { assessor_interface_filter_form: { location: "country:US" } }
-      end
+      let(:session) { { filter_params: { location: "country:US" } } }
 
       it do
         is_expected.to include(
@@ -250,50 +213,6 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
           ],
         )
       end
-    end
-  end
-
-  describe "#permitted_params" do
-    subject(:permitted_params) { view_object.permitted_params }
-
-    it { is_expected.to be_empty }
-
-    context "with permitted params" do
-      let(:params) do
-        {
-          assessor_interface_filter_form: {
-            assessor_ids: ["assessor_id"],
-            location: "location",
-            name: "name",
-            reference: "reference",
-            states: ["state"],
-          },
-          location_autocomplete: "location_autocomplete",
-          page: "page",
-        }
-      end
-
-      it do
-        is_expected.to eq(
-          {
-            "assessor_interface_filter_form" => {
-              "assessor_ids" => ["assessor_id"],
-              "location" => "location",
-              "name" => "name",
-              "reference" => "reference",
-              "states" => ["state"],
-            },
-            "location_autocomplete" => "location_autocomplete",
-            "page" => "page",
-          },
-        )
-      end
-    end
-
-    context "with unpermitted params" do
-      let(:params) { { unpermitted: "unpermitted" } }
-
-      it { is_expected.to be_empty }
     end
   end
 end

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -23,18 +23,6 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
     end
   end
 
-  describe "#back_link_path" do
-    subject(:back_link_path) { view_object.back_link_path }
-
-    it { is_expected.to eq("/assessor/applications") }
-
-    context "with form params" do
-      let(:params) { { search: { states: %w[awarded] } } }
-
-      it { is_expected.to eq("/assessor/applications?states%5B%5D=awarded") }
-    end
-  end
-
   describe "#assessment_tasks" do
     subject(:assessment_tasks) { view_object.assessment_tasks }
 


### PR DESCRIPTION
Rather than in query parameters and needing to remember to pass them around, we can store these in the session which means the filters a user has selected will always remain the same regardless of how they navigate around the site.

[Trello Card](https://trello.com/c/rOuiwQaH/1199-stickier-filters-in-case-management)