### PR TITLE
Always show registration number

### DIFF
--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -74,7 +74,9 @@ module CheckYourAnswersSummary
       {
         key: field[:key],
         title: row_title_for(field),
-        value: format_value(value_for(field), field),
+        value:
+          format_value(value_for(field), field).presence ||
+            "<em>None provided</em>".html_safe,
         href: changeable ? href_for(field) : nil,
       }
     end

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -34,11 +34,11 @@ module AssessorInterface
     end
 
     def show_registration_number_summary
-      registration_number.present?
+      application_form.needs_registration_number?
     end
 
     def show_written_statement_summary
-      application_form.written_statement_document.uploaded?
+      application_form.needs_written_statement?
     end
 
     def notes_label_key_for(failure_reason:)

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -90,7 +90,7 @@ en:
           age_range_subjects_matches: that the age range and subjects information the applicant has entered matches the qualifications they’ve provided
           email_contact_current_employer: the applicant has entered the name and email address of a contact for their current/most recent employer
           satisfactory_evidence_work_history: the applicant has provided satisfactory evidence of their work history
-          registration_number: registration number provided and verified
+          registration_number: registration number provided and verified (where applicable)
           written_statement_present: letter from the country or state’s competent authority provided
           written_statement_recent: letter from the country or state’s competent authority was issued within the last 3 months
           authorisation_to_teach: confirmation that authorisation to teach has never been suspended, barred, cancelled, revoked or restricted, and there are no sanctions present

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -222,7 +222,9 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
     end
 
     it "renders the value" do
-      expect(row.at_css(".govuk-summary-list__value").text).to eq("")
+      expect(row.at_css(".govuk-summary-list__value").text).to eq(
+        "None provided",
+      )
     end
 
     it "renders the change link" do

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -66,13 +66,13 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
   describe "show_registration_number_summary" do
     subject { super().show_registration_number_summary }
 
-    context "registration number is present" do
-      before { application_form.update(registration_number: "1233445") }
+    context "registration number is needed" do
+      before { application_form.update(needs_registration_number: true) }
       it { is_expected.to eq(true) }
     end
 
-    context "registration number not present" do
-      before { application_form.update(registration_number: nil) }
+    context "registration number is not needed" do
+      before { application_form.update(needs_registration_number: false) }
       it { is_expected.to eq(false) }
     end
   end
@@ -80,14 +80,13 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
   describe "show_written_statement_summary" do
     subject { super().show_written_statement_summary }
 
-    context "written statement is present" do
-      let(:application_form) do
-        create(:application_form, :with_written_statement)
-      end
+    context "written statement is needed" do
+      before { application_form.update(needs_written_statement: true) }
       it { is_expected.to eq(true) }
     end
 
-    context "written statement is not present" do
+    context "written statement is not needed" do
+      before { application_form.update(needs_written_statement: false) }
       it { is_expected.to eq(false) }
     end
   end


### PR DESCRIPTION
This ensures that the registration number check your answers component is always shown to the assessor, and if a value isn't provided they see the text "None provided".

[Trello Card](https://trello.com/c/Shz9pvWY/1307-view-of-bucket-1-or-3-applications-where-user-has-not-supplied-a-reference-number)

## Screenshot

<img width="682" alt="Screenshot 2023-01-02 at 20 33 48" src="https://user-images.githubusercontent.com/510498/210277181-ab6f654b-08a8-4ee0-b820-fb0a6994424a.png">
