### PR TITLE
Allow any staff member to create notes

### DIFF
--- a/app/controllers/assessor_interface/notes_controller.rb
+++ b/app/controllers/assessor_interface/notes_controller.rb
@@ -2,7 +2,7 @@
 
 module AssessorInterface
   class NotesController < BaseController
-    before_action :authorize_assessor
+    before_action :authorize_note
 
     def new
       @application_form = application_form
@@ -25,6 +25,10 @@ module AssessorInterface
     end
 
     private
+
+    def authorize_note
+      authorize :note
+    end
 
     def application_form
       @application_form ||= ApplicationForm.find(params[:application_form_id])

--- a/app/policies/note_policy.rb
+++ b/app/policies/note_policy.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class NotePolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  def update?
+    true
+  end
+
+  def destroy?
+    false
+  end
+end

--- a/spec/policies/note_policy_spec.rb
+++ b/spec/policies/note_policy_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NotePolicy do
+  let(:user) { nil }
+  let(:record) { nil }
+
+  subject(:policy) { described_class.new(user, record) }
+
+  it "must have a user" do
+    expect { policy }.to raise_error(Pundit::NotAuthorizedError)
+  end
+
+  context "with a user" do
+    let(:user) { create(:staff, :confirmed) }
+
+    describe "#index?" do
+      subject(:index?) { policy.index? }
+      it { is_expected.to be true }
+    end
+
+    describe "#show?" do
+      subject(:show?) { policy.show? }
+      it { is_expected.to be true }
+    end
+
+    describe "#create?" do
+      subject(:create?) { policy.create? }
+      it { is_expected.to be true }
+    end
+
+    describe "#new?" do
+      subject(:new?) { policy.new? }
+      it { is_expected.to be true }
+    end
+
+    describe "#update?" do
+      subject(:update?) { policy.update? }
+      it { is_expected.to be true }
+    end
+
+    describe "#edit?" do
+      subject(:edit?) { policy.edit? }
+      it { is_expected.to be true }
+    end
+
+    describe "#destroy?" do
+      subject(:destroy?) { policy.destroy? }
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
This creates a new policy for notes which allows every action exception destruction (although we don't have a controller action for that).

[Trello Card](https://trello.com/c/ScW4jmHh/1220-allow-staff-users-without-award-decline-to-add-notes-to-an-assessment)