### PR TITLE
Fix continue link on work history check your answers page

### DIFF
--- a/app/views/teacher_interface/new_regs/work_histories/check_member.html.erb
+++ b/app/views/teacher_interface/new_regs/work_histories/check_member.html.erb
@@ -9,7 +9,7 @@
            changeable: true %>
 
 <% if @next_work_history %>
-  <%= govuk_button_link_to "Continue", [:school, :teacher_interface, :application_form, @next_work_history] %>
+  <%= govuk_button_link_to "Continue", [:school, :teacher_interface, :application_form, :new_regs, @next_work_history] %>
 <% else %>
   <%= govuk_button_link_to "Continue", %i[add_another teacher_interface application_form new_regs work_histories] %>
 <% end %>


### PR DESCRIPTION
This fixes a link which was broken on the check your answers page for work histories in the new regulations.

https://sentry.io/organizations/dfe-teacher-services/issues/3865765930/?project=6426061&referrer=slack