### PR TITLE
Add a task to delete draft applications

### DIFF
--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -1,0 +1,18 @@
+namespace :application_forms do
+  desc "Delete all draft application forms."
+  task delete_drafts: :environment do
+    puts "This task is destructive! Are you sure you want to continue?"
+    $stdin.gets.chomp
+
+    original_count = ApplicationForm.count
+
+    ApplicationForm.draft.each do |application_form|
+      DestroyApplicationForm.call(application_form:)
+    end
+
+    new_count = ApplicationForm.count
+
+    puts "There were #{original_count} draft applications and there are now #{new_count}."
+    puts "There are #{ApplicationForm.count} applications overall."
+  end
+end


### PR DESCRIPTION
We'll need this task on the 1st February to delete all the existing draft applications before the new regulations come in to place.