### PR TITLE
Delete assessment section failure reasons when generating example data

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -48,6 +48,7 @@ namespace :example_data do
     end
 
     TimelineEvent.delete_all
+    AssessmentSectionFailureReason.delete_all
     AssessmentSection.delete_all
     Assessment.delete_all
     Qualification.delete_all


### PR DESCRIPTION
When re-generating the example data we need to delete these before we can delete the assessment sections.