### PR TITLE
Set the new regulations date in review environment

### DIFF
--- a/terraform/workspace_variables/review.tfvars.json
+++ b/terraform/workspace_variables/review.tfvars.json
@@ -3,5 +3,6 @@
   "key_vault_name": "s165d01-afqts-dv-kv",
   "resource_group_name": "s165d01-afqts-dv-rg",
   "paas_space": "tra-dev",
-  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital"
+  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital",
+  "new_regs_date": "2023-01-04"
 }


### PR DESCRIPTION
We want to start testing as if the new regulation date had passed, so we should set this date in the review environment as well as the test and dev ones.