### PR TITLE
[1209] Refactor failure reason definitions

### DIFF
--- a/app/forms/assessor_interface/assessment_section_form.rb
+++ b/app/forms/assessor_interface/assessment_section_form.rb
@@ -60,7 +60,7 @@ class AssessorInterface::AssessmentSectionForm
       assessment_section.failure_reasons.each do |failure_reason|
         klass.attribute "#{failure_reason}_checked", :boolean
         klass.attribute "#{failure_reason}_notes", :string
-        next if AssessmentSection.decline_failure_reason?(failure_reason:)
+        next if FailureReasons.decline?(failure_reason:)
 
         klass.validates "#{failure_reason}_notes",
                         presence: true,

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -35,4 +35,8 @@ class FailureReasons
   ].freeze
 
   ALL = (DECLINABLE + FURTHER_INFORMATIONABLE).freeze
+
+  def self.decline?(failure_reason:)
+    DECLINABLE.include?(failure_reason.to_s)
+  end
 end

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class FailureReasons
+  DECLINABLE = %w[
+    duplicate_application
+    applicant_already_qts
+    teaching_qualifications_from_ineligible_country
+    teaching_qualifications_not_at_required_level
+    not_qualified_to_teach_mainstream
+    teaching_hours_not_fulfilled
+    authorisation_to_teach
+    teaching_qualification
+    confirm_age_range_subjects
+    full_professional_status
+  ].freeze
+
+  FURTHER_INFORMATIONABLE = %w[
+    identification_document_expired
+    identification_document_illegible
+    identification_document_mismatch
+    name_change_document_illegible
+    applicant_already_dqt
+    application_and_qualification_names_do_not_match
+    qualifications_dont_match_subjects
+    qualifications_dont_match_other_details
+    teaching_certificate_illegible
+    teaching_transcript_illegible
+    degree_certificate_illegible
+    degree_transcript_illegible
+    satisfactory_evidence_work_history
+    registration_number
+    written_statement_illegible
+    written_statement_recent
+    qualified_to_teach
+  ].freeze
+
+  ALL = (DECLINABLE + FURTHER_INFORMATIONABLE).freeze
+end

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -55,24 +55,13 @@ class AssessmentSection < ApplicationRecord
     passed ? :completed : :action_required
   end
 
-  DECLINE_FAILURE_REASONS = %w[
-    duplicate_application
-    applicant_already_qts
-    teaching_qualifications_from_ineligible_country
-    teaching_qualifications_not_at_required_level
-    not_qualified_to_teach_mainstream
-    teaching_hours_not_fulfilled
-    authorisation_to_teach
-    teaching_qualification
-    confirm_age_range_subjects
-    full_professional_status
-  ].freeze
-
   def self.decline_failure_reason?(failure_reason:)
-    DECLINE_FAILURE_REASONS.include?(failure_reason.to_s)
+    FailureReasons::DECLINABLE.include?(failure_reason.to_s)
   end
 
   def declines_assessment?
-    DECLINE_FAILURE_REASONS.intersection(selected_failure_reasons.keys).present?
+    FailureReasons::DECLINABLE.intersection(
+      selected_failure_reasons.keys,
+    ).present?
   end
 end

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -55,10 +55,6 @@ class AssessmentSection < ApplicationRecord
     passed ? :completed : :action_required
   end
 
-  def self.decline_failure_reason?(failure_reason:)
-    FailureReasons::DECLINABLE.include?(failure_reason.to_s)
-  end
-
   def declines_assessment?
     FailureReasons::DECLINABLE.intersection(
       selected_failure_reasons.keys,

--- a/app/models/assessment_section_failure_reason.rb
+++ b/app/models/assessment_section_failure_reason.rb
@@ -22,36 +22,6 @@
 class AssessmentSectionFailureReason < ApplicationRecord
   belongs_to :assessment_section
 
-  ALL_FAILURE_REASONS = %i[
-    identification_document_expired
-    identification_document_illegible
-    identification_document_mismatch
-    name_change_document_illegible
-    duplicate_application
-    applicant_already_qts
-    applicant_already_dqt
-    application_and_qualification_names_do_not_match
-    teaching_qualifications_from_ineligible_country
-    teaching_qualifications_not_at_required_level
-    teaching_hours_not_fulfilled
-    not_qualified_to_teach_mainstream
-    qualifications_dont_match_subjects
-    qualifications_dont_match_other_details
-    teaching_certificate_illegible
-    teaching_transcript_illegible
-    degree_certificate_illegible
-    degree_transcript_illegible
-    satisfactory_evidence_work_history
-    registration_number
-    written_statement_illegible
-    written_statement_recent
-    authorisation_to_teach
-    teaching_qualification
-    confirm_age_range_subjects
-    qualified_to_teach
-    full_professional_status
-  ].freeze
-
   validates :key, presence: true
-  validates :key, inclusion: { in: ALL_FAILURE_REASONS.map(&:to_s) }
+  validates :key, inclusion: { in: FailureReasons::ALL }
 end

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -75,11 +75,7 @@ module AssessorInterface
     def build_key(failure_reason, key_section)
       key =
         "helpers.#{key_section}.assessor_interface_assessment_section_form.failure_reason_notes"
-      if AssessmentSection.decline_failure_reason?(failure_reason:)
-        "#{key}_decline"
-      else
-        key
-      end
+      FailureReasons.decline?(failure_reason:) ? "#{key}_decline" : key
     end
   end
 end

--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -34,8 +34,7 @@ class TeacherInterface::ApplicationFormShowViewObject
 
       failure_reasons =
         section.selected_failure_reasons.map do |key, assessor_feedback|
-          is_decline =
-            AssessmentSection.decline_failure_reason?(failure_reason: key)
+          is_decline = FailureReasons.decline?(failure_reason: key)
           assessor_feedback = "" unless is_decline
 
           { key:, is_decline:, assessor_feedback: }

--- a/app/views/assessor_interface/assessments/declare.html.erb
+++ b/app/views/assessor_interface/assessments/declare.html.erb
@@ -18,7 +18,7 @@
           <li>
             <h4 class="govuk-heading-s"><%= t("assessor_interface.assessment_sections.show.failure_reasons.#{key}") %></h4>
 
-            <% if AssessmentSection.decline_failure_reason?(failure_reason: key) %>
+            <% if FailureReasons.decline?(failure_reason: key) %>
               <p class="govuk-body govuk-!-margin-bottom-2">Your note to the applicant:</p>
             <% else %>
               <p class="govuk-body govuk-!-margin-bottom-2">Your note (the applicant won’t see this):</p>

--- a/spec/factories/assessment_section_failure_reasons.rb
+++ b/spec/factories/assessment_section_failure_reasons.rb
@@ -19,6 +19,6 @@
 #
 FactoryBot.define do
   factory :assessment_section_failure_reason do
-    key { AssessmentSectionFailureReason::ALL_FAILURE_REASONS.sample.to_s }
+    key { FailureReasons::ALL.sample.to_s }
   end
 end

--- a/spec/factories/assessment_sections.rb
+++ b/spec/factories/assessment_sections.rb
@@ -36,7 +36,7 @@ FactoryBot.define do
 
     trait :declines_assessment do
       selected_failure_reasons do
-        { AssessmentSection::DECLINE_FAILURE_REASONS.first => "Notes." }
+        { FailureReasons::DECLINABLE.first => "Notes." }
       end
     end
 

--- a/spec/forms/assessor_interface/assessment_section_form_spec.rb
+++ b/spec/forms/assessor_interface/assessment_section_form_spec.rb
@@ -10,9 +10,7 @@ RSpec.describe AssessorInterface::AssessmentSectionForm, type: :model do
       failure_reasons: [:reason_a, :reason_b, decline_failure_reason],
     )
   end
-  let(:decline_failure_reason) do
-    AssessmentSection::DECLINE_FAILURE_REASONS.sample.to_sym
-  end
+  let(:decline_failure_reason) { FailureReasons::DECLINABLE.sample.to_sym }
   let(:user) { create(:staff, :confirmed) }
   let(:attributes) { {} }
 

--- a/spec/models/assessment_section_failure_reason_spec.rb
+++ b/spec/models/assessment_section_failure_reason_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe AssessmentSectionFailureReason do
   describe "validations" do
     it { is_expected.to validate_presence_of(:key) }
     it do
-      is_expected.to validate_inclusion_of(:key).in_array(
-        described_class::ALL_FAILURE_REASONS.map(&:to_s),
-      )
+      is_expected.to validate_inclusion_of(:key).in_array(FailureReasons::ALL)
     end
   end
 end

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -98,20 +98,4 @@ RSpec.describe AssessmentSection, type: :model do
       it { is_expected.to be false }
     end
   end
-
-  describe ".decline_failure_reason?" do
-    subject { described_class.decline_failure_reason?(failure_reason:) }
-
-    context "with a decline failure reason" do
-      let(:failure_reason) { FailureReasons::DECLINABLE.sample }
-
-      it { is_expected.to eq(true) }
-    end
-
-    context "with a non-decline failure reason" do
-      let(:failure_reason) { :fitter_happier_more_productive }
-
-      it { is_expected.to eq(false) }
-    end
-  end
 end

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe AssessmentSection, type: :model do
     subject { described_class.decline_failure_reason?(failure_reason:) }
 
     context "with a decline failure reason" do
-      let(:failure_reason) { described_class::DECLINE_FAILURE_REASONS.sample }
+      let(:failure_reason) { FailureReasons::DECLINABLE.sample }
 
       it { is_expected.to eq(true) }
     end

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
     subject { super().notes_label_key_for(failure_reason:) }
 
     context "with a decline failure reason" do
-      let(:failure_reason) { AssessmentSection::DECLINE_FAILURE_REASONS.sample }
+      let(:failure_reason) { FailureReasons::DECLINABLE.sample }
 
       it do
         is_expected.to eq(
@@ -120,7 +120,7 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
     subject { super().notes_hint_key_for(failure_reason:) }
 
     context "with a decline failure reason" do
-      let(:failure_reason) { AssessmentSection::DECLINE_FAILURE_REASONS.sample }
+      let(:failure_reason) { FailureReasons::DECLINABLE.sample }
 
       it do
         is_expected.to eq(
@@ -144,7 +144,7 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
     subject { super().notes_placeholder_key_for(failure_reason:) }
 
     context "with a decline failure reason" do
-      let(:failure_reason) { AssessmentSection::DECLINE_FAILURE_REASONS.sample }
+      let(:failure_reason) { FailureReasons::DECLINABLE.sample }
 
       it do
         is_expected.to eq(


### PR DESCRIPTION
We use these in a number of places in the service for various things.

* Move them to one place... `FailureReasons`. 

We do also group these in some of the factory classes when building an assessment and failure reasons. I haven't moved those here as I don't need that currently for the work to move to using `AssessmentSectionFailureReason`. There's a reasonable argument for moving the section grouping into `FailureReasons` too but we can do that in a future PR.