### PR TITLE
Fix DQT country codes

### DIFF
--- a/app/lib/dqt/country_code.rb
+++ b/app/lib/dqt/country_code.rb
@@ -12,6 +12,18 @@ class DQT::CountryCode
       # Antarctica and Oceania not otherwise specified
       return "XX" if %w[AQ BAT IO TF HM].include?(code)
 
+      # England
+      return "XF" if code == "GB-ENG"
+
+      # Wales
+      return "XI" if code == "GB-WLS"
+
+      # Scotland
+      return "XH" if code == "GB-SCT"
+
+      # Northern Ireland
+      return "XG" if code == "GB-NIR"
+
       code
     end
   end

--- a/spec/lib/dqt/country_code_spec.rb
+++ b/spec/lib/dqt/country_code_spec.rb
@@ -51,5 +51,29 @@ RSpec.describe DQT::CountryCode do
 
       it { is_expected.to eq("XX") }
     end
+
+    context "with England" do
+      let(:code) { "GB-ENG" }
+
+      it { is_expected.to eq("XF") }
+    end
+
+    context "with Wales" do
+      let(:code) { "GB-WLS" }
+
+      it { is_expected.to eq("XI") }
+    end
+
+    context "with Scotland" do
+      let(:code) { "GB-SCT" }
+
+      it { is_expected.to eq("XH") }
+    end
+
+    context "with Northern Ireland" do
+      let(:code) { "GB-NIR" }
+
+      it { is_expected.to eq("XG") }
+    end
   end
 end


### PR DESCRIPTION
Add England, Wales, Scotland and NI conversions when creating params for DQT.