### PR TITLE
Add 'Get help' info

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -51,3 +51,8 @@ ul.autocomplete__menu {
   justify-content: space-between;
   align-items: center;
 }
+
+.govuk-footer__navigation {
+  margin-left: 0px;
+  margin-right: 0px;
+}

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -52,11 +52,22 @@
     </div>
 
     <%= govuk_footer(
-      meta_items_title: 'Footer links',
-      meta_items: {
-        'Accessibility': '/accessibility',
-        'Cookies': '/cookies',
-        'Privacy': '/privacy',
-      }) %>
+        meta_items_title: 'Footer links', 
+        meta_items: {
+          'Accessibility': '/accessibility',
+          'Cookies': '/cookies',
+          'Privacy': '/privacy'
+        } ) do |footer| %>
+      <% footer.navigation do %>
+        <% if current_teacher %>
+          <div class="govuk-footer__section">
+            <h3 style = "margin-left: 100px">Get help</h3>
+            <p>If you‘re having difficulty completing your application form, contact: <a class="govuk-link"
+            href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a> for support.</p>
+            <p>We‘ll aim to respond to you within 2 working days.</p>
+          </div>
+        <% end %>
+      <% end %>
+    <% end %>
   </body>
 </html>


### PR DESCRIPTION
Add support information to footer in the teacher interface
<img width="1385" alt="Screenshot 2022-12-15 at 15 41 21" src="https://user-images.githubusercontent.com/45995847/207903775-b2550877-4689-438a-8dc9-a5485b496862.png">


