### PR TITLE
Add 'eligibility_enabled' to countries model

### DIFF
--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -4,6 +4,7 @@
 #
 #  id                                      :bigint           not null, primary key
 #  code                                    :string           not null
+#  eligibility_enabled                     :boolean          default(TRUE), not null
 #  teaching_authority_address              :text             default(""), not null
 #  teaching_authority_certificate          :text             default(""), not null
 #  teaching_authority_checks_sanctions     :boolean          default(TRUE), not null

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -61,8 +61,13 @@ class EligibilityCheck < ApplicationRecord
 
   def country_code=(value)
     super(value)
-
-    regions = Region.joins(:country).where(country: { code: value })
+    regions =
+      Region.joins(:country).where(
+        country: {
+          eligibility_enabled: true,
+          code: value,
+        },
+      )
     self.region = regions.count == 1 ? regions.first : nil
   end
 
@@ -104,7 +109,11 @@ class EligibilityCheck < ApplicationRecord
 
   def country_eligibility_status
     return region_eligibility_status if region
-    Country.exists?(code: country_code) ? :region : :ineligible
+    if Country.where(eligibility_enabled: true).exists?(code: country_code)
+      :region
+    else
+      :ineligible
+    end
   end
 
   def region_eligibility_status

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -93,6 +93,7 @@
     - id
     - code
     - created_at
+    - eligibility_enabled
     - updated_at
     - teaching_authority_address
     - teaching_authority_emails

--- a/db/migrate/20230105155624_add_eligibility_enabled_to_countries.rb
+++ b/db/migrate/20230105155624_add_eligibility_enabled_to_countries.rb
@@ -1,0 +1,9 @@
+class AddEligibilityEnabledToCountries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :countries,
+               :eligibility_enabled,
+               :boolean,
+               default: true,
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_085100) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_05_155624) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -140,6 +140,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_085100) do
     t.string "teaching_authority_online_checker_url", default: "", null: false
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
+    t.boolean "eligibility_enabled", default: true, null: false
     t.index ["code"], name: "index_countries_on_code", unique: true
   end
 

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -4,6 +4,7 @@
 #
 #  id                                      :bigint           not null, primary key
 #  code                                    :string           not null
+#  eligibility_enabled                     :boolean          default(TRUE), not null
 #  teaching_authority_address              :text             default(""), not null
 #  teaching_authority_certificate          :text             default(""), not null
 #  teaching_authority_checks_sanctions     :boolean          default(TRUE), not null

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                                      :bigint           not null, primary key
 #  code                                    :string           not null
+#  eligibility_enabled                     :boolean          default(TRUE), not null
 #  teaching_authority_address              :text             default(""), not null
 #  teaching_authority_certificate          :text             default(""), not null
 #  teaching_authority_checks_sanctions     :boolean          default(TRUE), not null


### PR DESCRIPTION
Add a new field to the countries table
This field will be used for turning off and on the eligible checker for whole countries.

There is no interface for this in this pr as this pr is 1 part of : https://trello.com/c/rYd9rkdi/1314-add-nine-new-countries-to-the-support-console