### PR TITLE
Add ApplicationForm#created_under_new_regulations?

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -167,6 +167,10 @@ class ApplicationForm < ApplicationRecord
     english_language_citizenship_exempt || english_language_qualification_exempt
   end
 
+  def created_under_new_regulations?
+    created_at >= Date.parse(ENV.fetch("NEW_REGS_DATE", "2023-02-01"))
+  end
+
   private
 
   def build_documents

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -313,4 +313,46 @@ RSpec.describe ApplicationForm, type: :model do
       it { is_expected.to eq("2000003") }
     end
   end
+
+  describe "#created_under_new_regulations?" do
+    subject(:created_under_new_regulations?) do
+      application_form.created_under_new_regulations?
+    end
+
+    context "with default new regulations date" do
+      context "with an old application form" do
+        let(:application_form) do
+          create(:application_form, created_at: Date.new(2020, 1, 1))
+        end
+        it { is_expected.to be false }
+      end
+
+      context "with a new application form" do
+        let(:application_form) do
+          create(:application_form, created_at: Date.new(2024, 1, 1))
+        end
+        it { is_expected.to be true }
+      end
+    end
+
+    context "with a custom new regulations date" do
+      around do |example|
+        ClimateControl.modify(NEW_REGS_DATE: "2023-01-01") { example.run }
+      end
+
+      context "with an old application form" do
+        let(:application_form) do
+          create(:application_form, created_at: Date.new(2021, 12, 31))
+        end
+        it { is_expected.to be false }
+      end
+
+      context "with a new application form" do
+        let(:application_form) do
+          create(:application_form, created_at: Date.new(2023, 1, 1))
+        end
+        it { is_expected.to be true }
+      end
+    end
+  end
 end

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -18,6 +18,8 @@ locals {
     AZURE_STORAGE_CONTAINER    = azurerm_storage_container.uploads.name
 
     DQT_API_URL = var.dqt_api_url
+
+    NEW_REGS_DATE = var.new_regs_date
   })
   logstash_endpoint = data.azurerm_key_vault_secret.secrets["LOGSTASH-ENDPOINT"].value
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -102,6 +102,11 @@ variable "dqt_api_url" {
   type = string
 }
 
+variable "new_regs_date" {
+  type    = string
+  default = "2023-02-01"
+}
+
 locals {
   apply_qts_routes = flatten([
     cloudfoundry_route.apply_qts_public,

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -6,5 +6,6 @@
   "education_hostnames": ["dev"],
   "prometheus_app": "prometheus-tra-monitoring-dev",
   "forms_storage_account_name": "s165d01afqtsformsdv",
-  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital"
+  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital",
+  "new_regs_date": "2023-01-04"
 }

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -13,5 +13,6 @@
       "confirmations": 2
     }
   },
-  "dqt_api_url": "https://test-teacher-qualifications-api.education.gov.uk"
+  "dqt_api_url": "https://test-teacher-qualifications-api.education.gov.uk",
+  "new_regs_date": "2023-01-04"
 }


### PR DESCRIPTION
This can be used in multiple places to check if an application form has been created after the new regulations have come in to force.