### PR TITLE
Add responding to a reference request

### DIFF
--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -22,21 +22,24 @@ module StatusTag
 
     COLOURS = {
       action_required: "red",
-      not_started: "grey",
-      in_progress: "blue",
-      initial_assessment: "blue",
-      further_information_requested: "yellow",
-      further_information_received: "purple",
-      awarded_pending_checks: "green",
       awarded: "green",
-      declined: "red",
-      draft: "grey",
-      submitted: "grey",
+      awarded_pending_checks: "green",
       cannot_start_yet: "grey",
       completed: {
         assessor: "green",
       },
+      declined: "red",
+      draft: "grey",
+      expired: "red",
+      further_information_received: "purple",
+      further_information_requested: "yellow",
+      in_progress: "blue",
+      initial_assessment: "blue",
+      not_started: "grey",
       potential_duplicate_in_dqt: "red",
+      received: "purple",
+      requested: "yellow",
+      submitted: "grey",
     }.freeze
 
     def colour

--- a/app/controllers/concerns/handle_application_form_section.rb
+++ b/app/controllers/concerns/handle_application_form_section.rb
@@ -9,7 +9,7 @@ module HandleApplicationFormSection
     if_success_then_redirect: %i[teacher_interface application_form],
     if_failure_then_render: :edit
   )
-    save_and_continue = params[:button] == "save_and_continue"
+    save_and_continue = params[:button] != "save_and_return"
 
     if form.save(validate: save_and_continue)
       check_path = check_path_if_previous(check_identifier)

--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -1,11 +1,18 @@
+# frozen_string_literal: true
+
 class PersonasController < ApplicationController
   include EligibilityCurrentNamespace
 
   before_action :ensure_feature_active
-  before_action :load_teacher_personas
+  before_action :load_teacher_personas, only: :index
 
   def index
     @staff = Staff.all
+
+    @reference_requests =
+      ReferenceRequest.states.values.filter_map do |state|
+        ReferenceRequest.find_by(state:)
+      end
   end
 
   def staff_sign_in

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -6,6 +6,7 @@ module TeacherInterface
     include HistoryTrackable
 
     skip_before_action :authenticate_teacher!
+    before_action :load_requested_reference_request, except: :show
 
     define_history_origin :show
     define_history_reset :show
@@ -19,6 +20,19 @@ module TeacherInterface
     end
 
     def edit
+    end
+
+    def update
+      reference_request.received! if reference_request.responses_given?
+
+      redirect_to teacher_interface_reference_request_path
+    end
+
+    private
+
+    attr_reader :reference_request
+
+    def load_requested_reference_request
       @reference_request =
         ReferenceRequest.requested.find_by!(slug: params[:slug])
       @work_history = reference_request.work_history

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class ReferenceRequestsController < BaseController
+    include HandleApplicationFormSection
+    include HistoryTrackable
+
+    skip_before_action :authenticate_teacher!
+
+    define_history_origin :show
+    define_history_reset :show
+
+    def show
+      @reference_request =
+        ReferenceRequest.not_expired.find_by!(slug: params[:slug])
+      @application_form = reference_request.application_form
+      @work_history = reference_request.work_history
+    end
+
+    private
+
+    attr_reader :reference_request
+  end
+end

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -9,11 +9,18 @@ module TeacherInterface
 
     define_history_origin :show
     define_history_reset :show
+    define_history_check :edit
 
     def show
       @reference_request =
         ReferenceRequest.not_expired.find_by!(slug: params[:slug])
       @application_form = reference_request.application_form
+      @work_history = reference_request.work_history
+    end
+
+    def edit
+      @reference_request =
+        ReferenceRequest.requested.find_by!(slug: params[:slug])
       @work_history = reference_request.work_history
     end
 

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -71,8 +71,30 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @form,
-        if_success_then_redirect: edit_teacher_interface_reference_request_path,
+        if_success_then_redirect:
+          children_teacher_interface_reference_request_path,
         if_failure_then_render: :edit_hours,
+      )
+    end
+
+    def edit_children
+      @form =
+        ReferenceRequestChildrenResponseForm.new(
+          reference_request:,
+          children_response: reference_request.children_response,
+        )
+    end
+
+    def update_children
+      @form =
+        ReferenceRequestChildrenResponseForm.new(
+          children_response_form_params.merge(reference_request:),
+        )
+
+      handle_application_form_section(
+        form: @form,
+        if_success_then_redirect: edit_teacher_interface_reference_request_path,
+        if_failure_then_render: :edit_children,
       )
     end
 
@@ -95,6 +117,12 @@ module TeacherInterface
       params.require(
         :teacher_interface_reference_request_hours_response_form,
       ).permit(:hours_response)
+    end
+
+    def children_response_form_params
+      params.require(
+        :teacher_interface_reference_request_children_response_form,
+      ).permit(:children_response)
     end
   end
 end

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -137,8 +137,31 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @form,
-        if_success_then_redirect: edit_teacher_interface_reference_request_path,
+        if_success_then_redirect:
+          additional_information_teacher_interface_reference_request_path,
         if_failure_then_render: :edit_reports,
+      )
+    end
+
+    def edit_additional_information
+      @form =
+        ReferenceRequestAdditionalInformationResponseForm.new(
+          reference_request:,
+          additional_information_response:
+            reference_request.additional_information_response,
+        )
+    end
+
+    def update_additional_information
+      @form =
+        ReferenceRequestAdditionalInformationResponseForm.new(
+          additional_information_response_form_params.merge(reference_request:),
+        )
+
+      handle_application_form_section(
+        form: @form,
+        if_success_then_redirect: edit_teacher_interface_reference_request_path,
+        if_failure_then_render: :edit_additional_information,
       )
     end
 
@@ -179,6 +202,12 @@ module TeacherInterface
       params.require(
         :teacher_interface_reference_request_reports_response_form,
       ).permit(:reports_response)
+    end
+
+    def additional_information_response_form_params
+      params.require(
+        :teacher_interface_reference_request_additional_information_response_form,
+      ).permit(:additional_information_response)
     end
   end
 end

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -93,8 +93,30 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @form,
-        if_success_then_redirect: edit_teacher_interface_reference_request_path,
+        if_success_then_redirect:
+          lessons_teacher_interface_reference_request_path,
         if_failure_then_render: :edit_children,
+      )
+    end
+
+    def edit_lessons
+      @form =
+        ReferenceRequestLessonsResponseForm.new(
+          reference_request:,
+          lessons_response: reference_request.lessons_response,
+        )
+    end
+
+    def update_lessons
+      @form =
+        ReferenceRequestLessonsResponseForm.new(
+          lessons_response_form_params.merge(reference_request:),
+        )
+
+      handle_application_form_section(
+        form: @form,
+        if_success_then_redirect: edit_teacher_interface_reference_request_path,
+        if_failure_then_render: :edit_lessons,
       )
     end
 
@@ -123,6 +145,12 @@ module TeacherInterface
       params.require(
         :teacher_interface_reference_request_children_response_form,
       ).permit(:children_response)
+    end
+
+    def lessons_response_form_params
+      params.require(
+        :teacher_interface_reference_request_lessons_response_form,
+      ).permit(:lessons_response)
     end
   end
 end

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -115,8 +115,30 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @form,
-        if_success_then_redirect: edit_teacher_interface_reference_request_path,
+        if_success_then_redirect:
+          reports_teacher_interface_reference_request_path,
         if_failure_then_render: :edit_lessons,
+      )
+    end
+
+    def edit_reports
+      @form =
+        ReferenceRequestReportsResponseForm.new(
+          reference_request:,
+          reports_response: reference_request.reports_response,
+        )
+    end
+
+    def update_reports
+      @form =
+        ReferenceRequestReportsResponseForm.new(
+          reports_response_form_params.merge(reference_request:),
+        )
+
+      handle_application_form_section(
+        form: @form,
+        if_success_then_redirect: edit_teacher_interface_reference_request_path,
+        if_failure_then_render: :edit_reports,
       )
     end
 
@@ -151,6 +173,12 @@ module TeacherInterface
       params.require(
         :teacher_interface_reference_request_lessons_response_form,
       ).permit(:lessons_response)
+    end
+
+    def reports_response_form_params
+      params.require(
+        :teacher_interface_reference_request_reports_response_form,
+      ).permit(:reports_response)
     end
   end
 end

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -45,8 +45,34 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @form,
-        if_success_then_redirect: edit_teacher_interface_reference_request_path,
+        if_success_then_redirect:
+          hours_teacher_interface_reference_request_path,
         if_failure_then_render: :edit_dates,
+      )
+    end
+
+    def edit_hours
+      @work_history = reference_request.work_history
+
+      @form =
+        ReferenceRequestHoursResponseForm.new(
+          reference_request:,
+          hours_response: reference_request.hours_response,
+        )
+    end
+
+    def update_hours
+      @work_history = reference_request.work_history
+
+      @form =
+        ReferenceRequestHoursResponseForm.new(
+          hours_response_form_params.merge(reference_request:),
+        )
+
+      handle_application_form_section(
+        form: @form,
+        if_success_then_redirect: edit_teacher_interface_reference_request_path,
+        if_failure_then_render: :edit_hours,
       )
     end
 
@@ -63,6 +89,12 @@ module TeacherInterface
       params.require(
         :teacher_interface_reference_request_dates_response_form,
       ).permit(:dates_response)
+    end
+
+    def hours_response_form_params
+      params.require(
+        :teacher_interface_reference_request_hours_response_form,
+      ).permit(:hours_response)
     end
   end
 end

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -20,12 +20,34 @@ module TeacherInterface
     end
 
     def edit
+      @work_history = reference_request.work_history
     end
 
     def update
       reference_request.received! if reference_request.responses_given?
 
       redirect_to teacher_interface_reference_request_path
+    end
+
+    def edit_dates
+      @form =
+        ReferenceRequestDatesResponseForm.new(
+          reference_request:,
+          dates_response: reference_request.dates_response,
+        )
+    end
+
+    def update_dates
+      @form =
+        ReferenceRequestDatesResponseForm.new(
+          dates_response_form_params.merge(reference_request:),
+        )
+
+      handle_application_form_section(
+        form: @form,
+        if_success_then_redirect: edit_teacher_interface_reference_request_path,
+        if_failure_then_render: :edit_dates,
+      )
     end
 
     private
@@ -35,11 +57,12 @@ module TeacherInterface
     def load_requested_reference_request
       @reference_request =
         ReferenceRequest.requested.find_by!(slug: params[:slug])
-      @work_history = reference_request.work_history
     end
 
-    private
-
-    attr_reader :reference_request
+    def dates_response_form_params
+      params.require(
+        :teacher_interface_reference_request_dates_response_form,
+      ).permit(:dates_response)
+    end
   end
 end

--- a/app/forms/teacher_interface/reference_request_additional_information_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_additional_information_response_form.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class ReferenceRequestAdditionalInformationResponseForm < BaseForm
+    attr_accessor :reference_request
+    attribute :additional_information_response, :string
+
+    validates :reference_request, presence: true
+
+    def update_model
+      reference_request.update!(additional_information_response:)
+    end
+  end
+end

--- a/app/forms/teacher_interface/reference_request_children_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_children_response_form.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class ReferenceRequestChildrenResponseForm < BaseForm
+    attr_accessor :reference_request
+    attribute :children_response, :boolean
+
+    validates :reference_request, presence: true
+    validates :children_response, inclusion: [true, false]
+
+    def update_model
+      reference_request.update!(children_response:)
+    end
+  end
+end

--- a/app/forms/teacher_interface/reference_request_dates_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_dates_response_form.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class ReferenceRequestDatesResponseForm < BaseForm
+    attr_accessor :reference_request
+    attribute :dates_response, :boolean
+
+    validates :reference_request, presence: true
+    validates :dates_response, inclusion: [true, false]
+
+    def update_model
+      reference_request.update!(dates_response:)
+    end
+  end
+end

--- a/app/forms/teacher_interface/reference_request_hours_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_hours_response_form.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class ReferenceRequestHoursResponseForm < BaseForm
+    attr_accessor :reference_request
+    attribute :hours_response, :boolean
+
+    validates :reference_request, presence: true
+    validates :hours_response, inclusion: [true, false]
+
+    def update_model
+      reference_request.update!(hours_response:)
+    end
+  end
+end

--- a/app/forms/teacher_interface/reference_request_lessons_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_lessons_response_form.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class ReferenceRequestLessonsResponseForm < BaseForm
+    attr_accessor :reference_request
+    attribute :lessons_response, :boolean
+
+    validates :reference_request, presence: true
+    validates :lessons_response, inclusion: [true, false]
+
+    def update_model
+      reference_request.update!(lessons_response:)
+    end
+  end
+end

--- a/app/forms/teacher_interface/reference_request_reports_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_reports_response_form.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class ReferenceRequestReportsResponseForm < BaseForm
+    attr_accessor :reference_request
+    attribute :reports_response, :boolean
+
+    validates :reference_request, presence: true
+    validates :reports_response, inclusion: [true, false]
+
+    def update_model
+      reference_request.update!(reports_response:)
+    end
+  end
+end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -32,6 +32,7 @@ class Assessment < ApplicationRecord
 
   has_many :sections, class_name: "AssessmentSection", dependent: :destroy
   has_many :further_information_requests, dependent: :destroy
+  has_many :reference_requests, dependent: :destroy
 
   enum :recommendation,
        {

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Requestable
+  extend ActiveSupport::Concern
+
+  included do
+    enum :state,
+         { requested: "requested", received: "received", expired: "expired" },
+         default: "requested"
+
+    validates :state, presence: true, inclusion: { in: states.values }
+
+    validates :received_at, presence: true, if: :received?
+
+    define_method :received! do
+      update!(state: "received", received_at: Time.zone.now)
+    end
+  end
+end

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -18,6 +18,8 @@
 #  index_further_information_requests_on_assessment_id  (assessment_id)
 #
 class FurtherInformationRequest < ApplicationRecord
+  include Requestable
+
   belongs_to :assessment
   has_many :items,
            class_name: "FurtherInformationRequestItem",
@@ -25,10 +27,6 @@ class FurtherInformationRequest < ApplicationRecord
            dependent: :destroy
 
   has_many :reminder_emails
-
-  enum :state,
-       { requested: "requested", received: "received", expired: "expired" },
-       default: :requested
 
   def failed
     passed == false

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reference_requests
+#
+#  id                              :bigint           not null, primary key
+#  additional_information_response :text             default(""), not null
+#  children_response               :boolean
+#  dates_response                  :boolean
+#  hours_response                  :boolean
+#  lessons_response                :boolean
+#  received_at                     :datetime
+#  reports_response                :boolean
+#  slug                            :string           not null
+#  state                           :string           not null
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  assessment_id                   :bigint           not null
+#  work_history_id                 :bigint           not null
+#
+# Indexes
+#
+#  index_reference_requests_on_assessment_id    (assessment_id)
+#  index_reference_requests_on_slug             (slug) UNIQUE
+#  index_reference_requests_on_work_history_id  (work_history_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#  fk_rails_...  (work_history_id => work_histories.id)
+#
+class ReferenceRequest < ApplicationRecord
+  include Requestable
+
+  has_secure_token :slug
+
+  belongs_to :assessment
+  belongs_to :work_history
+
+  with_options if: :received? do
+    validates :dates_response, inclusion: [true, false]
+    validates :hours_response, inclusion: [true, false]
+    validates :children_response, inclusion: [true, false]
+    validates :lessons_response, inclusion: [true, false]
+    validates :reports_response, inclusion: [true, false]
+  end
+
+  delegate :application_form, to: :assessment
+
+  def responses_given?
+    responses.none?(&:nil?)
+  end
+
+  def responses_valid?
+    responses.all?(&:present?)
+  end
+
+  private
+
+  def responses
+    [
+      dates_response,
+      hours_response,
+      children_response,
+      lessons_response,
+      reports_response,
+    ]
+  end
+end

--- a/app/services/submit_further_information_request.rb
+++ b/app/services/submit_further_information_request.rb
@@ -12,10 +12,7 @@ class SubmitFurtherInformationRequest
     raise AlreadySubmitted if further_information_request.received?
 
     ActiveRecord::Base.transaction do
-      further_information_request.update!(
-        state: "received",
-        received_at: Time.zone.now,
-      )
+      further_information_request.received!
 
       ChangeApplicationFormState.call(
         application_form:,

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -86,3 +86,40 @@
     end %>
   <% end %>
 </section>
+
+<section id="app-personas-references" class="app-personas">
+  <h2 class="govuk-heading-l">References</h2>
+
+  <% if @reference_requests.empty? %>
+    <p class="govuk-body">No reference requests.</p>
+  <% else %>
+    <%= govuk_table do |table|
+      table.head do |head|
+        head.row do |row|
+          row.cell(header: true, text: "Teacher email")
+          row.cell(header: true, text: "State")
+          row.cell(header: true, text: "Actions", numeric: true)
+        end
+      end
+
+      table.body do |body|
+        @reference_requests.each do |reference_request|
+          body.row do |row|
+            row.cell(text: reference_request.application_form.teacher.email)
+
+            row.cell(width: "one-third") do
+              render(StatusTag::Component.new(
+                key: "reference-request-#{reference_request.id}",
+                status: reference_request.state,
+              ))
+            end
+
+            row.cell(numeric: true) do
+              govuk_button_link_to "Sign&nbsp;in".html_safe, teacher_interface_reference_request_path(slug: reference_request.slug)
+            end
+          end
+        end
+      end
+    end %>
+  <% end %>
+</section>

--- a/app/views/teacher_interface/reference_requests/edit.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, t(".title") %>
+
+<h1 class="govuk-heading-xl"><%= t(".title") %></h1>
+
+<%= render(CheckYourAnswersSummary::Component.new(
+  id: "reference-request-#{@reference_request.id}",
+  model: @reference_request,
+  title: t(".reference_requested"),
+  fields: {
+    dates_response: {
+    },
+    hours_response: {
+    },
+    children_response: {
+    },
+    lessons_response: {
+    },
+    reports_response: {
+    },
+    additional_information_response: {
+    },
+  },
+  changeable: true
+)) %>

--- a/app/views/teacher_interface/reference_requests/edit.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit.html.erb
@@ -28,6 +28,8 @@
       href: reports_teacher_interface_reference_request_path,
     },
     additional_information_response: {
+      title: t("helpers.label.teacher_interface_reference_request_additional_information_response_form.additional_information_response"),
+      href: additional_information_teacher_interface_reference_request_path,
     },
   },
   changeable: true

--- a/app/views/teacher_interface/reference_requests/edit.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit.html.erb
@@ -22,3 +22,9 @@
   },
   changeable: true
 )) %>
+
+<% if @reference_request.responses_given? %>
+  <h3 class="govuk-heading-m">Submitting your response</h3>
+  <p class="govuk-body">By selecting the ‘Submit your response’ button, you confirm that, to the best of your knowledge, the details you’ve provided are correct.</p>
+  <%= govuk_button_to "Submit your response", teacher_interface_reference_request_path, method: :patch %>
+<% end %>

--- a/app/views/teacher_interface/reference_requests/edit.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit.html.erb
@@ -8,6 +8,8 @@
   title: t(".reference_requested"),
   fields: {
     dates_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response"),
+      href: dates_teacher_interface_reference_request_path,
     },
     hours_response: {
     },

--- a/app/views/teacher_interface/reference_requests/edit.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit.html.erb
@@ -24,6 +24,8 @@
       href: lessons_teacher_interface_reference_request_path,
     },
     reports_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_reports_response_form.reports_response"),
+      href: reports_teacher_interface_reference_request_path,
     },
     additional_information_response: {
     },

--- a/app/views/teacher_interface/reference_requests/edit.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit.html.erb
@@ -16,6 +16,8 @@
       href: hours_teacher_interface_reference_request_path,
     },
     children_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_children_response_form.children_response"),
+      href: children_teacher_interface_reference_request_path,
     },
     lessons_response: {
     },

--- a/app/views/teacher_interface/reference_requests/edit.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit.html.erb
@@ -12,6 +12,8 @@
       href: dates_teacher_interface_reference_request_path,
     },
     hours_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_hours_response_form.hours_response", count: @work_history.hours_per_week),
+      href: hours_teacher_interface_reference_request_path,
     },
     children_response: {
     },

--- a/app/views/teacher_interface/reference_requests/edit.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit.html.erb
@@ -20,6 +20,8 @@
       href: children_teacher_interface_reference_request_path,
     },
     lessons_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_lessons_response_form.lessons_response"),
+      href: lessons_teacher_interface_reference_request_path,
     },
     reports_response: {
     },

--- a/app/views/teacher_interface/reference_requests/edit_additional_information.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_additional_information.html.erb
@@ -1,0 +1,12 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.label.teacher_interface_reference_request_additional_information_response_form.additional_information_response")}" %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+
+<%= form_with model: @form, url: additional_information_teacher_interface_reference_request_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l">Any other comments (optional)</span>
+
+  <%= f.govuk_text_area :additional_information_response, label: { tag: "h1", size: "l" } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/teacher_interface/reference_requests/edit_children.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_children.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_children_response_form.children_response")}" %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+
+<%= form_with model: @form, url: children_teacher_interface_reference_request_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l">Question 3 of 5</span>
+
+  <%= f.govuk_collection_radio_buttons :children_response,
+                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
+                                       :value,
+                                       legend: { tag: "h1", size: "l" } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/teacher_interface/reference_requests/edit_dates.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_dates.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response")}" %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+
+<%= form_with model: @form, url: dates_teacher_interface_reference_request_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l">Question 1 of 5</span>
+
+  <%= f.govuk_collection_radio_buttons :dates_response,
+                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
+                                       :value,
+                                       legend: { tag: "h1", size: "l" } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/teacher_interface/reference_requests/edit_hours.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_hours.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_hours_response_form.hours_response", count: @work_history.hours_per_week)}" %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+
+<%= form_with model: @form, url: hours_teacher_interface_reference_request_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l">Question 2 of 5</span>
+
+  <%= f.govuk_collection_radio_buttons :hours_response,
+                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
+                                       :value,
+                                       legend: { tag: "h1", size: "l", text: t("helpers.legend.teacher_interface_reference_request_hours_response_form.hours_response", count: @work_history.hours_per_week) } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/teacher_interface/reference_requests/edit_lessons.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_lessons.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_lessons_response_form.lessons_response")}" %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+
+<%= form_with model: @form, url: lessons_teacher_interface_reference_request_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l">Question 4 of 5</span>
+
+  <%= f.govuk_collection_radio_buttons :lessons_response,
+                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
+                                       :value,
+                                       legend: { tag: "h1", size: "l" } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/teacher_interface/reference_requests/edit_reports.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_reports.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_reports_response_form.reports_response")}" %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+
+<%= form_with model: @form, url: reports_teacher_interface_reference_request_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l">Question 5 of 5</span>
+
+  <%= f.govuk_collection_radio_buttons :reports_response,
+                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
+                                       :value,
+                                       legend: { tag: "h1", size: "l" } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/teacher_interface/reference_requests/show.html.erb
+++ b/app/views/teacher_interface/reference_requests/show.html.erb
@@ -16,6 +16,8 @@
   <% end %>
 
   <p class="govuk-body">We need to to ask you a few questions about the applicant’s role. It should take no longer than 5 minutes.</p>
+
+  <%= govuk_start_button(text: "Start now", href: dates_teacher_interface_reference_request_path) %>
 <% else %>
   <%= govuk_panel(title_text: "You’ve successfully submitted your response") %>
 

--- a/app/views/teacher_interface/reference_requests/show.html.erb
+++ b/app/views/teacher_interface/reference_requests/show.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title, t(".title") %>
+
+<% if @reference_request.requested? %>
+  <h1 class="govuk-heading-xl"><%= t("service.name.teacher") %></h1>
+
+  <h2 class="govuk-heading-m"><%= t(".title") %></h2>
+
+  <p class="govuk-body"><%= application_form_full_name(@application_form) %> is applying for qualified teacher status (QTS) in England.</p>
+
+  <p class="govuk-body">As part of our assessment, we need to understand their work history and experience. They’ve provided your details to help us verify that they worked at:</p>
+
+  <%= govuk_inset_text do %>
+    <p class="govuk-body">
+      <%= @work_history.school_name %> from <%= @work_history.start_date.strftime("%B %Y") %> to <%= (@work_history.end_date || Time.zone.today).strftime("%B %Y") %>
+    </p>
+  <% end %>
+
+  <p class="govuk-body">We need to to ask you a few questions about the applicant’s role. It should take no longer than 5 minutes.</p>
+<% else %>
+  <%= govuk_panel(title_text: "You’ve successfully submitted your response") %>
+
+  <h3 class="govuk-heading-m">Thank you for submitting your response.</h3>
+
+  <p class="govuk-body">The QTS assessor will now review your response and continue their review of the applicant.</p>
+
+  <p class="govuk-body">You do not need to do anything else. You can now close this page.</p>
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -185,6 +185,21 @@
     - created_at
     - updated_at
     - part_of_university_degree
+  :reference_requests:
+    - id
+    - slug
+    - assessment_id
+    - work_history_id
+    - state
+    - received_at
+    - dates_response
+    - hours_response
+    - children_response
+    - lessons_response
+    - reports_response
+    - additional_information_response
+    - created_at
+    - updated_at
   :regions:
     - id
     - country_id

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -31,6 +31,8 @@
     - complete_date
     - certificate_date
     - part_of_university_degree
+  :reference_requests:
+    - additional_information_response
   :selected_failure_reasons:
     - assessor_feedback
   :staff:

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -1,22 +1,25 @@
 en:
   components:
     status_tag:
-      not_started: Not started
-      in_progress: In progress
-      initial_assessment: Initial assessment
-      further_information_requested: Further information requested
-      further_information_received: Further information received
-      awarded_pending_checks: Awarded pending checks
+      action_required: Action required
       awarded: Awarded
+      awarded_pending_checks: Awarded pending checks
+      cannot_start_yet: Cannot start yet
+      completed: Completed
       declined: Declined
       draft: Draft
+      expired: Expired
+      further_information_received: Further information received
+      further_information_requested: Further information requested
+      in_progress: In progress
+      initial_assessment: Initial assessment
+      not_started: Not started
+      potential_duplicate_in_dqt: Potential duplicate in DQT
+      received: Received
+      requested: Requested
       submitted:
         assessor: Not started
         teacher: Submitted
-      completed: Completed
-      action_required: Action required
-      cannot_start_yet: Cannot start yet
-      potential_duplicate_in_dqt: Potential duplicate in DQT
 
     timeline_entry:
       title:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -126,6 +126,8 @@ en:
         email: Email address
       teacher_interface_qualification_form:
         institution_country_location: Country of institution
+      teacher_interface_reference_request_additional_information_response_form:
+        additional_information_response: Is there anything else you’d like to tell us about this applicant?
       teacher_interface_reference_request_children_response_form:
         children_response_options:
           true: "Yes"

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -126,6 +126,10 @@ en:
         email: Email address
       teacher_interface_qualification_form:
         institution_country_location: Country of institution
+      teacher_interface_reference_request_children_response_form:
+        children_response_options:
+          true: "Yes"
+          false: "No"
       teacher_interface_reference_request_dates_response_form:
         dates_response_options:
           true: "Yes"
@@ -195,6 +199,8 @@ en:
         provider_id: Select your approved provider from the list
       teacher_interface_has_work_history_form:
         has_work_history: Have you worked professionally as a teacher?
+      teacher_interface_reference_request_children_response_form:
+        children_response: Did the applicant work unsupervised with children aged somewhere between 5 and 16 years?
       teacher_interface_reference_request_dates_response_form:
         dates_response: Did the applicant work at the school for the dates they provided?
       teacher_interface_reference_request_hours_response_form:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -126,6 +126,10 @@ en:
         email: Email address
       teacher_interface_qualification_form:
         institution_country_location: Country of institution
+      teacher_interface_reference_request_dates_response_form:
+        dates_response_options:
+          true: "Yes"
+          false: "No"
       teacher_interface_registration_number_form:
         registration_number: What is your registration number?
       teacher_interface_subjects_form:
@@ -187,6 +191,8 @@ en:
         provider_id: Select your approved provider from the list
       teacher_interface_has_work_history_form:
         has_work_history: Have you worked professionally as a teacher?
+      teacher_interface_reference_request_dates_response_form:
+        dates_response: Did the applicant work at the school for the dates they provided?
       teacher_interface_work_history_school_form:
         start_date: When did you start this role?
         still_employed: Are you still employed at this school?

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -138,6 +138,10 @@ en:
         hours_response_options:
           true: "Yes"
           false: "No"
+      teacher_interface_reference_request_lessons_response_form:
+        lessons_response_options:
+          true: "Yes"
+          false: "No"
       teacher_interface_registration_number_form:
         registration_number: What is your registration number?
       teacher_interface_subjects_form:
@@ -207,6 +211,8 @@ en:
         hours_response:
           one: Did they work approximately 1 hour per week in this role?
           other: Did they work approximately %{count} hours per week in this role?
+      teacher_interface_reference_request_lessons_response_form:
+        lessons_response: Was the applicant solely responsible for planning, preparing and delivering lessons to at least 4 students at a time?
       teacher_interface_work_history_school_form:
         start_date: When did you start this role?
         still_employed: Are you still employed at this school?

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -130,6 +130,10 @@ en:
         dates_response_options:
           true: "Yes"
           false: "No"
+      teacher_interface_reference_request_hours_response_form:
+        hours_response_options:
+          true: "Yes"
+          false: "No"
       teacher_interface_registration_number_form:
         registration_number: What is your registration number?
       teacher_interface_subjects_form:
@@ -193,6 +197,10 @@ en:
         has_work_history: Have you worked professionally as a teacher?
       teacher_interface_reference_request_dates_response_form:
         dates_response: Did the applicant work at the school for the dates they provided?
+      teacher_interface_reference_request_hours_response_form:
+        hours_response:
+          one: Did they work approximately 1 hour per week in this role?
+          other: Did they work approximately %{count} hours per week in this role?
       teacher_interface_work_history_school_form:
         start_date: When did you start this role?
         still_employed: Are you still employed at this school?

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -142,6 +142,10 @@ en:
         lessons_response_options:
           true: "Yes"
           false: "No"
+      teacher_interface_reference_request_reports_response_form:
+        reports_response_options:
+          true: "Yes"
+          false: "No"
       teacher_interface_registration_number_form:
         registration_number: What is your registration number?
       teacher_interface_subjects_form:
@@ -213,6 +217,8 @@ en:
           other: Did they work approximately %{count} hours per week in this role?
       teacher_interface_reference_request_lessons_response_form:
         lessons_response: Was the applicant solely responsible for planning, preparing and delivering lessons to at least 4 students at a time?
+      teacher_interface_reference_request_reports_response_form:
+        reports_response: Was the applicant solely responsible for assessing and reporting on the progress of the students?
       teacher_interface_work_history_school_form:
         start_date: When did you start this role?
         still_employed: Are you still employed at this school?

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -48,6 +48,9 @@ en:
           title: Check your answers
         delete:
           title: Delete work history
+    reference_requests:
+      show:
+        title: You’ve been asked to act as a reference
 
   application_form:
     tasks:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -51,6 +51,9 @@ en:
     reference_requests:
       show:
         title: You’ve been asked to act as a reference
+      edit:
+        title: Check your answers
+        reference_requested: Reference requested
 
   application_form:
     tasks:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -265,6 +265,10 @@ en:
           attributes:
             lessons_response:
               inclusion: Tell us whether the applicant was solely responsible for planning, preparing and delivering lessons to at least 4 students at a time
+        teacher_interface/reference_request_reports_response_form:
+          attributes:
+            reports_response:
+              inclusion: Tell us whether the applicant was solely responsible for assessing and reporting on the progress of the students
         teacher_interface/sanction_confirmation_form:
           attributes:
             confirmed_no_sanctions:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -253,6 +253,10 @@ en:
           attributes:
             dates_response:
               inclusion: Tell us whether the applicant worked at the school for the dates they provided
+        teacher_interface/reference_request_hours_response_form:
+          attributes:
+            hours_response:
+              inclusion: Tell us whether the applicant worked at the school for approximately the number of hours per week they provided
         teacher_interface/sanction_confirmation_form:
           attributes:
             confirmed_no_sanctions:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -249,6 +249,10 @@ en:
               invalid: Enter the certificate date in the format 27 3 1980
               future: Certificate date must be in the past
               comparison: Certificate date must be after completion date
+        teacher_interface/reference_request_children_response_form:
+          attributes:
+            children_response:
+              inclusion: Tell us whether the applicant worked unsupervised with children aged somewhere between 5 and 16 years
         teacher_interface/reference_request_dates_response_form:
           attributes:
             dates_response:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -261,6 +261,10 @@ en:
           attributes:
             hours_response:
               inclusion: Tell us whether the applicant worked at the school for approximately the number of hours per week they provided
+        teacher_interface/reference_request_lessons_response_form:
+          attributes:
+            lessons_response:
+              inclusion: Tell us whether the applicant was solely responsible for planning, preparing and delivering lessons to at least 4 students at a time
         teacher_interface/sanction_confirmation_form:
           attributes:
             confirmed_no_sanctions:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -249,6 +249,10 @@ en:
               invalid: Enter the certificate date in the format 27 3 1980
               future: Certificate date must be in the past
               comparison: Certificate date must be after completion date
+        teacher_interface/reference_request_dates_response_form:
+          attributes:
+            dates_response:
+              inclusion: Tell us whether the applicant worked at the school for the dates they provided
         teacher_interface/sanction_confirmation_form:
           attributes:
             confirmed_no_sanctions:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -245,6 +245,11 @@ Rails.application.routes.draw do
                   only: %i[edit update]
       end
     end
+
+    resources :reference_requests,
+              path: "/references",
+              param: :slug,
+              only: %i[show]
   end
 
   devise_for :teachers,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,6 +259,9 @@ Rails.application.routes.draw do
 
         get "children", to: "reference_requests#edit_children"
         post "children", to: "reference_requests#update_children"
+
+        get "lessons", to: "reference_requests#edit_lessons"
+        post "lessons", to: "reference_requests#update_lessons"
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -256,6 +256,9 @@ Rails.application.routes.draw do
 
         get "hours", to: "reference_requests#edit_hours"
         post "hours", to: "reference_requests#update_hours"
+
+        get "children", to: "reference_requests#edit_children"
+        post "children", to: "reference_requests#update_children"
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -249,7 +249,12 @@ Rails.application.routes.draw do
     resources :reference_requests,
               path: "/references",
               param: :slug,
-              only: %i[show edit update]
+              only: %i[show edit update] do
+      member do
+        get "dates", to: "reference_requests#edit_dates"
+        post "dates", to: "reference_requests#update_dates"
+      end
+    end
   end
 
   devise_for :teachers,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -249,7 +249,7 @@ Rails.application.routes.draw do
     resources :reference_requests,
               path: "/references",
               param: :slug,
-              only: %i[show]
+              only: %i[show edit]
   end
 
   devise_for :teachers,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -249,7 +249,7 @@ Rails.application.routes.draw do
     resources :reference_requests,
               path: "/references",
               param: :slug,
-              only: %i[show edit]
+              only: %i[show edit update]
   end
 
   devise_for :teachers,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -262,6 +262,9 @@ Rails.application.routes.draw do
 
         get "lessons", to: "reference_requests#edit_lessons"
         post "lessons", to: "reference_requests#update_lessons"
+
+        get "reports", to: "reference_requests#edit_reports"
+        post "reports", to: "reference_requests#update_reports"
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -265,6 +265,11 @@ Rails.application.routes.draw do
 
         get "reports", to: "reference_requests#edit_reports"
         post "reports", to: "reference_requests#update_reports"
+
+        get "additional-information",
+            to: "reference_requests#edit_additional_information"
+        post "additional-information",
+             to: "reference_requests#update_additional_information"
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -253,6 +253,9 @@ Rails.application.routes.draw do
       member do
         get "dates", to: "reference_requests#edit_dates"
         post "dates", to: "reference_requests#update_dates"
+
+        get "hours", to: "reference_requests#edit_hours"
+        post "hours", to: "reference_requests#update_hours"
       end
     end
   end

--- a/db/migrate/20230105115236_create_reference_request.rb
+++ b/db/migrate/20230105115236_create_reference_request.rb
@@ -1,0 +1,20 @@
+class CreateReferenceRequest < ActiveRecord::Migration[7.0]
+  def change
+    create_table :reference_requests do |t|
+      t.string :slug, null: false
+      t.references :assessment, null: false, foreign_key: true
+      t.references :work_history, null: false, foreign_key: true
+      t.string :state, null: false
+      t.datetime :received_at
+      t.boolean :dates_response
+      t.boolean :hours_response
+      t.boolean :children_response
+      t.boolean :lessons_response
+      t.boolean :reports_response
+      t.text :additional_information_response, null: false, default: ""
+      t.timestamps
+    end
+
+    add_index :reference_requests, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -242,6 +242,25 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_130126) do
     t.index ["application_form_id"], name: "index_qualifications_on_application_form_id"
   end
 
+  create_table "reference_requests", force: :cascade do |t|
+    t.string "slug", null: false
+    t.bigint "assessment_id", null: false
+    t.bigint "work_history_id", null: false
+    t.string "state", null: false
+    t.datetime "received_at"
+    t.boolean "dates_response"
+    t.boolean "hours_response"
+    t.boolean "children_response"
+    t.boolean "lessons_response"
+    t.boolean "reports_response"
+    t.text "additional_information_response", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessment_id"], name: "index_reference_requests_on_assessment_id"
+    t.index ["slug"], name: "index_reference_requests_on_slug", unique: true
+    t.index ["work_history_id"], name: "index_reference_requests_on_work_history_id"
+  end
+
   create_table "regions", force: :cascade do |t|
     t.bigint "country_id", null: false
     t.string "name", default: "", null: false
@@ -415,6 +434,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_130126) do
   add_foreign_key "notes", "application_forms"
   add_foreign_key "notes", "staff", column: "author_id"
   add_foreign_key "qualifications", "application_forms"
+  add_foreign_key "reference_requests", "assessments"
+  add_foreign_key "reference_requests", "work_histories"
   add_foreign_key "regions", "countries"
   add_foreign_key "reminder_emails", "further_information_requests"
   add_foreign_key "selected_failure_reasons", "assessment_sections"

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -31,6 +31,7 @@ namespace :example_data do
     end
 
     TimelineEvent.delete_all
+    ReferenceRequest.delete_all
     FurtherInformationRequest.delete_all
     SelectedFailureReason.delete_all
     AssessmentSection.delete_all
@@ -143,14 +144,23 @@ def create_application_forms(new_regs:)
 
       assessment = AssessmentFactory.call(application_form:)
 
-      next unless application_form.further_information_requested?
-
-      FactoryBot.create(
-        :further_information_request,
-        :requested,
-        :with_items,
-        assessment:,
-      )
+      if application_form.further_information_requested?
+        FactoryBot.create(
+          :further_information_request,
+          :requested,
+          :with_items,
+          assessment:,
+        )
+      elsif (work_history = assessment.application_form.work_histories.first) &&
+            rand(2).zero?
+        reference_request_trait = ReferenceRequest.states.keys.sample
+        FactoryBot.create(
+          :reference_request,
+          reference_request_trait,
+          assessment:,
+          work_history:,
+        )
+      end
     end
   end
 end

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -46,5 +46,16 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :with_reference_request do
+      after(:create) do |assessment, _evaluator|
+        create(
+          :reference_request,
+          :requested,
+          assessment:,
+          work_history: assessment.application_form.work_histories.first,
+        )
+      end
+    end
   end
 end

--- a/spec/factories/reference_requests.rb
+++ b/spec/factories/reference_requests.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reference_requests
+#
+#  id                              :bigint           not null, primary key
+#  additional_information_response :text             default(""), not null
+#  children_response               :boolean
+#  dates_response                  :boolean
+#  hours_response                  :boolean
+#  lessons_response                :boolean
+#  received_at                     :datetime
+#  reports_response                :boolean
+#  slug                            :string           not null
+#  state                           :string           not null
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  assessment_id                   :bigint           not null
+#  work_history_id                 :bigint           not null
+#
+# Indexes
+#
+#  index_reference_requests_on_assessment_id    (assessment_id)
+#  index_reference_requests_on_slug             (slug) UNIQUE
+#  index_reference_requests_on_work_history_id  (work_history_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#  fk_rails_...  (work_history_id => work_histories.id)
+#
+FactoryBot.define do
+  factory :reference_request do
+    slug { Faker::Internet.unique.slug }
+
+    association :assessment
+    association :work_history, :completed
+
+    trait :requested do
+      state { "requested" }
+    end
+
+    trait :received do
+      state { "received" }
+      received_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
+      receivable
+    end
+
+    trait :expired do
+      state { "expired" }
+    end
+
+    trait :receivable do
+      dates_response { Faker::Boolean.boolean }
+      hours_response { Faker::Boolean.boolean }
+      children_response { Faker::Boolean.boolean }
+      lessons_response { Faker::Boolean.boolean }
+      reports_response { Faker::Boolean.boolean }
+      additional_information_response { Faker::Lorem.sentence }
+    end
+
+    trait :responses_invalid do
+      dates_response { false }
+      hours_response { false }
+      children_response { false }
+      lessons_response { false }
+      reports_response { false }
+    end
+
+    trait :responses_valid do
+      dates_response { true }
+      hours_response { true }
+      children_response { true }
+      lessons_response { true }
+      reports_response { true }
+    end
+  end
+end

--- a/spec/forms/teacher_interface/reference_request_additional_information_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_additional_information_response_form_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::ReferenceRequestAdditionalInformationResponseForm,
+               type: :model do
+  let(:reference_request) { create(:reference_request) }
+
+  subject(:form) do
+    described_class.new(reference_request:, additional_information_response:)
+  end
+
+  describe "validations" do
+    let(:additional_information_response) { "" }
+
+    it { is_expected.to validate_presence_of(:reference_request) }
+    it do
+      is_expected.to_not validate_presence_of(:additional_information_response)
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save(validate: true) }
+
+    let(:additional_information_response) { "Some information." }
+
+    it "saves the application form" do
+      expect { save }.to change(
+        reference_request,
+        :additional_information_response,
+      ).to("Some information.")
+    end
+  end
+end

--- a/spec/forms/teacher_interface/reference_request_children_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_children_response_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::ReferenceRequestChildrenResponseForm,
+               type: :model do
+  let(:reference_request) { create(:reference_request) }
+
+  subject(:form) { described_class.new(reference_request:, children_response:) }
+
+  describe "validations" do
+    let(:children_response) { "" }
+
+    it { is_expected.to validate_presence_of(:reference_request) }
+    it { is_expected.to allow_values(true, false).for(:children_response) }
+  end
+
+  describe "#save" do
+    subject(:save) { form.save(validate: true) }
+
+    let(:children_response) { "true" }
+
+    it "saves the application form" do
+      expect { save }.to change(reference_request, :children_response).to(true)
+    end
+  end
+end

--- a/spec/forms/teacher_interface/reference_request_dates_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_dates_response_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::ReferenceRequestDatesResponseForm,
+               type: :model do
+  let(:reference_request) { create(:reference_request) }
+
+  subject(:form) { described_class.new(reference_request:, dates_response:) }
+
+  describe "validations" do
+    let(:dates_response) { "" }
+
+    it { is_expected.to validate_presence_of(:reference_request) }
+    it { is_expected.to allow_values(true, false).for(:dates_response) }
+  end
+
+  describe "#save" do
+    subject(:save) { form.save(validate: true) }
+
+    let(:dates_response) { "true" }
+
+    it "saves the application form" do
+      expect { save }.to change(reference_request, :dates_response).to(true)
+    end
+  end
+end

--- a/spec/forms/teacher_interface/reference_request_hours_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_hours_response_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::ReferenceRequestHoursResponseForm,
+               type: :model do
+  let(:reference_request) { create(:reference_request) }
+
+  subject(:form) { described_class.new(reference_request:, hours_response:) }
+
+  describe "validations" do
+    let(:hours_response) { "" }
+
+    it { is_expected.to validate_presence_of(:reference_request) }
+    it { is_expected.to allow_values(true, false).for(:hours_response) }
+  end
+
+  describe "#save" do
+    subject(:save) { form.save(validate: true) }
+
+    let(:hours_response) { "true" }
+
+    it "saves the application form" do
+      expect { save }.to change(reference_request, :hours_response).to(true)
+    end
+  end
+end

--- a/spec/forms/teacher_interface/reference_request_lessons_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_lessons_response_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::ReferenceRequestLessonsResponseForm,
+               type: :model do
+  let(:reference_request) { create(:reference_request) }
+
+  subject(:form) { described_class.new(reference_request:, lessons_response:) }
+
+  describe "validations" do
+    let(:lessons_response) { "" }
+
+    it { is_expected.to validate_presence_of(:reference_request) }
+    it { is_expected.to allow_values(true, false).for(:lessons_response) }
+  end
+
+  describe "#save" do
+    subject(:save) { form.save(validate: true) }
+
+    let(:lessons_response) { "true" }
+
+    it "saves the application form" do
+      expect { save }.to change(reference_request, :lessons_response).to(true)
+    end
+  end
+end

--- a/spec/forms/teacher_interface/reference_request_reports_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_reports_response_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::ReferenceRequestReportsResponseForm,
+               type: :model do
+  let(:reference_request) { create(:reference_request) }
+
+  subject(:form) { described_class.new(reference_request:, reports_response:) }
+
+  describe "validations" do
+    let(:reports_response) { "" }
+
+    it { is_expected.to validate_presence_of(:reference_request) }
+    it { is_expected.to allow_values(true, false).for(:reports_response) }
+  end
+
+  describe "#save" do
+    subject(:save) { form.save(validate: true) }
+
+    let(:reports_response) { "true" }
+
+    it "saves the application form" do
+      expect { save }.to change(reference_request, :reports_response).to(true)
+    end
+  end
+end

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -22,15 +22,11 @@
 require "rails_helper"
 
 RSpec.describe FurtherInformationRequest do
+  subject(:further_information_request) { build(:further_information_request) }
+
+  it_behaves_like "a requestable"
+
   describe "associations" do
     it { is_expected.to belong_to(:assessment) }
-  end
-
-  it do
-    is_expected.to define_enum_for(:state).with_values(
-      requested: "requested",
-      received: "received",
-      expired: "expired",
-    ).backed_by_column_of_type(:string)
   end
 end

--- a/spec/models/reference_request_spec.rb
+++ b/spec/models/reference_request_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reference_requests
+#
+#  id                              :bigint           not null, primary key
+#  additional_information_response :text             default(""), not null
+#  children_response               :boolean
+#  dates_response                  :boolean
+#  hours_response                  :boolean
+#  lessons_response                :boolean
+#  received_at                     :datetime
+#  reports_response                :boolean
+#  slug                            :string           not null
+#  state                           :string           not null
+#  created_at                      :datetime         not null
+#  updated_at                      :datetime         not null
+#  assessment_id                   :bigint           not null
+#  work_history_id                 :bigint           not null
+#
+# Indexes
+#
+#  index_reference_requests_on_assessment_id    (assessment_id)
+#  index_reference_requests_on_slug             (slug) UNIQUE
+#  index_reference_requests_on_work_history_id  (work_history_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#  fk_rails_...  (work_history_id => work_histories.id)
+#
+require "rails_helper"
+
+RSpec.describe ReferenceRequest do
+  it_behaves_like "a requestable" do
+    subject { build(:reference_request, :receivable) }
+  end
+
+  it { is_expected.to have_secure_token(:slug) }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:assessment) }
+    it { is_expected.to belong_to(:work_history) }
+  end
+
+  describe "validations" do
+    context "when received" do
+      subject { build(:reference_request, :received) }
+
+      it { is_expected.to_not allow_value(nil).for(:dates_response) }
+
+      it { is_expected.to_not allow_value(nil).for(:hours_response) }
+
+      it { is_expected.to_not allow_value(nil).for(:children_response) }
+
+      it { is_expected.to_not allow_value(nil).for(:lessons_response) }
+
+      it { is_expected.to_not allow_value(nil).for(:reports_response) }
+
+      it do
+        is_expected.to_not validate_presence_of(
+          :additional_information_response,
+        )
+      end
+    end
+  end
+
+  describe "#responses_given?" do
+    subject(:responses_given?) { reference_request.responses_given? }
+
+    context "when requested" do
+      let(:reference_request) { build(:reference_request, :requested) }
+      it { is_expected.to be false }
+    end
+
+    context "when requested and all responses given" do
+      let(:reference_request) do
+        build(:reference_request, :requested, :receivable)
+      end
+      it { is_expected.to be true }
+    end
+
+    context "when received" do
+      let(:reference_request) { build(:reference_request, :received) }
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "#responses_valid?" do
+    subject(:responses_valid?) { reference_request.responses_valid? }
+
+    context "when no responses are given" do
+      let(:reference_request) { build(:reference_request) }
+      it { is_expected.to be false }
+    end
+
+    context "when all responses are valid" do
+      let(:reference_request) { build(:reference_request, :responses_valid) }
+      it { is_expected.to be true }
+    end
+
+    context "when all responses are invalid" do
+      let(:reference_request) { build(:reference_request, :responses_invalid) }
+      it { is_expected.to be false }
+    end
+  end
+end

--- a/spec/services/destroy_application_form_spec.rb
+++ b/spec/services/destroy_application_form_spec.rb
@@ -17,10 +17,13 @@ RSpec.describe DestroyApplicationForm do
         create(
           :assessment,
           :with_further_information_request,
+          :with_reference_request,
           application_form:,
         )
+
       assessment_section =
         create(:assessment_section, :personal_information, assessment:)
+
       create(:selected_failure_reason, assessment_section:)
     end
   end
@@ -42,6 +45,7 @@ RSpec.describe DestroyApplicationForm do
   include_examples "deletes model", Document, 14, 7
   include_examples "deletes model", FurtherInformationRequest
   include_examples "deletes model", FurtherInformationRequestItem, 4, 2
+  include_examples "deletes model", ReferenceRequest
   include_examples "deletes model", Note
   include_examples "deletes model", Qualification
   include_examples "deletes model", Teacher

--- a/spec/support/autoload/page_objects/personas.rb
+++ b/spec/support/autoload/page_objects/personas.rb
@@ -13,5 +13,10 @@ module PageObjects
       element :heading, "h2"
       elements :buttons, ".govuk-button"
     end
+
+    section :references, "#app-personas-references" do
+      element :heading, "h2"
+      elements :buttons, ".govuk-button"
+    end
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/check_reference_request_answers.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/check_reference_request_answers.rb
@@ -6,6 +6,7 @@ module PageObjects
       set_url "/teacher/references/{slug}/edit"
 
       section :summary_list, GovukSummaryList, ".govuk-summary-list"
+      element :submit_button, ".govuk-button"
     end
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/check_reference_request_answers.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/check_reference_request_answers.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class CheckReferenceRequestAnswers < SitePrism::Page
+      set_url "/teacher/references/{slug}/edit"
+
+      section :summary_list, GovukSummaryList, ".govuk-summary-list"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_additional_information.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_additional_information.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class EditReferenceRequestAdditionalInformation < SitePrism::Page
+      set_url "/teacher/references/{slug}/additional-information"
+
+      section :form, "form" do
+        element :additional_information_textarea, ".govuk-textarea"
+        element :continue_button, ".govuk-button"
+      end
+
+      def submit(additional_information:)
+        form.additional_information_textarea.fill_in with:
+          additional_information
+        form.continue_button.click
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_children.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_children.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class EditReferenceRequestChildren < ReferenceRequestQuestionForm
+      set_url "/teacher/references/{slug}/children"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_dates.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_dates.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class EditReferenceRequestDates < ReferenceRequestQuestionForm
+      set_url "/teacher/references/{slug}/dates"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_hours.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_hours.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class EditReferenceRequestHours < ReferenceRequestQuestionForm
+      set_url "/teacher/references/{slug}/hours"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_lessons.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_lessons.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class EditReferenceRequestLessons < ReferenceRequestQuestionForm
+      set_url "/teacher/references/{slug}/lessons"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_reports.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_reports.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class EditReferenceRequestReports < ReferenceRequestQuestionForm
+      set_url "/teacher/references/{slug}/reports"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/reference_received.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/reference_received.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class ReferenceReceived < SitePrism::Page
+      set_url "/teacher/references/{slug}"
+
+      element :confirmation_panel, ".govuk-panel"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/reference_request_question_form.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/reference_request_question_form.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class ReferenceRequestQuestionForm < SitePrism::Page
+      section :form, "form" do
+        section :yes_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(1)"
+        section :no_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(2)"
+
+        element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
+      end
+
+      def submit_yes
+        form.yes_radio_item.choose
+        form.continue_button.click
+      end
+
+      def submit_no
+        form.no_radio_item.choose
+        form.continue_button.click
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/reference_requested.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/reference_requested.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class ReferenceRequested < SitePrism::Page
+      set_url "/teacher/references/{slug}"
+
+      element :work_history_details, ".govuk-inset-text p"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/reference_requested.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/reference_requested.rb
@@ -6,6 +6,7 @@ module PageObjects
       set_url "/teacher/references/{slug}"
 
       element :work_history_details, ".govuk-inset-text p"
+      element :start_button, ".govuk-button"
     end
   end
 end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -200,6 +200,11 @@ module PageHelpers
       PageObjects::TeacherInterface::CheckQualifications.new
   end
 
+  def teacher_check_reference_request_answers_page
+    @teacher_check_reference_request_answers_page ||=
+      PageObjects::TeacherInterface::CheckReferenceRequestAnswers.new
+  end
+
   def teacher_check_work_history_page
     @teacher_check_work_history_page ||=
       PageObjects::TeacherInterface::CheckWorkHistory.new

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -233,6 +233,11 @@ module PageHelpers
       PageObjects::TeacherInterface::DeleteWorkHistory.new
   end
 
+  def teacher_edit_reference_request_children_page
+    @teacher_edit_reference_request_children_page ||=
+      PageObjects::TeacherInterface::EditReferenceRequestChildren.new
+  end
+
   def teacher_edit_reference_request_dates_page
     @teacher_edit_reference_request_dates_page ||=
       PageObjects::TeacherInterface::EditReferenceRequestDates.new

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -248,6 +248,11 @@ module PageHelpers
       PageObjects::TeacherInterface::EditReferenceRequestHours.new
   end
 
+  def teacher_edit_reference_request_lessons_page
+    @teacher_edit_reference_request_lessons_page ||=
+      PageObjects::TeacherInterface::EditReferenceRequestLessons.new
+  end
+
   def teacher_edit_work_history_contact_page
     @teacher_edit_work_history_contact_page ||=
       PageObjects::TeacherInterface::EditWorkHistoryContact.new

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -238,6 +238,11 @@ module PageHelpers
       PageObjects::TeacherInterface::EditReferenceRequestDates.new
   end
 
+  def teacher_edit_reference_request_hours_page
+    @teacher_edit_reference_request_hours_page ||=
+      PageObjects::TeacherInterface::EditReferenceRequestHours.new
+  end
+
   def teacher_edit_work_history_contact_page
     @teacher_edit_work_history_contact_page ||=
       PageObjects::TeacherInterface::EditWorkHistoryContact.new

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -233,6 +233,11 @@ module PageHelpers
       PageObjects::TeacherInterface::DeleteWorkHistory.new
   end
 
+  def teacher_edit_reference_request_additional_information_page
+    @teacher_edit_reference_request_additional_information_page ||=
+      PageObjects::TeacherInterface::EditReferenceRequestAdditionalInformation.new
+  end
+
   def teacher_edit_reference_request_children_page
     @teacher_edit_reference_request_children_page ||=
       PageObjects::TeacherInterface::EditReferenceRequestChildren.new

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -253,6 +253,11 @@ module PageHelpers
       PageObjects::TeacherInterface::EditReferenceRequestLessons.new
   end
 
+  def teacher_edit_reference_request_reports_page
+    @teacher_edit_reference_request_reports_page ||=
+      PageObjects::TeacherInterface::EditReferenceRequestReports.new
+  end
+
   def teacher_edit_work_history_contact_page
     @teacher_edit_work_history_contact_page ||=
       PageObjects::TeacherInterface::EditWorkHistoryContact.new

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -268,6 +268,16 @@ module PageHelpers
       PageObjects::TeacherInterface::NewWorkHistory.new
   end
 
+  def teacher_reference_received_page
+    @teacher_reference_received_page ||=
+      PageObjects::TeacherInterface::ReferenceReceived.new
+  end
+
+  def teacher_reference_requested_page
+    @teacher_reference_requested_page ||=
+      PageObjects::TeacherInterface::ReferenceRequested.new
+  end
+
   def teacher_retry_otp_page
     @teacher_retry_otp_page = PageObjects::TeacherInterface::RetryOtp.new
   end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -233,6 +233,11 @@ module PageHelpers
       PageObjects::TeacherInterface::DeleteWorkHistory.new
   end
 
+  def teacher_edit_reference_request_dates_page
+    @teacher_edit_reference_request_dates_page ||=
+      PageObjects::TeacherInterface::EditReferenceRequestDates.new
+  end
+
   def teacher_edit_work_history_contact_page
     @teacher_edit_work_history_contact_page ||=
       PageObjects::TeacherInterface::EditWorkHistoryContact.new

--- a/spec/support/shared_examples/requestable.rb
+++ b/spec/support/shared_examples/requestable.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a requestable" do
+  it do
+    is_expected.to define_enum_for(:state).with_values(
+      requested: "requested",
+      received: "received",
+      expired: "expired",
+    ).backed_by_column_of_type(:string)
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:state) }
+
+    it { is_expected.to_not validate_presence_of(:received_at) }
+
+    context "when received" do
+      before { subject.state = "received" }
+
+      it { is_expected.to validate_presence_of(:received_at) }
+    end
+  end
+
+  describe "#received!" do
+    let(:call) { subject.received! }
+
+    it "changes the state" do
+      expect { call }.to change(subject, :received?).from(false).to(true)
+    end
+
+    it "sets the received at date" do
+      freeze_time do
+        expect { call }.to change(subject, :received_at).from(nil).to(
+          Time.zone.now,
+        )
+      end
+    end
+  end
+end

--- a/spec/system/personas_spec.rb
+++ b/spec/system/personas_spec.rb
@@ -27,7 +27,12 @@ RSpec.describe "Personas", type: :system do
       when_i_visit_the(:personas_page)
 
       when_i_sign_in_as_a_teacher_persona
-      then_i_see_the_teacher_application_form_page
+      then_i_see_the(:teacher_application_page)
+
+      when_i_visit_the(:personas_page)
+
+      when_i_sign_in_as_a_reference_persona
+      then_i_see_the(:teacher_reference_requested_page)
     end
   end
 
@@ -54,6 +59,8 @@ RSpec.describe "Personas", type: :system do
 
     teacher = create(:teacher, email: "teacher@example.com")
     create(:application_form, teacher:)
+
+    create(:reference_request, :requested)
   end
 
   def when_i_sign_in_as_a_staff_persona
@@ -62,6 +69,10 @@ RSpec.describe "Personas", type: :system do
 
   def when_i_sign_in_as_a_teacher_persona
     personas_page.teachers.buttons.first.click
+  end
+
+  def when_i_sign_in_as_a_reference_persona
+    personas_page.references.buttons.first.click
   end
 
   def and_i_see_no_personas
@@ -76,10 +87,5 @@ RSpec.describe "Personas", type: :system do
 
   def and_i_see_the_feature_disabled_message
     expect(personas_page).to have_content("Personas feature not active.")
-  end
-
-  def then_i_see_the_teacher_application_form_page
-    expect(page).to have_content("Application incomplete")
-    expect(page).to have_content("You have completed 0 of 3 sections.")
   end
 end

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe "Teacher reference", type: :system do
     then_i_see_the(:teacher_check_reference_request_answers_page, slug:)
     and_i_see_the_answers
 
-    reference_request.update!(state: "received", received_at: Time.zone.now)
-
-    when_i_visit_the(:teacher_reference_received_page, slug:)
+    when_i_submit_the_response
     then_i_see_the(:teacher_reference_received_page, slug:)
     and_i_see_the_confirmation_panel
   end
@@ -46,6 +44,10 @@ RSpec.describe "Teacher reference", type: :system do
     expect(
       teacher_check_reference_request_answers_page.summary_list,
     ).to be_visible
+  end
+
+  def when_i_submit_the_response
+    teacher_check_reference_request_answers_page.submit_button.click
   end
 
   def and_i_see_the_confirmation_panel

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -13,8 +13,6 @@ RSpec.describe "Teacher reference", type: :system do
     then_i_see_the(:teacher_reference_requested_page, slug:)
     and_i_see_the_work_history_details
 
-    reference_request.update!(reports_response: true)
-
     when_i_click_start_now
     then_i_see_the(:teacher_edit_reference_request_dates_page, slug:)
 
@@ -28,6 +26,9 @@ RSpec.describe "Teacher reference", type: :system do
     then_i_see_the(:teacher_edit_reference_request_lessons_page, slug:)
 
     when_i_choose_yes_for_lessons
+    then_i_see_the(:teacher_edit_reference_request_reports_page, slug:)
+
+    when_i_choose_yes_for_reports
     then_i_see_the(:teacher_check_reference_request_answers_page, slug:)
     and_i_see_the_answers
 
@@ -66,6 +67,10 @@ RSpec.describe "Teacher reference", type: :system do
     teacher_edit_reference_request_lessons_page.submit_yes
   end
 
+  def when_i_choose_yes_for_reports
+    teacher_edit_reference_request_reports_page.submit_yes
+  end
+
   def and_i_see_the_answers
     summary_list = teacher_check_reference_request_answers_page.summary_list
 
@@ -91,6 +96,12 @@ RSpec.describe "Teacher reference", type: :system do
         " to at least 4 students at a time?",
     )
     expect(summary_list.rows.fourth.value.text).to eq("Yes")
+
+    expect(summary_list.rows.fifth.key.text).to eq(
+      "Was the applicant solely responsible for assessing and reporting on the progress of" \
+        " the students?",
+    )
+    expect(summary_list.rows.fifth.value.text).to eq("Yes")
   end
 
   def when_i_submit_the_response

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -13,11 +13,7 @@ RSpec.describe "Teacher reference", type: :system do
     then_i_see_the(:teacher_reference_requested_page, slug:)
     and_i_see_the_work_history_details
 
-    reference_request.update!(
-      children_response: true,
-      lessons_response: true,
-      reports_response: true,
-    )
+    reference_request.update!(lessons_response: true, reports_response: true)
 
     when_i_click_start_now
     then_i_see_the(:teacher_edit_reference_request_dates_page, slug:)
@@ -26,6 +22,9 @@ RSpec.describe "Teacher reference", type: :system do
     then_i_see_the(:teacher_edit_reference_request_hours_page, slug:)
 
     when_i_choose_yes_for_hours
+    then_i_see_the(:teacher_edit_reference_request_children_page, slug:)
+
+    when_i_choose_yes_for_children
     then_i_see_the(:teacher_check_reference_request_answers_page, slug:)
     and_i_see_the_answers
 
@@ -53,7 +52,11 @@ RSpec.describe "Teacher reference", type: :system do
   end
 
   def when_i_choose_yes_for_hours
-    teacher_edit_reference_request_dates_page.submit_yes
+    teacher_edit_reference_request_hours_page.submit_yes
+  end
+
+  def when_i_choose_yes_for_children
+    teacher_edit_reference_request_children_page.submit_yes
   end
 
   def and_i_see_the_answers
@@ -70,6 +73,11 @@ RSpec.describe "Teacher reference", type: :system do
       "Did they work approximately 30 hours per week in this role?",
     )
     expect(summary_list.rows.second.value.text).to eq("Yes")
+
+    expect(summary_list.rows.third.key.text).to eq(
+      "Did the applicant work unsupervised with children aged somewhere between 5 and 16 years?",
+    )
+    expect(summary_list.rows.third.value.text).to eq("Yes")
   end
 
   def when_i_submit_the_response

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Teacher reference", type: :system do
+  before do
+    given_the_service_is_open
+    given_there_is_a_reference_request
+  end
+
+  it "allows filling in the reference" do
+    when_i_visit_the(:teacher_reference_requested_page, slug:)
+    then_i_see_the(:teacher_reference_requested_page, slug:)
+    and_i_see_the_work_history_details
+
+    reference_request.update!(
+      state: "received",
+      received_at: Time.zone.now,
+      dates_response: true,
+      hours_response: true,
+      children_response: true,
+      lessons_response: true,
+      reports_response: true,
+    )
+
+    when_i_visit_the(:teacher_reference_received_page, slug:)
+    then_i_see_the(:teacher_reference_received_page, slug:)
+    and_i_see_the_confirmation_panel
+  end
+
+  def given_there_is_a_reference_request
+    reference_request
+  end
+
+  def and_i_see_the_work_history_details
+    expect(teacher_reference_requested_page.work_history_details.text).to eq(
+      "School from January 2020 to January 2023",
+    )
+  end
+
+  def and_i_see_the_confirmation_panel
+    expect(teacher_reference_received_page.confirmation_panel).to be_visible
+  end
+
+  def reference_request
+    @reference_request ||= create(:reference_request, :requested)
+  end
+
+  delegate :slug, to: :reference_request
+end

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe "Teacher reference", type: :system do
     then_i_see_the(:teacher_edit_reference_request_reports_page, slug:)
 
     when_i_choose_yes_for_reports
+    then_i_see_the(
+      :teacher_edit_reference_request_additional_information_page,
+      slug:,
+    )
+
+    when_i_fill_in_additional_information
     then_i_see_the(:teacher_check_reference_request_answers_page, slug:)
     and_i_see_the_answers
 
@@ -71,37 +77,48 @@ RSpec.describe "Teacher reference", type: :system do
     teacher_edit_reference_request_reports_page.submit_yes
   end
 
+  def when_i_fill_in_additional_information
+    teacher_edit_reference_request_additional_information_page.submit(
+      additional_information: "Some information.",
+    )
+  end
+
   def and_i_see_the_answers
     summary_list = teacher_check_reference_request_answers_page.summary_list
 
     expect(summary_list).to be_visible
 
-    expect(summary_list.rows.first.key.text).to eq(
+    expect(summary_list.rows[0].key.text).to eq(
       "Did the applicant work at the school for the dates they provided?",
     )
-    expect(summary_list.rows.first.value.text).to eq("Yes")
+    expect(summary_list.rows[0].value.text).to eq("Yes")
 
-    expect(summary_list.rows.second.key.text).to eq(
+    expect(summary_list.rows[1].key.text).to eq(
       "Did they work approximately 30 hours per week in this role?",
     )
-    expect(summary_list.rows.second.value.text).to eq("Yes")
+    expect(summary_list.rows[1].value.text).to eq("Yes")
 
-    expect(summary_list.rows.third.key.text).to eq(
+    expect(summary_list.rows[2].key.text).to eq(
       "Did the applicant work unsupervised with children aged somewhere between 5 and 16 years?",
     )
-    expect(summary_list.rows.third.value.text).to eq("Yes")
+    expect(summary_list.rows[2].value.text).to eq("Yes")
 
-    expect(summary_list.rows.fourth.key.text).to eq(
+    expect(summary_list.rows[3].key.text).to eq(
       "Was the applicant solely responsible for planning, preparing and delivering lessons" \
         " to at least 4 students at a time?",
     )
-    expect(summary_list.rows.fourth.value.text).to eq("Yes")
+    expect(summary_list.rows[3].value.text).to eq("Yes")
 
-    expect(summary_list.rows.fifth.key.text).to eq(
+    expect(summary_list.rows[4].key.text).to eq(
       "Was the applicant solely responsible for assessing and reporting on the progress of" \
         " the students?",
     )
-    expect(summary_list.rows.fifth.value.text).to eq("Yes")
+    expect(summary_list.rows[4].value.text).to eq("Yes")
+
+    expect(summary_list.rows[5].key.text).to eq(
+      "Is there anything else you’d like to tell us about this applicant?",
+    )
+    expect(summary_list.rows[5].value.text).to eq("Some information.")
   end
 
   def when_i_submit_the_response

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -14,14 +14,16 @@ RSpec.describe "Teacher reference", type: :system do
     and_i_see_the_work_history_details
 
     reference_request.update!(
-      dates_response: true,
       hours_response: true,
       children_response: true,
       lessons_response: true,
       reports_response: true,
     )
 
-    when_i_visit_the(:teacher_check_reference_request_answers_page, slug:)
+    when_i_click_start_now
+    then_i_see_the(:teacher_edit_reference_request_dates_page, slug:)
+
+    when_i_choose_yes_for_dates
     then_i_see_the(:teacher_check_reference_request_answers_page, slug:)
     and_i_see_the_answers
 
@@ -40,10 +42,23 @@ RSpec.describe "Teacher reference", type: :system do
     )
   end
 
+  def when_i_click_start_now
+    teacher_reference_requested_page.start_button.click
+  end
+
+  def when_i_choose_yes_for_dates
+    teacher_edit_reference_request_dates_page.submit_yes
+  end
+
   def and_i_see_the_answers
-    expect(
-      teacher_check_reference_request_answers_page.summary_list,
-    ).to be_visible
+    summary_list = teacher_check_reference_request_answers_page.summary_list
+
+    expect(summary_list).to be_visible
+
+    expect(summary_list.rows.first.key.text).to eq(
+      "Did the applicant work at the school for the dates they provided?",
+    )
+    expect(summary_list.rows.first.value.text).to eq("Yes")
   end
 
   def when_i_submit_the_response

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Teacher reference", type: :system do
     then_i_see_the(:teacher_reference_requested_page, slug:)
     and_i_see_the_work_history_details
 
-    reference_request.update!(lessons_response: true, reports_response: true)
+    reference_request.update!(reports_response: true)
 
     when_i_click_start_now
     then_i_see_the(:teacher_edit_reference_request_dates_page, slug:)
@@ -25,6 +25,9 @@ RSpec.describe "Teacher reference", type: :system do
     then_i_see_the(:teacher_edit_reference_request_children_page, slug:)
 
     when_i_choose_yes_for_children
+    then_i_see_the(:teacher_edit_reference_request_lessons_page, slug:)
+
+    when_i_choose_yes_for_lessons
     then_i_see_the(:teacher_check_reference_request_answers_page, slug:)
     and_i_see_the_answers
 
@@ -59,6 +62,10 @@ RSpec.describe "Teacher reference", type: :system do
     teacher_edit_reference_request_children_page.submit_yes
   end
 
+  def when_i_choose_yes_for_lessons
+    teacher_edit_reference_request_lessons_page.submit_yes
+  end
+
   def and_i_see_the_answers
     summary_list = teacher_check_reference_request_answers_page.summary_list
 
@@ -78,6 +85,12 @@ RSpec.describe "Teacher reference", type: :system do
       "Did the applicant work unsupervised with children aged somewhere between 5 and 16 years?",
     )
     expect(summary_list.rows.third.value.text).to eq("Yes")
+
+    expect(summary_list.rows.fourth.key.text).to eq(
+      "Was the applicant solely responsible for planning, preparing and delivering lessons" \
+        " to at least 4 students at a time?",
+    )
+    expect(summary_list.rows.fourth.value.text).to eq("Yes")
   end
 
   def when_i_submit_the_response

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe "Teacher reference", type: :system do
     and_i_see_the_work_history_details
 
     reference_request.update!(
-      hours_response: true,
       children_response: true,
       lessons_response: true,
       reports_response: true,
@@ -24,6 +23,9 @@ RSpec.describe "Teacher reference", type: :system do
     then_i_see_the(:teacher_edit_reference_request_dates_page, slug:)
 
     when_i_choose_yes_for_dates
+    then_i_see_the(:teacher_edit_reference_request_hours_page, slug:)
+
+    when_i_choose_yes_for_hours
     then_i_see_the(:teacher_check_reference_request_answers_page, slug:)
     and_i_see_the_answers
 
@@ -50,6 +52,10 @@ RSpec.describe "Teacher reference", type: :system do
     teacher_edit_reference_request_dates_page.submit_yes
   end
 
+  def when_i_choose_yes_for_hours
+    teacher_edit_reference_request_dates_page.submit_yes
+  end
+
   def and_i_see_the_answers
     summary_list = teacher_check_reference_request_answers_page.summary_list
 
@@ -59,6 +65,11 @@ RSpec.describe "Teacher reference", type: :system do
       "Did the applicant work at the school for the dates they provided?",
     )
     expect(summary_list.rows.first.value.text).to eq("Yes")
+
+    expect(summary_list.rows.second.key.text).to eq(
+      "Did they work approximately 30 hours per week in this role?",
+    )
+    expect(summary_list.rows.second.value.text).to eq("Yes")
   end
 
   def when_i_submit_the_response

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -14,14 +14,18 @@ RSpec.describe "Teacher reference", type: :system do
     and_i_see_the_work_history_details
 
     reference_request.update!(
-      state: "received",
-      received_at: Time.zone.now,
       dates_response: true,
       hours_response: true,
       children_response: true,
       lessons_response: true,
       reports_response: true,
     )
+
+    when_i_visit_the(:teacher_check_reference_request_answers_page, slug:)
+    then_i_see_the(:teacher_check_reference_request_answers_page, slug:)
+    and_i_see_the_answers
+
+    reference_request.update!(state: "received", received_at: Time.zone.now)
 
     when_i_visit_the(:teacher_reference_received_page, slug:)
     then_i_see_the(:teacher_reference_received_page, slug:)
@@ -36,6 +40,12 @@ RSpec.describe "Teacher reference", type: :system do
     expect(teacher_reference_requested_page.work_history_details.text).to eq(
       "School from January 2020 to January 2023",
     )
+  end
+
+  def and_i_see_the_answers
+    expect(
+      teacher_check_reference_request_answers_page.summary_list,
+    ).to be_visible
   end
 
   def and_i_see_the_confirmation_panel


### PR DESCRIPTION
This implements the flow that referees will use when they are responding to a reference request for an item of work history. I've also added them to the example data and personas page so they're easy to test (and done some further improvements to that page).

Prototype: https://trello.com/c/CmHkbdrZ/1315-build-work-history-referee-answer-flow

[Trello Card](https://trello.com/c/CmHkbdrZ/1315-build-work-history-referee-answer-flow)

## Screenshots

<img width="675" alt="Screenshot 2023-01-06 at 15 56 04" src="https://user-images.githubusercontent.com/510498/211049231-5df13755-93dc-428d-ab77-38cbe70541f2.png">
<img width="653" alt="Screenshot 2023-01-06 at 15 56 09" src="https://user-images.githubusercontent.com/510498/211049282-afa9e63f-9873-49cc-9dd1-e0f334a3aa87.png">
<img width="730" alt="Screenshot 2023-01-06 at 15 56 12" src="https://user-images.githubusercontent.com/510498/211049297-8516fd27-2611-4e97-9cff-6514c47bd6b3.png">
<img width="679" alt="Screenshot 2023-01-06 at 15 56 16" src="https://user-images.githubusercontent.com/510498/211049321-49792271-f4b9-4483-8f2d-ead431c4bc49.png">
<img width="694" alt="Screenshot 2023-01-06 at 15 57 02" src="https://user-images.githubusercontent.com/510498/211049342-aea7a136-0478-4639-b504-3ae70b810d2e.png">
<img width="641" alt="Screenshot 2023-01-06 at 15 57 06" src="https://user-images.githubusercontent.com/510498/211049362-2915646e-335c-41f9-9c23-9912b5d9cf0b.png">
<img width="705" alt="Screenshot 2023-01-06 at 15 57 11" src="https://user-images.githubusercontent.com/510498/211049373-73d35cc1-bdcf-42eb-abfe-256fbc44f16e.png">
<img width="650" alt="Screenshot 2023-01-06 at 15 57 15" src="https://user-images.githubusercontent.com/510498/211049379-c84e8ae7-01ed-4e94-9936-1a8ad555dbfc.png">
<img width="690" alt="Screenshot 2023-01-06 at 15 57 20" src="https://user-images.githubusercontent.com/510498/211049384-68ff9b17-5a7f-4a4d-aea0-0fa404ced86b.png">
<img width="648" alt="Screenshot 2023-01-06 at 15 57 24" src="https://user-images.githubusercontent.com/510498/211049396-d1867062-0723-45bd-a7fd-6a8f08ff6c9b.png">
<img width="687" alt="Screenshot 2023-01-06 at 15 57 28" src="https://user-images.githubusercontent.com/510498/211049400-d2f3644e-a4da-420e-9659-afff6c3250b7.png">
<img width="724" alt="Screenshot 2023-01-06 at 15 57 33" src="https://user-images.githubusercontent.com/510498/211049412-865df4cc-728e-4a13-af8b-a56a8cca4b83.png">
<img width="702" alt="Screenshot 2023-01-06 at 15 57 46" src="https://user-images.githubusercontent.com/510498/211049416-43141ed2-d784-46ca-9d87-af1cf08979ba.png">
<img width="708" alt="Screenshot 2023-01-06 at 15 57 52" src="https://user-images.githubusercontent.com/510498/211049434-0ffba37c-040e-4ff2-b61c-f1062e07135e.png">
<img width="694" alt="Screenshot 2023-01-06 at 15 57 57" src="https://user-images.githubusercontent.com/510498/211049444-adcea706-3d89-4117-bd1b-e29a70046710.png">
