### PR TITLE
Make assessment_id column not nullable

### DIFF
--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -11,7 +11,7 @@
 #  working_days_since_received             :integer
 #  created_at                              :datetime         not null
 #  updated_at                              :datetime         not null
-#  assessment_id                           :bigint
+#  assessment_id                           :bigint           not null
 #
 # Indexes
 #

--- a/db/migrate/20230105085100_change_further_information_request_assessment_id.rb
+++ b/db/migrate/20230105085100_change_further_information_request_assessment_id.rb
@@ -1,0 +1,5 @@
+class ChangeFurtherInformationRequestAssessmentId < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :further_information_requests, :assessment_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_04_140156) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_085100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -205,7 +205,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_04_140156) do
   end
 
   create_table "further_information_requests", force: :cascade do |t|
-    t.bigint "assessment_id"
+    t.bigint "assessment_id", null: false
     t.string "state", null: false
     t.datetime "received_at"
     t.datetime "created_at", null: false

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -13,7 +13,7 @@
 #  working_days_since_received             :integer
 #  created_at                              :datetime         not null
 #  updated_at                              :datetime         not null
-#  assessment_id                           :bigint
+#  assessment_id                           :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -13,7 +13,7 @@
 #  working_days_since_received             :integer
 #  created_at                              :datetime         not null
 #  updated_at                              :datetime         not null
-#  assessment_id                           :bigint
+#  assessment_id                           :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
This is a foreign key column on further information requests that link to assessments, but it doesn't make sense to be nullable since it should never be null in normal operation.

We're seeing issues in Sentry related to this being null in the review environment:
- https://sentry.io/organizations/dfe-teacher-services/issues/3854623435/?project=6426061&query=is%3Aunresolved&referrer=issue-stream
- https://sentry.io/organizations/dfe-teacher-services/issues/3854775780/?project=6426061&query=is%3Aignored&referrer=issue-stream

It's not entirely clear to me why the data is in this state, but changing the column should at least tell us when the data ends up in this state.

I've checked the data in production and there's no cases where the value is null:

```
irb(main):001:0> FurtherInformationRequest.where(assessment_id: nil).count
=> 0
```