### PR TITLE
Require qualification country to match trained country

### DIFF
--- a/app/forms/teacher_interface/qualification_form.rb
+++ b/app/forms/teacher_interface/qualification_form.rb
@@ -15,7 +15,14 @@ module TeacherInterface
     validates :qualification, presence: true
     validates :title, presence: true
     validates :institution_name, presence: true
-    validates :institution_country_location, presence: true
+    validates :institution_country_location,
+              presence: true,
+              inclusion: {
+                in: ->(form) {
+                  [CountryCode.to_location(form.application_form.country.code)]
+                },
+              },
+              if: -> { qualification&.is_teaching_qualification? }
     validates :start_date, date: true
     validates :complete_date, date: true
     validates :certificate_date, date: true

--- a/app/views/eligibility_interface/countries/new.html.erb
+++ b/app/views/eligibility_interface/countries/new.html.erb
@@ -1,12 +1,14 @@
-<% content_for :page_title, "#{'Error: ' if @country_form.errors.any?}#{I18n.t('eligibility_check.country.label')}" %>
+<% content_for :page_title, "#{'Error: ' if @country_form.errors.any?}#{t("helpers.label.eligibility_interface_country_form.location")}" %>
 <% content_for :back_link_url, back_link_url(FeatureFlags::FeatureFlag.active?(:teacher_applications) ? create_or_new_teacher_session_path : eligibility_interface_start_path) %>
 
-<%= form_with model: @country_form, url: eligibility_interface_countries_url, method: :post do |f| %>
+<%= form_with model: @country_form, url: eligibility_interface_countries_path, method: :post do |f| %>
   <%= f.govuk_error_summary %>
+
   <%= f.govuk_select :location,
                      options_for_select(locations, @country_form.location),
-                     hint: { text: I18n.t("eligibility_check.country.hint") },
-                     label: { text: I18n.t("eligibility_check.country.label"), size: "l", tag: "h1" },
+                     label: { size: "l", tag: "h1" },
+                     hint: { text: t("helpers.hint.eligibility_interface_country_form.location").html_safe },
                      options: { include_blank: true } %>
+
   <%= f.govuk_submit prevent_double_click: false %>
 <% end %>

--- a/app/views/eligibility_interface/region/new.html.erb
+++ b/app/views/eligibility_interface/region/new.html.erb
@@ -1,13 +1,15 @@
-<% content_for :page_title, "#{'Error: ' if @region_form.errors.any?}#{I18n.t('eligibility_check.region.label')}" %>
-<% content_for :back_link_url, back_link_url(eligibility_interface_countries_url) %>
+<% content_for :page_title, "#{'Error: ' if @region_form.errors.any?}#{t("helpers.legend.eligibility_interface_region_form.region_id")}" %>
+<% content_for :back_link_url, back_link_url(eligibility_interface_countries_path) %>
 
-<%= form_with model: @region_form, url: eligibility_interface_region_url, method: :post do |f| %>
+<%= form_with model: @region_form, url: eligibility_interface_region_path, method: :post do |f| %>
   <%= f.govuk_error_summary %>
+
   <%= f.govuk_collection_radio_buttons :region_id,
                                        @regions,
                                        :id,
                                        :name,
-                                       legend: { text: I18n.t("eligibility_check.region.label"), size: "l", tag: "h1" },
-                                       hint: { text: I18n.t("eligibility_check.region.hint") } %>
+                                       legend: { size: "l", tag: "h1" },
+                                       hint: { text: t("helpers.hint.eligibility_interface_region_form.region_id").html_safe } %>
+
   <%= f.govuk_submit prevent_double_click: false %>
 <% end %>

--- a/app/views/shared/application_form/_qualifications_summary.html.erb
+++ b/app/views/shared/application_form/_qualifications_summary.html.erb
@@ -13,7 +13,7 @@
         href: [:edit, :teacher_interface, :application_form, qualification]
       },
       institution_country_name: {
-        title: I18n.t("application_form.qualifications.form.fields.institution_country"),
+        title: t("helpers.label.teacher_interface_qualification_form.institution_country_location"),
         href: [:edit, :teacher_interface, :application_form, qualification]
       },
       start_date: {

--- a/app/views/teacher_interface/application_forms/new.html.erb
+++ b/app/views/teacher_interface/application_forms/new.html.erb
@@ -1,7 +1,7 @@
 <% if @needs_region %>
-  <% content_for :page_title, I18n.t("eligibility_check.region.label") %>
+  <% content_for :page_title, I18n.t("helpers.legend.eligibility_interface_region_form.region_id") %>
 <% else %>
-  <% content_for :page_title, I18n.t("eligibility_check.country.label") %>
+  <% content_for :page_title, I18n.t("helpers.label.eligibility_interface_country_form.location") %>
 <% end %>
 
 <% if @already_applied %>
@@ -17,8 +17,8 @@
     <%= f.hidden_field :location %>
 
     <%= f.govuk_radio_buttons_fieldset :region_id,
-                                       legend: { text: I18n.t("eligibility_check.region.label"), size: "l", tag: "h1" },
-                                       hint: { text: I18n.t("eligibility_check.region.hint") } do %>
+                                       legend: { text: t("helpers.legend.eligibility_interface_region_form.region_id"), size: "l", tag: "h1" },
+                                       hint: { text: t("helpers.hint.eligibility_interface_region_form.region_id").html_safe } do %>
       <% @country_region_form.regions.each_with_index do |region, i| %>
         <%= f.govuk_radio_button :region_id,
                                  region.id,
@@ -29,8 +29,8 @@
   <% else %>
     <%= f.govuk_select :location,
                        options_for_select(locations, @country_region_form.location),
-                       hint: { text: I18n.t("eligibility_check.country.hint") },
-                       label: { text: I18n.t("eligibility_check.country.label"), size: "l", tag: "h1" },
+                       hint: { text: t("helpers.hint.eligibility_interface_country_form.location").html_safe },
+                       label: { text: t("helpers.label.eligibility_interface_country_form.location"), size: "l", tag: "h1" },
                        options: { include_blank: true } %>
   <% end %>
 

--- a/app/views/teacher_interface/qualifications/_form.html.erb
+++ b/app/views/teacher_interface/qualifications/_form.html.erb
@@ -7,7 +7,6 @@
 
     <%= f.govuk_select :institution_country_location,
                        options_for_select(locations, qualification_form.institution_country_location),
-                       label: { text: I18n.t("application_form.qualifications.form.fields.institution_country") },
                        options: { include_blank: true } %>
   <% end %>
 

--- a/config/locales/eligibility_interface.en.yml
+++ b/config/locales/eligibility_interface.en.yml
@@ -39,11 +39,3 @@ en:
           misconduct: To teach in England, you must not have any findings of misconduct or restrictions on your employment record.
           qualification: You have not completed a formal teaching qualification, for example, an undergraduate teaching degree or postgraduate teaching qualification.
           teach_children: You are not qualified to teach children who are aged somewhere between 5 and 16 years.
-
-  eligibility_check:
-    country:
-      label: In which country are you currently recognised as a teacher?
-      hint: This means you have all the qualifications needed to teach in a state school. You'll need to provide evidence of this if you apply for QTS.
-    region:
-      label: In which state/territory are you currently recognised as a teacher?
-      hint: This means you have all the qualifications needed to teach in a state school. You'll need to provide evidence of this if you apply for QTS.

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -8,6 +8,10 @@ en:
         failure_reason_notes_decline: As this reason triggers a decline, you do not need to add a note, but you can use the space below to add anything you feel might be helpful, if you want to.
       assessor_interface_create_note_form:
         text: Use the text box to add a note to the application history. Other assessors will be able to see any notes you add, but they will not be visible to the applicant.
+      eligibility_interface_country_form:
+        location: This means you have all the qualifications needed to teach in a state school.<br /><br />You’ll need to show that you completed your teaching qualification in the country that you select.
+      eligibility_interface_region_form:
+        region_id: This means you have all the qualifications needed to teach in a state school.<br /><br />You’ll need to show that you completed your teaching qualification in the country that you select.
       qualification:
         add_another: You can use the next section to tell us about additional degrees if you want to.
       teacher:
@@ -22,6 +26,8 @@ en:
         has_work_history: If you’re a recent university graduate, or you've just completed your teaching qualification, you may not have held a professional teaching position yet.
       teacher_interface_new_session_form:
         email: Enter the email address you used to register, and we will send you a code to sign in.
+      teacher_interface_qualification_form:
+        institution_country_location: This must be the country in which you’re recognised as a teacher.
       teacher_interface_registration_number_form:
         registration_number: Your country has an online register of teachers. If you have a registration number, enter it on this screen. If you do not have one, just select ‘Continue’.
       work_history:
@@ -56,6 +62,8 @@ en:
           true: "Yes"
           false: "No"
         failure_assessor_note: Explain why this section is not completed to your satisfaction
+      eligibility_interface_country_form:
+        location: In which country are you currently recognised as a teacher?
       qualification:
         add_another_options:
           true: "Yes"
@@ -79,6 +87,8 @@ en:
           false: "No"
       teacher_interface_new_session_form:
         email: Email address
+      teacher_interface_qualification_form:
+        institution_country_location: Country of institution
       teacher_interface_registration_number_form:
         registration_number: What is your registration number?
       teacher_interface_subjects_form:
@@ -112,6 +122,8 @@ en:
         submitted_at_before: End date
       assessor_interface_further_information_request_form:
         passed: Has the applicant completed this section to your satisfaction?
+      eligibility_interface_region_form:
+        region_id: In which state/territory are you currently recognised as a teacher?
       qualification:
         add_another: Add another qualification?
       teacher_interface_alternative_name_form:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -166,7 +166,7 @@ en:
               blank: Enter the qualification title
             institution_name:
               blank: Enter the name of the institution
-            institution_country_code:
+            institution_country_location:
               blank: Enter the country of the institution
               inclusion: The country of institution must be the country in which you’re recognised as a teacher.
             start_date:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -168,6 +168,7 @@ en:
               blank: Enter the name of the institution
             institution_country_code:
               blank: Enter the country of the institution
+              inclusion: The country of institution must be the country in which you’re recognised as a teacher.
             start_date:
               blank: Enter the start date in the format 27 3 1980
               invalid: Enter the start date in the format 27 3 1980

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -190,7 +190,12 @@ FactoryBot.define do
 
     trait :with_completed_qualification do
       after(:create) do |application_form, _evaluator|
-        create(:qualification, :completed, application_form:)
+        create(
+          :qualification,
+          :completed,
+          application_form:,
+          institution_country_code: application_form.country.code,
+        )
       end
     end
 

--- a/spec/forms/teacher_interface/qualification_form_spec.rb
+++ b/spec/forms/teacher_interface/qualification_form_spec.rb
@@ -1,7 +1,13 @@
 require "rails_helper"
 
 RSpec.describe TeacherInterface::QualificationForm, type: :model do
-  let(:qualification) { build(:qualification) }
+  let(:application_form) do
+    create(
+      :application_form,
+      region: create(:region, :in_country, country_code: "FR"),
+    )
+  end
+  let(:qualification) { build(:qualification, application_form:) }
 
   subject(:form) do
     described_class.new(
@@ -27,9 +33,25 @@ RSpec.describe TeacherInterface::QualificationForm, type: :model do
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_presence_of(:institution_name) }
     it { is_expected.to validate_presence_of(:institution_country_location) }
+    it do
+      is_expected.to validate_inclusion_of(
+        :institution_country_location,
+      ).in_array(%w[country:FR])
+    end
     it { is_expected.to validate_presence_of(:start_date) }
     it { is_expected.to validate_presence_of(:complete_date) }
     it { is_expected.to validate_presence_of(:certificate_date) }
+
+    context "with a university degree" do
+      # create the teaching qualification first
+      before { create(:qualification, application_form:) }
+
+      it do
+        is_expected.to_not validate_inclusion_of(
+          :institution_country_location,
+        ).in_array(%w[country:FR])
+      end
+    end
 
     context "with invalid dates" do
       let(:start_date) { { 1 => 2020, 2 => 1, 3 => 1 } }

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -582,7 +582,8 @@ RSpec.describe "Teacher application", type: :system do
     qualifications_form_page.form.title.fill_in with: "Title"
     qualifications_form_page.form.institution_name.fill_in with:
       "Institution Name"
-    qualifications_form_page.form.institution_country.fill_in with: "France"
+    qualifications_form_page.form.institution_country.fill_in with:
+      CountryName.from_country(application_form.country)
     qualifications_form_page.form.start_date_month.fill_in with: "1"
     qualifications_form_page.form.start_date_year.fill_in with: "2000"
     qualifications_form_page.form.complete_date_month.fill_in with: "1"
@@ -1003,7 +1004,7 @@ RSpec.describe "Teacher application", type: :system do
       "Name of institution\tInstitution Name",
     )
     expect(teacher_check_qualification_page.summary_list).to have_content(
-      "Country of institution\tFrance",
+      "Country of institution\t#{CountryName.from_country(application_form.country)}",
     )
   end
 
@@ -1129,7 +1130,7 @@ RSpec.describe "Teacher application", type: :system do
       "Application complete",
     )
     expect(submitted_application_page.panel.body.text).to eq(
-      "Your reference number\n#{ApplicationForm.last.reference}",
+      "Your reference number\n#{application_form.reference}",
     )
   end
 
@@ -1146,5 +1147,9 @@ RSpec.describe "Teacher application", type: :system do
       .form
       .confirm_no_sanctions
       .click
+  end
+
+  def application_form
+    @application_form ||= ApplicationForm.last
   end
 end

--- a/spec/system/teacher_interface/back_links_spec.rb
+++ b/spec/system/teacher_interface/back_links_spec.rb
@@ -283,7 +283,12 @@ RSpec.describe "Teacher back links", type: :system do
   end
 
   def application_form
-    @application_form ||= create(:application_form, teacher:)
+    @application_form ||=
+      create(
+        :application_form,
+        teacher:,
+        region: create(:region, :in_country, country_code: "FR"),
+      )
   end
 
   def qualification


### PR DESCRIPTION
This adds validation and a hint text that require the teaching qualification country to match the one the teacher trained in.

I've also refactored some locale strings to use helpers.

[Trello Card](https://trello.com/c/581YMElP/1280-you-must-have-qualified-in-the-country-where-you-are-recognised)

## Screenshots

<img width="692" alt="Screenshot 2022-12-23 at 14 54 52" src="https://user-images.githubusercontent.com/510498/209361732-01e6783b-dbbb-4283-b154-fd90fbbb27bb.png">
<img width="668" alt="Screenshot 2022-12-23 at 14 54 39" src="https://user-images.githubusercontent.com/510498/209361730-1a7a2b0c-5c3a-45b4-806e-5b6aef87f432.png">
<img width="676" alt="Screenshot 2022-12-23 at 15 29 24" src="https://user-images.githubusercontent.com/510498/209361736-294b1539-c635-425d-9d14-048e5e6552ec.png">
