### PR TITLE
Update feedback form links and content

### DIFF
--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -162,16 +162,22 @@
     <p class="govuk-body">We aim to reach a final decision on QTS applications within 80 working days (4 months) of submission.</p>
   <% end %>
 
-  <h2 class="govuk-heading-s govuk-!-font-weight-regular">If you have any questions, contact:</h2>
-  <p class="govuk-body"><a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.</p>
+  <h2 class="govuk-heading-s">Help us to improve this service</h2>
 
-  <aside class="govuk-!-margin-top-6">
-    <h2 class="govuk-heading-s">Help us to improve this service</h2>
+  <p class="govuk-body">
+    Please <a href="https://docs.google.com/forms/d/e/1FAIpQLSePiIC7xO1Dt6oxvIdL6jcGrlUkRDJDS1kxOcqvK-uspBED9w/viewform" class="govuk-link">give us feedback</a> about your experience of using this service. It should take less than 2 minutes to complete.
+  </p>
 
-    <p class="govuk-body">We’d like to talk to people about their experience of using this service. If you’d like to help, follow the link below. If you match our search criteria, we’ll invite you to a video call.</p>
+  <p class="govuk-body">
+    We’re always trying to improve this service and boost teacher recruitment from overseas. So we’d like to talk to people about their experience of using this service.
+  </p>
 
-    <p class="govuk-body">
-      <%= govuk_link_to "I’d like to take part in the user research", "https://forms.gle/wPx11E9TMjKgiZLe8" %>
-    </p>
-  </aside>
+  <p class="govuk-body">
+    If you'd like to help, please <a href="https://docs.google.com/forms/d/e/1FAIpQLSdH_nfDnt9OUolI25fLs27uitWWn63KibNWsGFOYT-Os14PRg/viewform" class="govuk-link">complete this form</a>.
+  </p>
+
+  <p class="govuk-body">If you match our search criteria, we'll invite you to take part in research.</p>
+
+  <h2 class="govuk-heading-s">If you have any questions, contact:</h2>
+  <p class="govuk-body"><a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a></p>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,7 +13,7 @@ en:
 
     email: qts.enquiries@education.gov.uk
     url: https://apply-for-qts-in-england.education.gov.uk
-    phase_banner_text: This is a new service – <a href="https://docs.google.com/forms/d/1OpMhXJ1blJu2qFqW7VWwKnfjIoU-5SmOLXdgI0Z_kZg/viewform">your feedback will help us to improve it</a>.
+    phase_banner_text: This is a new service – <a href="https://docs.google.com/forms/d/e/1FAIpQLSePiIC7xO1Dt6oxvIdL6jcGrlUkRDJDS1kxOcqvK-uspBED9w/viewform">your feedback will help us to improve it</a>.
 
   teacher:
     registration:


### PR DESCRIPTION
This makes a few changes to the content related to the feedback and changes the link to a new form.

[Trello Card](https://trello.com/c/vjWJnQhD/1233-i-can-give-feedback-about-the-service)

## Screenshot

![Screenshot 2022-12-06 at 12 15 58](https://user-images.githubusercontent.com/510498/205910513-e74a995e-3147-4d21-b637-1bb5ffbf60d1.png)
