### PR TITLE
Add more working days calculations

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -11,6 +11,7 @@
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null
+#  working_days_since_started                :integer
 #  working_days_started_to_recommendation    :integer
 #  working_days_submission_to_recommendation :integer
 #  working_days_submission_to_started        :integer

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -8,6 +8,7 @@
 #  received_at                             :datetime
 #  state                                   :string           not null
 #  working_days_received_to_recommendation :integer
+#  working_days_since_received             :integer
 #  created_at                              :datetime         not null
 #  updated_at                              :datetime         not null
 #  assessment_id                           :bigint

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -78,6 +78,7 @@
     - subjects
     - subjects_note
     - recommended_at
+    - working_days_since_started
     - working_days_submission_to_recommendation
     - working_days_submission_to_started
     - working_days_started_to_recommendation
@@ -137,6 +138,7 @@
     - assessment_id
     - passed
     - failure_assessor_note
+    - working_days_since_received
     - working_days_received_to_recommendation
   :further_information_request_items:
     - id

--- a/db/migrate/20221214083343_add_working_days_to_assessments_and_further_information_requests.rb
+++ b/db/migrate/20221214083343_add_working_days_to_assessments_and_further_information_requests.rb
@@ -1,0 +1,10 @@
+class AddWorkingDaysToAssessmentsAndFurtherInformationRequests < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    add_column :assessments, :working_days_since_started, :integer
+    add_column :further_information_requests,
+               :working_days_since_received,
+               :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_08_164016) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_14_083343) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -114,6 +114,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_164016) do
     t.integer "working_days_started_to_recommendation"
     t.integer "working_days_submission_to_recommendation"
     t.integer "working_days_submission_to_started"
+    t.integer "working_days_since_started"
     t.index ["application_form_id"], name: "index_assessments_on_application_form_id"
   end
 
@@ -194,6 +195,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_08_164016) do
     t.boolean "passed"
     t.string "failure_assessor_note", default: "", null: false
     t.integer "working_days_received_to_recommendation"
+    t.integer "working_days_since_received"
     t.index ["assessment_id"], name: "index_further_information_requests_on_assessment_id"
   end
 

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -11,6 +11,7 @@
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null
+#  working_days_since_started                :integer
 #  working_days_started_to_recommendation    :integer
 #  working_days_submission_to_recommendation :integer
 #  working_days_submission_to_started        :integer

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -10,6 +10,7 @@
 #  received_at                             :datetime
 #  state                                   :string           not null
 #  working_days_received_to_recommendation :integer
+#  working_days_since_received             :integer
 #  created_at                              :datetime         not null
 #  updated_at                              :datetime         not null
 #  assessment_id                           :bigint

--- a/spec/jobs/update_working_days_job_spec.rb
+++ b/spec/jobs/update_working_days_job_spec.rb
@@ -45,6 +45,25 @@ RSpec.describe UpdateWorkingDaysJob, type: :job do
       end
     end
 
+    describe "assessment working days since started" do
+      let(:not_started_assessment) { create(:assessment) }
+      let(:friday_assessment) do
+        create(:assessment, started_at: friday_application_form.submitted_at)
+      end
+
+      it "ignores not started assessments" do
+        expect { perform }.to_not(
+          change { not_started_assessment.reload.working_days_since_started },
+        )
+      end
+
+      it "sets the working days" do
+        expect { perform }.to change {
+          friday_assessment.reload.working_days_since_started
+        }.to(2)
+      end
+    end
+
     describe "assessment working days started to recommendation" do
       let(:recommended_assessment) do
         create(
@@ -113,6 +132,30 @@ RSpec.describe UpdateWorkingDaysJob, type: :job do
       it "sets the working days" do
         expect { perform }.to change {
           recommended_assessment.reload.working_days_submission_to_started
+        }.to(2)
+      end
+    end
+
+    describe "further information request days since received" do
+      let(:requested_fi_request) { create(:further_information_request) }
+      let(:received_fi_request) do
+        create(
+          :further_information_request,
+          :received,
+          assessment: create(:assessment, recommended_at: tuesday_today),
+          received_at: friday_application_form.submitted_at,
+        )
+      end
+
+      it "ignores requested further information requests" do
+        expect { perform }.to_not(
+          change { requested_fi_request.reload.working_days_since_received },
+        )
+      end
+
+      it "sets the working days" do
+        expect { perform }.to change {
+          received_fi_request.reload.working_days_since_received
         }.to(2)
       end
     end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -13,6 +13,7 @@
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null
+#  working_days_since_started                :integer
 #  working_days_started_to_recommendation    :integer
 #  working_days_submission_to_recommendation :integer
 #  working_days_submission_to_started        :integer

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -10,6 +10,7 @@
 #  received_at                             :datetime
 #  state                                   :string           not null
 #  working_days_received_to_recommendation :integer
+#  working_days_since_received             :integer
 #  created_at                              :datetime         not null
 #  updated_at                              :datetime         not null
 #  assessment_id                           :bigint


### PR DESCRIPTION
This adds two new working days calculations for analytics:

- The number of working days between when an assessment is started and the current day
- The number of working days between when a further information request is received and the current day

[Trello Card](https://trello.com/c/rvZhxXUp/1266-add-more-working-days-calculations)