### PR TITLE
Change recommended_at from date to datetime

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -7,7 +7,7 @@
 #  age_range_min                             :integer
 #  age_range_note                            :text             default(""), not null
 #  recommendation                            :string           default("unknown"), not null
-#  recommended_at                            :date
+#  recommended_at                            :datetime
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null

--- a/db/migrate/20230106130126_change_assessment_recommended_at.rb
+++ b/db/migrate/20230106130126_change_assessment_recommended_at.rb
@@ -1,0 +1,9 @@
+class ChangeAssessmentRecommendedAt < ActiveRecord::Migration[7.0]
+  def up
+    change_column :assessments, :recommended_at, :datetime
+  end
+
+  def down
+    change_column :assessments, :recommended_at, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_05_155624) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_06_130126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -115,7 +115,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_05_155624) do
     t.integer "age_range_min"
     t.integer "age_range_max"
     t.text "subjects", default: [], null: false, array: true
-    t.date "recommended_at"
+    t.datetime "recommended_at", precision: nil
     t.text "age_range_note", default: "", null: false
     t.text "subjects_note", default: "", null: false
     t.datetime "started_at"

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -7,7 +7,7 @@
 #  age_range_min                             :integer
 #  age_range_note                            :text             default(""), not null
 #  recommendation                            :string           default("unknown"), not null
-#  recommended_at                            :date
+#  recommended_at                            :datetime
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -9,7 +9,7 @@
 #  age_range_min                             :integer
 #  age_range_note                            :text             default(""), not null
 #  recommendation                            :string           default("unknown"), not null
-#  recommended_at                            :date
+#  recommended_at                            :datetime
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null


### PR DESCRIPTION
This changes the type of the recommended at field to include hours, minutes and seconds so we get better analytics on when the recommendation happened.