### PR TITLE
Send working days since submission to analytics

### DIFF
--- a/app/jobs/update_working_days_since_submission_job.rb
+++ b/app/jobs/update_working_days_since_submission_job.rb
@@ -5,10 +5,7 @@ class UpdateWorkingDaysSinceSubmissionJob < ApplicationJob
       .find_each do |application_form|
         working_days_since_submission =
           calendar.business_days_between(application_form.submitted_at, today)
-        application_form.update_column(
-          :working_days_since_submission,
-          working_days_since_submission,
-        )
+        application_form.update!(working_days_since_submission:)
       end
   end
 


### PR DESCRIPTION
Using the `update_column` method skips any callbacks, which makes this job fast, but means we don't send the changes to analytics.