### PR TITLE
[1209] Split notes from decline reasons - Part 1

### DIFF
--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -23,6 +23,7 @@
 #
 class AssessmentSection < ApplicationRecord
   belongs_to :assessment
+  has_many :assessment_section_failure_reasons
 
   enum :key,
        {

--- a/app/models/assessment_section_failure_reason.rb
+++ b/app/models/assessment_section_failure_reason.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: assessment_section_failure_reasons
+#
+#  id                    :bigint           not null, primary key
+#  assessor_feedback     :text
+#  key                   :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  assessment_section_id :bigint           not null
+#
+# Indexes
+#
+#  index_as_failure_reason_assessment_section_id  (assessment_section_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_section_id => assessment_sections.id)
+#
+class AssessmentSectionFailureReason < ApplicationRecord
+  belongs_to :assessment_section
+
+  ALL_FAILURE_REASONS = %i[
+    identification_document_expired
+    identification_document_illegible
+    identification_document_mismatch
+    name_change_document_illegible
+    duplicate_application
+    applicant_already_qts
+    applicant_already_dqt
+    application_and_qualification_names_do_not_match
+    teaching_qualifications_from_ineligible_country
+    teaching_qualifications_not_at_required_level
+    teaching_hours_not_fulfilled
+    not_qualified_to_teach_mainstream
+    qualifications_dont_match_subjects
+    qualifications_dont_match_other_details
+    teaching_certificate_illegible
+    teaching_transcript_illegible
+    degree_certificate_illegible
+    degree_transcript_illegible
+    satisfactory_evidence_work_history
+    registration_number
+    written_statement_illegible
+    written_statement_recent
+    authorisation_to_teach
+    teaching_qualification
+    confirm_age_range_subjects
+    qualified_to_teach
+    full_professional_status
+  ].freeze
+
+  validates :key, presence: true
+  validates :key, inclusion: { in: ALL_FAILURE_REASONS.map(&:to_s) }
+end

--- a/app/services/migrate_selected_failure_reasons.rb
+++ b/app/services/migrate_selected_failure_reasons.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class MigrateSelectedFailureReasons
+  include ServicePattern
+
+  def initialize(assessment_section:)
+    @assessment_section = assessment_section
+  end
+
+  def call
+    assessment_section.selected_failure_reasons.each do |key, assessor_feedback|
+      if assessment_section.assessment_section_failure_reasons.exists?(key:)
+        next
+      end
+
+      assessment_section.assessment_section_failure_reasons.create!(
+        key:,
+        assessor_feedback:,
+      )
+    end
+  end
+
+  private
+
+  attr_reader :assessment_section
+end

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -14,6 +14,13 @@ class UpdateAssessmentSection
 
     ActiveRecord::Base.transaction do
       next false unless assessment_section.update(params)
+
+      selected_keys = params[:selected_failure_reasons].keys
+      assessment_section
+        .assessment_section_failure_reasons
+        .where.not(key: selected_keys)
+        .destroy_all
+
       params[:selected_failure_reasons].each do |key, assessor_feedback|
         assessment_section
           .assessment_section_failure_reasons

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -15,10 +15,10 @@ class UpdateAssessmentSection
     ActiveRecord::Base.transaction do
       next false unless assessment_section.update(params)
       params[:selected_failure_reasons].each do |key, assessor_feedback|
-        assessment_section.assessment_section_failure_reasons.create(
-          key:,
-          assessor_feedback:,
-        )
+        assessment_section
+          .assessment_section_failure_reasons
+          .find_or_initialize_by(key:)
+          .update(assessor_feedback:)
       end
 
       create_timeline_event(old_state:)

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -14,6 +14,12 @@ class UpdateAssessmentSection
 
     ActiveRecord::Base.transaction do
       next false unless assessment_section.update(params)
+      params[:selected_failure_reasons].each do |key, assessor_feedback|
+        assessment_section.assessment_section_failure_reasons.create(
+          key:,
+          assessor_feedback:,
+        )
+      end
 
       create_timeline_event(old_state:)
       update_application_form_assessor

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -66,6 +66,13 @@
     - selected_failure_reasons
     - created_at
     - updated_at
+  :assessment_section_failure_reasons:
+    - id
+    - assessment_section_id
+    - key
+    - assessor_feedback
+    - created_at
+    - updated_at
   :assessments:
     - id
     - application_form_id

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -16,6 +16,8 @@
     - registration_number
     - has_work_history
     - subjects
+  :assessment_section_failure_reasons:
+    - assessor_feedback
   :further_information_requests:
     - failure_assessor_note
   :further_information_request_items:

--- a/db/migrate/20221128135028_create_assessment_section_failure_reasons.rb
+++ b/db/migrate/20221128135028_create_assessment_section_failure_reasons.rb
@@ -1,0 +1,15 @@
+class CreateAssessmentSectionFailureReasons < ActiveRecord::Migration[7.0]
+  def change
+    create_table :assessment_section_failure_reasons do |t|
+      t.references :assessment_section,
+                   null: false,
+                   foreign_key: true,
+                   index: {
+                     name: "index_as_failure_reason_assessment_section_id",
+                   }
+      t.string :key, null: false
+      t.text :assessor_feedback
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_28_122306) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_28_135028) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -84,6 +84,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_28_122306) do
     t.index ["reviewer_id"], name: "index_application_forms_on_reviewer_id"
     t.index ["state"], name: "index_application_forms_on_state"
     t.index ["teacher_id"], name: "index_application_forms_on_teacher_id"
+  end
+
+  create_table "assessment_section_failure_reasons", force: :cascade do |t|
+    t.bigint "assessment_section_id", null: false
+    t.string "key", null: false
+    t.text "assessor_feedback"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessment_section_id"], name: "index_as_failure_reason_assessment_section_id"
   end
 
   create_table "assessment_sections", force: :cascade do |t|
@@ -355,6 +364,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_28_122306) do
   add_foreign_key "application_forms", "staff", column: "assessor_id"
   add_foreign_key "application_forms", "staff", column: "reviewer_id"
   add_foreign_key "application_forms", "teachers"
+  add_foreign_key "assessment_section_failure_reasons", "assessment_sections"
   add_foreign_key "assessment_sections", "assessments"
   add_foreign_key "assessments", "application_forms"
   add_foreign_key "dqt_trn_requests", "application_forms"

--- a/spec/factories/assessment_section_failure_reasons.rb
+++ b/spec/factories/assessment_section_failure_reasons.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: assessment_section_failure_reasons
+#
+#  id                    :bigint           not null, primary key
+#  assessor_feedback     :text
+#  key                   :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  assessment_section_id :bigint           not null
+#
+# Indexes
+#
+#  index_as_failure_reason_assessment_section_id  (assessment_section_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_section_id => assessment_sections.id)
+#
+FactoryBot.define do
+  factory :assessment_section_failure_reasons do
+    key { AssessmentSectionFailureReason::ALL_FAILURE_REASONS.sample.to_s }
+  end
+end

--- a/spec/models/assessment_section_failure_reason_spec.rb
+++ b/spec/models/assessment_section_failure_reason_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: assessment_section_failure_reasons
+#
+#  id                    :bigint           not null, primary key
+#  assessor_feedback     :text
+#  key                   :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  assessment_section_id :bigint           not null
+#
+# Indexes
+#
+#  index_as_failure_reason_assessment_section_id  (assessment_section_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_section_id => assessment_sections.id)
+#
+require "rails_helper"
+
+RSpec.describe AssessmentSectionFailureReason do
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:key) }
+    it do
+      is_expected.to validate_inclusion_of(:key).in_array(
+        described_class::ALL_FAILURE_REASONS.map(&:to_s),
+      )
+    end
+  end
+end

--- a/spec/services/migrate_selected_failure_reasons_spec.rb
+++ b/spec/services/migrate_selected_failure_reasons_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MigrateSelectedFailureReasons do
+  describe ".call" do
+    let(:assessment_section) { create(:assessment_section, :qualifications) }
+    subject { described_class.call(assessment_section:) }
+
+    let(:reason_one_key) { assessment_section.failure_reasons.sample }
+    let(:reason_one_assessor_feedback) { "Feeding back" }
+
+    let(:reason_two_key) do
+      (assessment_section.failure_reasons - [reason_one_key]).sample
+    end
+    let(:reason_two_assessor_feedback) { "" }
+
+    let(:selected_failure_reasons) do
+      {
+        reason_one_key => reason_one_assessor_feedback,
+        reason_two_key => reason_two_assessor_feedback,
+      }
+    end
+
+    before do
+      assessment_section.update(selected_failure_reasons:, passed: false)
+    end
+
+    context "when the assessment_section_failure_reasons don't exist yet" do
+      it "creates one with feedback" do
+        subject
+        expect(
+          assessment_section
+            .assessment_section_failure_reasons
+            .find_by(key: reason_one_key)
+            .assessor_feedback,
+        ).to eq(reason_one_assessor_feedback)
+      end
+
+      it "creates one with empty feedback" do
+        subject
+        expect(
+          assessment_section
+            .assessment_section_failure_reasons
+            .find_by(key: reason_two_key)
+            .assessor_feedback,
+        ).to eq(reason_two_assessor_feedback)
+      end
+    end
+
+    context "when the assessment_section_failure_reason already exists" do
+      before do
+        assessment_section.assessment_section_failure_reasons.create(
+          key: reason_one_key,
+          assessor_feedback: reason_one_assessor_feedback,
+        )
+      end
+
+      it "creates any that are missing" do
+        expect { subject }.to change {
+          assessment_section.assessment_section_failure_reasons.count
+        }.by(1)
+      end
+
+      it "doesn't create duplicates" do
+        subject
+        expect(
+          assessment_section.assessment_section_failure_reasons.pluck(:key),
+        ).to contain_exactly(reason_one_key, reason_two_key)
+      end
+    end
+
+    context "when the assessment section doesn't have any failure reasons" do
+      let(:selected_failure_reasons) { {} }
+
+      it "doesn't create any" do
+        expect { subject }.not_to(
+          change do
+            assessment_section.assessment_section_failure_reasons.count
+          end,
+        )
+      end
+    end
+  end
+end

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -81,6 +81,28 @@ RSpec.describe UpdateAssessmentSection do
           }.to(selected_failure_reason_assessor_feedback)
         end
       end
+
+      context "when the failure reason is no longer selected" do
+        let(:different_key) do
+          (
+            assessment_section.failure_reasons -
+              Array(selected_failure_reason_key)
+          ).sample
+        end
+
+        before do
+          assessment_section.assessment_section_failure_reasons.create(
+            key: different_key,
+            assessor_feedback: "I need deleting",
+          )
+        end
+
+        it "deletes the now unselected failure reason" do
+          expect { subject }.to change {
+            AssessmentSectionFailureReason.where(key: different_key).count
+          }.by(-1)
+        end
+      end
     end
 
     it "changes the assessor" do

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -12,10 +12,14 @@ RSpec.describe UpdateAssessmentSection do
       assessment: create(:assessment, application_form:),
     )
   end
-  let(:selected_failure_reason) { assessment_section.failure_reasons.sample }
-  let(:params) do
-    { passed: false, selected_failure_reasons: [selected_failure_reason] }
+  let(:selected_failure_reasons) do
+    { selected_failure_reason_key => selected_failure_reason_assessor_note }
   end
+  let(:selected_failure_reason_key) do
+    assessment_section.failure_reasons.sample
+  end
+  let(:selected_failure_reason_assessor_note) { "Epic fail" }
+  let(:params) { { passed: false, selected_failure_reasons: } }
 
   subject { described_class.call(assessment_section:, user:, params:) }
 
@@ -37,7 +41,16 @@ RSpec.describe UpdateAssessmentSection do
     it "sets the failure reasons" do
       expect { subject }.to change {
         assessment_section.selected_failure_reasons
-      }.from({}).to([selected_failure_reason])
+      }.from({}).to(selected_failure_reasons)
+    end
+
+    it "creates the assessment failure reason records" do
+      expect { subject }.to change {
+        AssessmentSectionFailureReason.where(
+          assessment_section:,
+          key: selected_failure_reason_key,
+        ).count
+      }.by(1)
     end
 
     it "changes the assessor" do


### PR DESCRIPTION
We currently store assessment failure reasons and the associated assessor notes as a JSON field on the `AssessmentSection` record. This makes it tricky to analyse and to filter PII from.

We are going to separate these things out into a set of associated records.

As we already have existing data and this functionality is running in production we'll split it into 3 or 4 PRs and deploy them sequentially.

* Start saving the new records
* Copy existing data into the new records
* Update the functionally to use the new records
* Delete the old data and fix the temporary naming of the new association (`assessment_section_failure_reasons` -> `selected_failure_reasons` or something like that)

This is the first bit to start saving the new records to `AssessmentSectionFailureReason`