### PR TITLE
Add work experience to smoke test

### DIFF
--- a/spec/support/autoload/page_objects/eligibility_interface/work_experience.rb
+++ b/spec/support/autoload/page_objects/eligibility_interface/work_experience.rb
@@ -2,6 +2,21 @@ module PageObjects
   module EligibilityInterface
     class WorkExperience < Question
       set_url "/eligibility/work-experience"
+
+      def submit_under_9_months
+        form.radio_items[0].choose
+        form.continue_button.click
+      end
+
+      def submit_between_9_and_20_months
+        form.radio_items[1].choose
+        form.continue_button.click
+      end
+
+      def submit_over_20_months
+        form.radio_items[2].choose
+        form.continue_button.click
+      end
     end
   end
 end

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -370,13 +370,11 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def when_i_have_more_than_20_months_work_experience
-    work_experience_page.form.radio_items.third.choose
-    work_experience_page.form.continue_button.click
+    work_experience_page.submit_over_20_months
   end
 
   def when_i_have_under_9_months_work_experience
-    work_experience_page.form.radio_items.first.choose
-    work_experience_page.form.continue_button.click
+    work_experience_page.submit_under_9_months
   end
 
   def when_i_have_a_misconduct_record

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -17,6 +17,7 @@ require "support/autoload/page_objects/eligibility_interface/qualification"
 require "support/autoload/page_objects/eligibility_interface/region"
 require "support/autoload/page_objects/eligibility_interface/start"
 require "support/autoload/page_objects/eligibility_interface/teach_children"
+require "support/autoload/page_objects/eligibility_interface/work_experience"
 
 Capybara.javascript_driver = :cuprite
 Capybara.always_include_port = false
@@ -37,7 +38,8 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
     and_i_select_a_state
     and_i_have_a_teaching_qualification
     and_i_have_a_university_degree
-    and_i_am_qualified_to_teach
+    and_i_am_qualified_to_teach_children
+    and_i_have_work_experience
     and_i_dont_have_sanctions
     then_i_should_be_eligible_to_apply
   end
@@ -77,8 +79,18 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
     degree_page.submit_yes
   end
 
-  def and_i_am_qualified_to_teach
+  def and_i_am_qualified_to_teach_children
     teach_children_page.submit_yes
+  end
+
+  def and_i_have_work_experience
+    # dev & test environments have this feature enabled currently but production does
+    # not. We can remove this conditional when the feature is released
+    if page.has_content?(
+         "How long have you been employed as a recognised teacher?",
+       )
+      work_experience_page.submit_over_20_months
+    end
   end
 
   def and_i_dont_have_sanctions
@@ -112,6 +124,11 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
   def teach_children_page
     @teach_children_page ||=
       PageObjects::EligibilityInterface::TeachChildren.new
+  end
+
+  def work_experience_page
+    @work_experience_page ||=
+      PageObjects::EligibilityInterface::WorkExperience.new
   end
 
   def misconduct_page


### PR DESCRIPTION
A new work experience question was added to the eligibility checker in https://github.com/DFE-Digital/apply-for-qualified-teacher-status/commit/b7bbc219c6aa3611b858f47ac612f8fe24eeffac but the smoke tests weren't updated so now that the feature has been enabled in the dev and test environments, deploys are blocked as the smoke tests are failing.