### PR TITLE
Rename create or sign in

### DIFF
--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -6,7 +6,7 @@ class Teachers::SessionsController < Devise::SessionsController
 
   def new
     @new_session_form =
-      TeacherInterface::NewSessionForm.new(create_or_sign_in: "sign_in")
+      TeacherInterface::NewSessionForm.new(sign_in_or_sign_up: "sign_in")
   end
 
   def new_or_create
@@ -17,11 +17,11 @@ class Teachers::SessionsController < Devise::SessionsController
     @new_session_form =
       TeacherInterface::NewSessionForm.new(
         email: new_session_form_params[:email],
-        create_or_sign_in: new_session_form_params[:create_or_sign_in],
+        sign_in_or_sign_up: new_session_form_params[:sign_in_or_sign_up],
       )
 
     if @new_session_form.valid?
-      if @new_session_form.create?
+      if @new_session_form.sign_up?
         redirect_to :eligibility_interface_countries
         return
       end
@@ -37,7 +37,7 @@ class Teachers::SessionsController < Devise::SessionsController
       end
 
       redirect_to teacher_check_email_path(email: @new_session_form.email)
-    elsif @new_session_form.create_or_sign_in.blank?
+    elsif @new_session_form.sign_in_or_sign_up.blank?
       render :new_or_create, status: :unprocessable_entity
     else
       render :new, status: :unprocessable_entity
@@ -47,7 +47,7 @@ class Teachers::SessionsController < Devise::SessionsController
   def new_session_form_params
     params.require(:teacher_interface_new_session_form).permit(
       :email,
-      :create_or_sign_in,
+      :sign_in_or_sign_up,
     )
   end
 

--- a/app/forms/teacher_interface/new_session_form.rb
+++ b/app/forms/teacher_interface/new_session_form.rb
@@ -3,20 +3,20 @@
 module TeacherInterface
   class NewSessionForm < BaseForm
     attribute :email, :string
-    attribute :create_or_sign_in, :string
+    attribute :sign_in_or_sign_up, :string
 
-    validates :create_or_sign_in, presence: true
+    validates :sign_in_or_sign_up, presence: true
     validates :email,
               presence: true,
               valid_for_notify: true,
               if: -> { sign_in? }
 
     def sign_in?
-      create_or_sign_in == "sign_in"
+      sign_in_or_sign_up == "sign_in"
     end
 
-    def create?
-      create_or_sign_in == "create"
+    def sign_up?
+      sign_in_or_sign_up == "sign_up"
     end
   end
 end

--- a/app/views/teachers/sessions/new.html.erb
+++ b/app/views/teachers/sessions/new.html.erb
@@ -5,7 +5,7 @@
 <%= form_with model: @new_session_form, url: session_path(resource_name) do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.hidden_field :create_or_sign_in %>
+  <%= f.hidden_field :sign_in_or_sign_up %>
   <%= f.govuk_email_field :email, autocomplete: "email", label: { size: "m" } %>
 
   <%= f.govuk_submit %>

--- a/app/views/teachers/sessions/new_or_create.html.erb
+++ b/app/views/teachers/sessions/new_or_create.html.erb
@@ -7,12 +7,12 @@
 <%= form_with model: @new_session_form, url: session_path(resource_name) do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_radio_buttons_fieldset :create_or_sign_in, legend: { size: "m", text: "Have you used the service before?" } do %>
-    <%= f.govuk_radio_button :create_or_sign_in, "sign_in", label: { text: "Yes, sign in and continue application" }, link_errors: true do %>
+  <%= f.govuk_radio_buttons_fieldset :sign_in_or_sign_up, legend: { size: "m", text: "Have you used the service before?" } do %>
+    <%= f.govuk_radio_button :sign_in_or_sign_up, "sign_in", label: { text: "Yes, sign in and continue application" }, link_errors: true do %>
       <%= f.govuk_email_field :email, autocomplete: "email" %>
     <% end %>
 
-    <%= f.govuk_radio_button :create_or_sign_in, "create", label: { text: "No, I need to check if I can apply" } %>
+    <%= f.govuk_radio_button :sign_in_or_sign_up, "sign_up", label: { text: "No, I need to check if I can apply" } %>
   <% end %>
 
   <%= f.govuk_submit %>

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -145,7 +145,7 @@ en:
               blank: Enter your family name
         teacher_interface/new_session_form:
           attributes:
-            create_or_sign_in:
+            sign_in_or_sign_up:
               blank: Select whether you have used the service before
             email:
               blank: Enter your email address

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -201,7 +201,7 @@ Rails.application.routes.draw do
              }
 
   devise_scope :teacher do
-    get "/teacher/create_or_sign_in",
+    get "/teacher/sign_in_or_sign_up",
         to: "teachers/sessions#new_or_create",
         as: "create_or_new_teacher_session"
     get "/teacher/magic_link",

--- a/spec/support/autoload/page_objects/teacher_interface/sign_in_or_sign_up.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/sign_in_or_sign_up.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module TeacherInterface
-    class CreateOrSignIn < SitePrism::Page
-      set_url "/teacher/create_or_sign_in"
+    class SignInOrSignUp < SitePrism::Page
+      set_url "/teacher/sign_in_or_sign_up"
 
       element :heading, "h1"
 

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -189,13 +189,13 @@ module PageHelpers
     @timeline_page ||= PageObjects::AssessorInterface::Timeline.new
   end
 
-  def teacher_create_or_sign_in_page
-    @teacher_create_or_sign_in_page =
-      PageObjects::TeacherInterface::CreateOrSignIn.new
-  end
-
   def teacher_sign_in_page
     @teacher_sign_in_page = PageObjects::TeacherInterface::SignIn.new
+  end
+
+  def teacher_sign_in_or_sign_up_page
+    @teacher_sign_in_or_sign_up_page =
+      PageObjects::TeacherInterface::SignInOrSignUp.new
   end
 
   def teacher_sign_up_page

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe "Teacher authentication", type: :system do
 
     given_i_clear_my_session
 
-    when_i_visit_the(:teacher_create_or_sign_in_page)
-    then_i_see_the(:teacher_create_or_sign_in_page)
+    when_i_visit_the(:teacher_sign_in_or_sign_up_page)
+    then_i_see_the(:teacher_sign_in_or_sign_up_page)
 
     when_i_choose_yes_and_sign_in
     then_i_see_the(:teacher_check_email_page)
@@ -76,8 +76,8 @@ RSpec.describe "Teacher authentication", type: :system do
   end
 
   it "sign in when unconfirmed" do
-    when_i_visit_the(:teacher_create_or_sign_in_page)
-    then_i_see_the(:teacher_create_or_sign_in_page)
+    when_i_visit_the(:teacher_sign_in_or_sign_up_page)
+    then_i_see_the(:teacher_sign_in_or_sign_up_page)
 
     when_i_choose_yes_and_sign_in
     then_i_see_the(:teacher_check_email_page)
@@ -91,8 +91,8 @@ RSpec.describe "Teacher authentication", type: :system do
     then_i_see_the(:teacher_check_email_page)
     and_i_receive_a_teacher_confirmation_email
 
-    when_i_visit_the(:teacher_create_or_sign_in_page)
-    then_i_see_the(:teacher_create_or_sign_in_page)
+    when_i_visit_the(:teacher_sign_in_or_sign_up_page)
+    then_i_see_the(:teacher_sign_in_or_sign_up_page)
 
     when_i_choose_yes_and_sign_in
     then_i_see_the(:teacher_check_email_page)
@@ -113,7 +113,7 @@ RSpec.describe "Teacher authentication", type: :system do
     given_i_clear_my_session
 
     when_i_visit_the_teacher_confirmation_email
-    then_i_see_the(:teacher_create_or_sign_in_page)
+    then_i_see_the(:teacher_sign_in_or_sign_up_page)
     and_i_see_already_confirmed_message
   end
 
@@ -124,8 +124,8 @@ RSpec.describe "Teacher authentication", type: :system do
 
     given_i_clear_my_session
 
-    when_i_visit_the(:teacher_create_or_sign_in_page)
-    then_i_see_the(:teacher_create_or_sign_in_page)
+    when_i_visit_the(:teacher_sign_in_or_sign_up_page)
+    then_i_see_the(:teacher_sign_in_or_sign_up_page)
 
     when_i_choose_yes_and_sign_in
     then_i_see_the(:teacher_check_email_page)
@@ -183,7 +183,7 @@ RSpec.describe "Teacher authentication", type: :system do
   end
 
   def when_i_choose_yes_and_sign_in
-    teacher_create_or_sign_in_page.submit_sign_in(email: "test@example.com")
+    teacher_sign_in_or_sign_up_page.submit_sign_in(email: "test@example.com")
   end
 
   def when_i_visit_the_magic_link_email


### PR DESCRIPTION
I think the naming is a little confusing, it's clearer for it to be called sign up or sign in since those are the two options.