### PR TITLE
Remove migration for feature flags

### DIFF
--- a/db/migrate/20221215102100_migrate_feature_flags.rb
+++ b/db/migrate/20221215102100_migrate_feature_flags.rb
@@ -1,7 +1,0 @@
-class MigrateFeatureFlags < ActiveRecord::Migration[7.0]
-  def change
-    Feature.all.each do |feature|
-      FeatureFlags::Feature.create!(feature.attributes)
-    end
-  end
-end


### PR DESCRIPTION
It's not possible to run this migration anymore as the model it references no longer exists. It's already run in all the environments so we can safely delete it.

Should resolve https://sentry.io/organizations/dfe-teacher-services/issues/3822120387/.