### PR TITLE
Remove alternative_reference_email_address

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -139,7 +139,6 @@ class AssessmentFactory
       if under_new_regs
         [
           FailureReasons::WORK_HISTORY_BREAK,
-          FailureReasons::ALTERNATIVE_REFERENCE_EMAIL_ADDRESS,
           FailureReasons::SCHOOL_DETAILS_CANNOT_BE_VERIFIED,
         ]
       else

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -24,7 +24,6 @@ class FailureReasons
       "additional_degree_certificate_illegible",
     ADDITIONAL_DEGREE_TRANSCRIPT_ILLEGIBLE =
       "additional_degree_transcript_illegible",
-    ALTERNATIVE_REFERENCE_EMAIL_ADDRESS = "alternative_reference_email_address",
     APPLICANT_ALREADY_DQT = "applicant_already_dqt",
     APPLICATION_AND_QUALIFICATION_NAMES_DO_NOT_MATCH =
       "application_and_qualification_names_do_not_match",

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -106,7 +106,6 @@ en:
           additional_degree_certificate_illegible: An additional degree certificate (or translation) is illegible or in a format that we cannot accept.
           additional_degree_transcript_illegible: An additional degree transcript (or translation) is illegible or in a format that we cannot accept.
           age_range: The age range the applicant is qualified to teach does not fall within the requirements of QTS.
-          alternative_reference_email_address: We need to query whether the applicant can provide an alternative email address, for example, where the address provided uses a web-based service, such as Gmail.com.
           applicant_already_dqt: There’s a potential existing match for this applicant. We need to ask for an additional identifier.
           applicant_already_qts: The applicant already holds QTS and induction exemption.
           application_and_qualification_names_do_not_match: The name on the online application form is different from 1 or more qualification documents, but no evidence of change of name was provided.
@@ -175,8 +174,6 @@ en:
             additional_degree_transcript_illegible_notes:
               blank: Enter a note to the applicant
             age_range_notes:
-              blank: Enter a note to the applicant
-            alternative_reference_email_address_notes:
               blank: Enter a note to the applicant
             applicant_already_dqt_notes:
               blank: Enter a note to the applicant

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -30,7 +30,6 @@ en:
       show:
         failure_reason:
           age_range: Tell us more about the age range you can teach
-          alternative_reference_email_address: Provide an alternative email address for this reference
           applicant_already_dqt: Additional personal information
           qualifications_dont_match_other_details: Tell us more about your qualifications
           qualifications_dont_match_subjects: Tell us more about the subjects you can teach

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -222,11 +222,7 @@ RSpec.describe AssessmentFactory do
             )
 
             expect(section.failure_reasons).to eq(
-              %w[
-                work_history_break
-                alternative_reference_email_address
-                school_details_cannot_be_verified
-              ],
+              %w[work_history_break school_details_cannot_be_verified],
             )
           end
         end


### PR DESCRIPTION
This is a failure reason which we have decided to remove for now as we have no means of changing the contact email address for the reference emails that are automatically sent out.