### PR TITLE
Update URL for statuscake alert to main website

### DIFF
--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -11,8 +11,8 @@
   "forms_container_delete_retention_days": 30,
   "statuscake_alerts": {
     "tra-apply-for-qts-prod": {
-      "website_name": "apply-for-qts-in-england-production",
-      "website_url": "https://apply-for-qts-in-england-production.london.cloudapps.digital/healthcheck",
+      "website_name": "apply-for-qts-in-england.education.gov.uk",
+      "website_url": "https://apply-for-qts-in-england.education.gov.uk/healthcheck",
       "contact_group": [249142],
       "confirmations": 2
     }


### PR DESCRIPTION
**Context:** 

- Following our incident review we have agreed to fix status cakes alerts.

- The current statuscake check only monitors PaaS: [production.tfvars.json](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/terraform/workspace_variables/production.tfvars.json#L15)

- We should also monitor the main site URL: [Apply for qualified teacher status (QTS) in England](https://apply-for-qts-in-england.education.gov.uk/)
- This would have caught the certificate issue earlier.

**Changes proposed in this pull request**
Update the main site URL: https://apply-for-qts-in-england.education.gov.uk/healthcheck

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running manually


