### PR TITLE
Filter on date fields directly

### DIFF
--- a/app/jobs/update_working_days_job.rb
+++ b/app/jobs/update_working_days_job.rb
@@ -35,9 +35,8 @@ class UpdateWorkingDaysJob < ApplicationJob
 
   def update_assessments_started_to_recommendation
     Assessment
-      .includes(:application_form)
-      .started
-      .recommended
+      .where.not(started_at: nil)
+      .where.not(recommended_at: nil)
       .find_each do |assessment|
         assessment.update!(
           working_days_started_to_recommendation:
@@ -53,8 +52,8 @@ class UpdateWorkingDaysJob < ApplicationJob
     Assessment
       .joins(:application_form)
       .includes(:application_form)
-      .recommended
       .where.not(application_forms: { submitted_at: nil })
+      .where.not(recommended_at: nil)
       .find_each do |assessment|
         assessment.update!(
           working_days_submission_to_recommendation:
@@ -70,8 +69,8 @@ class UpdateWorkingDaysJob < ApplicationJob
     Assessment
       .joins(:application_form)
       .includes(:application_form)
-      .started
       .where.not(application_forms: { submitted_at: nil })
+      .where.not(started_at: nil)
       .find_each do |assessment|
         assessment.update!(
           working_days_submission_to_started:
@@ -87,8 +86,8 @@ class UpdateWorkingDaysJob < ApplicationJob
     FurtherInformationRequest
       .joins(:assessment)
       .includes(:assessment)
-      .received
-      .merge(Assessment.recommended)
+      .where.not(received_at: nil)
+      .where.not(assessment: { recommended_at: nil })
       .find_each do |further_information_request|
         further_information_request.update!(
           working_days_received_to_recommendation:

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -47,9 +47,6 @@ class Assessment < ApplicationRecord
               in: recommendations.values,
             }
 
-  scope :started, -> { where.not(started_at: nil) }
-  scope :recommended, -> { where.not(recommended_at: nil) }
-
   def finished?
     sections_finished? && (award? || decline?)
   end


### PR DESCRIPTION
When calculating working days we should filter only on the fields we're using later to calculate the working days, to ensure the calculation will always succeed, regardless of the state of the record.

This should fix [`NoMethodError: undefined method 'to_date' for nil:NilClass`](https://sentry.io/organizations/dfe-teacher-services/issues/3784409087/?project=6426061&query=is%3Aunresolved&referrer=issue-stream) error while running the job.