### PR TITLE
[1278] DQT duplicate state

### DIFF
--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -36,6 +36,7 @@ module StatusTag
       completed: {
         assessor: "green",
       },
+      potential_duplicate_in_dqt: "red",
     }.freeze
 
     def colour

--- a/app/jobs/update_dqt_trn_request_job.rb
+++ b/app/jobs/update_dqt_trn_request_job.rb
@@ -22,6 +22,9 @@ class UpdateDQTTRNRequestJob < ApplicationJob
       end
 
     dqt_trn_request.pending! if dqt_trn_request.initial?
+    if response[:potential_duplicate]
+      dqt_trn_request.application_form.potential_duplicate_in_dqt!
+    end
 
     if (trn = response[:trn]).present?
       AwardQTS.call(

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -86,6 +86,7 @@ class ApplicationForm < ApplicationRecord
          awarded_pending_checks: "awarded_pending_checks",
          awarded: "awarded",
          declined: "declined",
+         potential_duplicate_in_dqt: "potential_duplicate_in_dqt",
        }
 
   delegate :country, to: :region, allow_nil: true

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -43,6 +43,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
       awarded_pending_checks
       awarded
       declined
+      potential_duplicate_in_dqt
     ]
 
     states.map do |state|

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -16,6 +16,7 @@ en:
       completed: Completed
       action_required: Action required
       cannot_start_yet: Cannot start yet
+      potential_duplicate_in_dqt: Potential duplicate in DQT
 
     timeline_entry:
       title:

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -119,6 +119,11 @@ FactoryBot.define do
       submitted_at { Time.zone.now }
     end
 
+    trait :potential_duplicate_in_dqt do
+      state { "potential_duplicate_in_dqt" }
+      submitted_at { Time.zone.now }
+    end
+
     trait :with_assessment do
       after(:create) do |application_form, _evaluator|
         create(:assessment, application_form:)

--- a/spec/jobs/update_dqt_trn_request_job_spec.rb
+++ b/spec/jobs/update_dqt_trn_request_job_spec.rb
@@ -92,28 +92,60 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
       let(:dqt_trn_request) { create(:dqt_trn_request, :pending) }
 
       context "with a successful response" do
-        before do
-          expect(DQT::Client::ReadTRNRequest).to receive(:call).and_return(
-            { trn: "abcdef" },
-          )
+        context "with a TRN" do
+          before do
+            expect(DQT::Client::ReadTRNRequest).to receive(:call).and_return(
+              { trn: "abcdef", potentialDuplicate: false },
+            )
+          end
+
+          it "marks the request as complete" do
+            perform
+            expect(dqt_trn_request.reload.state).to eq("complete")
+          end
+
+          it "awards QTS" do
+            expect(AwardQTS).to receive(:call).with(
+              application_form:,
+              user: "DQT",
+              trn: "abcdef",
+            )
+            perform
+          end
+
+          it "doesn't raise an error" do
+            expect { perform }.to_not raise_error
+          end
         end
 
-        it "marks the request as complete" do
-          perform
-          expect(dqt_trn_request.reload.state).to eq("complete")
-        end
+        context "where a potential duplicate is found" do
+          before do
+            expect(DQT::Client::ReadTRNRequest).to receive(:call).and_return(
+              { trn: nil, potential_duplicate: true },
+            )
+          end
 
-        it "awards QTS" do
-          expect(AwardQTS).to receive(:call).with(
-            application_form:,
-            user: "DQT",
-            trn: "abcdef",
-          )
-          perform
-        end
+          it "leaves the request pending" do
+            perform_rescue_exception
+            expect(dqt_trn_request.reload.state).to eq("pending")
+          end
 
-        it "doesn't raise an error" do
-          expect { perform }.to_not raise_error
+          it "it does not award QTS" do
+            expect(AwardQTS).not_to receive(:call)
+            perform_rescue_exception
+          end
+
+          it "raises a still pending error" do
+            expect { perform }.to raise_error(
+              UpdateDQTTRNRequestJob::StillPending,
+            )
+          end
+
+          it "sets the application form to potential_duplicate_in_dqt" do
+            expect { perform_rescue_exception }.to change {
+              application_form.potential_duplicate_in_dqt?
+            }.from(false).to(true)
+          end
         end
       end
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -78,6 +78,7 @@ RSpec.describe ApplicationForm, type: :model do
         awarded: "awarded",
         awarded_pending_checks: "awarded_pending_checks",
         declined: "declined",
+        potential_duplicate_in_dqt: "potential_duplicate_in_dqt",
       ).backed_by_column_of_type(:string)
     end
 

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -173,6 +173,10 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
           ),
           OpenStruct.new(id: "awarded", label: "Awarded (0)"),
           OpenStruct.new(id: "declined", label: "Declined (0)"),
+          OpenStruct.new(
+            id: "potential_duplicate_in_dqt",
+            label: "Potential duplicate in DQT (0)",
+          ),
         ],
       )
     end
@@ -186,6 +190,7 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
         create_list(:application_form, 5, :awarded_pending_checks)
         create_list(:application_form, 6, :awarded)
         create_list(:application_form, 7, :declined)
+        create_list(:application_form, 1, :potential_duplicate_in_dqt)
       end
 
       it do
@@ -210,6 +215,10 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
             ),
             OpenStruct.new(id: "awarded", label: "Awarded (6)"),
             OpenStruct.new(id: "declined", label: "Declined (7)"),
+            OpenStruct.new(
+              id: "potential_duplicate_in_dqt",
+              label: "Potential duplicate in DQT (1)",
+            ),
           ],
         )
       end


### PR DESCRIPTION
Sometimes, when we send a record to the qualified teachers API for award, the response will indicate that there is a potential duplicate already in DQT. When this happens, manual intervention is required in DQT by one of the assessors. This response is currently not visible to the assessors.

* Update the application form state to `potential_duplicate_in_dqt`
* Continue to requeue the job so as we pick it up once it has been resolved
* Add a filter for this state to the application form list
* Show this state as a tag in red

