### PR TITLE
Add individual "check your answers" for qualifications

### DIFF
--- a/app/lib/document_continue_redirection.rb
+++ b/app/lib/document_continue_redirection.rb
@@ -19,6 +19,8 @@ class DocumentContinueRedirection
 
   attr_reader :document
 
+  delegate :documentable, to: :document
+
   def identification_url
     %i[teacher_interface application_form]
   end
@@ -28,23 +30,21 @@ class DocumentContinueRedirection
   end
 
   def qualification_certificate_url
-    [
-      :teacher_interface,
-      :application_form,
-      document.documentable.transcript_document,
-    ]
+    [:teacher_interface, :application_form, documentable.transcript_document]
   end
 
   def qualification_transcript_url
-    if document.documentable.is_teaching_qualification?
+    if documentable.is_teaching_qualification?
       [
         :part_of_university_degree,
         :teacher_interface,
         :application_form,
-        document.documentable,
+        documentable,
       ]
-    else
+    elsif documentable.is_last_qualification?
       %i[check teacher_interface application_form qualifications]
+    else
+      [:check, :teacher_interface, :application_form, documentable]
     end
   end
 
@@ -56,7 +56,7 @@ class DocumentContinueRedirection
     [
       :teacher_interface,
       :application_form,
-      document.documentable.further_information_request,
+      documentable.further_information_request,
     ]
   end
 end

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -39,6 +39,10 @@ class Qualification < ApplicationRecord
     !is_teaching_qualification?
   end
 
+  def is_last_qualification?
+    application_form.qualifications.ordered.last == self
+  end
+
   def locale_key
     is_teaching_qualification? ? "teaching_qualification" : "university_degree"
   end

--- a/app/views/teacher_interface/qualifications/check_collection.html.erb
+++ b/app/views/teacher_interface/qualifications/check_collection.html.erb
@@ -1,11 +1,8 @@
 <% content_for :page_title, I18n.t("application_form.tasks.sections.qualifications") %>
-<% content_for :back_link_url, back_history_path(origin: true, default: teacher_interface_application_form_path) %>
+<% content_for :back_link_url, back_history_path(origin: true, default: teacher_interface_application_form_qualifications_path) %>
 
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 <h1 class="govuk-heading-l">Check your answers</h1>
-
-<p class="govuk-body-l">Check the answers you’ve provided about your teaching qualification.</p>
-<p class="govuk-body">If your teaching qualification was separate from your university degree, you can tell us about your degree in the next section.</p>
 
 <%= render "shared/application_form/qualifications_summary",
            application_form: @application_form,

--- a/app/views/teacher_interface/qualifications/check_member.html.erb
+++ b/app/views/teacher_interface/qualifications/check_member.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title, t("application_form.tasks.sections.qualifications") %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_qualifications_path) %>
+
+<span class="govuk-caption-l"><%= t("application_form.tasks.sections.qualifications") %></span>
+<h1 class="govuk-heading-l">Check your answers</h1>
+
+<%= render "shared/application_form/qualifications_summary",
+           application_form: @application_form,
+           qualifications: [@qualification],
+           changeable: true %>
+
+<% if @next_qualification %>
+  <%= govuk_button_link_to "Continue", [:edit, :teacher_interface, :application_form, @next_qualification] %>
+<% else %>
+  <%= govuk_button_link_to "Continue", %i[check teacher_interface application_form qualifications] %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,7 +137,7 @@ Rails.application.routes.draw do
 
       resources :qualifications, except: %i[show] do
         collection do
-          get "check", to: "qualifications#check"
+          get "check", to: "qualifications#check_collection"
 
           get "add_another", to: "qualifications#add_another"
           post "add_another", to: "qualifications#submit_add_another"
@@ -145,6 +145,8 @@ Rails.application.routes.draw do
 
         member do
           get "delete"
+
+          get "check", to: "qualifications#check_member"
 
           get "part_of_university_degree",
               to: "qualifications#edit_part_of_university_degree"

--- a/spec/controllers/teacher_interface/qualifications_controller_spec.rb
+++ b/spec/controllers/teacher_interface/qualifications_controller_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe TeacherInterface::QualificationsController, type: :controller do
     include_examples "redirect unless application form is draft"
   end
 
-  describe "GET check" do
-    subject(:perform) { get :check }
+  describe "GET check_collection" do
+    subject(:perform) { get :check_collection }
 
     include_examples "redirect unless application form is draft"
   end
@@ -78,6 +78,14 @@ RSpec.describe TeacherInterface::QualificationsController, type: :controller do
     subject(:perform) do
       patch :update_part_of_university_degree, params: { id: qualification.id }
     end
+
+    include_examples "redirect unless application form is draft"
+  end
+
+  describe "GET check_member" do
+    let(:qualification) { create(:qualification, application_form:) }
+
+    subject(:perform) { get :check_member, params: { id: qualification.id } }
 
     include_examples "redirect unless application form is draft"
   end

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -73,6 +73,22 @@ RSpec.describe Qualification, type: :model do
     end
   end
 
+  describe "#is_university_degree?" do
+    subject(:is_last_qualification?) { qualification.is_last_qualification? }
+
+    before { qualification.save! }
+
+    it { is_expected.to be true }
+
+    context "with a second qualification" do
+      before do
+        create(:qualification, application_form: qualification.application_form)
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
   describe "#can_delete?" do
     subject(:can_delete?) { qualification.can_delete? }
 

--- a/spec/support/autoload/page_objects/teacher_interface/check_your_answers.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/check_your_answers.rb
@@ -20,7 +20,8 @@ module PageObjects
                 GovukSummaryList,
                 ".govuk-summary-list__card" \
                   ":not(#app-check-your-answers-summary-age-range)" \
-                  ":not(#app-check-your-answers-summary-subjects)"
+                  ":not(#app-check-your-answers-summary-subjects)",
+                match: :first
         section :age_range_summary_list,
                 GovukSummaryList,
                 "#app-check-your-answers-summary-age-range"

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -69,7 +69,30 @@ RSpec.describe "Teacher application", type: :system do
     when_i_choose_no
     and_i_click_continue
 
-    when_i_choose_yes
+    when_i_choose_no
+    and_i_click_continue
+    then_i_see_the_qualifications_summary
+
+    when_i_click_continue
+    then_i_see_the_university_degree_form
+
+    when_i_fill_in_qualifications
+    and_i_click_continue
+    then_i_see_the_upload_certificate_form
+
+    when_i_fill_in_the_upload_certificate_form
+    and_i_click_continue
+    then_i_see_the_check_your_certificate_uploads
+
+    when_i_choose_no
+    and_i_click_continue
+    then_i_see_the_upload_transcript_form
+
+    when_i_fill_in_the_upload_transcript_form
+    and_i_click_continue
+    then_i_see_the_check_your_transcript_uploads
+
+    when_i_choose_no
     and_i_click_continue
     then_i_see_the_qualifications_summary
 
@@ -788,6 +811,14 @@ RSpec.describe "Teacher application", type: :system do
     )
     expect(qualifications_form_page.body).to have_content(
       "This is the qualification that led to you being recognised as a teacher.",
+    )
+  end
+
+  def then_i_see_the_university_degree_form
+    expect(qualifications_form_page).to have_title("Your qualifications")
+    expect(qualifications_form_page.heading.text).to eq("University degree")
+    expect(qualifications_form_page.body).to have_content(
+      "Tell us about your university degree qualification.",
     )
   end
 


### PR DESCRIPTION
This splits the view in to a separate one for individual qualifications and one for checking all the qualifications.

Depends on #787 

[Trello Card](https://trello.com/c/YrMpjVrF/1067-add-separate-qualification-check-your-answers-ses)