### PR TITLE
Require a document from registration number FI

### DIFF
--- a/app/lib/further_information_request_items_factory.rb
+++ b/app/lib/further_information_request_items_factory.rb
@@ -62,5 +62,6 @@ class FurtherInformationRequestItemsFactory
     "written_statement_illegible" => :written_statement,
     "written_statement_recent" => :written_statement,
     "qualified_to_teach" => :written_statement,
+    "registration_number" => :written_statement,
   }.freeze
 end

--- a/spec/lib/further_information_request_items_factory_spec.rb
+++ b/spec/lib/further_information_request_items_factory_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe FurtherInformationRequestItemsFactory do
       )
     end
     let(:failure_reason_three) do
-      build(:assessment_section_failure_reason, key: "registration_number")
+      build(:assessment_section_failure_reason, key: "duplicate_application")
     end
 
     it { is_expected.to_not be_empty }


### PR DESCRIPTION
If an assessor marks the registration number as not being able to be verified using the online checker, we should be asking the applicant to upload a document (a written statement).

[Trello Card](https://trello.com/c/u3wOLNCB/1240-professional-standing-fi-should-trigger-file-upload-flow)