### PR TITLE
Allow non-assessors to access edit FI view

### DIFF
--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -2,7 +2,7 @@
 
 module AssessorInterface
   class FurtherInformationRequestsController < BaseController
-    before_action :authorize_assessor, except: :preview
+    before_action :authorize_assessor, except: %i[preview edit]
     before_action :load_application_form_and_assessment,
                   only: %i[preview new show edit]
     before_action :load_new_further_information_request, only: %i[preview new]
@@ -32,6 +32,8 @@ module AssessorInterface
     end
 
     def edit
+      authorize :assessor, :show?
+
       @further_information_request_form =
         FurtherInformationRequestForm.new(
           further_information_request: view_object.further_information_request,

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -9,17 +9,19 @@
   <%= render(CheckYourAnswersSummary::Component.new(**item.fetch(:check_your_answers))) %>
 <% end %>
 
-<%= form_with model: @further_information_request_form, url: [:assessor_interface, @view_object.application_form, @view_object.assessment, @view_object.further_information_request], method: :put do |f| %>
-  <%= f.govuk_error_summary %>
+<% if policy(:assessor).update? %>
+  <%= form_with model: @further_information_request_form, url: [:assessor_interface, @view_object.application_form, @view_object.assessment, @view_object.further_information_request], method: :put do |f| %>
+    <%= f.govuk_error_summary %>
 
-  <%= f.govuk_radio_buttons_fieldset :passed, legend: { size: "s" } do %>
-    <%= f.govuk_radio_button :passed, :true, link_errors: true %>
-    <%= f.govuk_radio_button :passed, :false do %>
-      <%= f.govuk_text_area :failure_assessor_note %>
+    <%= f.govuk_radio_buttons_fieldset :passed, legend: { size: "s" } do %>
+      <%= f.govuk_radio_button :passed, :true, link_errors: true %>
+      <%= f.govuk_radio_button :passed, :false do %>
+        <%= f.govuk_text_area :failure_assessor_note %>
+      <% end %>
     <% end %>
-  <% end %>
 
-  <%= f.govuk_submit prevent_double_click: false do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @view_object.application_form] %>
+    <%= f.govuk_submit prevent_double_click: false do %>
+      <%= govuk_link_to "Cancel", [:assessor_interface, @view_object.application_form] %>
+    <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
It's useful for non-assessors to be able to see this page, even if they can't submit the form.

[Trello Card](https://trello.com/c/R58o07bu/1229-view-only-internal-users-cannot-view-fi-responses-from-applicants)