### PR TITLE
Remove more when resetting example data

### DIFF
--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -31,6 +31,8 @@ namespace :example_data do
     end
 
     TimelineEvent.delete_all
+    DQTTRNRequest.delete_all
+    ReminderEmail.delete_all
     ReferenceRequest.delete_all
     FurtherInformationRequest.delete_all
     SelectedFailureReason.delete_all


### PR DESCRIPTION
We need to delete these otherwise there are potential foreign key constraints which prevent the later models from being deleted.