### PR TITLE
Go to first page after applying filters

### DIFF
--- a/app/controllers/assessor_interface/application_forms_controller.rb
+++ b/app/controllers/assessor_interface/application_forms_controller.rb
@@ -15,13 +15,13 @@ module AssessorInterface
       session[:filter_params] = extract_filter_params(
         remove_cleared_autocomplete_values(params),
       )
-      redirect_to assessor_interface_application_forms_path(page: params[:page])
+      redirect_to assessor_interface_application_forms_path
     end
 
     def clear_filters
       authorize :assessor, :index?
       session[:filter_params] = {}
-      redirect_to assessor_interface_application_forms_path(page: params[:page])
+      redirect_to assessor_interface_application_forms_path
     end
 
     def show

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -6,10 +6,8 @@
   <h2 class="govuk-heading-m"><%= t(".filters.title") %></h2>
 
   <%= form_with model: @view_object.filter_form, url: filters_apply_assessor_interface_application_forms_path, method: :post, class: "app-application-forms__filter-form" do |f| %>
-    <%= hidden_field_tag :page, params[:page] %>
-
     <%= f.govuk_submit t(".filters.apply") do %>
-      <%= govuk_link_to t(".filters.clear"), filters_clear_assessor_interface_application_forms_path(page: params[:page]) %>
+      <%= govuk_link_to t(".filters.clear"), filters_clear_assessor_interface_application_forms_path %>
     <%- end -%>
 
     <section id="app-applications-filters-assessor">


### PR DESCRIPTION
We're seeing an issue where if a user tries to apply filters on a page that wouldn't exist after the filters are applied, the user sees an error.

This should resolve: https://sentry.io/organizations/dfe-teacher-services/issues/3693260260/?project=6426061&query=is%3Aunresolved&referrer=issue-stream