### PR TITLE
Add application not submitted emails

### DIFF
--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -87,7 +87,10 @@ module TimelineEntry
     def email_sent_vars
       {
         subject:
-          I18n.t("mailer.teacher.#{timeline_event.mailer_action_name}.subject"),
+          timeline_event.message_subject.presence ||
+            I18n.t(
+              "mailer.teacher.#{timeline_event.mailer_action_name}.subject",
+            ),
       }
     end
 

--- a/app/lib/teacher_mailer_observer.rb
+++ b/app/lib/teacher_mailer_observer.rb
@@ -4,14 +4,19 @@ class TeacherMailerObserver
   def self.delivered_email(message)
     mailer_action_name = message.try(:mailer_action_name)
     application_form_id = message.try(:application_form_id)
+    message_subject = message.try(:subject)
 
-    return if mailer_action_name.blank? || application_form_id.blank?
+    if mailer_action_name.blank? || application_form_id.blank? ||
+         message_subject.blank?
+      return
+    end
 
     TimelineEvent.create!(
       creator_name: "Mailer",
       event_type: "email_sent",
       application_form_id:,
       mailer_action_name:,
+      message_subject:,
     )
   end
 end

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -34,6 +34,17 @@ class TeacherMailer < ApplicationMailer
     )
   end
 
+  def application_not_submitted
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: params[:teacher].email,
+      subject:
+        I18n.t(
+          "mailer.teacher.application_not_submitted.subject.#{params[:duration]}",
+        ),
+    )
+  end
+
   def application_received
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
@@ -69,7 +80,13 @@ class TeacherMailer < ApplicationMailer
   private
 
   def set_name
-    @name = "#{application_form.given_names} #{application_form.family_name}"
+    @name =
+      if application_form.given_names.present? ||
+           application_form.family_name.present?
+        "#{application_form.given_names} #{application_form.family_name}"
+      else
+        "applicant"
+      end
   end
 
   def set_reference

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -32,6 +32,11 @@ class Teacher < ApplicationRecord
 
   has_many :application_forms
 
+  scope :with_draft_application_forms,
+        -> {
+          joins(:application_forms).where(application_forms: { state: "draft" })
+        }
+
   def application_form
     @application_form ||= application_forms.order(created_at: :desc).first
   end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -10,6 +10,7 @@
 #  creator_type                   :string
 #  event_type                     :string           not null
 #  mailer_action_name             :string           default(""), not null
+#  message_subject                :string           default(""), not null
 #  new_state                      :string           default(""), not null
 #  old_state                      :string           default(""), not null
 #  created_at                     :datetime         not null
@@ -105,8 +106,14 @@ class TimelineEvent < ApplicationRecord
                 further_information_request_expired?
             }
 
-  validates :mailer_action_name, presence: true, if: :email_sent?
-  validates :mailer_action_name, absence: true, unless: :email_sent?
+  validates :mailer_action_name,
+            :message_subject,
+            presence: true,
+            if: :email_sent?
+  validates :mailer_action_name,
+            :message_subject,
+            absence: true,
+            unless: :email_sent?
 
   belongs_to :assessment, optional: true
   validates :assessment, presence: true, if: :age_range_subjects_verified?

--- a/app/views/teacher_mailer/application_not_submitted.text.erb
+++ b/app/views/teacher_mailer/application_not_submitted.text.erb
@@ -1,0 +1,18 @@
+Dear <%= @name %>
+
+We’ve noticed that you have a draft application for qualified teacher status (QTS) that has not been submitted.
+
+New regulations are being introduced to this service, which means that you’ll need to submit your application by 31 January 2023. Any application not submitted by this time will be deleted.
+
+# What happens next
+
+Sign in to complete and submit your application:
+
+<%= new_teacher_session_url %>
+
+You'll be able to submit a new application after 31 January 2023 under the new criteria:
+
+https://www.gov.uk/government/publications/awarding-qualified-teacher-status-to-overseas-teachers/a-fairer-approach-to-awarding-qts-to-overseas-teachers#criteria-for-awarding-qts
+
+Kind regards,
+The Teacher Qualifications Team

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -271,6 +271,7 @@
     - note_id
     - further_information_request_id
     - mailer_action_name
+    - message_subject
     - assessment_id
   :uploads:
     - id

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -5,6 +5,11 @@ en:
         subject: Your QTS application was successful
       application_declined:
         subject: Your QTS application has been declined
+      application_not_submitted:
+        subject:
+          two_weeks: Your QTS application has not been submitted
+          one_week: Your QTS application will be deleted in 1 week
+          two_days: Your QTS application will be deleted in 2 days
       application_received:
         subject: We’ve received your application for qualified teacher status (QTS)
       further_information_received:

--- a/db/migrate/20221229110153_add_message_subject_to_timeline_events.rb
+++ b/db/migrate/20221229110153_add_message_subject_to_timeline_events.rb
@@ -1,0 +1,9 @@
+class AddMessageSubjectToTimelineEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :timeline_events,
+               :message_subject,
+               :string,
+               null: false,
+               default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_21_104331) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_29_110153) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -361,6 +361,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_21_104331) do
     t.string "creator_name", default: "", null: false
     t.string "mailer_action_name", default: "", null: false
     t.bigint "assessment_id"
+    t.string "message_subject", default: "", null: false
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
     t.index ["assessment_id"], name: "index_timeline_events_on_assessment_id"
     t.index ["assessment_section_id"], name: "index_timeline_events_on_assessment_section_id"

--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+namespace :emails do
+  namespace :application_not_submitted do
+    namespace :two_weeks_before do
+      desc "Send the application not submitted email for two weeks before to all teachers."
+      task send_all: :environment do
+        send_application_not_submitted_emails(
+          Teacher.with_draft_application_forms,
+          "two_weeks",
+        )
+      end
+
+      desc "Send the application not submitted email for two weeks before to one teachers."
+      task :send_one, [:email] => :environment do |_, args|
+        send_application_not_submitted_emails(
+          Teacher.find_by!(email: args[:email]),
+          "two_weeks",
+        )
+      end
+    end
+
+    namespace :one_week_before do
+      desc "Send the application not submitted email for one week before to all teachers."
+      task send_all: :environment do
+        send_application_not_submitted_emails(
+          Teacher.with_draft_application_forms,
+          "one_week",
+        )
+      end
+
+      desc "Send the application not submitted email for one week before to one teachers."
+      task :send_one, [:email] => :environment do |_, args|
+        send_application_not_submitted_emails(
+          Teacher.find_by!(email: args[:email]),
+          "one_week",
+        )
+      end
+    end
+
+    namespace :two_days_before do
+      desc "Send the application not submitted email for two days before to all teachers."
+      task send_all: :environment do
+        send_application_not_submitted_emails(
+          Teacher.with_draft_application_forms,
+          "two_days",
+        )
+      end
+
+      desc "Send the application not submitted email for two days before to one teachers."
+      task :send_one, [:email] => :environment do |_, args|
+        send_application_not_submitted_emails(
+          Teacher.find_by!(email: args[:email]),
+          "two_days",
+        )
+      end
+    end
+  end
+end
+
+def send_application_not_submitted_emails(teachers, duration)
+  teachers = [teachers] if teachers.is_a?(Teacher)
+
+  teachers.each do |teacher|
+    TeacherMailer
+      .with(teacher:, duration:)
+      .application_not_submitted
+      .deliver_later
+  end
+end

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -169,14 +169,12 @@ RSpec.describe TimelineEntry::Component, type: :component do
       create(
         :timeline_event,
         :email_sent,
-        mailer_action_name: "application_received",
+        message_subject: "Application received",
       )
     end
 
     it "describes the event" do
-      expect(component.text).to include(
-        "We’ve received your application for qualified teacher status (QTS)",
-      )
+      expect(component.text).to include("Application received")
     end
 
     it "attributes to the creator" do

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -8,6 +8,7 @@
 #  creator_type                   :string
 #  event_type                     :string           not null
 #  mailer_action_name             :string           default(""), not null
+#  message_subject                :string           default(""), not null
 #  new_state                      :string           default(""), not null
 #  old_state                      :string           default(""), not null
 #  created_at                     :datetime         not null
@@ -92,6 +93,7 @@ FactoryBot.define do
     trait :email_sent do
       event_type { "email_sent" }
       mailer_action_name { "application_received" }
+      message_subject { "Application received" }
     end
   end
 end

--- a/spec/lib/teacher_mailer_observer_spec.rb
+++ b/spec/lib/teacher_mailer_observer_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe TeacherMailerObserver do
     expect(timeline_event.event_type).to eq("email_sent")
     expect(timeline_event.application_form).to eq(application_form)
     expect(timeline_event.mailer_action_name).to eq("application_received")
+    expect(timeline_event.message_subject).to eq(
+      "We’ve received your application for qualified teacher status (QTS)",
+    )
   end
 
   it "is called when an email is sent" do

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -100,6 +100,53 @@ RSpec.describe TeacherMailer, type: :mailer do
     end
   end
 
+  describe "#application_not_submitted" do
+    subject(:mail) do
+      described_class.with(teacher:, duration:).application_not_submitted
+    end
+
+    let(:duration) { nil }
+
+    describe "#subject" do
+      subject(:subject) { mail.subject }
+
+      context "with two weeks to go" do
+        let(:duration) { "two_weeks" }
+        it { is_expected.to eq("Your QTS application has not been submitted") }
+      end
+
+      context "with one week to go" do
+        let(:duration) { "one_week" }
+        it do
+          is_expected.to eq("Your QTS application will be deleted in 1 week")
+        end
+      end
+
+      context "with two days to go" do
+        let(:duration) { "two_days" }
+        it do
+          is_expected.to eq("Your QTS application will be deleted in 2 days")
+        end
+      end
+    end
+
+    describe "#to" do
+      subject(:to) { mail.to }
+
+      it { is_expected.to eq(["teacher@example.com"]) }
+    end
+
+    describe "#body" do
+      subject(:body) { mail.body.encoded }
+
+      it { is_expected.to include("Dear First Last") }
+      it { is_expected.to include("you have a draft application") }
+      it { is_expected.to include("http://localhost:3000/teacher/sign_in") }
+    end
+
+    include_examples "observer metadata", "application_not_submitted"
+  end
+
   describe "#application_received" do
     subject(:mail) { described_class.with(teacher:).application_received }
 

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -8,6 +8,7 @@
 #  creator_type                   :string
 #  event_type                     :string           not null
 #  mailer_action_name             :string           default(""), not null
+#  message_subject                :string           default(""), not null
 #  new_state                      :string           default(""), not null
 #  old_state                      :string           default(""), not null
 #  created_at                     :datetime         not null
@@ -92,6 +93,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
     end
 
@@ -105,6 +107,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
     end
 
@@ -118,6 +121,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
     end
 
@@ -131,6 +135,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
     end
 
@@ -144,6 +149,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
     end
 
@@ -159,6 +165,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_presence_of(:further_information_request) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
     end
 
@@ -174,6 +181,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_presence_of(:further_information_request) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
     end
 
@@ -187,6 +195,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
       it { is_expected.to validate_presence_of(:mailer_action_name) }
+      it { is_expected.to validate_presence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
     end
 
@@ -200,6 +209,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_presence_of(:assessment) }
     end
   end


### PR DESCRIPTION
This adds some emails which we will send out to applicants who have still got draft applications to warn them that they application is going to be deleted when the new regulations are in place on the 1st February.

## Screenshots

<img width="947" alt="Screenshot 2022-12-29 at 12 31 26" src="https://user-images.githubusercontent.com/510498/209951540-0317c809-1b7c-4150-8bea-84ce078ab409.png">
<img width="953" alt="Screenshot 2022-12-29 at 12 31 34" src="https://user-images.githubusercontent.com/510498/209951547-5bc3dc53-e8d4-44e4-a54b-11cac32265b3.png">
<img width="956" alt="Screenshot 2022-12-29 at 12 31 51" src="https://user-images.githubusercontent.com/510498/209951550-6faf6c65-1e1a-4d07-8ba6-1594c75f971f.png">


[Trello Card](https://trello.com/c/A1JEflVZ/1303-countdown-notifications-to-draft-applications-being-deleted)