### PR TITLE
Remove retry_on calls

### DIFF
--- a/app/jobs/update_dqt_trn_request_job.rb
+++ b/app/jobs/update_dqt_trn_request_job.rb
@@ -4,10 +4,6 @@ class UpdateDQTTRNRequestJob < ApplicationJob
   class StillPending < StandardError
   end
 
-  sidekiq_options retry: false
-  retry_on Faraday::Error, wait: :exponentially_longer, attempts: 3
-  retry_on StillPending, wait: 30.minutes, attempts: 7 * 24 * 2 # 1 week
-
   def perform(dqt_trn_request)
     return if dqt_trn_request.complete?
 


### PR DESCRIPTION
It looks like the jobs aren't retrying and the theory at the moment is that Sidekiq and ActiveJob are conflicting, so we're going to take out the `retry_on` method calls and instead fall back to the default Sidekiq behaviour and see if we start to see jobs retrying.

I suspect this change will start reporting errors to Sentry whenever a retry occurs, but we can filter them out if we see that.

[Trello Card](https://trello.com/c/pepHeyNp/1336-investigate-jobs-not-retrying)