### PR TITLE
Limit local log size

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,4 +70,8 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :file
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
+
+  # Limit log size to 50mb
+  config.logger =
+    ActiveSupport::Logger.new(config.paths["log"].first, 1, 50.megabytes)
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -58,4 +58,8 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   config.autoload_paths << "#{root}/spec/support/autoload"
+
+  #limit log size to 50mb
+  config.logger =
+    ActiveSupport::Logger.new(config.paths["log"].first, 1, 50.megabytes)
 end


### PR DESCRIPTION
Limit the log file size in development and test to 50mb. Spotted this in a PR on 'refer'. Seems like a good idea. 

This won't delete any existing massive local logs. That needs to be done manually.