### PR TITLE
Add English language proficiency content

### DIFF
--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -21,21 +21,26 @@
   <p class="govuk-body">You’ll need to provide the following evidence when you apply.</p>
 
   <%= govuk_accordion do |accordion| %>
-
-    <% accordion.section(heading_text: "1. Proof of identity") do %>
+    <% accordion.section(heading_text: "Proof of identity") do %>
       <%= render "shared/eligible_region_content_components/proof_of_identity" %>
     <% end %>
 
-    <% accordion.section(heading_text: "2. Proof of qualifications") do %>
-      <%= render "shared/eligible_region_content_components/proof_of_qualifications", region: region %>
+    <% accordion.section(heading_text: "Proof of qualifications") do %>
+      <%= render "shared/eligible_region_content_components/proof_of_qualifications", region: %>
     <% end %>
 
-    <% accordion.section(heading_text: "3. Proof that you’re recognised as a teacher") do %>
-    <%= render "shared/eligible_region_content_components/professional_recognition", region: region %>
+    <% if FeatureFlags::FeatureFlag.active?(:eligibility_english_language) %>
+      <% accordion.section(heading_text: "Proof of English language ability") do %>
+        <%= render "shared/eligible_region_content_components/english_language", region: %>
+      <% end %>
     <% end %>
 
-    <% accordion.section(heading_text: "4. Certified translations") do %>
-      <% render "shared/eligible_region_content_components/certified_translation", region: region%>
+    <% accordion.section(heading_text: "Proof that you’re recognised as a teacher") do %>
+      <%= render "shared/eligible_region_content_components/professional_recognition", region: %>
+    <% end %>
+
+    <% accordion.section(heading_text: "Certified translations") do %>
+      <% render "shared/eligible_region_content_components/certified_translation", region: %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/eligible_region_content_components/_english_language.html.erb
+++ b/app/views/shared/eligible_region_content_components/_english_language.html.erb
@@ -1,0 +1,69 @@
+<p class="govuk-body">We need to understand your level of English language proficiency. You can provide evidence in any of the following ways:</p>
+
+<ul class="govuk-list govuk-list--number">
+  <li>
+    <h3 class="govuk-heading-s">Show you were born or hold citizenship of a country that’s exempt from English language requirements</h3>
+    <p class="govuk-body">You can show this when you upload a copy of your passport or the official identification document for that country.</p>
+  </li>
+
+  <li>
+    <h3 class="govuk-heading-s">Show you were taught in English in a country that’s exempt from English language requirements</h3>
+    <p class="govuk-body">You can show this when you upload the transcript from your degree qualification.</p>
+  </li>
+
+  <li>
+    <h3 class="govuk-heading-s">Show you were taught in English, but in a country that’s NOT exempt from English language requirements</h3>
+    <p class="govuk-body">Upload the ‘Medium of instruction’ (MOI) from your degree qualification. You can get this by contacting the institution where you studied.</p>
+  </li>
+
+  <li>
+    <h3 class="govuk-heading-s">Show you hold an approved English language certificate</h3>
+    <p class="govuk-body">You’ll need a Secure English Language Test (SELT) at level B2 of the Common European Framework of Reference for Languages (CEFR) scale. This is higher than the B1 proficiency the UK Home Office requires when people apply for UK citizenship, because you’ll be instructing students in English.</p>
+    <p class="govuk-body">The test must be on the list of approved English language tests and awarded within the last 2 years before the date of your application.</p>
+  </li>
+</ul>
+
+<%= govuk_details(summary_text: "Which countries are exempt?") do %>
+  <p class="govuk-body">
+    The following countries are exempt from English language proficiency requirements:
+  </p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>Antigua and Barbuda</li>
+    <li>Australia</li>
+    <li>The Bahamas</li>
+    <li>Barbados</li>
+    <li>Belize</li>
+    <li>Canada</li>
+    <li>Dominica</li>
+    <li>Grenada</li>
+    <li>Guyana</li>
+    <li>Jamaica</li>
+    <li>Ireland</li>
+    <li>Malta</li>
+    <li>New Zealand</li>
+    <li>St Kitts and Nevis</li>
+    <li>St Lucia</li>
+    <li>St Vincent and the Grenadines</li>
+    <li>Trinidad and Tobago</li>
+    <li>USA</li>
+    <li>England</li>
+    <li>Scotland</li>
+    <li>Northern Ireland</li>
+    <li>Wales</li>
+  </ul>
+<% end %>
+
+<p class="govuk-body">Learn more about <a href="https://www.coe.int/en/web/common-european-framework-reference-languages/table-1-cefr-3.3-common-reference-levels-global-scale" class="govuk-link">level B2 English language</a>.</p>
+
+<p class="govuk-body">Find out about <a href="https://www.gov.uk/guidance/prove-your-english-language-abilities-with-a-secure-english-language-test-selt" class="govuk-link">approved test providers</a>.</p>
+
+<%= govuk_details(summary_text: "What about multiple nationalities?") do %>
+  <p class="govuk-body">
+    If you’re a national of more than 1 country and both are exempt from English language requirements, you can choose which of them you use to apply for QTS. Remember, you must be able to show a passport (or the recognised identity document for that country).
+  </p>
+
+  <p class="govuk-body">
+    If you hold a second nationality that is not exempt (and you apply for QTS using that nationality) you’ll need to prove your English language proficiency using one of the other methods.
+  </p>
+<% end %>

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,4 +1,9 @@
 feature_flags:
+  eligibility_english_language:
+    author: Thomas Leese
+    description: >
+      Add English language proficiency content to the eligible page.
+
   personas:
     author: Thomas Leese
     description: >

--- a/spec/views/shared/eligible_region_content_spec.rb
+++ b/spec/views/shared/eligible_region_content_spec.rb
@@ -3,9 +3,7 @@ require "rails_helper"
 RSpec.describe "Eligible region content", type: :view do
   let(:region) { nil }
 
-  before { render "shared/eligible_region_content", region: }
-
-  subject { rendered }
+  subject { render("shared/eligible_region_content", region:) }
 
   it { is_expected.to match(/You’re eligible/) }
   it { is_expected.to_not match(/What we’ll ask for/) }
@@ -80,5 +78,29 @@ RSpec.describe "Eligible region content", type: :view do
     let(:region) { create(:region, status_check: :none, sanction_check: :none) }
 
     it { is_expected.to match(/show evidence of your work history/) }
+  end
+
+  describe "English language proficiency" do
+    let(:region) { create(:region) }
+
+    context "when feature is inactive" do
+      it do
+        is_expected.to_not match(
+          /We need to understand your level of English language proficiency/,
+        )
+      end
+    end
+
+    context "when feature is active" do
+      before do
+        FeatureFlags::FeatureFlag.activate(:eligibility_english_language)
+      end
+
+      it do
+        is_expected.to match(
+          /We need to understand your level of English language proficiency/,
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds a new section to the eligible content outlining that we'll require a teacher to provide proof of their English language ability.

I've also removed the number from the accordion sections as they're not required.

[Trello Card](https://trello.com/c/oMPRZLK7/1253-add-new-english-language-proficiency-content-to-the-eligible-page)

## Screenshot

![Screenshot 2022-12-20 at 09 41 32](https://user-images.githubusercontent.com/510498/208635374-7c6ba908-a831-4157-a030-369b4a22b936.png)
