### PR TITLE
Fix flaky system test

### DIFF
--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe "Assessor filtering application forms", type: :system do
       create(
         :application_form,
         :submitted,
+        region: create(:region, country: create(:country, code: "ES")),
         given_names: "Arnold",
         family_name: "Drummond",
         assessor: assessors.first,
@@ -154,6 +155,7 @@ RSpec.describe "Assessor filtering application forms", type: :system do
       create(
         :application_form,
         :awarded,
+        region: create(:region, country: create(:country, code: "PT")),
         given_names: "John",
         family_name: "Smith",
         assessor: assessors.second,


### PR DESCRIPTION
This fixes a flaky test by ensuring the countries that are generated in the tests doesn't repeat the unique country codes.