### PR TITLE
[1210] Move region.teaching_authority_other content

### DIFF
--- a/app/views/teacher_interface/registration_number/edit.html.erb
+++ b/app/views/teacher_interface/registration_number/edit.html.erb
@@ -8,15 +8,15 @@
 
   <%= f.govuk_text_field :registration_number, label: { size: "l", tag: "h1" } %>
 
+  <% if @teaching_authority_other.present? %>
+    <%= raw GovukMarkdown.render(@teaching_authority_other) %>
+  <% end %>
+
   <%= govuk_details(summary_text: "When we might need more information") do %>
     <p>
       If we’re unable to find you using your registration number, we may need to
       contact you for more information as part of your application.
     </p>
-
-    <% if @teaching_authority_other.present? %>
-      <%= raw GovukMarkdown.render(@teaching_authority_other) %>
-    <% end %>
   <% end %>
 
   <%= render "shared/save_submit_buttons", f: %>

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -883,7 +883,7 @@ RSpec.describe "Teacher application", type: :system do
     )
 
     registration_number_form.details.summary.click
-    expect(registration_number_form.details.text).to have_content(
+    expect(registration_number_form).to have_content(
       "Other teaching authority information.",
     )
   end


### PR DESCRIPTION
Move the content out of the expandable bit on the registration form so as it is more obvious.

<img width="807" alt="Screenshot 2022-11-29 at 11 43 57" src="https://user-images.githubusercontent.com/5216/204521640-74900b38-bfef-4073-ae42-c46196f01ab4.png">
