### PR TITLE
Switch to Active Record session store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "3.1.2"
 
 gem "rails", "~> 7.0.4"
 
+gem "activerecord-session_store"
 gem "azure-storage-blob"
 gem "bootsnap", require: false
 gem "business"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,12 @@ GEM
     activerecord (7.0.4)
       activemodel (= 7.0.4)
       activesupport (= 7.0.4)
+    activerecord-session_store (2.0.0)
+      actionpack (>= 5.2.4.1)
+      activerecord (>= 5.2.4.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 3)
+      railties (>= 5.2.4.1)
     activestorage (7.0.4)
       actionpack (= 7.0.4)
       activejob (= 7.0.4)
@@ -493,6 +499,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-session_store
   annotate
   azure-storage-blob
   bootsnap

--- a/app/components/flash_message/component.rb
+++ b/app/components/flash_message/component.rb
@@ -5,7 +5,7 @@ module FlashMessage
 
     def initialize(flash:)
       super
-      @flash = flash.to_hash.symbolize_keys!
+      @flash = flash.to_hash.symbolize_keys
     end
 
     def message_key

--- a/app/controllers/assessor_interface/application_forms_controller.rb
+++ b/app/controllers/assessor_interface/application_forms_controller.rb
@@ -36,7 +36,7 @@ module AssessorInterface
     private
 
     def extract_filter_params(params)
-      params[:assessor_interface_filter_form].permit!
+      params[:assessor_interface_filter_form].permit!.to_h
     end
 
     def remove_cleared_autocomplete_values(params)

--- a/app/jobs/trim_sessions_job.rb
+++ b/app/jobs/trim_sessions_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Based off https://github.com/rails/activerecord-session_store/blob/9198a952916df925f36ac2beab247296ee5c0341/lib/tasks/database.rake#L14-L20
+
+class TrimSessionsJob < ApplicationJob
+  def perform
+    ActiveRecord::SessionStore::Session.where(
+      "updated_at < ?",
+      30.days.ago,
+    ).delete_all
+  end
+end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -1,5 +1,11 @@
 ---
 :shared:
+  :sessions:
+    - id
+    - session_id
+    - data
+    - created_at
+    - updated_at
   :staff:
     - encrypted_password
     - reset_password_token

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
-Rails.application.config.session_store :cookie_store,
+Rails.application.config.session_store :active_record_store,
                                        key: "_session_id",
                                        secure: Rails.env.production?,
                                        expire_after: 20.hours

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,3 +1,7 @@
+trim_sessions_job:
+  cron: "0 2 * * *"
+  class: TrimSessionsJob
+
 update_working_days_since_submission:
   cron: "0 3 * * *"
   class: UpdateWorkingDaysSinceSubmissionJob

--- a/db/migrate/20221128122306_add_sessions_table.rb
+++ b/db/migrate/20221128122306_add_sessions_table.rb
@@ -1,0 +1,12 @@
+class AddSessionsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_22_093227) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_28_122306) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -232,6 +232,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_22_093227) do
     t.string "teaching_authority_online_checker_url", default: "", null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
     t.index ["country_id"], name: "index_regions_on_country_id"
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "staff", force: :cascade do |t|

--- a/spec/jobs/trim_sessions_job_spec.rb
+++ b/spec/jobs/trim_sessions_job_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TrimSessionsJob, type: :job do
+  describe "#perform" do
+    subject(:perform) { described_class.new.perform }
+
+    let!(:session1) do
+      ActiveRecord::SessionStore::Session.create!(session_id: "1", data: "abc")
+    end
+    let!(:session2) do
+      ActiveRecord::SessionStore::Session.create!(
+        session_id: "2",
+        data: "abc",
+        updated_at: 60.days.ago,
+      )
+    end
+
+    it "deletes old sessions" do
+      expect { perform }.to change(
+        ActiveRecord::SessionStore::Session,
+        :count,
+      ).from(2).to(1)
+      expect { session2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+end


### PR DESCRIPTION
This changes the session store to use an Active Record one, allowing us to store more data in the session than the cookie store allows us to.

Replaces #775.