### PR TITLE
Improve application form back links

### DIFF
--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -24,7 +24,7 @@ module CheckYourAnswersSummary
     end
 
     def delete_link_to
-      path_with_next(@delete_link_to) if changeable && @delete_link_to
+      @delete_link_to if changeable && @delete_link_to
     end
 
     private
@@ -63,22 +63,11 @@ module CheckYourAnswersSummary
     end
 
     def href_for(field)
-      if (path = field[:href]).present?
-        path_with_next(path)
-      end
-    end
+      return if (path = field[:href]).blank?
 
-    def path_with_next(path)
-      next_path = request.path
+      return path if path.is_a?(String)
 
-      if path.is_a?(String)
-        return "#{path}?#{URI.encode_www_form(next: next_path)}"
-      end
-
-      Rails.application.routes.url_helpers.polymorphic_path(
-        path,
-        next: next_path,
-      )
+      Rails.application.routes.url_helpers.polymorphic_path(path)
     end
 
     def row_for_field(field)

--- a/app/controllers/concerns/handle_application_form_section.rb
+++ b/app/controllers/concerns/handle_application_form_section.rb
@@ -5,21 +5,34 @@ module HandleApplicationFormSection
 
   def handle_application_form_section(
     form:,
-    if_success_then_redirect:,
-    if_failure_then_render:
+    if_success_then_redirect: %i[teacher_interface application_form],
+    if_failure_then_render: :edit
   )
     save_and_continue = params[:button] == "save_and_continue"
 
     if form.save(validate: save_and_continue)
       if save_and_continue
-        redirect_to if_success_then_redirect.try(:call) ||
-                      if_success_then_redirect
+        redirect_to if_success_then_redirect.try(
+                      :call,
+                      check_path_if_previous,
+                    ) || check_path_if_previous || if_success_then_redirect
       else
-        redirect_to params[:next].presence ||
+        redirect_to check_path_if_previous ||
                       %i[teacher_interface application_form]
       end
     else
       render if_failure_then_render, status: :unprocessable_entity
     end
+  end
+
+  private
+
+  def history_stack
+    @history_stack ||= HistoryStack.new(session:)
+  end
+
+  def check_path_if_previous
+    entry = history_stack.last_entry
+    entry[:path] if entry && entry[:check]
   end
 end

--- a/app/controllers/concerns/history_trackable.rb
+++ b/app/controllers/concerns/history_trackable.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module HistoryTrackable
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :track_history, if: -> { request.get? }
+    cattr_accessor :history_origin_actions,
+                   :history_check_actions,
+                   :history_reset_actions
+  end
+
+  class_methods do
+    def define_history_origins(*actions)
+      self.history_origin_actions = actions.map(&:to_s)
+    end
+
+    def define_history_checks(*actions)
+      self.history_check_actions = actions.map(&:to_s)
+    end
+
+    def define_history_resets(*actions)
+      self.history_reset_actions = actions.map(&:to_s)
+    end
+  end
+
+  private
+
+  def track_history
+    origin = (history_origin_actions || []).include?(action_name)
+    check = (history_check_actions || []).include?(action_name)
+    reset = (history_reset_actions || []).include?(action_name)
+    history_stack.push_self(request, origin:, check:, reset:)
+  end
+
+  def history_stack
+    @history_stack ||= HistoryStack.new(session:)
+  end
+end

--- a/app/controllers/history_controller.rb
+++ b/app/controllers/history_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class HistoryController < ApplicationController
+  def back
+    to_origin = back_params[:origin] == "true"
+    method = to_origin ? :pop_to_origin : :pop_back
+
+    path = history_stack.send(method) || default_path
+    redirect_to path, status: :see_other
+  end
+
+  private
+
+  def default_path
+    URI.parse(back_params[:default] || "/teacher/application").path
+  end
+
+  def back_params
+    params.permit(:origin, :default)
+  end
+
+  def history_stack
+    @history_stack ||= HistoryStack.new(session:)
+  end
+end

--- a/app/controllers/teacher_interface/age_range_controller.rb
+++ b/app/controllers/teacher_interface/age_range_controller.rb
@@ -21,11 +21,7 @@ module TeacherInterface
       @age_range_form =
         AgeRangeForm.new(age_range_form_params.merge(application_form:))
 
-      handle_application_form_section(
-        form: @age_range_form,
-        if_success_then_redirect:,
-        if_failure_then_render: :edit,
-      )
+      handle_application_form_section(form: @age_range_form)
     end
 
     private
@@ -35,10 +31,6 @@ module TeacherInterface
         :minimum,
         :maximum,
       )
-    end
-
-    def if_success_then_redirect
-      params[:next].presence || %i[teacher_interface application_form]
     end
   end
 end

--- a/app/controllers/teacher_interface/age_range_controller.rb
+++ b/app/controllers/teacher_interface/age_range_controller.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class AgeRangeController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form

--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -1,8 +1,16 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class ApplicationFormsController < BaseController
+    include HistoryTrackable
+
     before_action :redirect_unless_application_form_is_draft,
                   only: %i[edit update]
     before_action :load_application_form, except: %i[new create]
+
+    define_history_origins :show
+    define_history_resets :show
+    define_history_checks :edit
 
     def new
       @country_region_form = CountryRegionForm.new

--- a/app/controllers/teacher_interface/base_controller.rb
+++ b/app/controllers/teacher_interface/base_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TeacherInterface::BaseController < ApplicationController
   include TeacherCurrentNamespace
 

--- a/app/controllers/teacher_interface/documents_controller.rb
+++ b/app/controllers/teacher_interface/documents_controller.rb
@@ -15,12 +15,10 @@ module TeacherInterface
       if document.uploads.empty?
         redirect_to new_teacher_interface_application_form_document_upload_path(
                       document,
-                      next: params[:next],
                     )
       else
         redirect_to edit_teacher_interface_application_form_document_path(
                       document,
-                      next: params[:next],
                     )
       end
     end
@@ -41,18 +39,15 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @add_another_upload_form,
-        if_success_then_redirect: -> do
+        if_success_then_redirect: ->(check_path) do
           if @add_another_upload_form.add_another
             new_teacher_interface_application_form_document_upload_path(
               document,
-              next: params[:next],
             )
           else
-            params[:next].presence ||
-              DocumentContinueRedirection.call(document:)
+            check_path || DocumentContinueRedirection.call(document:)
           end
         end,
-        if_failure_then_render: :edit,
       )
     end
   end

--- a/app/controllers/teacher_interface/documents_controller.rb
+++ b/app/controllers/teacher_interface/documents_controller.rb
@@ -6,14 +6,21 @@ module TeacherInterface
     before_action :load_application_form
     before_action :load_document
 
-    def edit
+    def show
       if document.uploads.empty?
         redirect_to new_teacher_interface_application_form_document_upload_path(
                       document,
                       next: params[:next],
                     )
+      else
+        redirect_to edit_teacher_interface_application_form_document_path(
+                      document,
+                      next: params[:next],
+                    )
       end
+    end
 
+    def edit
       @add_another_upload_form = AddAnotherUploadForm.new
     end
 

--- a/app/controllers/teacher_interface/documents_controller.rb
+++ b/app/controllers/teacher_interface/documents_controller.rb
@@ -1,10 +1,15 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class DocumentsController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_draft_or_further_information
     before_action :load_application_form
     before_action :load_document
+
+    skip_before_action :track_history, only: :show
 
     def show
       if document.uploads.empty?

--- a/app/controllers/teacher_interface/further_information_request_items_controller.rb
+++ b/app/controllers/teacher_interface/further_information_request_items_controller.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class FurtherInformationRequestItemsController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :load_application_form,
                   :load_further_information_request_and_item
@@ -47,6 +50,7 @@ module TeacherInterface
 
     def update_document
       if params[:button] == "save_and_continue"
+        history_stack.pop
         redirect_to document_path
       else
         redirect_to further_information_request_path

--- a/app/controllers/teacher_interface/further_information_request_items_controller.rb
+++ b/app/controllers/teacher_interface/further_information_request_items_controller.rb
@@ -85,7 +85,7 @@ module TeacherInterface
     end
 
     def document_path
-      edit_teacher_interface_application_form_document_path(
+      teacher_interface_application_form_document_path(
         further_information_request_item.document,
         next: params[:next],
       )

--- a/app/controllers/teacher_interface/further_information_request_items_controller.rb
+++ b/app/controllers/teacher_interface/further_information_request_items_controller.rb
@@ -43,8 +43,11 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @further_information_request_item_text_form,
-        if_success_then_redirect: further_information_request_path,
-        if_failure_then_render: :edit,
+        if_success_then_redirect: [
+          :teacher_interface,
+          :application_form,
+          further_information_request,
+        ],
       )
     end
 
@@ -83,15 +86,15 @@ module TeacherInterface
       ).permit(:response)
     end
 
-    def further_information_request_path
-      params[:next].presence ||
-        [:teacher_interface, :application_form, further_information_request]
-    end
-
     def document_path
       teacher_interface_application_form_document_path(
         further_information_request_item.document,
-        next: params[:next],
+      )
+    end
+
+    def further_information_request_path
+      teacher_interface_application_form_further_information_request_path(
+        further_information_request,
       )
     end
   end

--- a/app/controllers/teacher_interface/further_information_requests_controller.rb
+++ b/app/controllers/teacher_interface/further_information_requests_controller.rb
@@ -1,6 +1,13 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class FurtherInformationRequestsController < BaseController
+    include HistoryTrackable
+
     before_action :load_view_object
+
+    define_history_origins :show
+    define_history_checks :edit
 
     def show
     end

--- a/app/controllers/teacher_interface/personal_information_controller.rb
+++ b/app/controllers/teacher_interface/personal_information_controller.rb
@@ -1,9 +1,15 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class PersonalInformationController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
+
+    skip_before_action :track_history, only: :show
+    define_history_checks :check
 
     def show
       if application_form.task_item_completed?(

--- a/app/controllers/teacher_interface/personal_information_controller.rb
+++ b/app/controllers/teacher_interface/personal_information_controller.rb
@@ -49,7 +49,12 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @name_and_date_of_birth_form,
-        if_success_then_redirect: name_and_date_of_birth_success_path,
+        if_success_then_redirect: %i[
+          alternative_name
+          teacher_interface
+          application_form
+          personal_information
+        ],
         if_failure_then_render: :name_and_date_of_birth,
       )
     end
@@ -71,7 +76,16 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @alternative_name_form,
-        if_success_then_redirect: -> { alternative_name_success_path },
+        if_success_then_redirect: ->(check_path) do
+          if @alternative_name_form.has_alternative_name
+            teacher_interface_application_form_document_path(
+              application_form.name_change_document,
+            )
+          else
+            check_path ||
+              %i[check teacher_interface application_form personal_information]
+          end
+        end,
         if_failure_then_render: :alternative_name,
       )
     end
@@ -95,28 +109,6 @@ module TeacherInterface
         :alternative_given_names,
         :alternative_family_name,
       )
-    end
-
-    def name_and_date_of_birth_success_path
-      params[:next].presence ||
-        %i[
-          alternative_name
-          teacher_interface
-          application_form
-          personal_information
-        ]
-    end
-
-    def alternative_name_success_path
-      if @alternative_name_form.has_alternative_name
-        teacher_interface_application_form_document_path(
-          application_form.name_change_document,
-          next: params[:next],
-        )
-      else
-        params[:next].presence ||
-          %i[check teacher_interface application_form personal_information]
-      end
     end
   end
 end

--- a/app/controllers/teacher_interface/personal_information_controller.rb
+++ b/app/controllers/teacher_interface/personal_information_controller.rb
@@ -103,7 +103,7 @@ module TeacherInterface
 
     def alternative_name_success_path
       if @alternative_name_form.has_alternative_name
-        edit_teacher_interface_application_form_document_path(
+        teacher_interface_application_form_document_path(
           application_form.name_change_document,
           next: params[:next],
         )

--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -47,7 +47,6 @@ module TeacherInterface
         form: @qualification_form,
         if_success_then_redirect: -> do
           [
-            :edit,
             :teacher_interface,
             :application_form,
             qualification.certificate_document,
@@ -169,7 +168,6 @@ module TeacherInterface
     def update_success_path
       params[:next].presence ||
         [
-          :edit,
           :teacher_interface,
           :application_form,
           qualification.certificate_document,

--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -1,9 +1,15 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class QualificationsController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
+
+    skip_before_action :track_history, only: :index
+    define_history_checks :check
 
     def index
       if application_form.task_item_completed?(:qualifications, :qualifications)
@@ -46,6 +52,15 @@ module TeacherInterface
       handle_application_form_section(
         form: @qualification_form,
         if_success_then_redirect: -> do
+          history_stack.replace_self(
+            path:
+              edit_teacher_interface_application_form_qualification_path(
+                qualification,
+              ),
+            origin: false,
+            check: false,
+          )
+
           [
             :teacher_interface,
             :application_form,
@@ -63,6 +78,12 @@ module TeacherInterface
       if ActiveModel::Type::Boolean.new.cast(
            params.dig(:qualification, :add_another),
          )
+        history_stack.replace_self(
+          path: check_teacher_interface_application_form_qualifications_path,
+          origin: false,
+          check: true,
+        )
+
         redirect_to %i[new teacher_interface application_form qualification]
       else
         redirect_to %i[teacher_interface application_form]

--- a/app/controllers/teacher_interface/registration_number_controller.rb
+++ b/app/controllers/teacher_interface/registration_number_controller.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class RegistrationNumberController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form

--- a/app/controllers/teacher_interface/registration_number_controller.rb
+++ b/app/controllers/teacher_interface/registration_number_controller.rb
@@ -23,11 +23,7 @@ module TeacherInterface
           registration_number_form_params.merge(application_form:),
         )
 
-      handle_application_form_section(
-        form: @registration_number_form,
-        if_success_then_redirect:,
-        if_failure_then_render: :edit,
-      )
+      handle_application_form_section(form: @registration_number_form)
     end
 
     private
@@ -36,10 +32,6 @@ module TeacherInterface
       params.require(:teacher_interface_registration_number_form).permit(
         :registration_number,
       )
-    end
-
-    def if_success_then_redirect
-      params[:next].presence || %i[teacher_interface application_form]
     end
 
     def load_teaching_authority_other

--- a/app/controllers/teacher_interface/subjects_controller.rb
+++ b/app/controllers/teacher_interface/subjects_controller.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class SubjectsController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form

--- a/app/controllers/teacher_interface/subjects_controller.rb
+++ b/app/controllers/teacher_interface/subjects_controller.rb
@@ -22,11 +22,7 @@ module TeacherInterface
       @subjects_form =
         SubjectsForm.new(subjects_form_params.merge(application_form:))
 
-      handle_application_form_section(
-        form: @subjects_form,
-        if_success_then_redirect:,
-        if_failure_then_render: :edit,
-      )
+      handle_application_form_section(form: @subjects_form)
     end
 
     private
@@ -37,10 +33,6 @@ module TeacherInterface
         :subject_2,
         :subject_3,
       )
-    end
-
-    def if_success_then_redirect
-      params[:next].presence || %i[teacher_interface application_form]
     end
   end
 end

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class UploadsController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_draft_or_further_information
     before_action :load_application_form
@@ -16,7 +19,15 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @upload_form,
-        if_success_then_redirect: document_path,
+        if_success_then_redirect: -> do
+          history_stack.replace_self(
+            path:
+              edit_teacher_interface_application_form_document_path(document),
+            origin: false,
+            check: false,
+          )
+          document_path
+        end,
         if_failure_then_render: :new,
       )
     end

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -19,14 +19,15 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @upload_form,
-        if_success_then_redirect: -> do
+        if_success_then_redirect: ->(_check_path) do
           history_stack.replace_self(
             path:
               edit_teacher_interface_application_form_document_path(document),
             origin: false,
             check: false,
           )
-          document_path
+
+          [:teacher_interface, :application_form, document]
         end,
         if_failure_then_render: :new,
       )
@@ -44,7 +45,7 @@ module TeacherInterface
         )
 
       if @delete_upload_form.save(validate: true)
-        redirect_to document_path
+        redirect_to [:teacher_interface, :application_form, document]
       else
         render :delete, status: :unprocessable_entity
       end
@@ -66,13 +67,6 @@ module TeacherInterface
       )[
         :teacher_interface_upload_form
       ] || {}
-    end
-
-    def document_path
-      teacher_interface_application_form_document_path(
-        @document,
-        next: params[:next],
-      )
     end
   end
 end

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -58,7 +58,7 @@ module TeacherInterface
     end
 
     def document_path
-      edit_teacher_interface_application_form_document_path(
+      teacher_interface_application_form_document_path(
         @document,
         next: params[:next],
       )

--- a/app/controllers/teacher_interface/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/work_histories_controller.rb
@@ -1,9 +1,15 @@
+# frozen_string_literal: true
+
 module TeacherInterface
   class WorkHistoriesController < BaseController
     include HandleApplicationFormSection
+    include HistoryTrackable
 
     before_action :redirect_unless_application_form_is_draft
     before_action :load_application_form
+
+    skip_before_action :track_history, only: :index
+    define_history_checks :check
 
     def index
       if application_form.task_item_completed?(:work_history, :work_history)
@@ -35,7 +41,17 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @work_history_form,
-        if_success_then_redirect: update_success_path,
+        if_success_then_redirect: -> do
+          history_stack.replace_self(
+            path:
+              edit_teacher_interface_application_form_work_history_path(
+                work_history,
+              ),
+            origin: false,
+            check: false,
+          )
+          update_success_path
+        end,
         if_failure_then_render: :new,
       )
     end
@@ -47,6 +63,12 @@ module TeacherInterface
       if ActiveModel::Type::Boolean.new.cast(
            params.dig(:work_history, :add_another),
          )
+        history_stack.replace_self(
+          path: check_teacher_interface_application_form_work_histories_path,
+          origin: false,
+          check: true,
+        )
+
         redirect_to %i[new teacher_interface application_form work_history]
       else
         redirect_to %i[teacher_interface application_form]

--- a/app/controllers/teacher_interface/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/work_histories_controller.rb
@@ -41,7 +41,7 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @work_history_form,
-        if_success_then_redirect: -> do
+        if_success_then_redirect: ->(_check_path) do
           history_stack.replace_self(
             path:
               edit_teacher_interface_application_form_work_history_path(
@@ -50,7 +50,8 @@ module TeacherInterface
             origin: false,
             check: false,
           )
-          update_success_path
+
+          %i[check teacher_interface application_form work_histories]
         end,
         if_failure_then_render: :new,
       )
@@ -91,7 +92,9 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @has_work_history_form,
-        if_success_then_redirect: -> { has_work_history_success_path },
+        if_success_then_redirect: ->(check_path) do
+          has_work_history_success_path(check_path)
+        end,
         if_failure_then_render: :edit_has_work_history,
       )
     end
@@ -122,8 +125,12 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @work_history_form,
-        if_success_then_redirect: update_success_path,
-        if_failure_then_render: :edit,
+        if_success_then_redirect: %i[
+          check
+          teacher_interface
+          application_form
+          work_histories
+        ],
       )
     end
 
@@ -141,7 +148,7 @@ module TeacherInterface
         )
 
       if @delete_work_history_form.save(validate: true)
-        redirect_to update_success_path
+        redirect_to %i[check teacher_interface application_form work_histories]
       else
         render :delete, status: :unprocessable_entity
       end
@@ -155,14 +162,12 @@ module TeacherInterface
       )
     end
 
-    def has_work_history_success_path
+    def has_work_history_success_path(check_path)
       if @has_work_history_form.has_work_history
         if application_form.work_histories.empty?
-          new_teacher_interface_application_form_work_history_path(
-            next: params[:next],
-          )
+          new_teacher_interface_application_form_work_history_path
         else
-          params[:next].presence ||
+          check_path ||
             [
               :edit,
               :teacher_interface,
@@ -171,7 +176,7 @@ module TeacherInterface
             ]
         end
       else
-        params[:next].presence ||
+        check_path ||
           %i[check teacher_interface application_form work_histories]
       end
     end
@@ -192,11 +197,6 @@ module TeacherInterface
         :start_date,
         :still_employed,
       )
-    end
-
-    def update_success_path
-      params[:next].presence ||
-        %i[check teacher_interface application_form work_histories]
     end
   end
 end

--- a/app/lib/document_continue_redirection.rb
+++ b/app/lib/document_continue_redirection.rb
@@ -29,7 +29,6 @@ class DocumentContinueRedirection
 
   def qualification_certificate_url
     [
-      :edit,
       :teacher_interface,
       :application_form,
       document.documentable.transcript_document,

--- a/app/lib/history_stack.rb
+++ b/app/lib/history_stack.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class HistoryStack
+  def initialize(session:)
+    @session = session
+  end
+
+  def push(path:, origin:, check:, reset:)
+    apply_to_stack do |stack|
+      stack.clear if reset
+      current_entry = stack.last
+      new_entry = { path:, origin:, check: }
+      stack.push(new_entry) if current_entry != new_entry
+    end
+  end
+
+  def push_self(request, origin:, check:, reset: false)
+    push(path: request.fullpath, origin:, check:, reset:)
+  end
+
+  def pop
+    apply_to_stack(&:pop)
+  end
+
+  def pop_back
+    pop # self
+
+    entry = pop
+    entry[:path] if entry
+  end
+
+  def pop_to_origin
+    pop # self
+
+    loop do
+      entry = pop
+      return nil if entry.nil?
+      return entry[:path] if entry[:origin]
+    end
+  end
+
+  def replace_self(path:, origin:, check:)
+    pop
+    push(path:, origin:, check:, reset: false)
+  end
+
+  def last_entry
+    apply_to_stack(&:second_to_last)
+  end
+
+  private
+
+  def apply_to_stack
+    stack = session[:history_stack] || []
+    return_value = yield stack
+    session[:history_stack] = stack
+    return_value
+  end
+
+  attr_reader :session
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -169,7 +169,7 @@ class ApplicationForm < ApplicationRecord
 
     if key == :identification_document
       return(
-        url_helpers.edit_teacher_interface_application_form_document_path(
+        url_helpers.teacher_interface_application_form_document_path(
           identification_document,
         )
       )
@@ -177,7 +177,7 @@ class ApplicationForm < ApplicationRecord
 
     if key == :written_statement
       return(
-        url_helpers.edit_teacher_interface_application_form_document_path(
+        url_helpers.teacher_interface_application_form_document_path(
           written_statement_document,
         )
       )

--- a/app/views/shared/application_form/_identification_document_summary.html.erb
+++ b/app/views/shared/application_form/_identification_document_summary.html.erb
@@ -5,7 +5,7 @@
   fields: {
     identification_document: {
       title: "Identity documents",
-      href: [:edit, :teacher_interface, :application_form, application_form.identification_document]
+      href: [:teacher_interface, :application_form, application_form.identification_document]
     },
   },
   changeable:

--- a/app/views/shared/application_form/_personal_information_summary.html.erb
+++ b/app/views/shared/application_form/_personal_information_summary.html.erb
@@ -23,7 +23,7 @@
       href: %i[alternative_name teacher_interface application_form personal_information]
     } : nil,
     name_change_document: application_form.has_alternative_name? ? {
-      href: [:edit, :teacher_interface, :application_form, application_form.name_change_document]
+      href: [:teacher_interface, :application_form, application_form.name_change_document]
     } : nil,
   },
   changeable:

--- a/app/views/shared/application_form/_qualifications_summary.html.erb
+++ b/app/views/shared/application_form/_qualifications_summary.html.erb
@@ -32,10 +32,10 @@
         href: [:edit, :teacher_interface, :application_form, qualification]
       },
       certificate_document: {
-        href: [:edit, :teacher_interface, :application_form, qualification.certificate_document],
+        href: [:teacher_interface, :application_form, qualification.certificate_document],
       },
       transcript_document: {
-        href: [:edit, :teacher_interface, :application_form, qualification.transcript_document],
+        href: [:teacher_interface, :application_form, qualification.transcript_document],
       },
       part_of_university_degree: qualification.is_teaching_qualification? ? {
         title: "Part of your university degree?",

--- a/app/views/shared/application_form/_written_statement_summary.html.erb
+++ b/app/views/shared/application_form/_written_statement_summary.html.erb
@@ -5,7 +5,7 @@
   fields: {
     written_statement_document: {
       title: "Written statement",
-      href: [:edit, :teacher_interface, :application_form, application_form.written_statement_document]
+      href: [:teacher_interface, :application_form, application_form.written_statement_document]
     },
   },
   changeable:

--- a/app/views/teacher_interface/age_range/edit.erb
+++ b/app/views/teacher_interface/age_range/edit.erb
@@ -4,8 +4,6 @@
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 
 <%= form_with model: @age_range_form, url: %i[age_range teacher_interface application_form] do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_fieldset legend: { text: t("application_form.age_range.heading"), tag: "h1", size: "l" } do %>

--- a/app/views/teacher_interface/age_range/edit.erb
+++ b/app/views/teacher_interface/age_range/edit.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @age_range_form.errors.any?}#{t("application_form.tasks.items.age_range")}" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 

--- a/app/views/teacher_interface/application_forms/edit.html.erb
+++ b/app/views/teacher_interface/application_forms/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Check your answers" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <h1 class="govuk-heading-xl">Check your answers before submitting your application</h1>
 

--- a/app/views/teacher_interface/documents/edit.html.erb
+++ b/app/views/teacher_interface/documents/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @add_another_upload_form.errors.any?}Check your uploaded files" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <h1 class="govuk-heading-l">Check your uploaded files – <%= I18n.t("document.document_type.#{@document.document_type}") %> document</h1>
 

--- a/app/views/teacher_interface/documents/edit.html.erb
+++ b/app/views/teacher_interface/documents/edit.html.erb
@@ -12,7 +12,7 @@
       row.value { upload_link_to(upload) }
       row.action(
         text: "Delete",
-        href: delete_teacher_interface_application_form_document_upload_path(@document, upload, next: params[:next]),
+        href: delete_teacher_interface_application_form_document_upload_path(@document, upload),
         visually_hidden_text: upload.attachment.filename
       )
     end
@@ -20,8 +20,6 @@
 end %>
 
 <%= form_with model: @add_another_upload_form, url: [:teacher_interface, :application_form, @document], method: :patch do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_radio_buttons_fieldset :add_another,

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -6,8 +6,6 @@
 <p class="govuk-inset-text"><%= @further_information_request_item.failure_reason_assessor_feedback %></p>
 
 <%= form_with model: @further_information_request_item_text_form, url: teacher_interface_application_form_further_information_request_further_information_request_item_path, method: :put do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <% if @further_information_request_item.text? %>
     <%= f.govuk_text_area :response, label: { size: "s" } %>
   <% end %>

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @further_information_request_item_text_form&.errors&.any?}Further information required" %>
-<% content_for :back_link_url, back_link_url(teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
 
 <h1 class="govuk-heading-l">Further information required</h1>
 <h3 class="govuk-heading-s">Notes from the assessor</h3>

--- a/app/views/teacher_interface/further_information_requests/edit.html.erb
+++ b/app/views/teacher_interface/further_information_requests/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Check your answers before submitting your application" %>
-<% content_for :back_link_url, teacher_interface_application_form_further_information_request_path(@view_object.further_information_request) %>
+<% content_for :back_link_url, back_history_path(origin: true, default: teacher_interface_application_form_further_information_request_path(@view_object.further_information_request)) %>
 
 <h1 class="govuk-heading-xl">
   Check your answers before submitting your application

--- a/app/views/teacher_interface/further_information_requests/show.html.erb
+++ b/app/views/teacher_interface/further_information_requests/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Apply for qualified teacher status (QTS)" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <h1 class="govuk-heading-l">Apply for qualified teacher status (QTS)</h1>
 

--- a/app/views/teacher_interface/personal_information/alternative_name.html.erb
+++ b/app/views/teacher_interface/personal_information/alternative_name.html.erb
@@ -4,8 +4,6 @@
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.about_you") %></span>
 
 <%= form_with model: @alternative_name_form, url: [:alternative_name, :teacher_interface, :application_form, :personal_information] do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_radio_buttons_fieldset :has_alternative_name, legend: { size: "l", tag: "h1" } do %>

--- a/app/views/teacher_interface/personal_information/alternative_name.html.erb
+++ b/app/views/teacher_interface/personal_information/alternative_name.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @alternative_name_form.errors.any?}#{t("application_form.tasks.sections.about_you")}" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.about_you") %></span>
 

--- a/app/views/teacher_interface/personal_information/check.html.erb
+++ b/app/views/teacher_interface/personal_information/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Check your answers" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(origin: true, default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.about_you") %></span>
 <h1 class="govuk-heading-l">Check your answers</h1>

--- a/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
+++ b/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
@@ -5,8 +5,6 @@
 <h1 class="govuk-heading-l">Personal information</h1>
 
 <%= form_with model: @name_and_date_of_birth_form, url: [:name_and_date_of_birth, :teacher_interface, :application_form, :personal_information] do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_text_field :given_names,

--- a/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
+++ b/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @name_and_date_of_birth_form.errors.any?}About you" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l">About you</span>
 <h1 class="govuk-heading-l">Personal information</h1>

--- a/app/views/teacher_interface/qualifications/_form.html.erb
+++ b/app/views/teacher_interface/qualifications/_form.html.erb
@@ -1,6 +1,4 @@
 <%= form_with model: qualification_form, url: [:teacher_interface, :application_form, qualification], method: qualification.new_record? ? :post : :put do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_fieldset legend: { text: I18n.t("application_form.qualifications.form.title.#{qualification.locale_key}") } do %>

--- a/app/views/teacher_interface/qualifications/add_another.html.erb
+++ b/app/views/teacher_interface/qualifications/add_another.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, I18n.t("application_form.tasks.sections.qualifications") %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 

--- a/app/views/teacher_interface/qualifications/check.html.erb
+++ b/app/views/teacher_interface/qualifications/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, I18n.t("application_form.tasks.sections.qualifications") %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(origin: true, default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 <h1 class="govuk-heading-l">Check your answers</h1>

--- a/app/views/teacher_interface/qualifications/delete.html.erb
+++ b/app/views/teacher_interface/qualifications/delete.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Delete qualification" %>
-<% content_for :back_link_url, teacher_interface_application_form_qualifications_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_qualifications_path) %>
 
 <%= form_with model: @delete_qualification_form, url: [:teacher_interface, :application_form, @qualification], method: :delete do |f| %>
   <%= hidden_field_tag :next, params[:next] %>

--- a/app/views/teacher_interface/qualifications/delete.html.erb
+++ b/app/views/teacher_interface/qualifications/delete.html.erb
@@ -2,8 +2,6 @@
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_qualifications_path) %>
 
 <%= form_with model: @delete_qualification_form, url: [:teacher_interface, :application_form, @qualification], method: :delete do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :confirm,

--- a/app/views/teacher_interface/qualifications/edit.html.erb
+++ b/app/views/teacher_interface/qualifications/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @qualification_form.errors.any?}#{t("application_form.tasks.sections.qualifications")}" %>
-<% content_for :back_link_url, back_link_url(teacher_interface_application_form_path) %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= render "heading", qualification: @qualification %>
 

--- a/app/views/teacher_interface/qualifications/edit_part_of_university_degree.html.erb
+++ b/app/views/teacher_interface/qualifications/edit_part_of_university_degree.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, I18n.t("application_form.tasks.sections.qualifications") %>
-<% content_for :back_link_url, teacher_interface_application_form_qualifications_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_qualifications_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 

--- a/app/views/teacher_interface/qualifications/edit_part_of_university_degree.html.erb
+++ b/app/views/teacher_interface/qualifications/edit_part_of_university_degree.html.erb
@@ -4,8 +4,6 @@
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 
 <%= form_with model: @part_of_university_degree_form, url: [:part_of_university_degree, :teacher_interface, :application_form, @qualification] do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :part_of_university_degree,

--- a/app/views/teacher_interface/qualifications/new.html.erb
+++ b/app/views/teacher_interface/qualifications/new.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @qualification_form.errors.any?}#{t("application_form.tasks.sections.qualifications")}" %>
-<% content_for :back_link_url, @application_form.qualifications.empty? ?
-                                 teacher_interface_application_form_path :
-                                 teacher_interface_application_form_qualifications_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= render "heading", qualification: @qualification_form.qualification %>
 

--- a/app/views/teacher_interface/registration_number/edit.html.erb
+++ b/app/views/teacher_interface/registration_number/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @registration_number_form.errors.any?}#{t("application_form.tasks.items.registration_number")}" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= form_with model: @registration_number_form, url: %i[registration_number teacher_interface application_form] do |f| %>
   <%= hidden_field_tag :next, params[:next] %>

--- a/app/views/teacher_interface/registration_number/edit.html.erb
+++ b/app/views/teacher_interface/registration_number/edit.html.erb
@@ -2,8 +2,6 @@
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= form_with model: @registration_number_form, url: %i[registration_number teacher_interface application_form] do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_text_field :registration_number, label: { size: "l", tag: "h1" } %>

--- a/app/views/teacher_interface/subjects/edit.html.erb
+++ b/app/views/teacher_interface/subjects/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @subjects_form.errors.any?}#{t("application_form.tasks.items.subjects")}" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 <h1 class="govuk-heading-l"><%= I18n.t("application_form.subjects.heading") %></h1>

--- a/app/views/teacher_interface/subjects/edit.html.erb
+++ b/app/views/teacher_interface/subjects/edit.html.erb
@@ -6,8 +6,6 @@
 <p class="govuk-hint"><%= I18n.t("application_form.subjects.hint") %></p>
 
 <%= form_with model: @subjects_form, url: %i[subjects teacher_interface application_form] do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <% (1..3).map { |i| :"subject_#{i}" }.each do |field| %>

--- a/app/views/teacher_interface/uploads/delete.html.erb
+++ b/app/views/teacher_interface/uploads/delete.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @delete_upload_form.errors.any?}Delete #{@upload.attachment.filename}" %>
-<% content_for :back_link_url, edit_teacher_interface_application_form_document_path(@document) %>
+<% content_for :back_link_url, back_history_path(default: edit_teacher_interface_application_form_document_path(@document)) %>
 
 <%= form_with model: @delete_upload_form, url: [:teacher_interface, :application_form, @document, @upload], method: :delete do |f| %>
   <%= hidden_field_tag :next, params[:next] %>

--- a/app/views/teacher_interface/uploads/delete.html.erb
+++ b/app/views/teacher_interface/uploads/delete.html.erb
@@ -2,8 +2,6 @@
 <% content_for :back_link_url, back_history_path(default: edit_teacher_interface_application_form_document_path(@document)) %>
 
 <%= form_with model: @delete_upload_form, url: [:teacher_interface, :application_form, @document, @upload], method: :delete do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :confirm,

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @upload_form.errors.any?}Upload a document" %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <% if @document.uploads.empty? %>
   <% if @document.identification? %>

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -93,8 +93,6 @@
 <% end %>
 
 <%= form_with model: @upload_form, url: [:teacher_interface, :application_form, @document, :uploads] do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_file_field :original_attachment,

--- a/app/views/teacher_interface/work_histories/_form.html.erb
+++ b/app/views/teacher_interface/work_histories/_form.html.erb
@@ -1,6 +1,4 @@
 <%= form_with model: work_history_form, url: [:teacher_interface, :application_form, work_history], method: work_history.new_record? ? :post : :put do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_fieldset legend: { text: I18n.t(work_history.current_or_most_recent_role? ? "application_form.work_history.current_or_most_recent_role" : "application_form.work_history.previous_role") } do %>

--- a/app/views/teacher_interface/work_histories/add_another.html.erb
+++ b/app/views/teacher_interface/work_histories/add_another.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, I18n.t("application_form.tasks.sections.work_history") %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.work_history") %></span>
 

--- a/app/views/teacher_interface/work_histories/check.html.erb
+++ b/app/views/teacher_interface/work_histories/check.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, I18n.t("application_form.tasks.sections.work_history") %>
-<% content_for :back_link_url, teacher_interface_application_form_path %>
+<% content_for :back_link_url, back_history_path(origin: true, default: teacher_interface_application_form_path) %>
 
 <%= render "heading" %>
 

--- a/app/views/teacher_interface/work_histories/delete.html.erb
+++ b/app/views/teacher_interface/work_histories/delete.html.erb
@@ -2,8 +2,6 @@
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_work_histories_path) %>
 
 <%= form_with model: @delete_work_history_form, url: [:teacher_interface, :application_form, @work_history], method: :delete do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :confirm,

--- a/app/views/teacher_interface/work_histories/delete.html.erb
+++ b/app/views/teacher_interface/work_histories/delete.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Delete work history" %>
-<% content_for :back_link_url, teacher_interface_application_form_work_histories_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_work_histories_path) %>
 
 <%= form_with model: @delete_work_history_form, url: [:teacher_interface, :application_form, @work_history], method: :delete do |f| %>
   <%= hidden_field_tag :next, params[:next] %>

--- a/app/views/teacher_interface/work_histories/edit.html.erb
+++ b/app/views/teacher_interface/work_histories/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @work_history_form.errors.any?}#{t("application_form.tasks.sections.work_history")}" %>
-<% content_for :back_link_url, teacher_interface_application_form_work_histories_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_work_histories_path) %>
 
 <%= render "heading" %>
 

--- a/app/views/teacher_interface/work_histories/edit_has_work_history.html.erb
+++ b/app/views/teacher_interface/work_histories/edit_has_work_history.html.erb
@@ -2,8 +2,6 @@
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= form_with model: @has_work_history_form, url: [:has_work_history, :teacher_interface, :application_form, :work_histories] do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_collection_radio_buttons :has_work_history,

--- a/app/views/teacher_interface/work_histories/edit_has_work_history.html.erb
+++ b/app/views/teacher_interface/work_histories/edit_has_work_history.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @has_work_history_form.errors.any?}#{t("application_form.tasks.sections.work_history")}" %>
-<% content_for :back_link_url,  @application_form.work_histories.empty? ?
-                                 teacher_interface_application_form_path :
-                                 teacher_interface_application_form_work_histories_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= form_with model: @has_work_history_form, url: [:has_work_history, :teacher_interface, :application_form, :work_histories] do |f| %>
   <%= hidden_field_tag :next, params[:next] %>

--- a/app/views/teacher_interface/work_histories/new.html.erb
+++ b/app/views/teacher_interface/work_histories/new.html.erb
@@ -1,7 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @work_history_form.errors.any?}#{t("application_form.tasks.sections.work_history")}" %>
-<% content_for :back_link_url, @application_form.work_histories.empty? ?
-                                 teacher_interface_application_form_path :
-                                 teacher_interface_application_form_work_histories_path %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= render "heading" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -178,7 +178,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :documents, only: %i[edit update] do
+      resources :documents, only: %i[show edit update] do
         resources :uploads, only: %i[new create destroy] do
           get "delete", on: :member
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -215,6 +215,10 @@ Rails.application.routes.draw do
         as: "teacher_signed_out"
   end
 
+  resource :history, only: %i[] do
+    get "back", to: "history#back", on: :collection
+  end
+
   resources :personas, only: %i[index] do
     member do
       post "staff", to: "personas#staff_sign_in", as: "staff_sign_in"

--- a/docs/history-and-back-links.md
+++ b/docs/history-and-back-links.md
@@ -1,0 +1,25 @@
+# History and back links
+
+Back links and "check your answers" page have been implemented as per the following journey diagram:
+https://drive.google.com/file/d/1wAerFpEZVQpsu3otSc-Ib3HsDsM_bxXh/view?ts=6384846c
+
+As the user navigates through the site, their history is tracked in the session using the [`HistoryStack`][history-stack] class in combination with the [`HistoryTrackable`][history-trackable] concern. When a user clicks on a back link, we pop the latest entry from the stack and redirect them to the previous page using the [`HistoryController`][history-controller].
+
+## Types of pages
+
+Certain pages are given specific behaviours to support the journeys as described in the diagram above:
+
+- `origin: true` - If an entry in the stack has `origin` set to `true`, that means that it’s the start of a journey, and therefore when a user clicks on a back link from a "check your answers" page they will be taken directly to the previous origin page.
+- `check: true` - If an entry in the stack has `check` set to `true`, that means that it’s a "check your answers" page, and we use this to determine whether the user is currently part of a "check your answers" flow and should therefore be taken back to the "check your answers" page after answering a question.
+
+## `HistoryTrackable` concern
+
+The `HistoryTrackable` concern automatically records when a user navigates to a page (navigate here refers to any `GET` request) using a `track_history` `before_action` which can be skipped if necessary. There are a number of other methods defined to customise how the page is tracked.
+
+- `define_history_origins` - This takes action names which should be defined as origin pages when they’re tracked.
+- `define_history_checks` - This takes action names which should be defined as check pages when they’re tracked.
+- `define_history_resets` - This takes action names which should reset the history when they're navigated to, this is useful to clear the history when a user navigates directly to the start of the journey (for example by clicking on a link in the header).
+
+[history-stack]: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/app/lib/history_stack.rb
+[history-trackable]: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/app/controllers/concerns/history_trackable.rb
+[history-controller]: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/app/controllers/history_controller.rb

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
     it "renders a link" do
       a = component.at_css(".govuk-summary-list__card-actions a")
       expect(a.text.strip).to eq("Delete title")
-      expect(a.attribute("href").value).to eq("/delete?next=%2F")
+      expect(a.attribute("href").value).to eq("/delete")
     end
   end
 
@@ -126,7 +126,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change string")
-      expect(a.attribute("href").value).to eq("/string?next=%2F")
+      expect(a.attribute("href").value).to eq("/string")
     end
   end
 
@@ -145,7 +145,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change number")
-      expect(a.attribute("href").value).to eq("/number?next=%2F")
+      expect(a.attribute("href").value).to eq("/number")
     end
   end
 
@@ -166,7 +166,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change date")
-      expect(a.attribute("href").value).to eq("/date?next=%2F")
+      expect(a.attribute("href").value).to eq("/date")
     end
   end
 
@@ -189,7 +189,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change date without day")
-      expect(a.attribute("href").value).to eq("/date_without_day?next=%2F")
+      expect(a.attribute("href").value).to eq("/date_without_day")
     end
   end
 
@@ -210,7 +210,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change a custom key")
-      expect(a.attribute("href").value).to eq("/custom_key?next=%2F")
+      expect(a.attribute("href").value).to eq("/custom_key")
     end
   end
 
@@ -229,7 +229,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change nil value")
-      expect(a.attribute("href").value).to eq("/nil_value?next=%2F")
+      expect(a.attribute("href").value).to eq("/nil_value")
     end
   end
 
@@ -248,7 +248,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change boolean")
-      expect(a.attribute("href").value).to eq("/boolean?next=%2F")
+      expect(a.attribute("href").value).to eq("/boolean")
     end
   end
 
@@ -272,7 +272,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change document")
-      expect(a.attribute("href").value).to eq("/document?next=%2F")
+      expect(a.attribute("href").value).to eq("/document")
     end
   end
 
@@ -291,7 +291,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
       expect(a.text.strip).to eq("Change array")
-      expect(a.attribute("href").value).to eq("/array?next=%2F")
+      expect(a.attribute("href").value).to eq("/array")
     end
   end
 
@@ -318,9 +318,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
         a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
         expect(a.text.strip).to eq("Change translatable document")
-        expect(a.attribute("href").value).to eq(
-          "/translatable-document?next=%2F",
-        )
+        expect(a.attribute("href").value).to eq("/translatable-document")
       end
     end
 
@@ -346,9 +344,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
         a = row.at_css(".govuk-summary-list__actions .govuk-link")
 
         expect(a.text.strip).to eq("Change translatable document translation")
-        expect(a.attribute("href").value).to eq(
-          "/translatable-document?next=%2F",
-        )
+        expect(a.attribute("href").value).to eq("/translatable-document")
       end
     end
 

--- a/spec/controllers/concerns/handle_application_form_section_spec.rb
+++ b/spec/controllers/concerns/handle_application_form_section_spec.rb
@@ -10,7 +10,13 @@ RSpec.describe HandleApplicationFormSection, type: :controller do
   end
 
   subject(:controller) { controller_class.new }
-  before { allow(controller).to receive(:params).and_return(params) }
+
+  let(:session) { {} }
+
+  before do
+    allow(controller).to receive(:params).and_return(params)
+    allow(controller).to receive(:session).and_return(session)
+  end
 
   describe "#handle_application_form_section" do
     let(:form) { double }
@@ -59,11 +65,18 @@ RSpec.describe HandleApplicationFormSection, type: :controller do
         handle_application_form_section
       end
 
-      context "with a next path" do
-        before { params[:next] = "/next" }
+      context "with a check entry in the history" do
+        let(:session) do
+          {
+            history_stack: [
+              { path: "/check", check: true },
+              { path: "/current" },
+            ],
+          }
+        end
 
         it "redirects to application form" do
-          expect(controller).to receive(:redirect_to).with("/next")
+          expect(controller).to receive(:redirect_to).with("/check")
           handle_application_form_section
         end
       end

--- a/spec/controllers/history_controller_spec.rb
+++ b/spec/controllers/history_controller_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HistoryController, type: :controller do
+  before { FeatureFlag.activate(:service_open) }
+
+  describe "GET back" do
+    let(:default) { "/fallback" }
+
+    subject(:perform) { get :back, params: { origin:, default: } }
+
+    context "with origin true" do
+      let(:origin) { "true" }
+
+      context "with a destination" do
+        before do
+          expect_any_instance_of(HistoryStack).to receive(
+            :pop_to_origin,
+          ).and_return("/origin")
+        end
+
+        it "redirects to the destination" do
+          perform
+          expect(response).to redirect_to("/origin")
+        end
+      end
+
+      context "without a destination" do
+        before do
+          expect_any_instance_of(HistoryStack).to receive(
+            :pop_to_origin,
+          ).and_return(nil)
+        end
+
+        it "redirects to the default" do
+          perform
+          expect(response).to redirect_to("/fallback")
+        end
+      end
+    end
+
+    context "with origin false" do
+      let(:origin) { "false" }
+
+      context "with a destination" do
+        before do
+          expect_any_instance_of(HistoryStack).to receive(:pop_back).and_return(
+            "/previous",
+          )
+        end
+
+        it "redirects to the destination" do
+          perform
+          expect(response).to redirect_to("/previous")
+        end
+      end
+
+      context "without a destination" do
+        before do
+          expect_any_instance_of(HistoryStack).to receive(:pop_back).and_return(
+            nil,
+          )
+        end
+
+        it "redirects to the default" do
+          perform
+          expect(response).to redirect_to("/fallback")
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/document_continue_redirection_spec.rb
+++ b/spec/lib/document_continue_redirection_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe DocumentContinueRedirection do
       it do
         is_expected.to eq(
           [
-            :edit,
             :teacher_interface,
             :application_form,
             qualification.transcript_document,

--- a/spec/lib/history_stack_spec.rb
+++ b/spec/lib/history_stack_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HistoryStack do
+  subject(:history_stack) { described_class.new(session:) }
+
+  describe "#push_self" do
+    subject(:push_self) do
+      history_stack.push_self(request, origin:, check:, reset:)
+    end
+
+    let(:request) { double(fullpath: "/path?page=1") }
+    let(:check) { false }
+
+    context "with an empty session" do
+      let(:session) { {} }
+      let(:reset) { false }
+
+      context "when origin" do
+        let(:origin) { true }
+
+        it "stores the stack in the session" do
+          expect { push_self }.to change { session }.to(
+            {
+              history_stack: [
+                { origin: true, check: false, path: "/path?page=1" },
+              ],
+            },
+          )
+        end
+
+        it "doesn't store it twice" do
+          expect { 2.times { push_self } }.to change { session }.to(
+            {
+              history_stack: [
+                { origin: true, check: false, path: "/path?page=1" },
+              ],
+            },
+          )
+        end
+      end
+
+      context "when not origin" do
+        let(:origin) { false }
+
+        it "stores the stack in the session" do
+          expect { push_self }.to change { session }.to(
+            {
+              history_stack: [
+                { origin: false, check: false, path: "/path?page=1" },
+              ],
+            },
+          )
+        end
+      end
+    end
+
+    context "with an existing session" do
+      let(:session) do
+        { history_stack: [{ path: "/origin", check: false, origin: true }] }
+      end
+      let(:origin) { false }
+
+      context "when resetting" do
+        let(:reset) { true }
+
+        it "stores the stack in the session" do
+          expect { push_self }.to change { session }.to(
+            {
+              history_stack: [
+                { origin: false, check: false, path: "/path?page=1" },
+              ],
+            },
+          )
+        end
+      end
+
+      context "when not resetting" do
+        let(:reset) { false }
+
+        it "stores the stack in the session" do
+          expect { push_self }.to change { session }.to(
+            {
+              history_stack: [
+                { origin: true, check: false, path: "/origin" },
+                { origin: false, check: false, path: "/path?page=1" },
+              ],
+            },
+          )
+        end
+      end
+    end
+  end
+
+  describe "#pop_back" do
+    subject(:pop_back) { history_stack.pop_back }
+
+    context "with an empty session" do
+      let(:session) { {} }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "with an existing session" do
+      let(:session) do
+        {
+          history_stack: [
+            { path: "/origin", origin: true },
+            { path: "/page", origin: false },
+          ],
+        }
+      end
+
+      it { is_expected.to eq("/origin") }
+
+      it "stores the stack in the session" do
+        expect { pop_back }.to change { session }.to({ history_stack: [] })
+      end
+    end
+  end
+
+  describe "#pop_to_origin" do
+    subject(:pop_to_origin) { history_stack.pop_to_origin }
+
+    context "with an empty session" do
+      let(:session) { {} }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "with an existing session" do
+      let(:session) do
+        {
+          history_stack: [
+            { path: "/origin", origin: true },
+            { path: "/page1", origin: false },
+            { path: "/page2", origin: false },
+          ],
+        }
+      end
+
+      it { is_expected.to eq("/origin") }
+
+      it "stores the stack in the session" do
+        expect { pop_to_origin }.to change { session }.to({ history_stack: [] })
+      end
+    end
+  end
+
+  describe "#replace_self" do
+    subject(:replace_self) do
+      history_stack.replace_self(path:, origin:, check:)
+    end
+
+    let(:path) { "/path?page=1" }
+    let(:check) { false }
+
+    context "with an empty session" do
+      let(:session) { {} }
+
+      context "when origin" do
+        let(:origin) { true }
+
+        it "stores the stack in the session" do
+          expect { replace_self }.to change { session }.to(
+            {
+              history_stack: [
+                { origin: true, check: false, path: "/path?page=1" },
+              ],
+            },
+          )
+        end
+
+        it "doesn't store it twice" do
+          expect { 2.times { replace_self } }.to change { session }.to(
+            {
+              history_stack: [
+                { origin: true, check: false, path: "/path?page=1" },
+              ],
+            },
+          )
+        end
+      end
+
+      context "when not origin" do
+        let(:origin) { false }
+
+        it "stores the stack in the session" do
+          expect { replace_self }.to change { session }.to(
+            {
+              history_stack: [
+                { origin: false, check: false, path: "/path?page=1" },
+              ],
+            },
+          )
+        end
+      end
+    end
+
+    context "with an existing session" do
+      let(:session) do
+        { history_stack: [{ path: "/origin", check: false, origin: true }] }
+      end
+      let(:origin) { false }
+
+      it "stores the stack in the session" do
+        expect { replace_self }.to change { session }.to(
+          {
+            history_stack: [
+              { origin: false, check: false, path: "/path?page=1" },
+            ],
+          },
+        )
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/govuk_radio_item.rb
+++ b/spec/support/autoload/page_objects/govuk_radio_item.rb
@@ -2,5 +2,7 @@ module PageObjects
   class GovukRadioItem < SitePrism::Section
     element :input, ".govuk-radios__input", visible: false
     element :label, ".govuk-radios__label"
+
+    def_delegator :input, :choose
   end
 end

--- a/spec/support/autoload/page_objects/govuk_summary_list.rb
+++ b/spec/support/autoload/page_objects/govuk_summary_list.rb
@@ -7,5 +7,9 @@ module PageObjects
         element :link, ".govuk-link"
       end
     end
+
+    def find_row(key:)
+      rows.find { |row| row.key.text == key }
+    end
   end
 end

--- a/spec/support/autoload/page_objects/task_list.rb
+++ b/spec/support/autoload/page_objects/task_list.rb
@@ -7,7 +7,7 @@ module PageObjects
     end
 
     def click_item(link_text)
-      find_item(link_text).link.click
+      find_item(link_text).click
     end
   end
 end

--- a/spec/support/autoload/page_objects/task_list_item.rb
+++ b/spec/support/autoload/page_objects/task_list_item.rb
@@ -3,5 +3,7 @@ module PageObjects
     element :name, "span"
     element :link, "a"
     element :status_tag, ".govuk-tag"
+
+    def_delegator :link, :click
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/add_another_qualification.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/add_another_qualification.rb
@@ -1,0 +1,20 @@
+module PageObjects
+  module TeacherInterface
+    class AddAnotherQualification < SitePrism::Page
+      set_url "/teacher/application/qualifications/add_another"
+
+      element :heading, "h1"
+
+      section :form, "form" do
+        section :yes_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(1)"
+        section :no_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(2)"
+
+        element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/application.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/application.rb
@@ -11,6 +11,10 @@ module PageObjects
       element :save_and_sign_out, ".govuk-button:nth-of-type(2)"
 
       section :task_list, TaskList, ".app-task-list"
+
+      def qualifications_task_item
+        task_list.find_item("Add your teaching qualifications")
+      end
     end
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/check_qualifications.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/check_qualifications.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module TeacherInterface
+    class CheckQualifications < SitePrism::Page
+      set_url "/teacher/application/qualifications/check"
+
+      element :heading, "h1"
+      sections :summary_lists, GovukSummaryList, ".govuk-summary-list"
+      element :continue_button, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/edit_qualification.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/edit_qualification.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module TeacherInterface
+    class EditQualification < QualificationsForm
+      set_url "/teacher/application/qualifications/{qualification_id}/edit"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/new_qualification.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/new_qualification.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module TeacherInterface
+    class NewQualification < QualificationsForm
+      set_url "/teacher/application/qualifications/new"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/part_of_university_degree.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/part_of_university_degree.rb
@@ -1,0 +1,22 @@
+module PageObjects
+  module TeacherInterface
+    class PartOfUniversityDegree < SitePrism::Page
+      set_url "/teacher/application/qualifications/{qualification_id}/part_of_university_degree"
+
+      element :heading, "h1"
+
+      section :form, "form" do
+        section :yes_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(1)"
+        section :no_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(2)"
+
+        element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
+        element :save_and_come_back_later_button,
+                ".govuk-button.govuk-button--secondary"
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/qualifications_form.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/qualifications_form.rb
@@ -3,6 +3,30 @@ module PageObjects
     class QualificationsForm < SitePrism::Page
       element :heading, "h1"
       element :body, ".govuk-body-l"
+
+      section :form, "form" do
+        element :title, "#teacher-interface-qualification-form-title-field"
+        element :institution_name,
+                "#teacher-interface-qualification-form-institution-name-field"
+        element :institution_country,
+                "#teacher-interface-qualification-form-institution-country-location-field"
+        element :start_date_month,
+                "#teacher_interface_qualification_form_start_date_2i"
+        element :start_date_year,
+                "#teacher_interface_qualification_form_start_date_1i"
+        element :complete_date_month,
+                "#teacher_interface_qualification_form_complete_date_2i"
+        element :complete_date_year,
+                "#teacher_interface_qualification_form_complete_date_1i"
+        element :certificate_date_month,
+                "#teacher_interface_qualification_form_certificate_date_2i"
+        element :certificate_date_year,
+                "#teacher_interface_qualification_form_certificate_date_1i"
+
+        element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
+        element :save_and_come_back_later_button,
+                ".govuk-button.govuk-button--secondary"
+      end
     end
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/upload_document_form.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/upload_document_form.rb
@@ -8,6 +8,13 @@ module PageObjects
       section :form, "form" do
         element :original_attachment,
                 "#teacher-interface-upload-form-original-attachment-field"
+        element :translated_attachment,
+                "#teacher-interface-upload-form-translated-attachment-field"
+
+        sections :written_in_english_items,
+                 GovukRadioItem,
+                 ".govuk-radios__item"
+
         element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
         element :save_and_come_back_later_button,
                 ".govuk-button.govuk-button--secondary"

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -7,6 +7,11 @@ module PageHelpers
     send(page.to_sym).load(**args)
   end
 
+  def add_another_qualification_page
+    @add_another_qualification_page ||=
+      PageObjects::TeacherInterface::AddAnotherQualification.new
+  end
+
   def assessor_application_page
     @assessor_application_page ||=
       PageObjects::AssessorInterface::Application.new
@@ -81,6 +86,11 @@ module PageHelpers
     @degree_page ||= PageObjects::EligibilityInterface::Degree.new
   end
 
+  def edit_qualification_page
+    @edit_qualification_page ||=
+      PageObjects::TeacherInterface::EditQualification.new
+  end
+
   def eligible_page
     @eligible_page = PageObjects::EligibilityInterface::Eligible.new
   end
@@ -110,6 +120,16 @@ module PageHelpers
 
   def misconduct_page
     @misconduct_page ||= PageObjects::EligibilityInterface::Misconduct.new
+  end
+
+  def new_qualification_page
+    @new_qualification_page ||=
+      PageObjects::TeacherInterface::NewQualification.new
+  end
+
+  def part_of_university_degree_page
+    @part_of_university_degree_page ||=
+      PageObjects::TeacherInterface::PartOfUniversityDegree.new
   end
 
   def performance_page
@@ -145,6 +165,11 @@ module PageHelpers
   def teach_children_page
     @teach_children_page ||=
       PageObjects::EligibilityInterface::TeachChildren.new
+  end
+
+  def teacher_check_qualifications_page
+    @teacher_check_qualifications_page ||=
+      PageObjects::TeacherInterface::CheckQualifications.new
   end
 
   def timeline_page

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -517,41 +517,38 @@ RSpec.describe "Teacher application", type: :system do
   end
 
   def when_i_fill_in_the_upload_identification_form
-    attach_file "teacher-interface-upload-form-original-attachment-field",
-                Rails.root.join(file_fixture("upload.pdf"))
-  end
-
-  def when_i_click_qualifications
-    teacher_application_page.task_list.click_item(
-      "Add your teaching qualifications",
+    upload_document_page.form.original_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
     )
   end
 
+  def when_i_click_qualifications
+    teacher_application_page.qualifications_task_item.click
+  end
+
   def when_i_fill_in_qualifications
-    fill_in "teacher-interface-qualification-form-title-field", with: "Title"
-    fill_in "teacher-interface-qualification-form-institution-name-field",
-            with: "Institution Name"
-    fill_in "teacher-interface-qualification-form-institution-country-location-field",
-            with: "France"
-    fill_in "teacher_interface_qualification_form_start_date_2i", with: "1"
-    fill_in "teacher_interface_qualification_form_start_date_1i", with: "2000"
-    fill_in "teacher_interface_qualification_form_complete_date_2i", with: "1"
-    fill_in "teacher_interface_qualification_form_complete_date_1i",
-            with: "2003"
-    fill_in "teacher_interface_qualification_form_certificate_date_2i",
-            with: "1"
-    fill_in "teacher_interface_qualification_form_certificate_date_1i",
-            with: "2004"
+    qualifications_form_page.form.title.fill_in with: "Title"
+    qualifications_form_page.form.institution_name.fill_in with:
+      "Institution Name"
+    qualifications_form_page.form.institution_country.fill_in with: "France"
+    qualifications_form_page.form.start_date_month.fill_in with: "1"
+    qualifications_form_page.form.start_date_year.fill_in with: "2000"
+    qualifications_form_page.form.complete_date_month.fill_in with: "1"
+    qualifications_form_page.form.complete_date_year.fill_in with: "2003"
+    qualifications_form_page.form.certificate_date_month.fill_in with: "1"
+    qualifications_form_page.form.certificate_date_year.fill_in with: "2004"
   end
 
   def when_i_fill_in_the_upload_certificate_form
-    attach_file "teacher-interface-upload-form-original-attachment-field",
-                Rails.root.join(file_fixture("upload.pdf"))
+    upload_document_page.form.original_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
+    )
   end
 
   def when_i_fill_in_the_upload_transcript_form
-    attach_file "teacher-interface-upload-form-original-attachment-field",
-                Rails.root.join(file_fixture("upload.pdf"))
+    upload_document_page.form.original_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
+    )
   end
 
   def when_i_click_age_range

--- a/spec/system/teacher_interface/back_links_spec.rb
+++ b/spec/system/teacher_interface/back_links_spec.rb
@@ -1,0 +1,292 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Teacher back links", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_a_user(teacher)
+    given_an_application_form_exists
+  end
+
+  it "back links follow user" do
+    # teacher_application_page -> new_qualification_page
+    #  <- teacher_application_page
+
+    when_i_visit_the(:teacher_application_page)
+    then_i_see_the(:teacher_application_page)
+
+    when_i_click_qualifications
+    then_i_see_the(:new_qualification_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_application_page)
+
+    # teacher_application_page -> new_qualification_page -> upload_document_page
+    #  <- edit_qualification_page <- teacher_application_page
+
+    when_i_click_qualifications
+    and_i_fill_in_qualification
+    then_i_see_the(:upload_document_page)
+
+    when_i_click_back
+    then_i_see_the(:edit_qualification_page, qualification_id: qualification.id)
+
+    when_i_click_back
+    then_i_see_the(:teacher_application_page)
+
+    # teacher_application_page -> edit_qualification_page -> upload_document_page -> document_form_page
+    #  <- edit_qualification_page
+
+    when_i_click_qualifications
+    and_i_click_continue
+    then_i_see_the(:upload_document_page)
+
+    when_i_upload_a_document
+    then_i_see_the(:document_form_page)
+
+    when_i_click_back
+    then_i_see_the(:edit_qualification_page, qualification_id: qualification.id)
+
+    # edit_qualification_page -> document_form_page -> upload_document_page -> document_form_page
+    #  -> part_of_university_degree_page
+    #  <- document_form_page <- document_form_page <- edit_qualification_page
+
+    when_i_click_continue
+    then_i_see_the(:document_form_page)
+
+    when_i_dont_upload_another_document
+    then_i_see_the(:upload_document_page)
+
+    when_i_upload_a_document
+    then_i_see_the(:document_form_page)
+
+    when_i_dont_upload_another_document
+    then_i_see_the(
+      :part_of_university_degree_page,
+      qualification_id: qualification.id,
+    )
+
+    when_i_click_back
+    then_i_see_the(:document_form_page)
+
+    when_i_click_back
+    then_i_see_the(:document_form_page)
+
+    when_i_click_back
+    then_i_see_the(:edit_qualification_page, qualification_id: qualification.id)
+
+    # edit_qualification_page -> document_form_page -> document_form_page -> part_of_university_degree_page
+    #  -> teacher_check_qualifications_page
+    #  <- teacher_application_page
+
+    when_i_click_continue
+    then_i_see_the(:document_form_page)
+
+    when_i_dont_upload_another_document
+    then_i_see_the(:document_form_page)
+
+    when_i_dont_upload_another_document
+    then_i_see_the(
+      :part_of_university_degree_page,
+      qualification_id: qualification.id,
+    )
+
+    when_i_choose_part_of_university_degree
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_application_page)
+
+    # teacher_application_page -> teacher_check_qualifications_page -> edit_qualification_page
+    #  <- teacher_check_qualifications_page
+
+    when_i_click_qualifications
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    when_i_click_change_qualification_title
+    then_i_see_the(:edit_qualification_page, qualification_id: qualification.id)
+
+    when_i_click_back
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> edit_qualification_page -> teacher_check_qualifications_page
+
+    when_i_click_change_qualification_title
+    then_i_see_the(:edit_qualification_page, qualification_id: qualification.id)
+
+    when_i_click_continue
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> document_form_page
+    #  <- teacher_check_qualifications_page
+
+    when_i_click_change_certificate_document_title
+    then_i_see_the(:document_form_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> document_form_page -> teacher_check_qualifications_page
+
+    when_i_click_change_certificate_document_title
+    then_i_see_the(:document_form_page)
+
+    when_i_dont_upload_another_document
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> document_form_page -> upload_document_page
+    #  <- document_form_page <- teacher_check_qualifications_page
+
+    when_i_click_change_certificate_document_title
+    then_i_see_the(:document_form_page)
+
+    when_i_do_upload_another_document
+    then_i_see_the(:upload_document_page)
+
+    when_i_click_back
+    then_i_see_the(:document_form_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> document_form_page -> upload_document_page -> document_form_page
+    #  <- teacher_check_qualifications_page
+
+    when_i_click_change_certificate_document_title
+    then_i_see_the(:document_form_page)
+
+    when_i_do_upload_another_document
+    then_i_see_the(:upload_document_page)
+
+    when_i_upload_a_document
+    then_i_see_the(:document_form_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> document_form_page -> upload_document_page -> document_form_page
+    #  -> teacher_check_qualifications_page
+
+    when_i_click_change_certificate_document_title
+    then_i_see_the(:document_form_page)
+
+    when_i_do_upload_another_document
+    then_i_see_the(:upload_document_page)
+
+    when_i_upload_a_document
+    then_i_see_the(:document_form_page)
+
+    when_i_dont_upload_another_document
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> add_another_qualification_page
+    #  <- teacher_check_qualifications_page
+
+    teacher_check_qualifications_page.continue_button.click
+    then_i_see_the(:add_another_qualification_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_check_qualifications_page)
+
+    # teacher_check_qualifications_page -> add_another_qualification_page -> new_qualification_page
+    #  <- teacher_check_qualifications_page
+
+    teacher_check_qualifications_page.continue_button.click
+    then_i_see_the(:add_another_qualification_page)
+
+    when_i_add_another_qualification
+    then_i_see_the(:new_qualification_page)
+
+    when_i_click_back
+    then_i_see_the(:teacher_check_qualifications_page)
+  end
+
+  private
+
+  def given_an_application_form_exists
+    application_form
+  end
+
+  def when_i_click_back
+    click_link "Back"
+  end
+
+  def when_i_click_qualifications
+    teacher_application_page.qualifications_task_item.click
+  end
+
+  def and_i_fill_in_qualification
+    new_qualification_page.form.title.fill_in with: "Title"
+    new_qualification_page.form.institution_name.fill_in with:
+      "Institution Name"
+    new_qualification_page.form.institution_country.fill_in with: "France"
+    new_qualification_page.form.start_date_month.fill_in with: "1"
+    new_qualification_page.form.start_date_year.fill_in with: "2000"
+    new_qualification_page.form.complete_date_month.fill_in with: "1"
+    new_qualification_page.form.complete_date_year.fill_in with: "2003"
+    new_qualification_page.form.certificate_date_month.fill_in with: "1"
+    new_qualification_page.form.certificate_date_year.fill_in with: "2004"
+    new_qualification_page.form.continue_button.click
+  end
+
+  def when_i_upload_a_document
+    upload_document_page.form.original_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
+    )
+    upload_document_page.form.written_in_english_items.first.choose
+    upload_document_page.form.continue_button.click
+  end
+
+  def when_i_dont_upload_another_document
+    document_form_page.form.no_radio_item.choose
+    document_form_page.form.continue_button.click
+  end
+
+  def when_i_do_upload_another_document
+    document_form_page.form.yes_radio_item.choose
+    document_form_page.form.continue_button.click
+  end
+
+  def when_i_choose_part_of_university_degree
+    part_of_university_degree_page.form.yes_radio_item.choose
+    part_of_university_degree_page.form.continue_button.click
+  end
+
+  def when_i_click_change_qualification_title
+    teacher_check_qualifications_page
+      .summary_lists
+      .first
+      .find_row(key: "Qualification title")
+      .actions
+      .link
+      .click
+  end
+
+  def when_i_click_change_certificate_document_title
+    teacher_check_qualifications_page
+      .summary_lists
+      .first
+      .find_row(key: "Certificate document")
+      .actions
+      .link
+      .click
+  end
+
+  def when_i_add_another_qualification
+    add_another_qualification_page.form.yes_radio_item.choose
+    add_another_qualification_page.form.continue_button.click
+  end
+
+  def teacher
+    @teacher ||= create(:teacher, :confirmed)
+  end
+
+  def application_form
+    @application_form ||= create(:application_form, teacher:)
+  end
+
+  def qualification
+    @qualification ||= application_form.qualifications.first
+  end
+end

--- a/spec/system/teacher_interface/check_answers_spec.rb
+++ b/spec/system/teacher_interface/check_answers_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Teacher application", type: :system do
+RSpec.describe "Teacher application check answers", type: :system do
   before do
     given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -45,11 +45,13 @@ RSpec.describe "Teacher documents", type: :system do
   end
 
   def when_i_upload_a_document
-    attach_file "teacher-interface-upload-form-original-attachment-field",
-                Rails.root.join(file_fixture("upload.pdf"))
-    choose "No, I’ll upload a translation as well", visible: false
-    attach_file "teacher-interface-upload-form-translated-attachment-field",
-                Rails.root.join(file_fixture("upload.pdf"))
+    upload_document_page.form.original_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
+    )
+    upload_document_page.form.written_in_english_items.second.choose
+    upload_document_page.form.translated_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
+    )
   end
 
   def when_i_click_delete_on_the_first_document


### PR DESCRIPTION
This improves how back links work to ensure that the user is always taken to the right place. We will now store a history of where the user has been in the journey in the session and use that to determine the user should go when they click on a back link. For the most part, this is the previous entry in the stack, but from some pages (notably check your answers) we send the user back to the first "origin" page - which in most cases will be the overview task list.

This implements the journeys as described in this diagram: https://drive.google.com/file/d/1wAerFpEZVQpsu3otSc-Ib3HsDsM_bxXh/view?ts=6384846c

[Trello Card](https://trello.com/c/zJbHelII/1208-back-link-redo)