### PR TITLE
Add new regulations to qualifications

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -59,23 +59,43 @@ class AssessmentFactory
   end
 
   def qualifications_section
-    checks = %i[
-      qualifications_meet_level_6_or_equivalent
-      teaching_qualifications_completed_in_eligible_country
-      qualified_in_mainstream_education
-      has_teacher_qualification_certificate
-      has_teacher_qualification_transcript
-      has_university_degree_certificate
-      has_university_degree_transcript
-      has_additional_qualification_certificate
-      has_additional_degree_transcript
-    ]
+    checks = [
+      "qualifications_meet_level_6_or_equivalent",
+      "teaching_qualifications_completed_in_eligible_country",
+      "qualified_in_mainstream_education",
+      "has_teacher_qualification_certificate",
+      "has_teacher_qualification_transcript",
+      "has_university_degree_certificate",
+      "has_university_degree_transcript",
+      "has_additional_qualification_certificate",
+      "has_additional_degree_transcript",
+      (
+        if application_form.created_under_new_regulations?
+          "teaching_qualification_pedagogy"
+        end
+      ),
+      (
+        if application_form.created_under_new_regulations?
+          "teaching_qualification_1_year"
+        end
+      ),
+    ].compact
 
     failure_reasons = [
       FailureReasons::APPLICATION_AND_QUALIFICATION_NAMES_DO_NOT_MATCH,
       FailureReasons::TEACHING_QUALIFICATIONS_FROM_INELIGIBLE_COUNTRY,
       FailureReasons::TEACHING_QUALIFICATIONS_NOT_AT_REQUIRED_LEVEL,
       FailureReasons::TEACHING_HOURS_NOT_FULFILLED,
+      (
+        if application_form.created_under_new_regulations?
+          FailureReasons::TEACHING_QUALIFICATION_PEDAGOGY
+        end
+      ),
+      (
+        if application_form.created_under_new_regulations?
+          FailureReasons::TEACHING_QUALIFICATION_1_YEAR
+        end
+      ),
       FailureReasons::NOT_QUALIFIED_TO_TEACH_MAINSTREAM,
       FailureReasons::QUALIFICATIONS_DONT_MATCH_SUBJECTS,
       FailureReasons::QUALIFICATIONS_DONT_MATCH_OTHER_DETAILS,
@@ -85,7 +105,7 @@ class AssessmentFactory
       FailureReasons::DEGREE_TRANSCRIPT_ILLEGIBLE,
       FailureReasons::ADDITIONAL_DEGREE_CERTIFICATE_ILLEGIBLE,
       FailureReasons::ADDITIONAL_DEGREE_TRANSCRIPT_ILLEGIBLE,
-    ]
+    ].compact
 
     AssessmentSection.new(key: "qualifications", checks:, failure_reasons:)
   end

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -11,6 +11,8 @@ class FailureReasons
     NOT_QUALIFIED_TO_TEACH_MAINSTREAM = "not_qualified_to_teach_mainstream",
     TEACHING_HOURS_NOT_FULFILLED = "teaching_hours_not_fulfilled",
     TEACHING_QUALIFICATION = "teaching_qualification",
+    TEACHING_QUALIFICATION_1_YEAR = "teaching_qualification_1_year",
+    TEACHING_QUALIFICATION_PEDAGOGY = "teaching_qualification_pedagogy",
     TEACHING_QUALIFICATIONS_FROM_INELIGIBLE_COUNTRY =
       "teaching_qualifications_from_ineligible_country",
     TEACHING_QUALIFICATIONS_NOT_AT_REQUIRED_LEVEL =

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -89,12 +89,14 @@ en:
           has_university_degree_transcript: university degree transcript is present (and translation if required)
           identification_document_present: a valid ID document is present
           name_change_document_present: evidence of name change is present (if the name entered on the form is different to the name on their ID)
-          qualifications_meet_level_6_or_equivalent: applicant holds qualifications that meet the required academic level (level 6 academic qualification or equivalent)
+          qualifications_meet_level_6_or_equivalent: applicant holds qualifications that meet the required academic level (level 6 qualification or higher)
           qualified_in_mainstream_education: they’re qualified to teach in mainstream education (not vocationally only/SEN only/early years/pre-school only)
           qualified_to_teach: the applicant is qualified to teach at state or government schools
           registration_number: registration number provided and verified (where applicable)
           satisfactory_evidence_work_history: the applicant has provided satisfactory evidence of their work history
           teaching_qualification: confirmation of the applicant’s teaching qualification
+          teaching_qualification_1_year: the teaching qualification lasted at least 1 academic year
+          teaching_qualification_pedagogy: the teaching qualification had at least 75% of the course focused on pedagogy
           teaching_qualifications_completed_in_eligible_country: teaching qualifications were completed in an eligible country (for example, we cannot award QTS where they applied through Spain, but their teaching was completed in South Africa)
           written_statement_present: letter from the country or state’s competent authority provided
           written_statement_recent: letter from the country or state’s competent authority was issued within the last 3 months
@@ -124,8 +126,10 @@ en:
           teaching_certificate_illegible: The teaching qualification certificate (or translation) is illegible or in a format that we cannot accept.
           teaching_hours_not_fulfilled: The required teaching hours have not been fulfilled.
           teaching_qualification: We were not provided with sufficient evidence to confirm the teaching qualification entered on the online application form.
+          teaching_qualification_1_year: The teacher training course qualification did not last at least 1 academic year.
+          teaching_qualification_pedagogy: The teaching qualification did not have enough focus on pedagogy (at least 75% of modules focus on pedagogy).
           teaching_qualifications_from_ineligible_country: Teaching qualifications were completed in an ineligible country.
-          teaching_qualifications_not_at_required_level: Teaching qualifications do not meet the required academic level.
+          teaching_qualifications_not_at_required_level: Teaching qualifications do not meet the required academic level (level 6).
           teaching_transcript_illegible: The teaching qualification transcript (or translation) is illegible or in a format that we cannot accept.
           written_statement_illegible: The letter from the country or state’s authority is illegible or in a format that we cannot accept.
           written_statement_recent: The letter from the country or state’s authority was not issued within the last 3 months.
@@ -210,6 +214,10 @@ en:
             teaching_hours_not_fulfilled_notes:
               blank: Enter a note to the applicant
             teaching_qualification_notes:
+              blank: Enter a note to the applicant
+            teaching_qualification_1_year_notes:
+              blank: Enter a note to the applicant
+            teaching_qualification_pedagogy:
               blank: Enter a note to the applicant
             teaching_qualifications_from_ineligible_country_notes:
               blank: Enter a note to the applicant

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -146,6 +146,10 @@ FactoryBot.define do
       submitted_at { Time.zone.now }
     end
 
+    trait :new_regs do
+      created_at { Date.new(2023, 2, 1) }
+    end
+
     trait :with_assessment do
       after(:create) do |application_form, _evaluator|
         create(:assessment, application_form:)

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -116,6 +116,50 @@ RSpec.describe AssessmentFactory do
             ],
           )
         end
+
+        context "with a new regulations application form" do
+          let(:application_form) { create(:application_form, :new_regs) }
+
+          it "has the right checks and failure reasons" do
+            section = sections.qualifications.first
+
+            expect(section.checks).to eq(
+              %w[
+                qualifications_meet_level_6_or_equivalent
+                teaching_qualifications_completed_in_eligible_country
+                qualified_in_mainstream_education
+                has_teacher_qualification_certificate
+                has_teacher_qualification_transcript
+                has_university_degree_certificate
+                has_university_degree_transcript
+                has_additional_qualification_certificate
+                has_additional_degree_transcript
+                teaching_qualification_pedagogy
+                teaching_qualification_1_year
+              ],
+            )
+
+            expect(section.failure_reasons).to eq(
+              %w[
+                application_and_qualification_names_do_not_match
+                teaching_qualifications_from_ineligible_country
+                teaching_qualifications_not_at_required_level
+                teaching_hours_not_fulfilled
+                teaching_qualification_pedagogy
+                teaching_qualification_1_year
+                not_qualified_to_teach_mainstream
+                qualifications_dont_match_subjects
+                qualifications_dont_match_other_details
+                teaching_certificate_illegible
+                teaching_transcript_illegible
+                degree_certificate_illegible
+                degree_transcript_illegible
+                additional_degree_certificate_illegible
+                additional_degree_transcript_illegible
+              ],
+            )
+          end
+        end
       end
 
       describe "age range and subjects section" do


### PR DESCRIPTION
This adds the new checks and failure reasons required for qualifications part of the new regulations.

[Trello Card](https://trello.com/c/vgpYP1cw/1311-build-quals-initial-assessment-spoke-updated-for-new-regs)

## Screenshots

<img width="674" alt="Screenshot 2023-01-04 at 13 49 11" src="https://user-images.githubusercontent.com/510498/210569176-bd85ff0d-f416-44ab-a98e-b205756deb01.png">
<img width="663" alt="Screenshot 2023-01-04 at 13 49 34" src="https://user-images.githubusercontent.com/510498/210569192-d205429a-9529-4fad-95c3-f1dccea4a8f1.png">
