### PR TITLE
View FI details after award or decline

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -51,10 +51,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
       further_information_request = further_information_requests[index]
 
       if further_information_request.received? &&
-           (
-             further_information_request.passed.nil? ||
-               assessment.request_further_information?
-           )
+           assessment.request_further_information?
         url_helpers.edit_assessor_interface_application_form_assessment_further_information_request_path(
           application_form,
           assessment,

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -9,7 +9,7 @@
   <%= render(CheckYourAnswersSummary::Component.new(**item.fetch(:check_your_answers))) %>
 <% end %>
 
-<% if policy(:assessor).update? %>
+<% if policy(:assessor).update? && @view_object.further_information_request.passed.nil? %>
   <%= form_with model: @further_information_request_form, url: [:assessor_interface, @view_object.application_form, @view_object.assessment, @view_object.further_information_request], method: :put do |f| %>
     <%= f.govuk_error_summary %>
 

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -42,6 +42,21 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     and_i_see_a_decline_qts_option
   end
 
+  it "further information request passed" do
+    @further_information_request.update!(passed: true)
+
+    when_i_visit_the(:assessor_application_page, application_id:)
+    and_i_click_review_requested_information
+    then_i_see_the(
+      :review_further_information_request_page,
+      application_id:,
+      assessment_id:,
+      further_information_request_id:,
+    )
+    and_i_see_the_check_your_answers_items
+    and_i_do_not_see_the_review_further_information_form
+  end
+
   private
 
   def given_there_is_an_application_form_with_failure_reasons
@@ -87,6 +102,10 @@ RSpec.describe "Assessor reviewing further information", type: :system do
 
   def and_i_see_a_decline_qts_option
     expect(complete_assessment_page.decline_qts).to_not be_nil
+  end
+
+  def and_i_do_not_see_the_review_further_information_form
+    expect(review_further_information_request_page).not_to have_form
   end
 
   def application_form

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -132,6 +132,11 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
         let!(:further_information_request) do
           create(:further_information_request, :received, assessment:)
         end
+
+        before do
+          assessment.update!(recommendation: "request_further_information")
+        end
+
         it do
           is_expected.to eq(
             "/assessor/applications/#{application_form.id}/assessments/#{assessment.id}" \


### PR DESCRIPTION
## Trello 

https://trello.com/c/RWlWJnk5/1310-view-fi-docs-details-after-award-decline

## Context and changes made

Assessors should be able to see FI details if the application has been awared or declined.
We use the `passed` value on the `FurtherInformationRequest` record to determine whether the FI details are read only or editable.

Not sure whether we intend to render the check-answers component information in the read-only view (see screenshot)
 

## Edit page in read only state

![image](https://user-images.githubusercontent.com/93511/211338849-1caae56f-ba3a-477a-a9ee-3313febd3a90.png)



