### PR TITLE
Delete AssessmentSectionFailureReasons

### DIFF
--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -23,7 +23,7 @@
 #
 class AssessmentSection < ApplicationRecord
   belongs_to :assessment
-  has_many :assessment_section_failure_reasons
+  has_many :assessment_section_failure_reasons, dependent: :destroy
 
   enum :key,
        {

--- a/spec/factories/assessment_section_failure_reasons.rb
+++ b/spec/factories/assessment_section_failure_reasons.rb
@@ -18,7 +18,7 @@
 #  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #
 FactoryBot.define do
-  factory :assessment_section_failure_reasons do
+  factory :assessment_section_failure_reason do
     key { AssessmentSectionFailureReason::ALL_FAILURE_REASONS.sample.to_s }
   end
 end

--- a/spec/services/destroy_application_form_spec.rb
+++ b/spec/services/destroy_application_form_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe DestroyApplicationForm do
           :with_further_information_request,
           application_form:,
         )
-      create(:assessment_section, :personal_information, assessment:)
+      assessment_section =
+        create(:assessment_section, :personal_information, assessment:)
+      create(:assessment_section_failure_reason, assessment_section:)
     end
   end
 
@@ -36,6 +38,7 @@ RSpec.describe DestroyApplicationForm do
   include_examples "deletes model", ApplicationForm
   include_examples "deletes model", Assessment
   include_examples "deletes model", AssessmentSection
+  include_examples "deletes model", AssessmentSectionFailureReason
   include_examples "deletes model", Document, 12, 6
   include_examples "deletes model", FurtherInformationRequest
   include_examples "deletes model", FurtherInformationRequestItem, 4, 2


### PR DESCRIPTION
When deleting an assessment section we should also delete its failure reasons.