### PR TITLE
Ensure teacher is saved

### DIFF
--- a/app/controllers/teachers/registrations_controller.rb
+++ b/app/controllers/teachers/registrations_controller.rb
@@ -54,6 +54,6 @@ class Teachers::RegistrationsController < Devise::RegistrationsController
   end
 
   def teacher_requires_application_form?
-    resource.application_form.nil?
+    resource.persisted? && resource.application_form.nil?
   end
 end


### PR DESCRIPTION
Before creating an application form associated with the teacher we should make sure that's committed to the database otherwise the application form will fail to create. This situation can occur if there are validation errors in the model.

This should resolve: https://sentry.io/organizations/dfe-teacher-services/issues/3802618151/