### PR TITLE
Add content about certified translations

### DIFF
--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -129,6 +129,10 @@
       <%= f.govuk_radio_button :written_in_english, :true, label: { text: "Yes" }, link_errors: true %>
 
       <%= f.govuk_radio_button :written_in_english, :false, label: { text: "No, I’ll upload a certified translation as well" } do %>
+        <p class="govuk-body">
+          This must be a certified translation showing the translator’s signature, name, contact details and official stamp or ID number, plus the date of translation.
+        </p>
+
         <%= f.govuk_file_field :translated_attachment,
                                label: { text: "Select a file to upload" },
                                hint: { text: "You can upload your files in PDF, JPG, PNG, DOCX or DOC format. Each file must be no larger than 50MB." } %>


### PR DESCRIPTION
We hope this will reduce the number of translated documents we receive which haven't been certified.

[Trello Card](https://trello.com/c/QBL0L8ks/1308-upload-certified-translation-add-guidance-to-app-form)

## Screenshot

<img width="678" alt="Screenshot 2023-01-02 at 20 13 33" src="https://user-images.githubusercontent.com/510498/210274902-f0a9208d-72c3-4ef3-98e3-3b71c3be83eb.png">
