### PR TITLE
Define view object in update controller

### DIFF
--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -62,6 +62,8 @@ module TeacherInterface
     end
 
     def update
+      @view_object = ApplicationFormShowViewObject.new(current_teacher:)
+
       if (
            @sanction_confirmation_form =
              SanctionConfirmationForm.new(


### PR DESCRIPTION
This fixes a bug where the object is not accessible when re-rendering from this controller.

Should fix: https://sentry.io/organizations/dfe-teacher-services/issues/3832230248/?referrer=slack