### PR TITLE
Add UUIDs to teachers

### DIFF
--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -14,12 +14,14 @@
 #  sign_in_count        :integer          default(0), not null
 #  trn                  :string
 #  unconfirmed_email    :string
+#  uuid                 :uuid             not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #
 # Indexes
 #
 #  index_teachers_on_email  (email) UNIQUE
+#  index_teachers_on_uuid   (uuid) UNIQUE
 #
 class Teacher < ApplicationRecord
   devise :magic_link_authenticatable,

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -227,6 +227,7 @@
     - support_console_permission
   :teachers:
     - id
+    - uuid
     - email
     - created_at
     - updated_at

--- a/db/migrate/20221207120352_add_uuid_to_teacher.rb
+++ b/db/migrate/20221207120352_add_uuid_to_teacher.rb
@@ -1,0 +1,13 @@
+class AddUuidToTeacher < ActiveRecord::Migration[7.0]
+  def change
+    enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
+
+    add_column :teachers,
+               :uuid,
+               :uuid,
+               default: "gen_random_uuid()",
+               null: false
+
+    add_index :teachers, :uuid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_05_102028) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_07_120352) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -322,7 +323,9 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_05_102028) do
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.string "trn"
+    t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.index ["email"], name: "index_teachers_on_email", unique: true
+    t.index ["uuid"], name: "index_teachers_on_uuid", unique: true
   end
 
   create_table "timeline_events", force: :cascade do |t|

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -14,12 +14,14 @@
 #  sign_in_count        :integer          default(0), not null
 #  trn                  :string
 #  unconfirmed_email    :string
+#  uuid                 :uuid             not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #
 # Indexes
 #
 #  index_teachers_on_email  (email) UNIQUE
+#  index_teachers_on_uuid   (uuid) UNIQUE
 #
 FactoryBot.define do
   factory :teacher do

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -14,12 +14,14 @@
 #  sign_in_count        :integer          default(0), not null
 #  trn                  :string
 #  unconfirmed_email    :string
+#  uuid                 :uuid             not null
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #
 # Indexes
 #
 #  index_teachers_on_email  (email) UNIQUE
+#  index_teachers_on_uuid   (uuid) UNIQUE
 #
 require "rails_helper"
 


### PR DESCRIPTION
This is necessary to enable OTP authentication, as we don't want to expose an autoincrementing number so instead we can use a random UUID.

Based off https://github.com/DFE-Digital/refer-serious-misconduct/pull/255

[Trello Card](https://trello.com/c/nLrL1b0P/1235-update-auth-to-use-otp-instead-of-not-so-magic-links)