### PR TITLE
[1209] MigrateSelectedFailureReason service. Split notes from decline reasons - Part 2

### DIFF
--- a/app/services/migrate_selected_failure_reasons.rb
+++ b/app/services/migrate_selected_failure_reasons.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class MigrateSelectedFailureReasons
+  include ServicePattern
+
+  def initialize(assessment_section:)
+    @assessment_section = assessment_section
+  end
+
+  def call
+    assessment_section.selected_failure_reasons.each do |key, assessor_feedback|
+      if assessment_section.assessment_section_failure_reasons.exists?(key:)
+        next
+      end
+
+      assessment_section.assessment_section_failure_reasons.create!(
+        key:,
+        assessor_feedback:,
+      )
+    end
+  end
+
+  private
+
+  attr_reader :assessment_section
+end

--- a/spec/services/migrate_selected_failure_reasons_spec.rb
+++ b/spec/services/migrate_selected_failure_reasons_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MigrateSelectedFailureReasons do
+  describe ".call" do
+    let(:assessment_section) { create(:assessment_section, :qualifications) }
+    subject { described_class.call(assessment_section:) }
+
+    let(:reason_one_key) { assessment_section.failure_reasons.sample }
+    let(:reason_one_assessor_feedback) { "Feeding back" }
+
+    let(:reason_two_key) do
+      (assessment_section.failure_reasons - [reason_one_key]).sample
+    end
+    let(:reason_two_assessor_feedback) { "" }
+
+    let(:selected_failure_reasons) do
+      {
+        reason_one_key => reason_one_assessor_feedback,
+        reason_two_key => reason_two_assessor_feedback,
+      }
+    end
+
+    before do
+      assessment_section.update(selected_failure_reasons:, passed: false)
+    end
+
+    context "when the assessment_section_failure_reasons don't exist yet" do
+      it "creates one with feedback" do
+        subject
+        expect(
+          assessment_section
+            .assessment_section_failure_reasons
+            .find_by(key: reason_one_key)
+            .assessor_feedback,
+        ).to eq(reason_one_assessor_feedback)
+      end
+
+      it "creates one with empty feedback" do
+        subject
+        expect(
+          assessment_section
+            .assessment_section_failure_reasons
+            .find_by(key: reason_two_key)
+            .assessor_feedback,
+        ).to eq(reason_two_assessor_feedback)
+      end
+    end
+
+    context "when the assessment_section_failure_reason already exists" do
+      before do
+        assessment_section.assessment_section_failure_reasons.create(
+          key: reason_one_key,
+          assessor_feedback: reason_one_assessor_feedback,
+        )
+      end
+
+      it "creates any that are missing" do
+        expect { subject }.to change {
+          assessment_section.assessment_section_failure_reasons.count
+        }.by(1)
+      end
+
+      it "doesn't create duplicates" do
+        subject
+        expect(
+          assessment_section.assessment_section_failure_reasons.pluck(:key),
+        ).to contain_exactly(reason_one_key, reason_two_key)
+      end
+    end
+
+    context "when the assessment section doesn't have any failure reasons" do
+      let(:selected_failure_reasons) { {} }
+
+      it "doesn't create any" do
+        expect { subject }.not_to(
+          change do
+            assessment_section.assessment_section_failure_reasons.count
+          end,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Part 2 of https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/781

* Add service to copy over `AssessmentSection#selected_failure_reasons` into the the new `AssessmentSectionFailureReason` records

This will be used to backfill the data as part of the migration.

I expect we'll run this from the console and pass in all assessment sections in a loop. I can add it as a rake task but it should be fine to just run `AssessmentSection.all` through it 🤷 