### PR TITLE
Allow teachers to apply again

### DIFF
--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -52,7 +52,7 @@ class PersonasController < ApplicationController
   def load_teacher_personas
     all_teachers =
       Teacher.includes(
-        application_form: {
+        application_forms: {
           region: [],
           documents: :uploads,
           qualifications: {

--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -13,16 +13,28 @@ module TeacherInterface
     define_history_check :edit
 
     def new
-      @country_region_form = CountryRegionForm.new
+      existing_application_form = current_teacher.application_form
+
+      @already_applied = existing_application_form.present?
+      @needs_region = false
+
+      @country_region_form =
+        CountryRegionForm.new(
+          location:
+            CountryCode.to_location(existing_application_form&.country&.code),
+        )
     end
 
     def create
+      @already_applied = current_teacher.application_form.present?
+
       @country_region_form =
         CountryRegionForm.new(
           country_region_form_params.merge(teacher: current_teacher),
         )
 
       if @country_region_form.needs_region?
+        @needs_region = true
         render :new
       elsif @country_region_form.save(validate: true)
         redirect_to teacher_interface_application_form_path

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -88,6 +88,8 @@ class ApplicationForm < ApplicationRecord
          declined: "declined",
        }
 
+  delegate :country, to: :region, allow_nil: true
+
   STATUS_COLUMNS = %i[
     personal_information_status
     identification_document_status

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -28,7 +28,7 @@ class Teacher < ApplicationRecord
 
   self.timeout_in = 1.hour
 
-  has_one :application_form
+  has_many :application_forms
 
   validates :email,
             presence: true,
@@ -38,6 +38,10 @@ class Teacher < ApplicationRecord
               if: :will_save_change_to_email?,
             },
             valid_for_notify: true
+
+  def application_form
+    @application_form ||= application_forms.order(created_at: :desc).first
+  end
 
   def send_otp(*)
     otp = Devise::Otp.derive_otp(secret_key)

--- a/app/services/destroy_application_form.rb
+++ b/app/services/destroy_application_form.rb
@@ -13,7 +13,7 @@ class DestroyApplicationForm
       dqt_trn_request&.destroy!
       assessment&.destroy!
       application_form.destroy!
-      teacher.destroy!
+      teacher.destroy! unless teacher.application_forms.exists?
     end
   end
 

--- a/app/views/teacher_interface/application_forms/new.html.erb
+++ b/app/views/teacher_interface/application_forms/new.html.erb
@@ -1,13 +1,19 @@
-<% if @country_region_form.needs_region? %>
+<% if @needs_region %>
   <% content_for :page_title, I18n.t("eligibility_check.region.label") %>
 <% else %>
   <% content_for :page_title, I18n.t("eligibility_check.country.label") %>
 <% end %>
 
+<% if @already_applied %>
+  <aside>
+    <%= govuk_warning_text(text: "If you reapply for QTS, you will not be able to review the details of your previous application.") %>
+  </aside>
+<% end %>
+
 <%= form_with model: @country_region_form, url: %i[teacher_interface application_form] do |f| %>
   <%= f.govuk_error_summary %>
 
-  <% if @country_region_form.needs_region? %>
+  <% if @needs_region %>
     <%= f.hidden_field :location %>
 
     <%= f.govuk_radio_buttons_fieldset :region_id,

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -96,8 +96,12 @@
 
   <% unless @view_object.declined_cannot_reapply? %>
     <p class="govuk-body">While your QTS application was declined this time, you can make a new application in future, if you’re able to address the decline reasons we’ve set out.</p>
-    <p class="govuk-body">If you decide to reapply, you must first contact:</p>
-    <p class="govuk-body"><%= govuk_link_to t("service.email"), "mailto:#{t("service.email")}" %></p>
+
+    <p class="govuk-body">If you reapply for QTS, you will not be able to review the details of your previous application.</p>
+
+    <p class="govuk-body">
+      <%= govuk_button_link_to "Apply again", new_teacher_interface_application_form_path %>
+    </p>
 
     <p class="govuk-body">You may want to explore other routes to teaching in England. QTS is not a requirement to teach in independent (private) schools, academies, free schools and in the further education (FE) sector in England.</p>
 

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -26,9 +26,5 @@ FactoryBot.define do
   factory :teacher do
     sequence(:email) { |n| "teacher#{n}@example.org" }
     uuid { SecureRandom.uuid }
-
-    trait :with_application_form do
-      association :application_form
-    end
   end
 end

--- a/spec/lib/teacher_mailer_preview_spec.rb
+++ b/spec/lib/teacher_mailer_preview_spec.rb
@@ -2,7 +2,9 @@ require "rails_helper"
 
 RSpec.describe TeacherMailerPreview do
   let(:further_information_request) { create(:further_information_request) }
-  let(:teacher) { create(:teacher, :with_application_form) }
+  let(:teacher) do
+    further_information_request.assessment.application_form.teacher
+  end
   let(:notify_key) { "notify-key" }
   let(:notify_client) do
     double(generate_template_preview: notify_template_preview)

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -68,8 +68,6 @@ RSpec.describe ApplicationForm, type: :model do
   end
 
   describe "columns" do
-    it { is_expected.to have_many(:notes) }
-
     it do
       is_expected.to define_enum_for(:state).with_values(
         draft: "draft",
@@ -170,6 +168,11 @@ RSpec.describe ApplicationForm, type: :model do
         .with_prefix(:written_statement_status)
         .backed_by_column_of_type(:string)
     end
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:teacher) }
+    it { is_expected.to have_many(:notes) }
   end
 
   describe "validations" do

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -35,4 +35,33 @@ RSpec.describe Teacher, type: :model do
       is_expected.to validate_uniqueness_of(:email).ignoring_case_sensitivity
     end
   end
+
+  describe "associations" do
+    it { is_expected.to have_many(:application_forms) }
+  end
+
+  describe "#application_form" do
+    subject(:application_form) { teacher.application_form }
+
+    context "without an application form" do
+      it { is_expected.to be_nil }
+    end
+
+    context "with an application form" do
+      let!(:application_form) { create(:application_form, teacher:) }
+
+      it { is_expected.to eq(application_form) }
+    end
+
+    context "with two application forms" do
+      let!(:first_application_form) do
+        create(:application_form, teacher:, created_at: Date.new(2020, 1, 1))
+      end
+      let!(:second_application_form) do
+        create(:application_form, teacher:, created_at: Date.new(2020, 6, 1))
+      end
+
+      it { is_expected.to eq(second_application_form) }
+    end
+  end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/declined_application.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/declined_application.rb
@@ -1,0 +1,12 @@
+module PageObjects
+  module TeacherInterface
+    class DeclinedApplication < SitePrism::Page
+      set_url "/teacher/application"
+
+      element :heading, "h1"
+      element :apply_again_button, ".govuk-button"
+
+      load_validation { has_heading? && has_apply_again_button? }
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -167,6 +167,10 @@ module PageHelpers
       PageObjects::EligibilityInterface::TeachChildren.new
   end
 
+  def teacher_application_page
+    @teacher_application_page = PageObjects::TeacherInterface::Application.new
+  end
+
   def teacher_check_email_page
     @teacher_check_email_page = PageObjects::TeacherInterface::CheckEmail.new
   end
@@ -237,10 +241,6 @@ module PageHelpers
   def check_uploaded_files_page
     @check_uploaded_files_page =
       PageObjects::TeacherInterface::CheckUploadedFiles.new
-  end
-
-  def teacher_application_page
-    @teacher_application_page = PageObjects::TeacherInterface::Application.new
   end
 
   def subjects_form_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -195,6 +195,11 @@ module PageHelpers
     @teacher_confirm_otp_page = PageObjects::TeacherInterface::ConfirmOtp.new
   end
 
+  def teacher_declined_application_page
+    @teacher_declined_application_page ||=
+      PageObjects::TeacherInterface::DeclinedApplication.new
+  end
+
   def teacher_new_application_page
     @teacher_new_application_page =
       PageObjects::TeacherInterface::NewApplication.new

--- a/spec/system/teacher_interface/reapply_spec.rb
+++ b/spec/system/teacher_interface/reapply_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Teacher reapply", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_a_user(teacher)
+    given_there_is_an_application_form
+  end
+
+  it "allows reapplying" do
+    when_i_visit_the(:teacher_application_page)
+    then_i_see_the(:teacher_declined_application_page)
+
+    when_i_click_apply_again
+    then_i_see_the(:teacher_new_application_page)
+    and_i_see_the_reapply_warning
+
+    when_i_click_continue
+    then_i_see_the(:teacher_application_page)
+  end
+
+  def given_there_is_an_application_form
+    application_form
+  end
+
+  def when_i_click_apply_again
+    teacher_declined_application_page.apply_again_button.click
+  end
+
+  def and_i_see_the_reapply_warning
+    expect(teacher_new_application_page).to have_content(
+      "If you reapply for QTS, you will not be able to review the details of your previous application.",
+    )
+  end
+
+  def teacher
+    @teacher ||= create(:teacher)
+  end
+
+  def application_form
+    @application_form ||=
+      create(
+        :application_form,
+        :declined,
+        teacher:,
+        region: create(:region, :national),
+      )
+  end
+end


### PR DESCRIPTION
This allows teachers to apply again after submitted an application which has been declined. I've changed the data model so teachers have many application forms and added an apply again button which takes them to the new application view.

We don't have designs for this flow so I've made a few decisions myself, specifically around allowing the user to change the country/region they put in the first application. It doesn't seem likely that this would be needed often, however it felt wrong if we were letting a user reapply without at least giving them the option.

[Trello Card](https://trello.com/c/XOTK13g7/1242-apply-again)

## Screenshots

![Screenshot 2022-12-14 at 13 18 03](https://user-images.githubusercontent.com/510498/207610050-2e196645-1207-4c96-8210-5c259c001fb0.png)

![Screenshot 2022-12-14 at 13 19 18](https://user-images.githubusercontent.com/510498/207610055-50e1fe97-ddf1-4bd2-87b1-3fe1cf3ae589.png)
