### PR TITLE
Change potential DQT status using service class

### DIFF
--- a/app/jobs/update_dqt_trn_request_job.rb
+++ b/app/jobs/update_dqt_trn_request_job.rb
@@ -22,8 +22,13 @@ class UpdateDQTTRNRequestJob < ApplicationJob
       end
 
     dqt_trn_request.pending! if dqt_trn_request.initial?
+
     if response[:potential_duplicate]
-      dqt_trn_request.application_form.potential_duplicate_in_dqt!
+      ChangeApplicationFormState.call(
+        application_form: dqt_trn_request.application_form,
+        user: "DQT",
+        new_state: "potential_duplicate_in_dqt",
+      )
     end
 
     if (trn = response[:trn]).present?

--- a/spec/jobs/update_dqt_trn_request_job_spec.rb
+++ b/spec/jobs/update_dqt_trn_request_job_spec.rb
@@ -142,9 +142,12 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           end
 
           it "sets the application form to potential_duplicate_in_dqt" do
-            expect { perform_rescue_exception }.to change {
-              application_form.potential_duplicate_in_dqt?
-            }.from(false).to(true)
+            expect(ChangeApplicationFormState).to receive(:call).with(
+              application_form:,
+              user: "DQT",
+              new_state: "potential_duplicate_in_dqt",
+            )
+            perform_rescue_exception
           end
         end
       end


### PR DESCRIPTION
Using the service class ensures that we get a timeline event recording when the status of the application changed to "potential duplicate in DQT".