### PR TITLE
Refactor failure reasons

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -38,15 +38,17 @@ class AssessmentFactory
     ].compact
 
     failure_reasons = [
-      :identification_document_expired,
-      :identification_document_illegible,
-      :identification_document_mismatch,
+      FailureReasons::IDENTIFICATION_DOCUMENT_EXPIRED,
+      FailureReasons::IDENTIFICATION_DOCUMENT_ILLEGIBLE,
+      FailureReasons::IDENTIFICATION_DOCUMENT_MISMATCH,
       (
-        :name_change_document_illegible if application_form.has_alternative_name
+        if application_form.has_alternative_name
+          FailureReasons::NAME_CHANGE_DOCUMENT_ILLEGIBLE
+        end
       ),
-      :duplicate_application,
-      :applicant_already_qts,
-      :applicant_already_dqt,
+      FailureReasons::DUPLICATE_APPLICATION,
+      FailureReasons::APPLICANT_ALREADY_QTS,
+      FailureReasons::APPLICANT_ALREADY_DQT,
     ].compact
 
     AssessmentSection.new(
@@ -69,20 +71,20 @@ class AssessmentFactory
       has_additional_degree_transcript
     ]
 
-    failure_reasons = %i[
-      application_and_qualification_names_do_not_match
-      teaching_qualifications_from_ineligible_country
-      teaching_qualifications_not_at_required_level
-      teaching_hours_not_fulfilled
-      not_qualified_to_teach_mainstream
-      qualifications_dont_match_subjects
-      qualifications_dont_match_other_details
-      teaching_certificate_illegible
-      teaching_transcript_illegible
-      degree_certificate_illegible
-      degree_transcript_illegible
-      additional_degree_certificate_illegible
-      additional_degree_transcript_illegible
+    failure_reasons = [
+      FailureReasons::APPLICATION_AND_QUALIFICATION_NAMES_DO_NOT_MATCH,
+      FailureReasons::TEACHING_QUALIFICATIONS_FROM_INELIGIBLE_COUNTRY,
+      FailureReasons::TEACHING_QUALIFICATIONS_NOT_AT_REQUIRED_LEVEL,
+      FailureReasons::TEACHING_HOURS_NOT_FULFILLED,
+      FailureReasons::NOT_QUALIFIED_TO_TEACH_MAINSTREAM,
+      FailureReasons::QUALIFICATIONS_DONT_MATCH_SUBJECTS,
+      FailureReasons::QUALIFICATIONS_DONT_MATCH_OTHER_DETAILS,
+      FailureReasons::TEACHING_CERTIFICATE_ILLEGIBLE,
+      FailureReasons::TEACHING_TRANSCRIPT_ILLEGIBLE,
+      FailureReasons::DEGREE_CERTIFICATE_ILLEGIBLE,
+      FailureReasons::DEGREE_TRANSCRIPT_ILLEGIBLE,
+      FailureReasons::ADDITIONAL_DEGREE_CERTIFICATE_ILLEGIBLE,
+      FailureReasons::ADDITIONAL_DEGREE_TRANSCRIPT_ILLEGIBLE,
     ]
 
     AssessmentSection.new(key: "qualifications", checks:, failure_reasons:)
@@ -91,7 +93,10 @@ class AssessmentFactory
   def age_range_subjects_section
     checks = %i[qualified_in_mainstream_education age_range_subjects_matches]
 
-    failure_reasons = %i[not_qualified_to_teach_mainstream age_range]
+    failure_reasons = [
+      FailureReasons::NOT_QUALIFIED_TO_TEACH_MAINSTREAM,
+      FailureReasons::AGE_RANGE,
+    ]
 
     AssessmentSection.new(key: "age_range_subjects", checks:, failure_reasons:)
   end
@@ -104,7 +109,7 @@ class AssessmentFactory
       satisfactory_evidence_work_history
     ]
 
-    failure_reasons = %i[satisfactory_evidence_work_history]
+    failure_reasons = [FailureReasons::SATISFACTORY_EVIDENCE_WORK_HISTORY]
 
     AssessmentSection.new(key: "work_history", checks:, failure_reasons:)
   end
@@ -127,16 +132,26 @@ class AssessmentFactory
     ].compact
 
     failure_reasons = [
-      application_form.needs_registration_number ? :registration_number : nil,
       (
-        :written_statement_illegible if application_form.needs_written_statement
+        if application_form.needs_registration_number
+          FailureReasons::REGISTRATION_NUMBER
+        end
       ),
-      (:written_statement_recent if application_form.needs_written_statement),
-      :authorisation_to_teach,
-      :teaching_qualification,
-      :confirm_age_range_subjects,
-      :qualified_to_teach,
-      :full_professional_status,
+      (
+        if application_form.needs_written_statement
+          FailureReasons::WRITTEN_STATEMENT_ILLEGIBLE
+        end
+      ),
+      (
+        if application_form.needs_written_statement
+          FailureReasons::WRITTEN_STATEMENT_RECENT
+        end
+      ),
+      FailureReasons::AUTHORISATION_TO_TEACH,
+      FailureReasons::TEACHING_QUALIFICATION,
+      FailureReasons::CONFIRM_AGE_RANGE_SUBJECTS,
+      FailureReasons::QUALIFIED_TO_TEACH,
+      FailureReasons::FULL_PROFESSIONAL_STATUS,
     ].compact
 
     AssessmentSection.new(

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -1,60 +1,67 @@
 # frozen_string_literal: true
 
 class FailureReasons
-  DECLINABLE = %w[
-    duplicate_application
-    applicant_already_qts
-    teaching_qualifications_from_ineligible_country
-    teaching_qualifications_not_at_required_level
-    not_qualified_to_teach_mainstream
-    teaching_hours_not_fulfilled
-    authorisation_to_teach
-    teaching_qualification
-    confirm_age_range_subjects
-    full_professional_status
+  DECLINABLE = [
+    DUPLICATE_APPLICATION = "duplicate_application",
+    APPLICANT_ALREADY_QTS = "applicant_already_qts",
+    TEACHING_QUALIFICATIONS_FROM_INELIGIBLE_COUNTRY =
+      "teaching_qualifications_from_ineligible_country",
+    TEACHING_QUALIFICATIONS_NOT_AT_REQUIRED_LEVEL =
+      "teaching_qualifications_not_at_required_level",
+    NOT_QUALIFIED_TO_TEACH_MAINSTREAM = "not_qualified_to_teach_mainstream",
+    TEACHING_HOURS_NOT_FULFILLED = "teaching_hours_not_fulfilled",
+    AGE_RANGE = "age_range",
+    AUTHORISATION_TO_TEACH = "authorisation_to_teach",
+    TEACHING_QUALIFICATION = "teaching_qualification",
+    CONFIRM_AGE_RANGE_SUBJECTS = "confirm_age_range_subjects",
+    FULL_PROFESSIONAL_STATUS = "full_professional_status",
   ].freeze
 
-  FURTHER_INFORMATIONABLE = %w[
-    identification_document_expired
-    identification_document_illegible
-    identification_document_mismatch
-    name_change_document_illegible
-    applicant_already_dqt
-    application_and_qualification_names_do_not_match
-    qualifications_dont_match_subjects
-    qualifications_dont_match_other_details
-    teaching_certificate_illegible
-    teaching_transcript_illegible
-    degree_certificate_illegible
-    degree_transcript_illegible
-    additional_degree_certificate_illegible
-    additional_degree_transcript_illegible
-    satisfactory_evidence_work_history
-    registration_number
-    written_statement_illegible
-    written_statement_recent
-    qualified_to_teach
+  FURTHER_INFORMATIONABLE = [
+    IDENTIFICATION_DOCUMENT_EXPIRED = "identification_document_expired",
+    IDENTIFICATION_DOCUMENT_ILLEGIBLE = "identification_document_illegible",
+    IDENTIFICATION_DOCUMENT_MISMATCH = "identification_document_mismatch",
+    NAME_CHANGE_DOCUMENT_ILLEGIBLE = "name_change_document_illegible",
+    APPLICANT_ALREADY_DQT = "applicant_already_dqt",
+    APPLICATION_AND_QUALIFICATION_NAMES_DO_NOT_MATCH =
+      "application_and_qualification_names_do_not_match",
+    QUALIFICATIONS_DONT_MATCH_SUBJECTS = "qualifications_dont_match_subjects",
+    QUALIFICATIONS_DONT_MATCH_OTHER_DETAILS =
+      "qualifications_dont_match_other_details",
+    TEACHING_CERTIFICATE_ILLEGIBLE = "teaching_certificate_illegible",
+    TEACHING_TRANSCRIPT_ILLEGIBLE = "teaching_transcript_illegible",
+    DEGREE_CERTIFICATE_ILLEGIBLE = "degree_certificate_illegible",
+    DEGREE_TRANSCRIPT_ILLEGIBLE = "degree_transcript_illegible",
+    ADDITIONAL_DEGREE_CERTIFICATE_ILLEGIBLE =
+      "additional_degree_certificate_illegible",
+    ADDITIONAL_DEGREE_TRANSCRIPT_ILLEGIBLE =
+      "additional_degree_transcript_illegible",
+    SATISFACTORY_EVIDENCE_WORK_HISTORY = "satisfactory_evidence_work_history",
+    REGISTRATION_NUMBER = "registration_number",
+    WRITTEN_STATEMENT_ILLEGIBLE = "written_statement_illegible",
+    WRITTEN_STATEMENT_RECENT = "written_statement_recent",
+    QUALIFIED_TO_TEACH = "qualified_to_teach",
   ].freeze
 
   ALL = (DECLINABLE + FURTHER_INFORMATIONABLE).freeze
 
   DOCUMENT_FAILURE_REASONS = {
-    "identification_document_expired" => :identification,
-    "identification_document_illegible" => :identification,
-    "identification_document_mismatch" => :name_change,
-    "name_change_document_illegible" => :name_change,
-    "teaching_certificate_illegible" => :qualification_certificate,
-    "teaching_transcript_illegible" => :qualification_transcript,
-    "degree_certificate_illegible" => :qualification_certificate,
-    "degree_transcript_illegible" => :qualification_transcript,
-    "additional_degree_certificate_illegible" => :qualification_certificate,
-    "additional_degree_transcript_illegible" => :qualification_transcript,
-    "qualifications_dont_match_subjects" => :qualification_document,
-    "application_and_qualification_names_do_not_match" => :name_change,
-    "written_statement_illegible" => :written_statement,
-    "written_statement_recent" => :written_statement,
-    "qualified_to_teach" => :written_statement,
-    "registration_number" => :written_statement,
+    IDENTIFICATION_DOCUMENT_EXPIRED => :identification,
+    IDENTIFICATION_DOCUMENT_ILLEGIBLE => :identification,
+    IDENTIFICATION_DOCUMENT_MISMATCH => :name_change,
+    NAME_CHANGE_DOCUMENT_ILLEGIBLE => :name_change,
+    TEACHING_CERTIFICATE_ILLEGIBLE => :qualification_certificate,
+    TEACHING_TRANSCRIPT_ILLEGIBLE => :qualification_transcript,
+    DEGREE_CERTIFICATE_ILLEGIBLE => :qualification_certificate,
+    DEGREE_TRANSCRIPT_ILLEGIBLE => :qualification_transcript,
+    ADDITIONAL_DEGREE_CERTIFICATE_ILLEGIBLE => :qualification_certificate,
+    ADDITIONAL_DEGREE_TRANSCRIPT_ILLEGIBLE => :qualification_transcript,
+    QUALIFICATIONS_DONT_MATCH_SUBJECTS => :qualification_document,
+    APPLICATION_AND_QUALIFICATION_NAMES_DO_NOT_MATCH => :name_change,
+    WRITTEN_STATEMENT_ILLEGIBLE => :written_statement,
+    WRITTEN_STATEMENT_RECENT => :written_statement,
+    QUALIFIED_TO_TEACH => :written_statement,
+    REGISTRATION_NUMBER => :written_statement,
   }.freeze
 
   def self.decline?(failure_reason:)

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -38,7 +38,30 @@ class FailureReasons
 
   ALL = (DECLINABLE + FURTHER_INFORMATIONABLE).freeze
 
+  DOCUMENT_FAILURE_REASONS = {
+    "identification_document_expired" => :identification,
+    "identification_document_illegible" => :identification,
+    "identification_document_mismatch" => :name_change,
+    "name_change_document_illegible" => :name_change,
+    "teaching_certificate_illegible" => :qualification_certificate,
+    "teaching_transcript_illegible" => :qualification_transcript,
+    "degree_certificate_illegible" => :qualification_certificate,
+    "degree_transcript_illegible" => :qualification_transcript,
+    "additional_degree_certificate_illegible" => :qualification_certificate,
+    "additional_degree_transcript_illegible" => :qualification_transcript,
+    "qualifications_dont_match_subjects" => :qualification_document,
+    "application_and_qualification_names_do_not_match" => :name_change,
+    "written_statement_illegible" => :written_statement,
+    "written_statement_recent" => :written_statement,
+    "qualified_to_teach" => :written_statement,
+    "registration_number" => :written_statement,
+  }.freeze
+
   def self.decline?(failure_reason:)
     DECLINABLE.include?(failure_reason.to_s)
+  end
+
+  def self.further_information_request_document_type(failure_reason:)
+    DOCUMENT_FAILURE_REASONS[failure_reason.to_s]
   end
 end

--- a/app/lib/further_information_request_items_factory.rb
+++ b/app/lib/further_information_request_items_factory.rb
@@ -30,7 +30,12 @@ class FurtherInformationRequestItemsFactory
     failure_reason_key,
     failure_reason_assessor_feedback
   )
-    if (document_type = DOCUMENT_FAILURE_REASONS[failure_reason_key]).present?
+    if (
+         document_type =
+           FailureReasons.further_information_request_document_type(
+             failure_reason: failure_reason_key,
+           )
+       ).present?
       FurtherInformationRequestItem.new(
         information_type: :document,
         failure_reason_key:,
@@ -45,23 +50,4 @@ class FurtherInformationRequestItemsFactory
       )
     end
   end
-
-  DOCUMENT_FAILURE_REASONS = {
-    "identification_document_expired" => :identification,
-    "identification_document_illegible" => :identification,
-    "identification_document_mismatch" => :name_change,
-    "name_change_document_illegible" => :name_change,
-    "teaching_certificate_illegible" => :qualification_certificate,
-    "teaching_transcript_illegible" => :qualification_transcript,
-    "degree_certificate_illegible" => :qualification_certificate,
-    "degree_transcript_illegible" => :qualification_transcript,
-    "additional_degree_certificate_illegible" => :qualification_certificate,
-    "additional_degree_transcript_illegible" => :qualification_transcript,
-    "qualifications_dont_match_subjects" => :qualification_document,
-    "application_and_qualification_names_do_not_match" => :name_change,
-    "written_statement_illegible" => :written_statement,
-    "written_statement_recent" => :written_statement,
-    "qualified_to_teach" => :written_statement,
-    "registration_number" => :written_statement,
-  }.freeze
 end


### PR DESCRIPTION
This refactors the `FailureReasons` class so everything related to failure reason keys are handled by the class rather than being spread around around the project.

[Trello Card](https://trello.com/c/U76NBxXw/1304-further-failurereasons-refactoring)