### PR TITLE
Add fields to support console

### DIFF
--- a/app/views/shared/_teaching_authority_form_fields.html.erb
+++ b/app/views/shared/_teaching_authority_form_fields.html.erb
@@ -8,6 +8,10 @@
 
 <%= f.govuk_text_area :teaching_authority_other, label: { text: "Teaching authority other" } %>
 
+<%= f.govuk_text_area :teaching_authority_status_information, label: { text: "Teaching authority status information" } %>
+
+<%= f.govuk_text_area :teaching_authority_sanction_information, label: { text: "Teaching authority sanction information" } %>
+
 <%= f.govuk_text_field :teaching_authority_certificate, label: { text: "Teaching authority certificate" } %>
 
 <%= f.govuk_text_field :teaching_authority_online_checker_url, label: { text: "Teaching authority online checker URL" } %>

--- a/app/views/support_interface/countries/confirm_edit.html.erb
+++ b/app/views/support_interface/countries/confirm_edit.html.erb
@@ -55,6 +55,8 @@
   <%= f.hidden_field :teaching_authority_emails_string, value: @country.teaching_authority_emails_string %>
   <%= f.hidden_field :teaching_authority_websites_string, value: @country.teaching_authority_websites_string %>
   <%= f.hidden_field :teaching_authority_certificate, value: @country.teaching_authority_certificate %>
+  <%= f.hidden_field :teaching_authority_sanction_information, value: @country.teaching_authority_sanction_information%>
+  <%= f.hidden_field :teaching_authority_status_information, value: @country.teaching_authority_status_information%>
   <%= f.hidden_field :teaching_authority_other, value: @country.teaching_authority_other %>
   <%= f.hidden_field :teaching_authority_online_checker_url, value: @country.teaching_authority_online_checker_url %>
   <%= f.hidden_field :teaching_authority_checks_sanctions, value: @country.teaching_authority_checks_sanctions %>

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_emails
     when_i_fill_teaching_authority_websites
     when_i_fill_teaching_authority_other
+    when_i_fill_teaching_authority_sanction_information
+    when_i_fill_teaching_authority_status_information
     when_i_fill_teaching_authority_certificate
     when_i_fill_teaching_authority_online_checker_url
     when_i_fill_teaching_authority_checks_sanctions
@@ -45,6 +47,8 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_emails
     when_i_fill_teaching_authority_websites
     when_i_fill_teaching_authority_other
+    when_i_fill_teaching_authority_sanction_information
+    when_i_fill_teaching_authority_status_information
     when_i_fill_teaching_authority_certificate
     when_i_fill_teaching_authority_online_checker_url
     and_i_save_and_preview
@@ -192,6 +196,22 @@ RSpec.describe "Countries support", type: :system do
 
   def when_i_fill_teaching_authority_checks_sanctions
     check "country-teaching-authority-checks-sanctions-1-field", visible: false
+  end
+
+  def when_i_fill_teaching_authority_sanction_information
+    fill_in "region-teaching-authority-sanction-information-field",
+            with: "Sanction information"
+  rescue Capybara::ElementNotFound
+    fill_in "country-teaching-authority-sanction-information-field",
+            with: "Sanction information"
+  end
+
+  def when_i_fill_teaching_authority_status_information
+    fill_in "region-teaching-authority-status-information-field",
+            with: "Status information"
+  rescue Capybara::ElementNotFound
+    fill_in "country-teaching-authority-status-information-field",
+            with: "Status information"
   end
 
   def and_i_save


### PR DESCRIPTION
Add sanction info and status info to support console for teaching authorities

This pr forms the second part of https://trello.com/c/roDCVI5L/1219-fix-teaching-authority-other-field