### PR TITLE
Add application_forms:set_awarded_at

### DIFF
--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+namespace :application_forms do
+  desc "Generate a countries CSV file for analytics dashboards."
+  task set_awarded_at: :environment do
+    ApplicationForm
+      .awarded
+      .where(awarded_at: nil)
+      .each do |application_form|
+        timeline_event =
+          TimelineEvent.state_changed.find_by(
+            application_form:,
+            new_state: "awarded",
+          )
+        application_form.update!(awarded_at: timeline_event.created_at)
+      end
+  end
+end


### PR DESCRIPTION
This is a Rake task which we can use to backfill the new awarded_at column which was added in a512175ddfd82326f2a13db822482bcec0a6d25a.

Once the column has been deployed to all environments, this Rake task can be run to backfill the value. I've tested the task manually in the dev environment and it works, once this has been run I'll delete the Rake task.