### PR TITLE
Render assessor feedback and notes with paragraphs

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -14,11 +14,11 @@
     <% if timeline_event.age_range_subjects_verified? %>
       <p class="govuk-body">Age range: <%= description_vars[:age_range_min] %> to <%= description_vars[:age_range_max] %></p>
       <% if (text = description_vars[:age_range_note]).present? %>
-        <p class="govuk-body"><%= text %></p>
+        <%= simple_format text %>
       <% end %>
       <p class="govuk-body">Subjects: <%= description_vars[:subjects] %></p>
       <% if (text = description_vars[:subjects_note]).present? %>
-        <p class="govuk-body"><%= text %></p>
+        <%= simple_format text %>
       <% end %>
     <% elsif timeline_event.assessment_section_recorded? %>
       <p class="govuk-body">
@@ -35,8 +35,10 @@
         <ul class="govuk-list--bullet">
           <% description_vars[:failure_reasons].each do |failure_reason| %>
             <li>
-              <%= t("assessor_interface.assessment_sections.show.failure_reasons.#{failure_reason.key}") %><br />
-              <%= failure_reason.assessor_feedback %>
+              <p class="govuk-body">
+                <%= t("assessor_interface.assessment_sections.show.failure_reasons.#{failure_reason.key}") %>
+              </p>
+              <%= simple_format failure_reason.assessor_feedback %>
             </li>
           <% end %>
         </ul>
@@ -45,11 +47,13 @@
       <p class="govuk-body">Further information request has been assessed.</p>
 
       <% if (failure_assessor_note = description_vars[:failure_assessor_note]).present? %>
-        <%= govuk_inset_text(text: failure_assessor_note) %>
+        <%= govuk_inset_text do %>
+          <%= simple_format failure_assessor_note %>
+        <% end %>
       <% end %>
     <% else %>
       <p class="govuk-body">
-        <%= t("components.timeline_entry.description.#{timeline_event.event_type}", **description_vars).html_safe %>
+        <%= simple_format t("components.timeline_entry.description.#{timeline_event.event_type}", **description_vars).html_safe %>
       </p>
     <% end %>
   </div>

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -29,7 +29,7 @@ module TimelineEntry
               class_context: "timeline-event",
               context: :assessor,
             ),
-          ),
+          ).strip,
         new_state:
           render(
             StatusTag::Component.new(
@@ -38,7 +38,7 @@ module TimelineEntry
               class_context: "timeline-event",
               context: :assessor,
             ),
-          ),
+          ).strip,
       }
     end
 

--- a/app/views/assessor_interface/assessments/declare.html.erb
+++ b/app/views/assessor_interface/assessments/declare.html.erb
@@ -24,7 +24,9 @@
               <p class="govuk-body govuk-!-margin-bottom-2">Your note (the applicant won’t see this):</p>
             <% end %>
 
-            <%= govuk_inset_text(text: failure_reason.assessor_feedback) %>
+            <%= govuk_inset_text do %>
+              <%= simple_format failure_reason.assessor_feedback %>
+            <% end %>
           </li>
         <% end %>
       </ul>

--- a/app/views/assessor_interface/further_information_requests/preview.html.erb
+++ b/app/views/assessor_interface/further_information_requests/preview.html.erb
@@ -14,7 +14,10 @@
   <section class="app-further-information-request-item">
     <h3 class="govuk-heading-s"><%= I18n.t("assessor_interface.assessment_sections.show.failure_reasons.#{item.failure_reason_key}") %></h3>
     <p class="govuk-body govuk-!-margin-bottom-2">Your note to the applicant:</p>
-    <p class="govuk-inset-text"><%= item.failure_reason_assessor_feedback %></p>
+
+    <%= govuk_inset_text do %>
+      <%= simple_format item.failure_reason_assessor_feedback %>
+    <% end %>
   </section>
 <% end %>
 

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -84,7 +84,7 @@
             </h5>
 
             <% if (text = failure_reason[:assessor_feedback]).present? %>
-              <%= govuk_inset_text(text:) %>
+              <%= govuk_inset_text { simple_format text } %>
             <% end %>
           </li>
         <% end %>

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -3,7 +3,10 @@
 
 <h1 class="govuk-heading-l">Further information required</h1>
 <h3 class="govuk-heading-s">Notes from the assessor</h3>
-<p class="govuk-inset-text"><%= @further_information_request_item.failure_reason_assessor_feedback %></p>
+
+<%= govuk_inset_text do %>
+  <%= simple_format @further_information_request_item.failure_reason_assessor_feedback %>
+<% end %>
 
 <%= form_with model: @further_information_request_item_text_form, url: teacher_interface_application_form_further_information_request_further_information_request_item_path, method: :put do |f| %>
   <% if @further_information_request_item.text? %>


### PR DESCRIPTION
This changes how the feedback and notes from assessors are rendered so that any double new lines are rendered as separate paragraphs using the `simple_format` Rails method which should make them clearer to users.

[Trello Card](https://trello.com/c/cpB4MSGs/1218-formatted-paragraphs-in-the-timeline)

## Screenshots

<img width="347" alt="Screenshot 2022-12-14 at 09 23 03" src="https://user-images.githubusercontent.com/510498/207560093-8dfd2bd8-4e98-42e2-97d0-b7b6f8bdb2cc.png">
<img width="533" alt="Screenshot 2022-12-14 at 09 26 19" src="https://user-images.githubusercontent.com/510498/207560103-35c7026c-1708-494f-aca0-8288c3b51358.png">
