### PR TITLE
Add helpdesk persona

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -14,7 +14,7 @@ namespace :example_data do
     Faker::Config.locale = "en-GB"
     Faker::UniqueGenerator.clear
 
-    staff_members = admins + assessors
+    staff_members = admins + assessors + helpdesk_users
 
     staff_members.each do |staff|
       FactoryBot.create(:staff, :confirmed, **staff)
@@ -85,6 +85,17 @@ def admins
       name: "Sally Admin",
       email: "admin-sally@example.com",
       support_console_permission: true,
+      award_decline_permission: false,
+    },
+  ]
+end
+
+def helpdesk_users
+  [
+    {
+      name: "Antonio Helpdesk",
+      email: "helpdesk-antonio@example.com",
+      support_console_permission: false,
       award_decline_permission: false,
     },
   ]


### PR DESCRIPTION
Add a user without award/decline or support console permission. 

This user should currently be able to view applications but not edit and not be able to access the support console.