### PR TITLE
Case insensitive emails

### DIFF
--- a/app/controllers/teachers/registrations_controller.rb
+++ b/app/controllers/teachers/registrations_controller.rb
@@ -8,7 +8,7 @@ class Teachers::RegistrationsController < Devise::RegistrationsController
   layout "two_thirds"
 
   def create
-    self.resource = Teacher.find_or_initialize_by(sign_up_params)
+    self.resource = Teacher.find_or_initialize_by_email(sign_up_params[:email])
 
     if resource.save
       resource.create_otp

--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -26,7 +26,7 @@ class Teachers::SessionsController < Devise::SessionsController
         return
       end
 
-      self.resource = resource_class.find_by(email: @new_session_form.email)
+      self.resource = resource_class.find_by_email(@new_session_form.email)
 
       if resource
         resource.create_otp

--- a/app/models/concerns/emailable.rb
+++ b/app/models/concerns/emailable.rb
@@ -1,0 +1,24 @@
+module Emailable
+  extend ActiveSupport::Concern
+
+  included do
+    validates :email,
+              presence: true,
+              uniqueness: {
+                allow_blank: true,
+                case_sensitive: false,
+                if: :will_save_change_to_email?,
+              },
+              valid_for_notify: true
+  end
+
+  class_methods do
+    def find_by_email(email)
+      find_by("LOWER(email) = ?", email.downcase)
+    end
+
+    def find_or_initialize_by_email(email)
+      find_by_email(email) || new(email:)
+    end
+  end
+end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -45,6 +45,8 @@
 #  index_staff_on_unlock_token          (unlock_token) UNIQUE
 #
 class Staff < ApplicationRecord
+  include Emailable
+
   devise :database_authenticatable,
          :confirmable,
          :recoverable,

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -37,10 +37,10 @@
 # Indexes
 #
 #  index_staff_on_confirmation_token    (confirmation_token) UNIQUE
-#  index_staff_on_email                 (email) UNIQUE
 #  index_staff_on_invitation_token      (invitation_token) UNIQUE
 #  index_staff_on_invited_by            (invited_by_type,invited_by_id)
 #  index_staff_on_invited_by_id         (invited_by_id)
+#  index_staff_on_lower_email           (lower((email)::text)) UNIQUE
 #  index_staff_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_staff_on_unlock_token          (unlock_token) UNIQUE
 #

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -23,21 +23,14 @@
 #  index_teachers_on_uuid        (uuid) UNIQUE
 #
 class Teacher < ApplicationRecord
+  include Emailable
+
   devise :registerable, :timeoutable, :trackable
   include Devise::Models::OtpAuthenticatable
 
   self.timeout_in = 1.hour
 
   has_many :application_forms
-
-  validates :email,
-            presence: true,
-            uniqueness: {
-              allow_blank: true,
-              case_sensitive: true,
-              if: :will_save_change_to_email?,
-            },
-            valid_for_notify: true
 
   def application_form
     @application_form ||= application_forms.order(created_at: :desc).first

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -19,8 +19,8 @@
 #
 # Indexes
 #
-#  index_teachers_on_email  (email) UNIQUE
-#  index_teachers_on_uuid   (uuid) UNIQUE
+#  index_teacher_on_lower_email  (lower((email)::text)) UNIQUE
+#  index_teachers_on_uuid        (uuid) UNIQUE
 #
 class Teacher < ApplicationRecord
   devise :registerable, :timeoutable, :trackable

--- a/db/migrate/20221218202149_change_email_index_to_case_insensitive.rb
+++ b/db/migrate/20221218202149_change_email_index_to_case_insensitive.rb
@@ -1,0 +1,15 @@
+class ChangeEmailIndexToCaseInsensitive < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :staff, :email, unique: true
+    remove_index :teachers, :email, unique: true
+
+    add_index :staff,
+              "LOWER(email)",
+              name: "index_staff_on_lower_email",
+              unique: true
+    add_index :teachers,
+              "LOWER(email)",
+              name: "index_teacher_on_lower_email",
+              unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_15_105051) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_18_202149) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -301,8 +301,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_15_105051) do
     t.text "name", default: "", null: false
     t.boolean "award_decline_permission", default: false
     t.boolean "support_console_permission", default: false, null: false
+    t.index "lower((email)::text)", name: "index_staff_on_lower_email", unique: true
     t.index ["confirmation_token"], name: "index_staff_on_confirmation_token", unique: true
-    t.index ["email"], name: "index_staff_on_email", unique: true
     t.index ["invitation_token"], name: "index_staff_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_staff_on_invited_by_id"
     t.index ["invited_by_type", "invited_by_id"], name: "index_staff_on_invited_by"
@@ -324,7 +324,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_15_105051) do
     t.string "secret_key"
     t.integer "otp_guesses", default: 0, null: false
     t.datetime "otp_created_at", precision: nil
-    t.index ["email"], name: "index_teachers_on_email", unique: true
+    t.index "lower((email)::text)", name: "index_teacher_on_lower_email", unique: true
     t.index ["uuid"], name: "index_teachers_on_uuid", unique: true
   end
 

--- a/spec/factories/staff.rb
+++ b/spec/factories/staff.rb
@@ -37,10 +37,10 @@
 # Indexes
 #
 #  index_staff_on_confirmation_token    (confirmation_token) UNIQUE
-#  index_staff_on_email                 (email) UNIQUE
 #  index_staff_on_invitation_token      (invitation_token) UNIQUE
 #  index_staff_on_invited_by            (invited_by_type,invited_by_id)
 #  index_staff_on_invited_by_id         (invited_by_id)
+#  index_staff_on_lower_email           (lower((email)::text)) UNIQUE
 #  index_staff_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_staff_on_unlock_token          (unlock_token) UNIQUE
 #

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -19,8 +19,8 @@
 #
 # Indexes
 #
-#  index_teachers_on_email  (email) UNIQUE
-#  index_teachers_on_uuid   (uuid) UNIQUE
+#  index_teacher_on_lower_email  (lower((email)::text)) UNIQUE
+#  index_teachers_on_uuid        (uuid) UNIQUE
 #
 FactoryBot.define do
   factory :teacher do

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -37,10 +37,10 @@
 # Indexes
 #
 #  index_staff_on_confirmation_token    (confirmation_token) UNIQUE
-#  index_staff_on_email                 (email) UNIQUE
 #  index_staff_on_invitation_token      (invitation_token) UNIQUE
 #  index_staff_on_invited_by            (invited_by_type,invited_by_id)
 #  index_staff_on_invited_by_id         (invited_by_id)
+#  index_staff_on_lower_email           (lower((email)::text)) UNIQUE
 #  index_staff_on_reset_password_token  (reset_password_token) UNIQUE
 #  index_staff_on_unlock_token          (unlock_token) UNIQUE
 #

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -19,8 +19,8 @@
 #
 # Indexes
 #
-#  index_teachers_on_email  (email) UNIQUE
-#  index_teachers_on_uuid   (uuid) UNIQUE
+#  index_teacher_on_lower_email  (lower((email)::text)) UNIQUE
+#  index_teachers_on_uuid        (uuid) UNIQUE
 #
 require "rails_helper"
 

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -55,6 +55,27 @@ RSpec.describe "Teacher authentication", type: :system do
     then_i_see_the(:teacher_signed_out_page)
   end
 
+  it "allows signing up and signing in with case insensitive" do
+    given_countries_exist
+
+    when_i_visit_the(:teacher_sign_up_page)
+    then_i_see_the(:teacher_sign_up_page)
+
+    when_i_sign_up
+    then_i_see_the(:teacher_confirm_otp_page)
+    and_i_receive_a_teacher_otp_email
+
+    given_i_clear_my_session
+
+    when_i_visit_the(:teacher_sign_in_page)
+    then_i_see_the(:teacher_sign_in_page)
+
+    when_i_sign_in_with_different_case
+    then_i_see_the(:teacher_confirm_otp_page)
+    and_i_receive_a_teacher_otp_email
+    and_only_one_teacher_exists
+  end
+
   it "sign out with navigation link" do
     when_i_visit_the(:teacher_sign_up_page)
     then_i_see_the(:teacher_sign_up_page)
@@ -148,6 +169,10 @@ RSpec.describe "Teacher authentication", type: :system do
     teacher_sign_in_page.submit(email: "test@example.com")
   end
 
+  def when_i_sign_in_with_different_case
+    teacher_sign_in_page.submit(email: "TEST@example.com")
+  end
+
   def when_i_choose_yes_and_sign_in
     teacher_sign_in_or_sign_up_page.submit_sign_in(email: "test@example.com")
   end
@@ -172,5 +197,9 @@ RSpec.describe "Teacher authentication", type: :system do
     expect(teacher_sign_up_page).to have_content(
       "Your email address is already confirmed, please sign in.",
     )
+  end
+
+  def and_only_one_teacher_exists
+    expect(Teacher.count).to eq(1)
   end
 end


### PR DESCRIPTION
This changes how we store and look up teachers and stuff to make sure the emails are case insensitive so users can always sign in even if they use a different case to when they signed in.

[Trello Card](https://trello.com/b/2c0VdUpm/tra-apply-for-qualified-teacher-status-in-england-service-team)