### PR TITLE
Record mailer class name on timeline events

### DIFF
--- a/app/lib/application_mailer_observer.rb
+++ b/app/lib/application_mailer_observer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TeacherMailerObserver
+class ApplicationMailerObserver
   def self.delivered_email(message)
     mailer_action_name = message.try(:mailer_action_name)
     application_form_id = message.try(:application_form_id)
@@ -21,4 +21,4 @@ class TeacherMailerObserver
   end
 end
 
-ActionMailer::Base.register_observer(TeacherMailerObserver)
+ActionMailer::Base.register_observer(ApplicationMailerObserver)

--- a/app/lib/application_mailer_observer.rb
+++ b/app/lib/application_mailer_observer.rb
@@ -2,12 +2,13 @@
 
 class ApplicationMailerObserver
   def self.delivered_email(message)
+    mailer_class_name = message.try(:mailer_class_name)
     mailer_action_name = message.try(:mailer_action_name)
     application_form_id = message.try(:application_form_id)
     message_subject = message.try(:subject)
 
-    if mailer_action_name.blank? || application_form_id.blank? ||
-         message_subject.blank?
+    if mailer_class_name.blank? || mailer_action_name.blank? ||
+         application_form_id.blank? || message_subject.blank?
       return
     end
 
@@ -15,6 +16,7 @@ class ApplicationMailerObserver
       creator_name: "Mailer",
       event_type: "email_sent",
       application_form_id:,
+      mailer_class_name:,
       mailer_action_name:,
       message_subject:,
     )

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -4,12 +4,15 @@ class ApplicationMailer < Mail::Notify::Mailer
   after_action :store_observer_metadata
 
   def store_observer_metadata
+    mailer_class_name = self.class.name.demodulize
     mailer_action_name = action_name
     application_form_id = application_form.id
 
+    message.instance_variable_set(:@mailer_class_name, mailer_class_name)
     message.instance_variable_set(:@mailer_action_name, mailer_action_name)
     message.instance_variable_set(:@application_form_id, application_form_id)
 
+    message.class.send(:attr_reader, :mailer_class_name)
     message.class.send(:attr_reader, :mailer_action_name)
     message.class.send(:attr_reader, :application_form_id)
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,3 +1,16 @@
 class ApplicationMailer < Mail::Notify::Mailer
   default from: "qts.enquiries@education.gov.uk"
+
+  after_action :store_observer_metadata
+
+  def store_observer_metadata
+    mailer_action_name = action_name
+    application_form_id = application_form.id
+
+    message.instance_variable_set(:@mailer_action_name, mailer_action_name)
+    message.instance_variable_set(:@application_form_id, application_form_id)
+
+    message.class.send(:attr_reader, :mailer_action_name)
+    message.class.send(:attr_reader, :application_form_id)
+  end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,12 @@
 class ApplicationMailer < Mail::Notify::Mailer
   default from: "qts.enquiries@education.gov.uk"
 
+  GOVUK_NOTIFY_TEMPLATE_ID =
+    ENV.fetch(
+      "GOVUK_NOTIFY_TEMPLATE_ID_APPLICATION",
+      "95adafaf-0920-4623-bddc-340853c047af",
+    )
+
   after_action :store_observer_metadata
 
   def store_observer_metadata

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -13,12 +13,6 @@ class TeacherMailer < ApplicationMailer
   before_action :set_further_information_requested, only: :application_declined
   before_action :set_due_date, only: :further_information_reminder
 
-  GOVUK_NOTIFY_TEMPLATE_ID =
-    ENV.fetch(
-      "GOVUK_NOTIFY_TEMPLATE_ID_TEACHER",
-      "95adafaf-0920-4623-bddc-340853c047af",
-    )
-
   def application_awarded
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TeacherMailer < ApplicationMailer
   before_action :set_name
   before_action :set_reference,
@@ -10,7 +12,6 @@ class TeacherMailer < ApplicationMailer
                 ]
   before_action :set_further_information_requested, only: :application_declined
   before_action :set_due_date, only: :further_information_reminder
-  after_action :store_observer_metadata
 
   GOVUK_NOTIFY_TEMPLATE_ID =
     ENV.fetch(
@@ -108,16 +109,5 @@ class TeacherMailer < ApplicationMailer
 
   def assessment
     application_form.assessment
-  end
-
-  def store_observer_metadata
-    mailer_action_name = action_name
-    application_form_id = params[:teacher].application_form.id
-
-    message.instance_variable_set(:@mailer_action_name, mailer_action_name)
-    message.instance_variable_set(:@application_form_id, application_form_id)
-
-    message.class.send(:attr_reader, :mailer_action_name)
-    message.class.send(:attr_reader, :application_form_id)
   end
 end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -10,6 +10,7 @@
 #  creator_type                   :string
 #  event_type                     :string           not null
 #  mailer_action_name             :string           default(""), not null
+#  mailer_class_name              :string           default(""), not null
 #  message_subject                :string           default(""), not null
 #  new_state                      :string           default(""), not null
 #  old_state                      :string           default(""), not null
@@ -106,11 +107,13 @@ class TimelineEvent < ApplicationRecord
                 further_information_request_expired?
             }
 
-  validates :mailer_action_name,
+  validates :mailer_class_name,
+            :mailer_action_name,
             :message_subject,
             presence: true,
             if: :email_sent?
-  validates :mailer_action_name,
+  validates :mailer_class_name,
+            :mailer_action_name,
             :message_subject,
             absence: true,
             unless: :email_sent?

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -288,6 +288,7 @@
     - assessment_section_id
     - note_id
     - further_information_request_id
+    - mailer_class_name
     - mailer_action_name
     - message_subject
     - assessment_id

--- a/db/migrate/20230111084632_add_mailer_class_name_to_timeline_events.rb
+++ b/db/migrate/20230111084632_add_mailer_class_name_to_timeline_events.rb
@@ -1,0 +1,15 @@
+class AddMailerClassNameToTimelineEvents < ActiveRecord::Migration[7.0]
+  def up
+    add_column :timeline_events,
+               :mailer_class_name,
+               :string,
+               default: "",
+               null: false
+
+    TimelineEvent.email_sent.update_all(mailer_class_name: "TeacherMailer")
+  end
+
+  def down
+    remove_column :timeline_events, :mailer_class_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_06_130126) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_11_084632) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -384,6 +384,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_06_130126) do
     t.string "mailer_action_name", default: "", null: false
     t.bigint "assessment_id"
     t.string "message_subject", default: "", null: false
+    t.string "mailer_class_name", default: "", null: false
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
     t.index ["assessment_id"], name: "index_timeline_events_on_assessment_id"
     t.index ["assessment_section_id"], name: "index_timeline_events_on_assessment_section_id"

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -8,6 +8,7 @@
 #  creator_type                   :string
 #  event_type                     :string           not null
 #  mailer_action_name             :string           default(""), not null
+#  mailer_class_name              :string           default(""), not null
 #  message_subject                :string           default(""), not null
 #  new_state                      :string           default(""), not null
 #  old_state                      :string           default(""), not null
@@ -92,6 +93,7 @@ FactoryBot.define do
 
     trait :email_sent do
       event_type { "email_sent" }
+      mailer_class_name { "TeacherMailer" }
       mailer_action_name { "application_received" }
       message_subject { "Application received" }
     end

--- a/spec/lib/application_mailer_observer_spec.rb
+++ b/spec/lib/application_mailer_observer_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe ApplicationMailerObserver do
 
     expect(timeline_event.event_type).to eq("email_sent")
     expect(timeline_event.application_form).to eq(application_form)
+    expect(timeline_event.mailer_class_name).to eq("TeacherMailer")
     expect(timeline_event.mailer_action_name).to eq("application_received")
     expect(timeline_event.message_subject).to eq(
       "We’ve received your application for qualified teacher status (QTS)",

--- a/spec/lib/application_mailer_observer_spec.rb
+++ b/spec/lib/application_mailer_observer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe TeacherMailerObserver do
+RSpec.describe ApplicationMailerObserver do
   let(:teacher) { create(:teacher) }
   let!(:application_form) { create(:application_form, teacher:) }
   let(:message) { TeacherMailer.with(teacher:).application_received }
@@ -29,7 +29,7 @@ RSpec.describe TeacherMailerObserver do
     message =
       TeacherMailer.with(teacher: application_form.teacher).application_received
 
-    expect(TeacherMailerObserver).to receive(:delivered_email).with(message)
+    expect(ApplicationMailerObserver).to receive(:delivered_email).with(message)
 
     message.deliver_now
   end

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -15,20 +15,6 @@ RSpec.describe TeacherMailer, type: :mailer do
     )
   end
 
-  shared_examples "observer metadata" do |expected_action_name|
-    describe "#mailer_action_name" do
-      subject(:mailer_action_name) { mail.mailer_action_name }
-
-      it { is_expected.to eq(expected_action_name) }
-    end
-
-    describe "#application_form_id" do
-      subject(:application_form_id) { mail.application_form_id }
-
-      it { is_expected.to eq(application_form.id) }
-    end
-  end
-
   describe "#application_awarded" do
     subject(:mail) { described_class.with(teacher:).application_awarded }
 
@@ -51,7 +37,7 @@ RSpec.describe TeacherMailer, type: :mailer do
       it { is_expected.to include("abc") }
     end
 
-    include_examples "observer metadata", "application_awarded"
+    it_behaves_like "an observable mailer", "application_awarded"
   end
 
   describe "#application_declined" do
@@ -81,7 +67,7 @@ RSpec.describe TeacherMailer, type: :mailer do
       end
     end
 
-    include_examples "observer metadata", "application_declined"
+    it_behaves_like "an observable mailer", "application_declined"
 
     context "further information requested" do
       let(:assessment) do
@@ -144,7 +130,7 @@ RSpec.describe TeacherMailer, type: :mailer do
       it { is_expected.to include("http://localhost:3000/teacher/sign_in") }
     end
 
-    include_examples "observer metadata", "application_not_submitted"
+    it_behaves_like "an observable mailer", "application_not_submitted"
   end
 
   describe "#application_received" do
@@ -173,7 +159,7 @@ RSpec.describe TeacherMailer, type: :mailer do
       it { is_expected.to include("abc") }
     end
 
-    include_examples "observer metadata", "application_received"
+    it_behaves_like "an observable mailer", "application_received"
   end
 
   describe "#further_information_received" do
@@ -204,7 +190,7 @@ RSpec.describe TeacherMailer, type: :mailer do
       it { is_expected.to include("abc") }
     end
 
-    include_examples "observer metadata", "further_information_received"
+    it_behaves_like "an observable mailer", "further_information_received"
   end
 
   describe "#further_information_requested" do
@@ -245,7 +231,7 @@ RSpec.describe TeacherMailer, type: :mailer do
       it { is_expected.to include("http://localhost:3000/teacher/sign_in") }
     end
 
-    include_examples "observer metadata", "further_information_requested"
+    it_behaves_like "an observable mailer", "further_information_requested"
   end
 
   describe "#further_information_reminder" do
@@ -290,6 +276,6 @@ RSpec.describe TeacherMailer, type: :mailer do
       it { is_expected.to include("http://localhost:3000/teacher/sign_in") }
     end
 
-    include_examples "observer metadata", "further_information_reminder"
+    it_behaves_like "an observable mailer", "further_information_reminder"
   end
 end

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -8,6 +8,7 @@
 #  creator_type                   :string
 #  event_type                     :string           not null
 #  mailer_action_name             :string           default(""), not null
+#  mailer_class_name              :string           default(""), not null
 #  message_subject                :string           default(""), not null
 #  new_state                      :string           default(""), not null
 #  old_state                      :string           default(""), not null
@@ -92,6 +93,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
@@ -106,6 +108,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
@@ -120,6 +123,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
@@ -134,6 +138,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
@@ -148,6 +153,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_presence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
@@ -164,6 +170,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_presence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
@@ -180,6 +187,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_presence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
@@ -194,6 +202,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_presence_of(:mailer_class_name) }
       it { is_expected.to validate_presence_of(:mailer_action_name) }
       it { is_expected.to validate_presence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
@@ -208,6 +217,7 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:assessment_section) }
       it { is_expected.to validate_absence_of(:note) }
       it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_presence_of(:assessment) }

--- a/spec/support/shared_examples/observable_mailer.rb
+++ b/spec/support/shared_examples/observable_mailer.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "an observable mailer" do |expected_action_name|
+  describe "#mailer_class_name" do
+    subject(:mailer_class_name) { mail.mailer_class_name }
+
+    it { is_expected.to eq(described_class.name) }
+  end
+
   describe "#mailer_action_name" do
     subject(:mailer_action_name) { mail.mailer_action_name }
 

--- a/spec/support/shared_examples/observable_mailer.rb
+++ b/spec/support/shared_examples/observable_mailer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "an observable mailer" do |expected_action_name|
+  describe "#mailer_action_name" do
+    subject(:mailer_action_name) { mail.mailer_action_name }
+
+    it { is_expected.to eq(expected_action_name) }
+  end
+
+  describe "#application_form_id" do
+    subject(:application_form_id) { mail.application_form_id }
+
+    it { is_expected.to eq(application_form.id) }
+  end
+end


### PR DESCRIPTION
As we start to send more emails (for references and written statements) we might want to start having multiple mailer classes. To handle this, I've refactored the observer to support tracking emails from any mailer class by recording the class name on the timeline event model.