### PR TITLE
Send awarded at date to DQT under new regulations

### DIFF
--- a/app/lib/dqt/trn_request_params.rb
+++ b/app/lib/dqt/trn_request_params.rb
@@ -27,7 +27,7 @@ module DQT
           RecognitionRoute.for_country_code(
             application_form.region.country.code,
           ),
-        qtsDate: assessment.recommended_at.iso8601,
+        qtsDate: qts_decision_at.to_date.iso8601,
         inductionRequired: false,
       }
     end
@@ -77,6 +77,14 @@ module DQT
         else
           application_form.degree_qualifications.first
         end
+    end
+
+    def qts_decision_at
+      if application_form.created_under_new_regulations?
+        application_form.awarded_at
+      else
+        application_form.submitted_at
+      end
     end
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -8,6 +8,7 @@
 #  age_range_status                      :string           default("not_started"), not null
 #  alternative_family_name               :text             default(""), not null
 #  alternative_given_names               :text             default(""), not null
+#  awarded_at                            :datetime
 #  confirmed_no_sanctions                :boolean          default(FALSE)
 #  date_of_birth                         :date
 #  english_language_citizenship_exempt   :boolean
@@ -85,6 +86,7 @@ class ApplicationForm < ApplicationRecord
   validate :assessor_and_reviewer_must_be_different
 
   validates :submitted_at, presence: true, unless: :draft?
+  validates :awarded_at, presence: true, if: :awarded?
 
   enum :english_language_proof_method,
        { medium_of_instruction: "medium_of_instruction", provider: "provider" },

--- a/app/services/award_qts.rb
+++ b/app/services/award_qts.rb
@@ -16,6 +16,8 @@ class AwardQTS
     ActiveRecord::Base.transaction do
       teacher.update!(trn:)
 
+      application_form.update!(awarded_at: Time.zone.now)
+
       ChangeApplicationFormState.call(
         application_form:,
         user:,

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -51,6 +51,7 @@
     - assessor_id
     - reviewer_id
     - submitted_at
+    - awarded_at
     - working_days_since_submission
     - needs_work_history
     - needs_written_statement

--- a/db/migrate/20230104140156_add_awarded_at_to_application_forms.rb
+++ b/db/migrate/20230104140156_add_awarded_at_to_application_forms.rb
@@ -1,0 +1,5 @@
+class AddAwardedAtToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_forms, :awarded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_29_110153) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_04_140156) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -83,6 +83,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_29_110153) do
     t.string "english_language_proof_method"
     t.bigint "english_language_provider_id"
     t.text "english_language_provider_reference", default: "", null: false
+    t.datetime "awarded_at"
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["english_language_provider_id"], name: "index_application_forms_on_english_language_provider_id"
     t.index ["family_name"], name: "index_application_forms_on_family_name"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -8,6 +8,7 @@
 #  age_range_status                      :string           default("not_started"), not null
 #  alternative_family_name               :text             default(""), not null
 #  alternative_given_names               :text             default(""), not null
+#  awarded_at                            :datetime
 #  confirmed_no_sanctions                :boolean          default(FALSE)
 #  date_of_birth                         :date
 #  english_language_citizenship_exempt   :boolean
@@ -132,6 +133,7 @@ FactoryBot.define do
     trait :awarded do
       state { "awarded" }
       submitted_at { Time.zone.now }
+      awarded_at { Time.zone.now }
     end
 
     trait :declined do

--- a/spec/lib/dqt/trn_request_params_spec.rb
+++ b/spec/lib/dqt/trn_request_params_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe DQT::TRNRequestParams do
     let(:application_form) do
       create(
         :application_form,
+        :awarded,
         teacher:,
+        created_at: Date.new(2020, 1, 1),
+        submitted_at: Date.new(2020, 1, 1),
+        awarded_at: Date.new(2020, 1, 7),
         region: create(:region, country: create(:country, code: "AU")),
         date_of_birth: Date.new(1960, 1, 1),
         given_names: "Given",
@@ -22,7 +26,6 @@ RSpec.describe DQT::TRNRequestParams do
         :assessment,
         :award,
         application_form:,
-        recommended_at: Date.new(2020, 1, 1),
         age_range_min: 7,
         age_range_max: 11,
         subjects: %w[physics french_language],
@@ -77,6 +80,16 @@ RSpec.describe DQT::TRNRequestParams do
           teacherType: "OverseasQualifiedTeacher",
         },
       )
+    end
+
+    context "with a new regulations application form" do
+      around do |example|
+        ClimateControl.modify(NEW_REGS_DATE: "2020-01-01") { example.run }
+      end
+
+      it "should use the assessed date" do
+        expect(call[:qtsDate]).to eq("2020-01-07")
+      end
     end
   end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -8,6 +8,7 @@
 #  age_range_status                      :string           default("not_started"), not null
 #  alternative_family_name               :text             default(""), not null
 #  alternative_given_names               :text             default(""), not null
+#  awarded_at                            :datetime
 #  confirmed_no_sanctions                :boolean          default(FALSE)
 #  date_of_birth                         :date
 #  english_language_citizenship_exempt   :boolean
@@ -242,6 +243,23 @@ RSpec.describe ApplicationForm, type: :model do
 
       context "with submitted_at" do
         before { application_form.submitted_at = Time.zone.now }
+
+        it { is_expected.to be_valid }
+      end
+    end
+
+    context "when awarded" do
+      before do
+        application_form.assign_attributes(
+          state: "awarded",
+          submitted_at: Time.zone.now,
+        )
+      end
+
+      it { is_expected.to_not be_valid }
+
+      context "with awarded_at" do
+        before { application_form.awarded_at = Time.zone.now }
 
         it { is_expected.to be_valid }
       end

--- a/spec/services/award_qts_spec.rb
+++ b/spec/services/award_qts_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe AwardQTS do
       )
       call
     end
+
+    it "sets the awarded at date" do
+      freeze_time do
+        expect { call }.to change(application_form, :awarded_at).to(
+          Time.zone.now,
+        )
+      end
+    end
   end
 
   context "with an awarded application form" do
@@ -60,6 +68,10 @@ RSpec.describe AwardQTS do
     it "doesn't change the status" do
       expect(ChangeApplicationFormState).to_not receive(:call)
       call
+    end
+
+    it "doesn't change the awarded at date" do
+      expect { call }.to_not change(application_form, :awarded_at)
     end
   end
 end

--- a/spec/services/change_application_form_state_spec.rb
+++ b/spec/services/change_application_form_state_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ChangeApplicationFormState do
   let!(:application_form) { create(:application_form, :submitted) }
   let(:user) { create(:staff) }
-  let(:new_state) { :awarded }
+  let(:new_state) { :awarded_pending_checks }
 
   subject(:call) { described_class.call(application_form:, user:, new_state:) }
 
@@ -17,13 +17,16 @@ RSpec.describe ChangeApplicationFormState do
     context "after calling the service" do
       before { call }
 
-      it { is_expected.to eq("awarded") }
+      it { is_expected.to eq("awarded_pending_checks") }
     end
   end
 
   describe "record timeline event" do
     subject(:timeline_event) do
-      TimelineEvent.find_by(application_form:, new_state: "awarded")
+      TimelineEvent.find_by(
+        application_form:,
+        new_state: "awarded_pending_checks",
+      )
     end
 
     it { is_expected.to be_nil }
@@ -36,7 +39,7 @@ RSpec.describe ChangeApplicationFormState do
       it "sets the attributes correctly" do
         expect(timeline_event.creator).to eq(user)
         expect(timeline_event.old_state).to eq("submitted")
-        expect(timeline_event.new_state).to eq("awarded")
+        expect(timeline_event.new_state).to eq("awarded_pending_checks")
       end
     end
   end


### PR DESCRIPTION
Under the new regulations we need to send the awarded at date to DQT as the "QTS date" rather than the date when the application was submitted. I've implemented this by capturing a new field on the application form rather than looking at the timeline events.

[Trello Card](https://trello.com/c/v3NTpD6F/1312-qts-date-change-dqt-integration)