### PR TITLE
[1209] Rename `AssessmentSectionFailureReason`

### DIFF
--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -57,7 +57,7 @@ module TimelineEntry
       {
         section_name: section.key.titleize,
         section_state: timeline_event.new_state,
-        failure_reasons: section.assessment_section_failure_reasons,
+        failure_reasons: section.selected_failure_reasons,
       }
     end
 

--- a/app/forms/assessor_interface/assessment_section_form.rb
+++ b/app/forms/assessor_interface/assessment_section_form.rb
@@ -74,8 +74,7 @@ class AssessorInterface::AssessmentSectionForm
       {
         assessment_section:,
         passed: assessment_section.passed,
-        selected_failure_reasons:
-          assessment_section.assessment_section_failure_reasons,
+        selected_failure_reasons: assessment_section.selected_failure_reasons,
       }
     end
 

--- a/app/lib/further_information_request_items_factory.rb
+++ b/app/lib/further_information_request_items_factory.rb
@@ -18,9 +18,7 @@ class FurtherInformationRequestItemsFactory
   attr_reader :further_information_request, :assessment_sections
 
   def build_further_information_request_items(assessment_section)
-    assessment_section
-      .assessment_section_failure_reasons
-      .map do |failure_reason|
+    assessment_section.selected_failure_reasons.map do |failure_reason|
       build_further_information_request_item(
         failure_reason.key,
         failure_reason.assessor_feedback,

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -22,7 +22,9 @@
 #
 class AssessmentSection < ApplicationRecord
   belongs_to :assessment
-  has_many :assessment_section_failure_reasons, dependent: :destroy
+  has_many :selected_failure_reasons,
+           class_name: "AssessmentSectionFailureReason",
+           dependent: :destroy
 
   enum :key,
        {
@@ -42,10 +44,10 @@ class AssessmentSection < ApplicationRecord
               in: keys.values,
             }
 
-  validates :assessment_section_failure_reasons,
+  validates :selected_failure_reasons,
             presence: true,
             if: -> { passed == false }
-  validates :assessment_section_failure_reasons,
+  validates :selected_failure_reasons,
             absence: true,
             if: -> { passed || passed.nil? }
 
@@ -55,6 +57,6 @@ class AssessmentSection < ApplicationRecord
   end
 
   def declines_assessment?
-    assessment_section_failure_reasons.declinable.any?
+    selected_failure_reasons.declinable.any?
   end
 end

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -22,9 +22,7 @@
 #
 class AssessmentSection < ApplicationRecord
   belongs_to :assessment
-  has_many :selected_failure_reasons,
-           class_name: "AssessmentSectionFailureReason",
-           dependent: :destroy
+  has_many :selected_failure_reasons, dependent: :destroy
 
   enum :key,
        {

--- a/app/models/selected_failure_reason.rb
+++ b/app/models/selected_failure_reason.rb
@@ -2,7 +2,7 @@
 
 # == Schema Information
 #
-# Table name: assessment_section_failure_reasons
+# Table name: selected_failure_reasons
 #
 #  id                    :bigint           not null, primary key
 #  assessor_feedback     :text
@@ -19,7 +19,7 @@
 #
 #  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #
-class AssessmentSectionFailureReason < ApplicationRecord
+class SelectedFailureReason < ApplicationRecord
   belongs_to :assessment_section
 
   validates :key, presence: true

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -17,13 +17,13 @@ class UpdateAssessmentSection
       selected_keys = selected_failure_reasons.keys
 
       assessment_section
-        .assessment_section_failure_reasons
+        .selected_failure_reasons
         .where.not(key: selected_keys)
         .destroy_all
 
       selected_failure_reasons.each do |key, assessor_feedback|
         assessment_section
-          .assessment_section_failure_reasons
+          .selected_failure_reasons
           .find_or_initialize_by(key:)
           .update(assessor_feedback:)
       end

--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -30,10 +30,10 @@ class TeacherInterface::ApplicationFormShowViewObject
     return [] if assessment.nil? || further_information_request.present?
 
     assessment.sections.filter_map do |section|
-      next nil if section.assessment_section_failure_reasons.empty?
+      next nil if section.selected_failure_reasons.empty?
 
       failure_reasons =
-        section.assessment_section_failure_reasons.map do |failure_reason|
+        section.selected_failure_reasons.map do |failure_reason|
           is_decline =
             FailureReasons.decline?(failure_reason: failure_reason.key)
 
@@ -57,7 +57,7 @@ class TeacherInterface::ApplicationFormShowViewObject
     return false if assessment.nil?
 
     assessment.sections.any? do |section|
-      section.assessment_section_failure_reasons.any? do |failure_reason|
+      section.selected_failure_reasons.any? do |failure_reason|
         %w[authorisation_to_teach applicant_already_qts].include?(
           failure_reason.key,
         )

--- a/app/views/assessor_interface/assessments/declare.html.erb
+++ b/app/views/assessor_interface/assessments/declare.html.erb
@@ -11,10 +11,10 @@
   <h2 class="govuk-heading-l">Your decline reasons and notes</h2>
 
   <% @assessment.sections.each do |section| %>
-    <% if section.assessment_section_failure_reasons.present? %>
+    <% if section.selected_failure_reasons.present? %>
       <h3 class="govuk-heading-m"><%= t(".assessment_section.#{section.key}") %></h3>
       <ul class="govuk-list">
-        <% section.assessment_section_failure_reasons.each do |failure_reason| %>
+        <% section.selected_failure_reasons.each do |failure_reason| %>
           <li>
             <h4 class="govuk-heading-s"><%= t("assessor_interface.assessment_sections.show.failure_reasons.#{failure_reason.key}") %></h4>
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -65,13 +65,6 @@
     - failure_reasons
     - created_at
     - updated_at
-  :assessment_section_failure_reasons:
-    - id
-    - assessment_section_id
-    - key
-    - assessor_feedback
-    - created_at
-    - updated_at
   :assessments:
     - id
     - application_form_id
@@ -197,6 +190,13 @@
     - created_at
     - updated_at
     - further_information_request_id
+  :selected_failure_reasons:
+    - id
+    - created_at
+    - updated_at
+    - key
+    - assessor_feedback
+    - assessment_section_id
   :staff:
     - id
     - email

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -16,8 +16,6 @@
     - registration_number
     - has_work_history
     - subjects
-  :assessment_section_failure_reasons:
-    - assessor_feedback
   :further_information_requests:
     - failure_assessor_note
   :further_information_request_items:
@@ -33,6 +31,8 @@
     - complete_date
     - certificate_date
     - part_of_university_degree
+  :selected_failure_reasons:
+    - assessor_feedback
   :staff:
     - email
     - unconfirmed_email

--- a/db/migrate/20221208164016_rename_assessment_section_failure_reasons.rb
+++ b/db/migrate/20221208164016_rename_assessment_section_failure_reasons.rb
@@ -1,0 +1,5 @@
+class RenameAssessmentSectionFailureReasons < ActiveRecord::Migration[7.0]
+  def change
+    rename_table :assessment_section_failure_reasons, :selected_failure_reasons
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_07_183958) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_08_164016) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -85,15 +85,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_07_183958) do
     t.index ["reviewer_id"], name: "index_application_forms_on_reviewer_id"
     t.index ["state"], name: "index_application_forms_on_state"
     t.index ["teacher_id"], name: "index_application_forms_on_teacher_id"
-  end
-
-  create_table "assessment_section_failure_reasons", force: :cascade do |t|
-    t.bigint "assessment_section_id", null: false
-    t.string "key", null: false
-    t.text "assessor_feedback"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["assessment_section_id"], name: "index_as_failure_reason_assessment_section_id"
   end
 
   create_table "assessment_sections", force: :cascade do |t|
@@ -259,6 +250,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_07_183958) do
     t.index ["further_information_request_id"], name: "index_reminder_emails_on_further_information_request_id"
   end
 
+  create_table "selected_failure_reasons", force: :cascade do |t|
+    t.bigint "assessment_section_id", null: false
+    t.string "key", null: false
+    t.text "assessor_feedback"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessment_section_id"], name: "index_as_failure_reason_assessment_section_id"
+  end
+
   create_table "sessions", force: :cascade do |t|
     t.string "session_id", null: false
     t.text "data"
@@ -382,7 +382,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_07_183958) do
   add_foreign_key "application_forms", "staff", column: "assessor_id"
   add_foreign_key "application_forms", "staff", column: "reviewer_id"
   add_foreign_key "application_forms", "teachers"
-  add_foreign_key "assessment_section_failure_reasons", "assessment_sections"
   add_foreign_key "assessment_sections", "assessments"
   add_foreign_key "assessments", "application_forms"
   add_foreign_key "dqt_trn_requests", "application_forms"
@@ -392,6 +391,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_07_183958) do
   add_foreign_key "qualifications", "application_forms"
   add_foreign_key "regions", "countries"
   add_foreign_key "reminder_emails", "further_information_requests"
+  add_foreign_key "selected_failure_reasons", "assessment_sections"
   add_foreign_key "timeline_events", "application_forms"
   add_foreign_key "timeline_events", "assessment_sections"
   add_foreign_key "timeline_events", "assessments"

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -48,7 +48,7 @@ namespace :example_data do
     end
 
     TimelineEvent.delete_all
-    AssessmentSectionFailureReason.delete_all
+    SelectedFailureReason.delete_all
     AssessmentSection.delete_all
     Assessment.delete_all
     Qualification.delete_all

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -87,9 +87,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
       )
     end
 
-    let(:failure_reason) do
-      assessment_section.assessment_section_failure_reasons.first
-    end
+    let(:failure_reason) { assessment_section.selected_failure_reasons.first }
     let(:expected_failure_reason_text) do
       I18n.t(
         "assessor_interface.assessment_sections.show.failure_reasons.#{failure_reason.key}",

--- a/spec/factories/assessment_sections.rb
+++ b/spec/factories/assessment_sections.rb
@@ -4,7 +4,6 @@
 #
 #  id              :bigint           not null, primary key
 #  checks          :string           default([]), is an Array
-#  failure_reasons :string           default([]), is an Array
 #  key             :string           not null
 #  passed          :boolean
 #  created_at      :datetime         not null

--- a/spec/factories/assessment_sections.rb
+++ b/spec/factories/assessment_sections.rb
@@ -4,6 +4,7 @@
 #
 #  id              :bigint           not null, primary key
 #  checks          :string           default([]), is an Array
+#  failure_reasons :string           default([]), is an Array
 #  key             :string           not null
 #  passed          :boolean
 #  created_at      :datetime         not null
@@ -31,28 +32,28 @@ FactoryBot.define do
     trait :failed do
       passed { false }
       selected_failure_reasons do
-        [build(:assessment_section_failure_reason, :fi_requestable)]
+        [build(:selected_failure_reason, :fi_requestable)]
       end
     end
 
     trait :declines_assessment do
       passed { false }
       selected_failure_reasons do
-        [build(:assessment_section_failure_reason, :declinable)]
+        [build(:selected_failure_reason, :declinable)]
       end
     end
 
     trait :declines_with_sanctions do
       passed { false }
       selected_failure_reasons do
-        [build(:assessment_section_failure_reason, :with_sanctions)]
+        [build(:selected_failure_reason, :with_sanctions)]
       end
     end
 
     trait :declines_with_already_qts do
       passed { false }
       selected_failure_reasons do
-        [build(:assessment_section_failure_reason, :with_already_qts)]
+        [build(:selected_failure_reason, :with_already_qts)]
       end
     end
 

--- a/spec/factories/assessment_sections.rb
+++ b/spec/factories/assessment_sections.rb
@@ -31,37 +31,29 @@ FactoryBot.define do
 
     trait :failed do
       passed { false }
-      assessment_section_failure_reasons do
+      selected_failure_reasons do
         [build(:assessment_section_failure_reason, :fi_requestable)]
       end
     end
 
     trait :declines_assessment do
       passed { false }
-      assessment_section_failure_reasons do
+      selected_failure_reasons do
         [build(:assessment_section_failure_reason, :declinable)]
       end
     end
 
     trait :declines_with_sanctions do
       passed { false }
-      assessment_section_failure_reasons do
+      selected_failure_reasons do
         [build(:assessment_section_failure_reason, :with_sanctions)]
       end
     end
 
     trait :declines_with_already_qts do
       passed { false }
-      assessment_section_failure_reasons do
+      selected_failure_reasons do
         [build(:assessment_section_failure_reason, :with_already_qts)]
-      end
-    end
-
-    trait :with_selected_failure_reasons do
-      passed { false }
-      transient { selected_assessment_section_failure_reasons { [] } }
-      assessment_section_failure_reasons do
-        selected_assessment_section_failure_reasons
       end
     end
 

--- a/spec/factories/selected_failure_reasons.rb
+++ b/spec/factories/selected_failure_reasons.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: assessment_section_failure_reasons
+# Table name: selected_failure_reasons
 #
 #  id                    :bigint           not null, primary key
 #  assessor_feedback     :text
@@ -18,7 +18,7 @@
 #  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #
 FactoryBot.define do
-  factory :assessment_section_failure_reason do
+  factory :selected_failure_reason do
     association :assessment_section
     key { FailureReasons::ALL.sample }
 

--- a/spec/lib/further_information_request_items_factory_spec.rb
+++ b/spec/lib/further_information_request_items_factory_spec.rb
@@ -34,27 +34,19 @@ RSpec.describe FurtherInformationRequestItemsFactory do
     end
 
     let(:failure_reason_one) do
-      build(
-        :assessment_section_failure_reason,
-        key: "identification_document_expired",
-      )
+      build(:selected_failure_reason, key: "identification_document_expired")
     end
     let(:failure_reason_two) do
-      build(
-        :assessment_section_failure_reason,
-        assessor_feedback: "More stuff needed",
-      )
+      build(:selected_failure_reason, assessor_feedback: "More stuff needed")
     end
     let(:failure_reason_three) do
-      build(:assessment_section_failure_reason, key: "duplicate_application")
+      build(:selected_failure_reason, key: "duplicate_application")
     end
 
     it { is_expected.to_not be_empty }
 
     it "creates an item for each failure reason" do
-      expect { subject }.to change { AssessmentSectionFailureReason.count }.by(
-        3,
-      )
+      expect { subject }.to change { SelectedFailureReason.count }.by(3)
     end
 
     it "sets the information type" do

--- a/spec/lib/further_information_request_items_factory_spec.rb
+++ b/spec/lib/further_information_request_items_factory_spec.rb
@@ -19,11 +19,8 @@ RSpec.describe FurtherInformationRequestItemsFactory do
       create(
         :assessment_section,
         :personal_information,
-        :with_selected_failure_reasons,
-        selected_assessment_section_failure_reasons: [
-          failure_reason_one,
-          failure_reason_two,
-        ],
+        :failed,
+        selected_failure_reasons: [failure_reason_one, failure_reason_two],
       )
     end
 
@@ -31,8 +28,8 @@ RSpec.describe FurtherInformationRequestItemsFactory do
       create(
         :assessment_section,
         :qualifications,
-        :with_selected_failure_reasons,
-        selected_assessment_section_failure_reasons: [failure_reason_three],
+        :failed,
+        selected_failure_reasons: [failure_reason_three],
       )
     end
 

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe AssessmentSection, type: :model do
       before do
         assessment_section.passed = true
         assessment_section.selected_failure_reasons << build(
-          :assessment_section_failure_reason,
+          :selected_failure_reason,
         )
       end
 
@@ -89,11 +89,7 @@ RSpec.describe AssessmentSection, type: :model do
 
     context "with a decline failure reason" do
       before do
-        create(
-          :assessment_section_failure_reason,
-          :declinable,
-          assessment_section:,
-        )
+        create(:selected_failure_reason, :declinable, assessment_section:)
       end
 
       it { is_expected.to be true }
@@ -101,11 +97,7 @@ RSpec.describe AssessmentSection, type: :model do
 
     context "with no decline failure reasons" do
       before do
-        create(
-          :assessment_section_failure_reason,
-          :fi_requestable,
-          assessment_section:,
-        )
+        create(:selected_failure_reason, :fi_requestable, assessment_section:)
       end
 
       it { is_expected.to be false }

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -45,25 +45,23 @@ RSpec.describe AssessmentSection, type: :model do
     context "when passed" do
       before do
         assessment_section.passed = true
-        assessment_section.assessment_section_failure_reasons << build(
+        assessment_section.selected_failure_reasons << build(
           :assessment_section_failure_reason,
         )
       end
 
       it "is expected to be invalid?" do
         assessment_section.valid?
-        expect(
-          assessment_section.errors[:assessment_section_failure_reasons],
-        ).to eq(["must be blank"])
+        expect(assessment_section.errors[:selected_failure_reasons]).to eq(
+          ["must be blank"],
+        )
       end
     end
 
     context "when not passed" do
       before { assessment_section.passed = false }
 
-      it do
-        is_expected.to validate_presence_of(:assessment_section_failure_reasons)
-      end
+      it { is_expected.to validate_presence_of(:selected_failure_reasons) }
     end
   end
 

--- a/spec/models/selected_failure_reason_spec.rb
+++ b/spec/models/selected_failure_reason_spec.rb
@@ -2,7 +2,7 @@
 
 # == Schema Information
 #
-# Table name: assessment_section_failure_reasons
+# Table name: selected_failure_reasons
 #
 #  id                    :bigint           not null, primary key
 #  assessor_feedback     :text
@@ -21,7 +21,7 @@
 #
 require "rails_helper"
 
-RSpec.describe AssessmentSectionFailureReason do
+RSpec.describe SelectedFailureReason do
   describe "validations" do
     it { is_expected.to validate_presence_of(:key) }
     it do
@@ -33,22 +33,22 @@ RSpec.describe AssessmentSectionFailureReason do
     subject { described_class.declinable }
 
     context "where a record has a key that is declinable" do
-      let(:assessment_section_failure_reason) do
-        create(:assessment_section_failure_reason, :declinable)
+      let(:selected_failure_reason) do
+        create(:selected_failure_reason, :declinable)
       end
 
       it "is returned" do
-        expect(subject).to eq([assessment_section_failure_reason])
+        expect(subject).to eq([selected_failure_reason])
       end
     end
 
     context "where a record has a key that isn't declinable" do
-      let(:assessment_section_failure_reason) do
-        create(:assessment_section_failure_reason, :fi_requestable)
+      let(:selected_failure_reason) do
+        create(:selected_failure_reason, :fi_requestable)
       end
 
       it "is not returned" do
-        expect(subject).not_to eq([assessment_section_failure_reason])
+        expect(subject).not_to eq([selected_failure_reason])
       end
     end
   end

--- a/spec/services/destroy_application_form_spec.rb
+++ b/spec/services/destroy_application_form_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe DestroyApplicationForm do
         )
       assessment_section =
         create(:assessment_section, :personal_information, assessment:)
-      create(:assessment_section_failure_reason, assessment_section:)
+      create(:selected_failure_reason, assessment_section:)
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe DestroyApplicationForm do
   include_examples "deletes model", ApplicationForm
   include_examples "deletes model", Assessment
   include_examples "deletes model", AssessmentSection
-  include_examples "deletes model", AssessmentSectionFailureReason
+  include_examples "deletes model", SelectedFailureReason
   include_examples "deletes model", Document, 12, 6
   include_examples "deletes model", FurtherInformationRequest
   include_examples "deletes model", FurtherInformationRequestItem, 4, 2

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe UpdateAssessmentSection do
     context "when the failure reason already exists" do
       context "when the feedback has been updated" do
         before do
-          assessment_section.assessment_section_failure_reasons.create(
+          assessment_section.selected_failure_reasons.create(
             key: selected_failure_reason_key,
             assessor_feedback: "I need updating",
           )
@@ -80,7 +80,7 @@ RSpec.describe UpdateAssessmentSection do
         end
 
         before do
-          assessment_section.assessment_section_failure_reasons.create(
+          assessment_section.selected_failure_reasons.create(
             key: different_key,
             assessor_feedback: "I need deleting",
           )

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe UpdateAssessmentSection do
 
     it "creates the assessment failure reason records" do
       expect { subject }.to change {
-        AssessmentSectionFailureReason.where(
+        SelectedFailureReason.where(
           assessment_section:,
           key: selected_failure_reason_key,
         ).count
@@ -54,7 +54,7 @@ RSpec.describe UpdateAssessmentSection do
         it "doesn't create a new assessment failure reason record" do
           expect { subject }.not_to(
             change do
-              AssessmentSectionFailureReason.where(
+              SelectedFailureReason.where(
                 assessment_section:,
                 key: selected_failure_reason_key,
               ).count
@@ -64,7 +64,7 @@ RSpec.describe UpdateAssessmentSection do
 
         it "updates the existing record" do
           expect { subject }.to change {
-            AssessmentSectionFailureReason.find_by(
+            SelectedFailureReason.find_by(
               key: selected_failure_reason_key,
             ).assessor_feedback
           }.to(selected_failure_reason_assessor_feedback)
@@ -88,7 +88,7 @@ RSpec.describe UpdateAssessmentSection do
 
         it "deletes the now unselected failure reason" do
           expect { subject }.to change {
-            AssessmentSectionFailureReason.where(key: different_key).count
+            SelectedFailureReason.where(key: different_key).count
           }.by(-1)
         end
       end

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -125,8 +125,8 @@ RSpec.describe "Assessor completing assessment", type: :system do
     create(
       :assessment_section,
       :personal_information,
-      :with_selected_failure_reasons,
-      selected_assessment_section_failure_reasons: [
+      :failed,
+      selected_failure_reasons: [
         build(
           :assessment_section_failure_reason,
           assessor_feedback: @assessor_feedback = "Note.",

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
       :failed,
       selected_failure_reasons: [
         build(
-          :assessment_section_failure_reason,
+          :selected_failure_reason,
           assessor_feedback: @assessor_feedback = "Note.",
           key: @key = "applicant_already_qts",
         ),

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
           :failed,
           selected_failure_reasons: [
             build(
-              :assessment_section_failure_reason,
+              :selected_failure_reason,
               key: "qualifications_dont_match_subjects",
               assessor_feedback: "A note.",
             ),

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -110,8 +110,8 @@ RSpec.describe "Assessor requesting further information", type: :system do
         application_form.assessment.sections << create(
           :assessment_section,
           :qualifications,
-          :with_selected_failure_reasons,
-          selected_assessment_section_failure_reasons: [
+          :failed,
+          selected_failure_reasons: [
             build(
               :assessment_section_failure_reason,
               key: "qualifications_dont_match_subjects",

--- a/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
@@ -65,9 +65,7 @@ RSpec.describe TeacherInterface::ApplicationFormShowViewObject do
       let(:assessment_section) do
         create(:assessment_section, :personal_information, :failed, assessment:)
       end
-      let!(:failure_reasons) do
-        assessment_section.assessment_section_failure_reasons
-      end
+      let!(:failure_reasons) { assessment_section.selected_failure_reasons }
 
       it do
         is_expected.to eq(


### PR DESCRIPTION
~**DNM until #817 and then #820 have been deployed.**~

Final part of splitting the selected failure reasons into their own model.

This PR renames the `AssessmentSection` association to `selected_failure_reason` and renames the model to `SelectedFailureReason`.

I don't think the complexity of splitting the migration and the code change out to avoid errors during deployment is worth it given the small number of users we have. I'll merge over the weekend when we should have 0 users updating these records.