### PR TITLE
Always show online checker information

### DIFF
--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -53,11 +53,6 @@ module AssessorInterface
       build_key(failure_reason, "placeholder")
     end
 
-    def show_online_checker?
-      assessment_section.key == "professional_standing" &&
-        show_registration_number_summary && online_checker_url.present?
-    end
-
     def online_checker_url
       @online_checker_url ||=
         region.teaching_authority_online_checker_url.presence ||

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -48,10 +48,10 @@
 
 <% if @assessment_section_view_object.professional_standing? %>
   <%= govuk_accordion do |accordion| %>
-    <% if @assessment_section_view_object.show_online_checker? %>
+    <% if (online_checker_url = @assessment_section_view_object.online_checker_url).present? %>
       <% accordion.section(heading_text: "Online checker") do %>
         <p class="govuk-body">This authority has an online checker for validating the supplied reference number:</p>
-        <p class="govuk-body"><%= govuk_link_to @assessment_section_view_object.online_checker_url, @assessment_section_view_object.online_checker_url, target: "_blank" %></p>
+        <p class="govuk-body"><%= govuk_link_to online_checker_url, online_checker_url, target: "_blank" %></p>
       <% end %>
     <% end %>
 

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -164,54 +164,6 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
     end
   end
 
-  describe "#show_online_checker?" do
-    subject(:show_online_checker?) { view_object.show_online_checker? }
-
-    it { is_expected.to be false }
-
-    context "with a professional standing spoke" do
-      before do
-        params[:key] = "professional_standing"
-        assessment_section.update!(key: "professional_standing")
-      end
-
-      it { is_expected.to be false }
-    end
-
-    context "with a registration number" do
-      before { application_form.update!(registration_number: "abcdef") }
-
-      it { is_expected.to be false }
-    end
-
-    context "with a checker URL" do
-      before do
-        region.country.update!(
-          teaching_authority_online_checker_url:
-            "https://www.example.com/checks",
-        )
-      end
-
-      it { is_expected.to be false }
-    end
-
-    context "with a professional standing spoke and a registration number and a checker URL" do
-      before do
-        params[:key] = "professional_standing"
-        assessment_section.update!(key: "professional_standing")
-
-        application_form.update!(registration_number: "abcdef")
-
-        region.country.update!(
-          teaching_authority_online_checker_url:
-            "https://www.example.com/checks",
-        )
-      end
-
-      it { is_expected.to be true }
-    end
-  end
-
   describe "#online_checker_url" do
     subject(:online_checker_url) { view_object.online_checker_url }
 


### PR DESCRIPTION
At the moment we only show this section is the user has submitted a registration number, however there's no reason to hide it from the assessors in this case as they might need it for other reasons or to check using the applicants name.

[Trello Card](https://trello.com/c/Fgw7x5zj/1244-online-checker-content-url-visible-to-assessor-if-no-reg-number-supplied)