### PR TITLE
Improve application form back links

### DIFF
--- a/app/controllers/concerns/history_trackable.rb
+++ b/app/controllers/concerns/history_trackable.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module HistoryTrackable
+  extend ActiveSupport::Concern
+
+  included { before_action :push_self, if: -> { request.get? } }
+
+  def push_self
+    history_stack.push_self(request, origin: false)
+  end
+
+  def push_self_as_origin
+    history_stack.push_self(request, origin: true)
+  end
+
+  def push_self_as_origin_and_reset
+    history_stack.push_self(request, origin: true, reset: true)
+  end
+
+  private
+
+  def history_stack
+    @history_stack ||= HistoryStack.new(session:)
+  end
+end

--- a/app/controllers/history_controller.rb
+++ b/app/controllers/history_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class HistoryController < ApplicationController
+  def back
+    to_origin = back_params[:origin] == "true"
+    method = to_origin ? :pop_to_origin : :pop_back
+
+    path = history_stack.send(method) || default_path
+    redirect_to path, status: :see_other
+  end
+
+  private
+
+  def default_path
+    URI.parse(back_params[:default] || "/teacher/application").path
+  end
+
+  def back_params
+    params.permit(:origin, :default)
+  end
+
+  def history_stack
+    @history_stack ||= HistoryStack.new(session:)
+  end
+end

--- a/app/controllers/teacher_interface/age_range_controller.rb
+++ b/app/controllers/teacher_interface/age_range_controller.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class AgeRangeController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form

--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -1,8 +1,15 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class ApplicationFormsController < BaseController
+    include HistoryTrackable
+
     before_action :redirect_unless_application_form_is_draft,
                   only: %i[edit update]
     before_action :load_application_form, except: %i[new create]
+
+    skip_before_action :push_self, only: :show
+    before_action :push_self_as_origin_and_reset, only: :show
 
     def new
       @country_region_form = CountryRegionForm.new

--- a/app/controllers/teacher_interface/base_controller.rb
+++ b/app/controllers/teacher_interface/base_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TeacherInterface::BaseController < ApplicationController
   include TeacherCurrentNamespace
 

--- a/app/controllers/teacher_interface/documents_controller.rb
+++ b/app/controllers/teacher_interface/documents_controller.rb
@@ -1,10 +1,15 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class DocumentsController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_draft_or_further_information
     before_action :load_application_form
     before_action :load_document
+
+    skip_before_action :push_self, only: :show
 
     def show
       if document.uploads.empty?

--- a/app/controllers/teacher_interface/documents_controller.rb
+++ b/app/controllers/teacher_interface/documents_controller.rb
@@ -6,14 +6,21 @@ module TeacherInterface
     before_action :load_application_form
     before_action :load_document
 
-    def edit
+    def show
       if document.uploads.empty?
         redirect_to new_teacher_interface_application_form_document_upload_path(
                       document,
                       next: params[:next],
                     )
+      else
+        redirect_to edit_teacher_interface_application_form_document_path(
+                      document,
+                      next: params[:next],
+                    )
       end
+    end
 
+    def edit
       @add_another_upload_form = AddAnotherUploadForm.new
     end
 

--- a/app/controllers/teacher_interface/further_information_request_items_controller.rb
+++ b/app/controllers/teacher_interface/further_information_request_items_controller.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class FurtherInformationRequestItemsController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :load_application_form,
                   :load_further_information_request_and_item

--- a/app/controllers/teacher_interface/further_information_request_items_controller.rb
+++ b/app/controllers/teacher_interface/further_information_request_items_controller.rb
@@ -85,7 +85,7 @@ module TeacherInterface
     end
 
     def document_path
-      edit_teacher_interface_application_form_document_path(
+      teacher_interface_application_form_document_path(
         further_information_request_item.document,
         next: params[:next],
       )

--- a/app/controllers/teacher_interface/further_information_requests_controller.rb
+++ b/app/controllers/teacher_interface/further_information_requests_controller.rb
@@ -1,6 +1,13 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class FurtherInformationRequestsController < BaseController
+    include HistoryTrackable
+
     before_action :load_view_object
+
+    skip_before_action :push_self, only: :show
+    before_action :push_self_as_origin, only: :show
 
     def show
     end

--- a/app/controllers/teacher_interface/personal_information_controller.rb
+++ b/app/controllers/teacher_interface/personal_information_controller.rb
@@ -1,9 +1,14 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class PersonalInformationController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
+
+    skip_before_action :push_self, only: :show
 
     def show
       if application_form.task_item_completed?(

--- a/app/controllers/teacher_interface/personal_information_controller.rb
+++ b/app/controllers/teacher_interface/personal_information_controller.rb
@@ -103,7 +103,7 @@ module TeacherInterface
 
     def alternative_name_success_path
       if @alternative_name_form.has_alternative_name
-        edit_teacher_interface_application_form_document_path(
+        teacher_interface_application_form_document_path(
           application_form.name_change_document,
           next: params[:next],
         )

--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -1,9 +1,14 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class QualificationsController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
+
+    skip_before_action :push_self, only: :index
 
     def index
       if application_form.task_item_completed?(:qualifications, :qualifications)
@@ -46,6 +51,13 @@ module TeacherInterface
       handle_application_form_section(
         form: @qualification_form,
         if_success_then_redirect: -> do
+          history_stack.replace_self(
+            path:
+              edit_teacher_interface_application_form_qualification_path(
+                qualification,
+              ),
+            origin: false,
+          )
           [
             :teacher_interface,
             :application_form,
@@ -63,6 +75,11 @@ module TeacherInterface
       if ActiveModel::Type::Boolean.new.cast(
            params.dig(:qualification, :add_another),
          )
+        history_stack.replace_self(
+          path: check_teacher_interface_application_form_qualifications_path,
+          origin: true,
+        )
+
         redirect_to %i[new teacher_interface application_form qualification]
       else
         redirect_to %i[teacher_interface application_form]

--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -47,7 +47,6 @@ module TeacherInterface
         form: @qualification_form,
         if_success_then_redirect: -> do
           [
-            :edit,
             :teacher_interface,
             :application_form,
             qualification.certificate_document,
@@ -169,7 +168,6 @@ module TeacherInterface
     def update_success_path
       params[:next].presence ||
         [
-          :edit,
           :teacher_interface,
           :application_form,
           qualification.certificate_document,

--- a/app/controllers/teacher_interface/registration_number_controller.rb
+++ b/app/controllers/teacher_interface/registration_number_controller.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class RegistrationNumberController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form

--- a/app/controllers/teacher_interface/subjects_controller.rb
+++ b/app/controllers/teacher_interface/subjects_controller.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class SubjectsController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class UploadsController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_draft_or_further_information
     before_action :load_application_form
@@ -16,7 +19,14 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @upload_form,
-        if_success_then_redirect: document_path,
+        if_success_then_redirect: -> do
+          history_stack.replace_self(
+            path:
+              edit_teacher_interface_application_form_document_path(document),
+            origin: false,
+          )
+          document_path
+        end,
         if_failure_then_render: :new,
       )
     end

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -58,7 +58,7 @@ module TeacherInterface
     end
 
     def document_path
-      edit_teacher_interface_application_form_document_path(
+      teacher_interface_application_form_document_path(
         @document,
         next: params[:next],
       )

--- a/app/lib/document_continue_redirection.rb
+++ b/app/lib/document_continue_redirection.rb
@@ -29,7 +29,6 @@ class DocumentContinueRedirection
 
   def qualification_certificate_url
     [
-      :edit,
       :teacher_interface,
       :application_form,
       document.documentable.transcript_document,

--- a/app/lib/history_stack.rb
+++ b/app/lib/history_stack.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class HistoryStack
+  def initialize(session:)
+    @session = session
+  end
+
+  def push_self(request, origin:, reset: false)
+    push(path: request.fullpath, origin:, reset:)
+  end
+
+  def replace_self(path:, origin:)
+    pop
+    push(path:, origin:, reset: false)
+  end
+
+  def pop_back
+    pop # self
+
+    entry = pop
+    entry[:path] if entry
+  end
+
+  def pop_to_origin
+    pop # self
+
+    loop do
+      entry = pop
+      return nil if entry.nil?
+      return entry[:path] if entry[:origin]
+    end
+  end
+
+  private
+
+  def push(path:, origin:, reset:)
+    update_stack do |stack|
+      stack.clear if reset
+      current_entry = stack.last
+      new_entry = { path:, origin: }
+      stack.push(new_entry) if current_entry != new_entry
+    end
+  end
+
+  def pop
+    update_stack(&:pop)
+  end
+
+  def update_stack
+    stack = session[:history_stack] || []
+    return_value = yield stack
+    session[:history_stack] = stack
+    return_value
+  end
+
+  attr_reader :session
+end

--- a/app/lib/history_stack.rb
+++ b/app/lib/history_stack.rb
@@ -6,7 +6,7 @@ class HistoryStack
   end
 
   def push_self(request, origin:, reset: false)
-    push(path: request.fullpath, origin:, reset:)
+    push(path: request.path, origin:, reset:)
   end
 
   def replace_self(path:, origin:)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -169,7 +169,7 @@ class ApplicationForm < ApplicationRecord
 
     if key == :identification_document
       return(
-        url_helpers.edit_teacher_interface_application_form_document_path(
+        url_helpers.teacher_interface_application_form_document_path(
           identification_document,
         )
       )
@@ -177,7 +177,7 @@ class ApplicationForm < ApplicationRecord
 
     if key == :written_statement
       return(
-        url_helpers.edit_teacher_interface_application_form_document_path(
+        url_helpers.teacher_interface_application_form_document_path(
           written_statement_document,
         )
       )

--- a/app/views/shared/application_form/_identification_document_summary.html.erb
+++ b/app/views/shared/application_form/_identification_document_summary.html.erb
@@ -5,7 +5,7 @@
   fields: {
     identification_document: {
       title: "Identity documents",
-      href: [:edit, :teacher_interface, :application_form, application_form.identification_document]
+      href: [:teacher_interface, :application_form, application_form.identification_document]
     },
   },
   changeable:

--- a/app/views/shared/application_form/_personal_information_summary.html.erb
+++ b/app/views/shared/application_form/_personal_information_summary.html.erb
@@ -23,7 +23,7 @@
       href: %i[alternative_name teacher_interface application_form personal_information]
     } : nil,
     name_change_document: application_form.has_alternative_name? ? {
-      href: [:edit, :teacher_interface, :application_form, application_form.name_change_document]
+      href: [:teacher_interface, :application_form, application_form.name_change_document]
     } : nil,
   },
   changeable:

--- a/app/views/shared/application_form/_qualifications_summary.html.erb
+++ b/app/views/shared/application_form/_qualifications_summary.html.erb
@@ -32,10 +32,10 @@
         href: [:edit, :teacher_interface, :application_form, qualification]
       },
       certificate_document: {
-        href: [:edit, :teacher_interface, :application_form, qualification.certificate_document],
+        href: [:teacher_interface, :application_form, qualification.certificate_document],
       },
       transcript_document: {
-        href: [:edit, :teacher_interface, :application_form, qualification.transcript_document],
+        href: [:teacher_interface, :application_form, qualification.transcript_document],
       },
       part_of_university_degree: qualification.is_teaching_qualification? ? {
         title: "Part of your university degree?",

--- a/app/views/shared/application_form/_written_statement_summary.html.erb
+++ b/app/views/shared/application_form/_written_statement_summary.html.erb
@@ -5,7 +5,7 @@
   fields: {
     written_statement_document: {
       title: "Written statement",
-      href: [:edit, :teacher_interface, :application_form, application_form.written_statement_document]
+      href: [:teacher_interface, :application_form, application_form.written_statement_document]
     },
   },
   changeable:

--- a/app/views/teacher_interface/age_range/edit.erb
+++ b/app/views/teacher_interface/age_range/edit.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @age_range_form.errors.any?}#{t("application_form.tasks.items.age_range")}" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 

--- a/app/views/teacher_interface/application_forms/edit.html.erb
+++ b/app/views/teacher_interface/application_forms/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Check your answers" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <h1 class="govuk-heading-xl">Check your answers before submitting your application</h1>
 

--- a/app/views/teacher_interface/documents/edit.html.erb
+++ b/app/views/teacher_interface/documents/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @add_another_upload_form.errors.any?}Check your uploaded files" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <h1 class="govuk-heading-l">Check your uploaded files – <%= I18n.t("document.document_type.#{@document.document_type}") %> document</h1>
 

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @further_information_request_item_text_form&.errors&.any?}Further information required" %>
-<% content_for :back_link_url, back_link_url(teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
 
 <h1 class="govuk-heading-l">Further information required</h1>
 <h3 class="govuk-heading-s">Notes from the assessor</h3>

--- a/app/views/teacher_interface/further_information_requests/edit.html.erb
+++ b/app/views/teacher_interface/further_information_requests/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Check your answers before submitting your application" %>
-<% content_for :back_link_url, teacher_interface_application_form_further_information_request_path(@view_object.further_information_request) %>
+<% content_for :back_link_url, back_history_path(origin: true, default: teacher_interface_application_form_further_information_request_path(@view_object.further_information_request)) %>
 
 <h1 class="govuk-heading-xl">
   Check your answers before submitting your application

--- a/app/views/teacher_interface/further_information_requests/show.html.erb
+++ b/app/views/teacher_interface/further_information_requests/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Apply for qualified teacher status (QTS)" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <h1 class="govuk-heading-l">Apply for qualified teacher status (QTS)</h1>
 

--- a/app/views/teacher_interface/personal_information/alternative_name.html.erb
+++ b/app/views/teacher_interface/personal_information/alternative_name.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @alternative_name_form.errors.any?}#{t("application_form.tasks.sections.about_you")}" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.about_you") %></span>
 

--- a/app/views/teacher_interface/personal_information/check.html.erb
+++ b/app/views/teacher_interface/personal_information/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Check your answers" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(origin: true, default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.about_you") %></span>
 <h1 class="govuk-heading-l">Check your answers</h1>

--- a/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
+++ b/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @name_and_date_of_birth_form.errors.any?}About you" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l">About you</span>
 <h1 class="govuk-heading-l">Personal information</h1>

--- a/app/views/teacher_interface/qualifications/add_another.html.erb
+++ b/app/views/teacher_interface/qualifications/add_another.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, I18n.t("application_form.tasks.sections.qualifications") %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 

--- a/app/views/teacher_interface/qualifications/check.html.erb
+++ b/app/views/teacher_interface/qualifications/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, I18n.t("application_form.tasks.sections.qualifications") %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(origin: true, default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 <h1 class="govuk-heading-l">Check your answers</h1>

--- a/app/views/teacher_interface/qualifications/delete.html.erb
+++ b/app/views/teacher_interface/qualifications/delete.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Delete qualification" %>
-<% content_for :back_link_url, teacher_interface_application_form_qualifications_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_qualifications_path) %>
 
 <%= form_with model: @delete_qualification_form, url: [:teacher_interface, :application_form, @qualification], method: :delete do |f| %>
   <%= hidden_field_tag :next, params[:next] %>

--- a/app/views/teacher_interface/qualifications/edit.html.erb
+++ b/app/views/teacher_interface/qualifications/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @qualification_form.errors.any?}#{t("application_form.tasks.sections.qualifications")}" %>
-<% content_for :back_link_url, back_link_url(teacher_interface_application_form_path) %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= render "heading", qualification: @qualification %>
 

--- a/app/views/teacher_interface/qualifications/edit_part_of_university_degree.html.erb
+++ b/app/views/teacher_interface/qualifications/edit_part_of_university_degree.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, I18n.t("application_form.tasks.sections.qualifications") %>
-<% content_for :back_link_url, teacher_interface_application_form_qualifications_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_qualifications_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 

--- a/app/views/teacher_interface/qualifications/new.html.erb
+++ b/app/views/teacher_interface/qualifications/new.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @qualification_form.errors.any?}#{t("application_form.tasks.sections.qualifications")}" %>
-<% content_for :back_link_url, @application_form.qualifications.empty? ?
-                                 teacher_interface_application_form_path :
-                                 teacher_interface_application_form_qualifications_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= render "heading", qualification: @qualification_form.qualification %>
 

--- a/app/views/teacher_interface/registration_number/edit.html.erb
+++ b/app/views/teacher_interface/registration_number/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @registration_number_form.errors.any?}#{t("application_form.tasks.items.registration_number")}" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= form_with model: @registration_number_form, url: %i[registration_number teacher_interface application_form] do |f| %>
   <%= hidden_field_tag :next, params[:next] %>

--- a/app/views/teacher_interface/subjects/edit.html.erb
+++ b/app/views/teacher_interface/subjects/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @subjects_form.errors.any?}#{t("application_form.tasks.items.subjects")}" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 <h1 class="govuk-heading-l"><%= I18n.t("application_form.subjects.heading") %></h1>

--- a/app/views/teacher_interface/uploads/delete.html.erb
+++ b/app/views/teacher_interface/uploads/delete.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @delete_upload_form.errors.any?}Delete #{@upload.attachment.filename}" %>
-<% content_for :back_link_url, edit_teacher_interface_application_form_document_path(@document) %>
+<% content_for :back_link_url, back_history_path(default: edit_teacher_interface_application_form_document_path(@document)) %>
 
 <%= form_with model: @delete_upload_form, url: [:teacher_interface, :application_form, @document, @upload], method: :delete do |f| %>
   <%= hidden_field_tag :next, params[:next] %>

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @upload_form.errors.any?}Upload a document" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <% if @document.uploads.empty? %>
   <% if @document.identification? %>

--- a/app/views/teacher_interface/work_histories/add_another.html.erb
+++ b/app/views/teacher_interface/work_histories/add_another.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, I18n.t("application_form.tasks.sections.work_history") %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.work_history") %></span>
 

--- a/app/views/teacher_interface/work_histories/check.html.erb
+++ b/app/views/teacher_interface/work_histories/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, I18n.t("application_form.tasks.sections.work_history") %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(origin: true, default: teacher_interface_application_form_path) %>
 
 <%= render "heading" %>
 

--- a/app/views/teacher_interface/work_histories/delete.html.erb
+++ b/app/views/teacher_interface/work_histories/delete.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Delete work history" %>
-<% content_for :back_link_url, teacher_interface_application_form_work_histories_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_work_histories_path) %>
 
 <%= form_with model: @delete_work_history_form, url: [:teacher_interface, :application_form, @work_history], method: :delete do |f| %>
   <%= hidden_field_tag :next, params[:next] %>

--- a/app/views/teacher_interface/work_histories/edit.html.erb
+++ b/app/views/teacher_interface/work_histories/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @work_history_form.errors.any?}#{t("application_form.tasks.sections.work_history")}" %>
-<% content_for :back_link_url, teacher_interface_application_form_work_histories_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_work_histories_path) %>
 
 <%= render "heading" %>
 

--- a/app/views/teacher_interface/work_histories/edit_has_work_history.html.erb
+++ b/app/views/teacher_interface/work_histories/edit_has_work_history.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @has_work_history_form.errors.any?}#{t("application_form.tasks.sections.work_history")}" %>
-<% content_for :back_link_url,  @application_form.work_histories.empty? ?
-                                 teacher_interface_application_form_path :
-                                 teacher_interface_application_form_work_histories_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= form_with model: @has_work_history_form, url: [:has_work_history, :teacher_interface, :application_form, :work_histories] do |f| %>
   <%= hidden_field_tag :next, params[:next] %>

--- a/app/views/teacher_interface/work_histories/new.html.erb
+++ b/app/views/teacher_interface/work_histories/new.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @work_history_form.errors.any?}#{t("application_form.tasks.sections.work_history")}" %>
-<% content_for :back_link_url, @application_form.work_histories.empty? ?
-                                 teacher_interface_application_form_path :
-                                 teacher_interface_application_form_work_histories_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= render "heading" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :documents, only: %i[edit update] do
+      resources :documents, only: %i[show edit update] do
         resources :uploads, only: %i[new create destroy] do
           get "delete", on: :member
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -215,6 +215,10 @@ Rails.application.routes.draw do
         as: "teacher_signed_out"
   end
 
+  resource :history, only: %i[] do
+    get "back", to: "history#back", on: :collection
+  end
+
   resources :personas, only: %i[index] do
     member do
       post "staff", to: "personas#staff_sign_in", as: "staff_sign_in"

--- a/spec/controllers/history_controller_spec.rb
+++ b/spec/controllers/history_controller_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HistoryController, type: :controller do
+  before { FeatureFlag.activate(:service_open) }
+
+  describe "GET back" do
+    let(:default) { "/fallback" }
+
+    subject(:perform) { get :back, params: { origin:, default: } }
+
+    context "with origin true" do
+      let(:origin) { "true" }
+
+      context "with a destination" do
+        before do
+          expect_any_instance_of(HistoryStack).to receive(
+            :pop_to_origin,
+          ).and_return("/origin")
+        end
+
+        it "redirects to the destination" do
+          perform
+          expect(response).to redirect_to("/origin")
+        end
+      end
+
+      context "without a destination" do
+        before do
+          expect_any_instance_of(HistoryStack).to receive(
+            :pop_to_origin,
+          ).and_return(nil)
+        end
+
+        it "redirects to the default" do
+          perform
+          expect(response).to redirect_to("/fallback")
+        end
+      end
+    end
+
+    context "with origin false" do
+      let(:origin) { "false" }
+
+      context "with a destination" do
+        before do
+          expect_any_instance_of(HistoryStack).to receive(:pop_back).and_return(
+            "/previous",
+          )
+        end
+
+        it "redirects to the destination" do
+          perform
+          expect(response).to redirect_to("/previous")
+        end
+      end
+
+      context "without a destination" do
+        before do
+          expect_any_instance_of(HistoryStack).to receive(:pop_back).and_return(
+            nil,
+          )
+        end
+
+        it "redirects to the default" do
+          perform
+          expect(response).to redirect_to("/fallback")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/document_continue_redirection_spec.rb
+++ b/spec/lib/document_continue_redirection_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe DocumentContinueRedirection do
         it do
           is_expected.to eq(
             [
-              :edit,
               :teacher_interface,
               :application_form,
               qualification.transcript_document,

--- a/spec/lib/history_stack_spec.rb
+++ b/spec/lib/history_stack_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HistoryStack do
+  subject(:history_stack) { described_class.new(session:) }
+
+  describe "#push_self" do
+    subject(:push_self) { history_stack.push_self(request, origin:, reset:) }
+
+    let(:request) { double(fullpath: "/path?page=1") }
+
+    context "with an empty session" do
+      let(:session) { {} }
+      let(:reset) { false }
+
+      context "when origin" do
+        let(:origin) { true }
+
+        it "stores the stack in the session" do
+          expect { push_self }.to change { session }.to(
+            { history_stack: [{ origin: true, path: "/path?page=1" }] },
+          )
+        end
+
+        it "doesn't store it twice" do
+          expect { 2.times { push_self } }.to change { session }.to(
+            { history_stack: [{ origin: true, path: "/path?page=1" }] },
+          )
+        end
+      end
+
+      context "when not origin" do
+        let(:origin) { false }
+
+        it "stores the stack in the session" do
+          expect { push_self }.to change { session }.to(
+            { history_stack: [{ origin: false, path: "/path?page=1" }] },
+          )
+        end
+      end
+    end
+
+    context "with an existing session" do
+      let(:session) { { history_stack: [{ path: "/origin", origin: true }] } }
+      let(:origin) { false }
+
+      context "when resetting" do
+        let(:reset) { true }
+
+        it "stores the stack in the session" do
+          expect { push_self }.to change { session }.to(
+            { history_stack: [{ origin: false, path: "/path?page=1" }] },
+          )
+        end
+      end
+
+      context "when not resetting" do
+        let(:reset) { false }
+
+        it "stores the stack in the session" do
+          expect { push_self }.to change { session }.to(
+            {
+              history_stack: [
+                { origin: true, path: "/origin" },
+                { origin: false, path: "/path?page=1" },
+              ],
+            },
+          )
+        end
+      end
+    end
+  end
+
+  describe "#replace_self" do
+    subject(:replace_self) { history_stack.replace_self(path:, origin:) }
+
+    let(:path) { "/path?page=1" }
+
+    context "with an empty session" do
+      let(:session) { {} }
+
+      context "when origin" do
+        let(:origin) { true }
+
+        it "stores the stack in the session" do
+          expect { replace_self }.to change { session }.to(
+            { history_stack: [{ origin: true, path: "/path?page=1" }] },
+          )
+        end
+
+        it "doesn't store it twice" do
+          expect { 2.times { replace_self } }.to change { session }.to(
+            { history_stack: [{ origin: true, path: "/path?page=1" }] },
+          )
+        end
+      end
+
+      context "when not origin" do
+        let(:origin) { false }
+
+        it "stores the stack in the session" do
+          expect { replace_self }.to change { session }.to(
+            { history_stack: [{ origin: false, path: "/path?page=1" }] },
+          )
+        end
+      end
+    end
+
+    context "with an existing session" do
+      let(:session) { { history_stack: [{ path: "/origin", origin: true }] } }
+      let(:origin) { false }
+
+      it "stores the stack in the session" do
+        expect { replace_self }.to change { session }.to(
+          { history_stack: [{ origin: false, path: "/path?page=1" }] },
+        )
+      end
+    end
+  end
+
+  describe "#pop_back" do
+    subject(:pop_back) { history_stack.pop_back }
+
+    context "with an empty session" do
+      let(:session) { {} }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "with an existing session" do
+      let(:session) do
+        {
+          history_stack: [
+            { path: "/origin", origin: true },
+            { path: "/page", origin: false },
+          ],
+        }
+      end
+
+      it { is_expected.to eq("/origin") }
+
+      it "stores the stack in the session" do
+        expect { pop_back }.to change { session }.to({ history_stack: [] })
+      end
+    end
+  end
+
+  describe "#pop_to_origin" do
+    subject(:pop_to_origin) { history_stack.pop_to_origin }
+
+    context "with an empty session" do
+      let(:session) { {} }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "with an existing session" do
+      let(:session) do
+        {
+          history_stack: [
+            { path: "/origin", origin: true },
+            { path: "/page1", origin: false },
+            { path: "/page2", origin: false },
+          ],
+        }
+      end
+
+      it { is_expected.to eq("/origin") }
+
+      it "stores the stack in the session" do
+        expect { pop_to_origin }.to change { session }.to({ history_stack: [] })
+      end
+    end
+  end
+end

--- a/spec/lib/history_stack_spec.rb
+++ b/spec/lib/history_stack_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe HistoryStack do
   describe "#push_self" do
     subject(:push_self) { history_stack.push_self(request, origin:, reset:) }
 
-    let(:request) { double(fullpath: "/path?page=1") }
+    let(:request) { double(path: "/path") }
 
     context "with an empty session" do
       let(:session) { {} }
@@ -19,13 +19,13 @@ RSpec.describe HistoryStack do
 
         it "stores the stack in the session" do
           expect { push_self }.to change { session }.to(
-            { history_stack: [{ origin: true, path: "/path?page=1" }] },
+            { history_stack: [{ origin: true, path: "/path" }] },
           )
         end
 
         it "doesn't store it twice" do
           expect { 2.times { push_self } }.to change { session }.to(
-            { history_stack: [{ origin: true, path: "/path?page=1" }] },
+            { history_stack: [{ origin: true, path: "/path" }] },
           )
         end
       end
@@ -35,7 +35,7 @@ RSpec.describe HistoryStack do
 
         it "stores the stack in the session" do
           expect { push_self }.to change { session }.to(
-            { history_stack: [{ origin: false, path: "/path?page=1" }] },
+            { history_stack: [{ origin: false, path: "/path" }] },
           )
         end
       end
@@ -50,7 +50,7 @@ RSpec.describe HistoryStack do
 
         it "stores the stack in the session" do
           expect { push_self }.to change { session }.to(
-            { history_stack: [{ origin: false, path: "/path?page=1" }] },
+            { history_stack: [{ origin: false, path: "/path" }] },
           )
         end
       end
@@ -63,7 +63,7 @@ RSpec.describe HistoryStack do
             {
               history_stack: [
                 { origin: true, path: "/origin" },
-                { origin: false, path: "/path?page=1" },
+                { origin: false, path: "/path" },
               ],
             },
           )
@@ -75,7 +75,7 @@ RSpec.describe HistoryStack do
   describe "#replace_self" do
     subject(:replace_self) { history_stack.replace_self(path:, origin:) }
 
-    let(:path) { "/path?page=1" }
+    let(:path) { "/path" }
 
     context "with an empty session" do
       let(:session) { {} }
@@ -85,13 +85,13 @@ RSpec.describe HistoryStack do
 
         it "stores the stack in the session" do
           expect { replace_self }.to change { session }.to(
-            { history_stack: [{ origin: true, path: "/path?page=1" }] },
+            { history_stack: [{ origin: true, path: "/path" }] },
           )
         end
 
         it "doesn't store it twice" do
           expect { 2.times { replace_self } }.to change { session }.to(
-            { history_stack: [{ origin: true, path: "/path?page=1" }] },
+            { history_stack: [{ origin: true, path: "/path" }] },
           )
         end
       end
@@ -101,7 +101,7 @@ RSpec.describe HistoryStack do
 
         it "stores the stack in the session" do
           expect { replace_self }.to change { session }.to(
-            { history_stack: [{ origin: false, path: "/path?page=1" }] },
+            { history_stack: [{ origin: false, path: "/path" }] },
           )
         end
       end
@@ -113,7 +113,7 @@ RSpec.describe HistoryStack do
 
       it "stores the stack in the session" do
         expect { replace_self }.to change { session }.to(
-          { history_stack: [{ origin: false, path: "/path?page=1" }] },
+          { history_stack: [{ origin: false, path: "/path" }] },
         )
       end
     end

--- a/spec/support/autoload/page_objects/govuk_radio_item.rb
+++ b/spec/support/autoload/page_objects/govuk_radio_item.rb
@@ -2,5 +2,7 @@ module PageObjects
   class GovukRadioItem < SitePrism::Section
     element :input, ".govuk-radios__input", visible: false
     element :label, ".govuk-radios__label"
+
+    def_delegator :input, :choose
   end
 end

--- a/spec/support/autoload/page_objects/govuk_summary_list.rb
+++ b/spec/support/autoload/page_objects/govuk_summary_list.rb
@@ -7,5 +7,9 @@ module PageObjects
         element :link, ".govuk-link"
       end
     end
+
+    def find_row(key:)
+      rows.find { |row| row.key.text == key }
+    end
   end
 end

--- a/spec/support/autoload/page_objects/task_list.rb
+++ b/spec/support/autoload/page_objects/task_list.rb
@@ -7,7 +7,7 @@ module PageObjects
     end
 
     def click_item(link_text)
-      find_item(link_text).link.click
+      find_item(link_text).click
     end
   end
 end

--- a/spec/support/autoload/page_objects/task_list_item.rb
+++ b/spec/support/autoload/page_objects/task_list_item.rb
@@ -3,5 +3,7 @@ module PageObjects
     element :name, "span"
     element :link, "a"
     element :status_tag, ".govuk-tag"
+
+    def_delegator :link, :click
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/add_another_qualification.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/add_another_qualification.rb
@@ -1,0 +1,20 @@
+module PageObjects
+  module TeacherInterface
+    class AddAnotherQualification < SitePrism::Page
+      set_url "/teacher/application/qualifications/add_another"
+
+      element :heading, "h1"
+
+      section :form, "form" do
+        section :yes_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(1)"
+        section :no_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(2)"
+
+        element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/application.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/application.rb
@@ -11,6 +11,10 @@ module PageObjects
       element :save_and_sign_out, ".govuk-button:nth-of-type(2)"
 
       section :task_list, TaskList, ".app-task-list"
+
+      def qualifications_task_item
+        task_list.find_item("Add your teaching qualifications")
+      end
     end
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/check_qualifications.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/check_qualifications.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module TeacherInterface
+    class CheckQualifications < SitePrism::Page
+      set_url "/teacher/application/qualifications/check"
+
+      element :heading, "h1"
+      sections :summary_lists, GovukSummaryList, ".govuk-summary-list"
+      element :continue_button, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/edit_qualification.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/edit_qualification.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module TeacherInterface
+    class EditQualification < QualificationsForm
+      set_url "/teacher/application/qualifications/{qualification_id}/edit"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/new_qualification.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/new_qualification.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module TeacherInterface
+    class NewQualification < QualificationsForm
+      set_url "/teacher/application/qualifications/new"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/part_of_university_degree.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/part_of_university_degree.rb
@@ -1,0 +1,22 @@
+module PageObjects
+  module TeacherInterface
+    class PartOfUniversityDegree < SitePrism::Page
+      set_url "/teacher/application/qualifications/{qualification_id}/part_of_university_degree"
+
+      element :heading, "h1"
+
+      section :form, "form" do
+        section :yes_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(1)"
+        section :no_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(2)"
+
+        element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
+        element :save_and_come_back_later_button,
+                ".govuk-button.govuk-button--secondary"
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/qualifications_form.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/qualifications_form.rb
@@ -3,6 +3,30 @@ module PageObjects
     class QualificationsForm < SitePrism::Page
       element :heading, "h1"
       element :body, ".govuk-body-l"
+
+      section :form, "form" do
+        element :title, "#teacher-interface-qualification-form-title-field"
+        element :institution_name,
+                "#teacher-interface-qualification-form-institution-name-field"
+        element :institution_country,
+                "#teacher-interface-qualification-form-institution-country-location-field"
+        element :start_date_month,
+                "#teacher_interface_qualification_form_start_date_2i"
+        element :start_date_year,
+                "#teacher_interface_qualification_form_start_date_1i"
+        element :complete_date_month,
+                "#teacher_interface_qualification_form_complete_date_2i"
+        element :complete_date_year,
+                "#teacher_interface_qualification_form_complete_date_1i"
+        element :certificate_date_month,
+                "#teacher_interface_qualification_form_certificate_date_2i"
+        element :certificate_date_year,
+                "#teacher_interface_qualification_form_certificate_date_1i"
+
+        element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
+        element :save_and_come_back_later_button,
+                ".govuk-button.govuk-button--secondary"
+      end
     end
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/upload_document_form.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/upload_document_form.rb
@@ -8,6 +8,13 @@ module PageObjects
       section :form, "form" do
         element :original_attachment,
                 "#teacher-interface-upload-form-original-attachment-field"
+        element :translated_attachment,
+                "#teacher-interface-upload-form-translated-attachment-field"
+
+        sections :written_in_english_items,
+                 GovukRadioItem,
+                 ".govuk-radios__item"
+
         element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
         element :save_and_come_back_later_button,
                 ".govuk-button.govuk-button--secondary"

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -7,6 +7,11 @@ module PageHelpers
     send(page.to_sym).load(**args)
   end
 
+  def add_another_qualification_page
+    @add_another_qualification_page ||=
+      PageObjects::TeacherInterface::AddAnotherQualification.new
+  end
+
   def assessor_application_page
     @assessor_application_page ||=
       PageObjects::AssessorInterface::Application.new
@@ -81,6 +86,11 @@ module PageHelpers
     @degree_page ||= PageObjects::EligibilityInterface::Degree.new
   end
 
+  def edit_qualification_page
+    @edit_qualification_page ||=
+      PageObjects::TeacherInterface::EditQualification.new
+  end
+
   def eligible_page
     @eligible_page = PageObjects::EligibilityInterface::Eligible.new
   end
@@ -110,6 +120,16 @@ module PageHelpers
 
   def misconduct_page
     @misconduct_page ||= PageObjects::EligibilityInterface::Misconduct.new
+  end
+
+  def new_qualification_page
+    @new_qualification_page ||=
+      PageObjects::TeacherInterface::NewQualification.new
+  end
+
+  def part_of_university_degree_page
+    @part_of_university_degree_page ||=
+      PageObjects::TeacherInterface::PartOfUniversityDegree.new
   end
 
   def performance_page
@@ -145,6 +165,11 @@ module PageHelpers
   def teach_children_page
     @teach_children_page ||=
       PageObjects::EligibilityInterface::TeachChildren.new
+  end
+
+  def teacher_check_qualifications_page
+    @teacher_check_qualifications_page ||=
+      PageObjects::TeacherInterface::CheckQualifications.new
   end
 
   def timeline_page

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -517,41 +517,38 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_fill_in_the_upload_identification_form
-    attach_file "teacher-interface-upload-form-original-attachment-field",
-                Rails.root.join(file_fixture("upload.pdf"))
-  end
-
-  def when_i_click_qualifications
-    teacher_application_page.task_list.click_item(
-      "Add your teaching qualifications",
+    upload_document_page.form.original_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
     )
   end
 
+  def when_i_click_qualifications
+    teacher_application_page.qualifications_task_item.click
+  end
+
   def when_i_fill_in_qualifications
-    fill_in "teacher-interface-qualification-form-title-field", with: "Title"
-    fill_in "teacher-interface-qualification-form-institution-name-field",
-            with: "Institution Name"
-    fill_in "teacher-interface-qualification-form-institution-country-location-field",
-            with: "France"
-    fill_in "teacher_interface_qualification_form_start_date_2i", with: "1"
-    fill_in "teacher_interface_qualification_form_start_date_1i", with: "2000"
-    fill_in "teacher_interface_qualification_form_complete_date_2i", with: "1"
-    fill_in "teacher_interface_qualification_form_complete_date_1i",
-            with: "2003"
-    fill_in "teacher_interface_qualification_form_certificate_date_2i",
-            with: "1"
-    fill_in "teacher_interface_qualification_form_certificate_date_1i",
-            with: "2004"
+    qualifications_form_page.form.title.fill_in with: "Title"
+    qualifications_form_page.form.institution_name.fill_in with:
+      "Institution Name"
+    qualifications_form_page.form.institution_country.fill_in with: "France"
+    qualifications_form_page.form.start_date_month.fill_in with: "1"
+    qualifications_form_page.form.start_date_year.fill_in with: "2000"
+    qualifications_form_page.form.complete_date_month.fill_in with: "1"
+    qualifications_form_page.form.complete_date_year.fill_in with: "2003"
+    qualifications_form_page.form.certificate_date_month.fill_in with: "1"
+    qualifications_form_page.form.certificate_date_year.fill_in with: "2004"
   end
 
   def when_i_fill_in_the_upload_certificate_form
-    attach_file "teacher-interface-upload-form-original-attachment-field",
-                Rails.root.join(file_fixture("upload.pdf"))
+    upload_document_page.form.original_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
+    )
   end
 
   def when_i_fill_in_the_upload_transcript_form
-    attach_file "teacher-interface-upload-form-original-attachment-field",
-                Rails.root.join(file_fixture("upload.pdf"))
+    upload_document_page.form.original_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
+    )
   end
 
   def when_i_click_age_range

--- a/spec/system/teacher_interface/back_links_spec.rb
+++ b/spec/system/teacher_interface/back_links_spec.rb
@@ -1,0 +1,292 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Teacher back links", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_a_user(teacher)
+    given_an_application_form_exists
+  end
+
+  it "back links follow user" do
+    # teacher_application_page -> new_qualification_page
+    #  <- teacher_application_page
+
+    when_i_visit_the(:teacher_application_page)
+    then_i_see_the(:teacher_application_page)
+
+    when_i_click_qualifications
+    then_i_see_the(:new_qualification_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_application_page)
+
+    # teacher_application_page -> new_qualification_page -> upload_document_page
+    #  <- edit_qualification_page <- teacher_application_page
+
+    when_i_click_qualifications
+    and_i_fill_in_qualification
+    then_i_see_the(:upload_document_page)
+
+    when_i_click_back
+    then_i_see_the(:edit_qualification_page, qualification_id: qualification.id)
+
+    when_i_click_back
+    then_i_see_the(:teacher_application_page)
+
+    # teacher_application_page -> edit_qualification_page -> upload_document_page -> document_form_page
+    #  <- edit_qualification_page
+
+    when_i_click_qualifications
+    and_i_click_continue
+    then_i_see_the(:upload_document_page)
+
+    when_i_upload_a_document
+    then_i_see_the(:document_form_page)
+
+    when_i_click_back
+    then_i_see_the(:edit_qualification_page, qualification_id: qualification.id)
+
+    # edit_qualification_page -> document_form_page -> upload_document_page -> document_form_page
+    #  -> part_of_university_degree_page
+    #  <- document_form_page <- document_form_page <- edit_qualification_page
+
+    when_i_click_continue
+    then_i_see_the(:document_form_page)
+
+    when_i_dont_upload_another_document
+    then_i_see_the(:upload_document_page)
+
+    when_i_upload_a_document
+    then_i_see_the(:document_form_page)
+
+    when_i_dont_upload_another_document
+    then_i_see_the(
+      :part_of_university_degree_page,
+      qualification_id: qualification.id,
+    )
+
+    when_i_click_back
+    then_i_see_the(:document_form_page)
+
+    when_i_click_back
+    then_i_see_the(:document_form_page)
+
+    when_i_click_back
+    then_i_see_the(:edit_qualification_page, qualification_id: qualification.id)
+
+    # edit_qualification_page -> document_form_page -> document_form_page -> part_of_university_degree_page
+    #  -> teacher_check_qualifications_page
+    #  <- teacher_application_page
+
+    when_i_click_continue
+    then_i_see_the(:document_form_page)
+
+    when_i_dont_upload_another_document
+    then_i_see_the(:document_form_page)
+
+    when_i_dont_upload_another_document
+    then_i_see_the(
+      :part_of_university_degree_page,
+      qualification_id: qualification.id,
+    )
+
+    when_i_choose_part_of_university_degree
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_application_page)
+
+    # teacher_application_page -> teacher_check_qualifications_page -> edit_qualification_page
+    #  <- teacher_check_qualifications_page
+
+    when_i_click_qualifications
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    when_i_click_change_qualification_title
+    then_i_see_the(:edit_qualification_page, qualification_id: qualification.id)
+
+    when_i_click_back
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> edit_qualification_page -> teacher_check_qualifications_page
+
+    when_i_click_change_qualification_title
+    then_i_see_the(:edit_qualification_page, qualification_id: qualification.id)
+
+    when_i_click_continue
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> document_form_page
+    #  <- teacher_check_qualifications_page
+
+    when_i_click_change_certificate_document_title
+    then_i_see_the(:document_form_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> document_form_page -> teacher_check_qualifications_page
+
+    when_i_click_change_certificate_document_title
+    then_i_see_the(:document_form_page)
+
+    when_i_dont_upload_another_document
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> document_form_page -> upload_document_page
+    #  <- document_form_page <- teacher_check_qualifications_page
+
+    when_i_click_change_certificate_document_title
+    then_i_see_the(:document_form_page)
+
+    when_i_do_upload_another_document
+    then_i_see_the(:upload_document_page)
+
+    when_i_click_back
+    then_i_see_the(:document_form_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> document_form_page -> upload_document_page -> document_form_page
+    #  <- teacher_check_qualifications_page
+
+    when_i_click_change_certificate_document_title
+    then_i_see_the(:document_form_page)
+
+    when_i_do_upload_another_document
+    then_i_see_the(:upload_document_page)
+
+    when_i_upload_a_document
+    then_i_see_the(:document_form_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> document_form_page -> upload_document_page -> document_form_page
+    #  -> teacher_check_qualifications_page
+
+    when_i_click_change_certificate_document_title
+    then_i_see_the(:document_form_page)
+
+    when_i_do_upload_another_document
+    then_i_see_the(:upload_document_page)
+
+    when_i_upload_a_document
+    then_i_see_the(:document_form_page)
+
+    when_i_dont_upload_another_document
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> add_another_qualification_page
+    #  <- teacher_check_qualifications_page
+
+    teacher_check_qualifications_page.continue_button.click
+    then_i_see_the(:add_another_qualification_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> add_another_qualification_page -> new_qualification_page
+    #  <- teacher_check_qualifications_page
+
+    teacher_check_qualifications_page.continue_button.click
+    then_i_see_the(:add_another_qualification_page)
+
+    when_i_add_another_qualification
+    then_i_see_the(:new_qualification_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_check_qualifications_page)
+  end
+
+  private
+
+  def given_an_application_form_exists
+    application_form
+  end
+
+  def when_i_click_back
+    click_link "Back"
+  end
+
+  def when_i_click_qualifications
+    teacher_application_page.qualifications_task_item.click
+  end
+
+  def and_i_fill_in_qualification
+    new_qualification_page.form.title.fill_in with: "Title"
+    new_qualification_page.form.institution_name.fill_in with:
+      "Institution Name"
+    new_qualification_page.form.institution_country.fill_in with: "France"
+    new_qualification_page.form.start_date_month.fill_in with: "1"
+    new_qualification_page.form.start_date_year.fill_in with: "2000"
+    new_qualification_page.form.complete_date_month.fill_in with: "1"
+    new_qualification_page.form.complete_date_year.fill_in with: "2003"
+    new_qualification_page.form.certificate_date_month.fill_in with: "1"
+    new_qualification_page.form.certificate_date_year.fill_in with: "2004"
+    new_qualification_page.form.continue_button.click
+  end
+
+  def when_i_upload_a_document
+    upload_document_page.form.original_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
+    )
+    upload_document_page.form.written_in_english_items.first.choose
+    upload_document_page.form.continue_button.click
+  end
+
+  def when_i_dont_upload_another_document
+    document_form_page.form.no_radio_item.choose
+    document_form_page.form.continue_button.click
+  end
+
+  def when_i_do_upload_another_document
+    document_form_page.form.yes_radio_item.choose
+    document_form_page.form.continue_button.click
+  end
+
+  def when_i_choose_part_of_university_degree
+    part_of_university_degree_page.form.yes_radio_item.choose
+    part_of_university_degree_page.form.continue_button.click
+  end
+
+  def when_i_click_change_qualification_title
+    teacher_check_qualifications_page
+      .summary_lists
+      .first
+      .find_row(key: "Qualification title")
+      .actions
+      .link
+      .click
+  end
+
+  def when_i_click_change_certificate_document_title
+    teacher_check_qualifications_page
+      .summary_lists
+      .first
+      .find_row(key: "Certificate document")
+      .actions
+      .link
+      .click
+  end
+
+  def when_i_add_another_qualification
+    add_another_qualification_page.form.yes_radio_item.choose
+    add_another_qualification_page.form.continue_button.click
+  end
+
+  def teacher
+    @teacher ||= create(:teacher, :confirmed)
+  end
+
+  def application_form
+    @application_form ||= create(:application_form, teacher:)
+  end
+
+  def qualification
+    @qualification ||= application_form.qualifications.first
+  end
+end

--- a/spec/system/teacher_interface/check_answers_spec.rb
+++ b/spec/system/teacher_interface/check_answers_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Teacher application", type: :system do
+RSpec.describe "Teacher application check answers", type: :system do
   before do
     given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -45,11 +45,13 @@ RSpec.describe "Teacher documents", type: :system do
   end
 
   def when_i_upload_a_document
-    attach_file "teacher-interface-upload-form-original-attachment-field",
-                Rails.root.join(file_fixture("upload.pdf"))
-    choose "No, I’ll upload a translation as well", visible: false
-    attach_file "teacher-interface-upload-form-translated-attachment-field",
-                Rails.root.join(file_fixture("upload.pdf"))
+    upload_document_page.form.original_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
+    )
+    upload_document_page.form.written_in_english_items.second.choose
+    upload_document_page.form.translated_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
+    )
   end
 
   def when_i_click_delete_on_the_first_document


### PR DESCRIPTION
This improves how back links work to ensure that the user is always taken to the right place. We will now store a history of where the user has been in the journey in the session and use that to determine the user should go when they click on a back link. For the most part, this is the previous entry in the stack, but from some pages (notably check your answers) we send the user back to the first "origin" page - which in most cases will be the overview task list.

This implements the journeys as described in this diagram: https://drive.google.com/file/d/1wAerFpEZVQpsu3otSc-Ib3HsDsM_bxXh/view?ts=6384846c

I'm anticipating a follow up PR from this which replaces the `?next=` params with the history stack.

[Trello Card](https://trello.com/c/zJbHelII/1208-back-link-redo)