### PR TITLE
Add applicant already in DQT check and failure reason

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -34,6 +34,7 @@ class AssessmentFactory
       (:name_change_document_present if application_form.has_alternative_name),
       :duplicate_application,
       :applicant_already_qts,
+      :applicant_already_dqt,
     ].compact
 
     failure_reasons = [
@@ -45,6 +46,7 @@ class AssessmentFactory
       ),
       :duplicate_application,
       :applicant_already_qts,
+      :applicant_already_dqt,
     ].compact
 
     AssessmentSection.new(

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -77,6 +77,7 @@ en:
           name_change_document_present: evidence of name change is present (if the name entered on the form is different to the name on their ID)
           duplicate_application: up-front duplication check shows the applicant does not have another in-flight application
           applicant_already_qts: applicant does not already hold QTS and induction exemption
+          applicant_already_dqt: applicant does not already appear in DQT
           qualifications_meet_level_6_or_equivalent: applicant holds qualifications that meet the required academic level (level 6 academic qualification or equivalent)
           teaching_qualifications_completed_in_eligible_country: teaching qualifications were completed in an eligible country (for example, we cannot award QTS where they applied through Spain, but their teaching was completed in South Africa)
           qualified_in_mainstream_education: they’re qualified to teach in mainstream education (not vocationally only/SEN only/early years/pre-school only)
@@ -104,6 +105,7 @@ en:
           name_change_document_illegible: The evidence of change of name is illegible or in a format that we cannot accept.
           duplicate_application: There’s already another in-flight application for this applicant.
           applicant_already_qts: The applicant already holds QTS and induction exemption.
+          applicant_already_dqt: There’s a potential existing match for this applicant. We need to ask for an additional identifier.
           teaching_qualifications_from_ineligible_country: Teaching qualifications were completed in an ineligible country.
           teaching_qualifications_not_at_required_level: Teaching qualifications do not meet the required academic level.
           not_qualified_to_teach_mainstream: Applicant is not qualified to teach in mainstream education.
@@ -168,6 +170,8 @@ en:
             duplicate_application_notes:
               blank: Enter a note to the applicant
             applicant_already_qts_notes:
+              blank: Enter a note to the applicant
+            applicant_already_dqt_notes:
               blank: Enter a note to the applicant
             teaching_qualifications_from_ineligible_country_notes:
               blank: Enter a note to the applicant

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -3,6 +3,7 @@ en:
     further_information_request:
       show:
         failure_reason:
+          applicant_already_dqt: Additional personal information
           qualifications_dont_match_subjects: Tell us more about the subjects you can teach
           qualifications_dont_match_other_details: Tell us more about your qualifications
           age_range: Tell us more about the age range you can teach

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe AssessmentFactory do
               identification_document_present
               duplicate_application
               applicant_already_qts
+              applicant_already_dqt
             ],
           )
           expect(section.failure_reasons).to eq(
@@ -57,6 +58,7 @@ RSpec.describe AssessmentFactory do
               identification_document_mismatch
               duplicate_application
               applicant_already_qts
+              applicant_already_dqt
             ],
           )
         end


### PR DESCRIPTION
This is a new check we want the assessors to do and comes with an associated failure reason.

[Trello Card](https://trello.com/c/20R2pmwl/1207-priority-new-fi-reason-potential-match-found-records-not-from-qts-but-other-ways)

## Screenshot

<img width="671" alt="Screenshot 2022-11-25 at 13 02 10" src="https://user-images.githubusercontent.com/510498/203992071-8cc0f3ff-b430-45a6-a0b7-a4ecb01c60a9.png">
