### PR TITLE
Add postgres to asdf .tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,6 @@
 azure-cli 2.37.0
 nodejs 18.1.0
+postgres 13.5
 ruby 3.1.2
 terraform 1.0.10
 yarn 1.22.19

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install dependencies using your preferred method, using `asdf` or `rbenv` or
 # The first time
 brew install asdf # Mac-specific
 asdf plugin add ruby
+asdf plugin add postgres # Unless you are managing postgres yourself
 asdf plugin add nodejs
 asdf plugin add yarn
 asdf plugin add terraform
@@ -75,12 +76,20 @@ brew install libvips
 
 #### PostgreSQL
 
-You’ll need to install PostgreSQL 13.x. The way to do this is different on each operating system, but on macOS you can try the following:
+You’ll need to install PostgreSQL 13.x. This can be installed via `asdf`, otherwise the way to do this is different on each operating system.
+
+On macOS you can try the following:
 
 ```bash
 brew install postgresql@13
 # Add to utilities to the path
 echo 'export PATH="/opt/homebrew/opt/postgresql@13/bin:$PATH"' >> ~/.zshrc
+```
+
+Start `postgres` database service if installed via `asdf`:
+
+```sh
+pg_ctl start
 ```
 
 Set up the `postgres` user if it doesn't exist:


### PR DESCRIPTION
It's possible to install and manage `postgres` using `asdf`. We do this on many other DFE/TRA projects.

- Add `postgres` to `.tool-versions`
- Document option to install via `asdf` or manage as system dependency.