### PR TITLE
Add emails related to references

### DIFF
--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -1,6 +1,13 @@
+# frozen_string_literal: true
+
 module ApplicationFormHelper
   def application_form_full_name(application_form)
-    "#{application_form.given_names} #{application_form.family_name}"
+    if application_form.given_names.present? ||
+         application_form.family_name.present?
+      "#{application_form.given_names} #{application_form.family_name}".strip
+    else
+      "applicant"
+    end
   end
 
   def application_form_summary_rows(

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class RefereeMailer < ApplicationMailer
+  include ApplicationFormHelper
+
+  before_action :set_reference_request, :set_work_history, :set_application_form
+
+  helper :application_form
+
+  def reference_reminder
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: work_history.contact_email,
+      subject:
+        I18n.t(
+          "mailer.referee.reference_reminder.subject",
+          name: application_form_full_name(application_form),
+        ),
+    )
+  end
+
+  def reference_requested
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: work_history.contact_email,
+      subject:
+        I18n.t(
+          "mailer.referee.reference_requested.subject",
+          name: application_form_full_name(application_form),
+        ),
+    )
+  end
+
+  private
+
+  def reference_request
+    params[:reference_request]
+  end
+
+  delegate :application_form, :work_history, to: :reference_request
+
+  def set_reference_request
+    @reference_request = reference_request
+  end
+
+  def set_work_history
+    @work_history = work_history
+  end
+
+  def set_application_form
+    @application_form = application_form
+  end
+end

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -1,17 +1,7 @@
 # frozen_string_literal: true
 
 class TeacherMailer < ApplicationMailer
-  include ApplicationFormHelper
-
-  before_action :set_name
-  before_action :set_reference,
-                only: %i[
-                  application_awarded
-                  application_declined
-                  application_received
-                  further_information_received
-                  further_information_reminder
-                ]
+  before_action :set_application_form
   before_action :set_further_information_requested, only: :application_declined
   before_action :set_due_date, only: :further_information_reminder
 
@@ -20,7 +10,7 @@ class TeacherMailer < ApplicationMailer
   def application_awarded
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
-      to: params[:teacher].email,
+      to: teacher.email,
       subject: I18n.t("mailer.teacher.application_awarded.subject"),
     )
   end
@@ -28,7 +18,7 @@ class TeacherMailer < ApplicationMailer
   def application_declined
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
-      to: params[:teacher].email,
+      to: teacher.email,
       subject: I18n.t("mailer.teacher.application_declined.subject"),
     )
   end
@@ -36,7 +26,7 @@ class TeacherMailer < ApplicationMailer
   def application_not_submitted
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
-      to: params[:teacher].email,
+      to: teacher.email,
       subject:
         I18n.t(
           "mailer.teacher.application_not_submitted.subject.#{params[:duration]}",
@@ -47,7 +37,7 @@ class TeacherMailer < ApplicationMailer
   def application_received
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
-      to: params[:teacher].email,
+      to: teacher.email,
       subject: I18n.t("mailer.teacher.application_received.subject"),
     )
   end
@@ -55,7 +45,7 @@ class TeacherMailer < ApplicationMailer
   def further_information_received
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
-      to: params[:teacher].email,
+      to: teacher.email,
       subject: I18n.t("mailer.teacher.further_information_received.subject"),
     )
   end
@@ -63,7 +53,7 @@ class TeacherMailer < ApplicationMailer
   def further_information_requested
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
-      to: params[:teacher].email,
+      to: teacher.email,
       subject: I18n.t("mailer.teacher.further_information_requested.subject"),
     )
   end
@@ -71,23 +61,22 @@ class TeacherMailer < ApplicationMailer
   def further_information_reminder
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
-      to: params[:teacher].email,
+      to: teacher.email,
       subject: I18n.t("mailer.teacher.further_information_reminder.subject"),
     )
   end
 
   private
 
-  def set_name
-    @name = application_form_full_name(application_form)
+  def teacher
+    params[:teacher]
   end
 
-  def set_reference
-    @reference = params[:teacher].application_form.reference
-  end
+  delegate :application_form, to: :teacher
+  delegate :assessment, to: :application_form
 
-  def set_due_date
-    @due_date = params[:due_date]
+  def set_application_form
+    @application_form = application_form
   end
 
   def set_further_information_requested
@@ -95,11 +84,7 @@ class TeacherMailer < ApplicationMailer
       assessment.further_information_requests.any?
   end
 
-  def application_form
-    params[:teacher].application_form
-  end
-
-  def assessment
-    application_form.assessment
+  def set_due_date
+    @due_date = params[:due_date]
   end
 end

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class TeacherMailer < ApplicationMailer
+  include ApplicationFormHelper
+
   before_action :set_name
   before_action :set_reference,
                 only: %i[
@@ -12,6 +14,8 @@ class TeacherMailer < ApplicationMailer
                 ]
   before_action :set_further_information_requested, only: :application_declined
   before_action :set_due_date, only: :further_information_reminder
+
+  helper :application_form
 
   def application_awarded
     view_mail(
@@ -75,13 +79,7 @@ class TeacherMailer < ApplicationMailer
   private
 
   def set_name
-    @name =
-      if application_form.given_names.present? ||
-           application_form.family_name.present?
-        "#{application_form.given_names} #{application_form.family_name}"
-      else
-        "applicant"
-      end
+    @name = application_form_full_name(application_form)
   end
 
   def set_reference

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -66,6 +66,14 @@ class TeacherMailer < ApplicationMailer
     )
   end
 
+  def references_requested
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: teacher.email,
+      subject: I18n.t("mailer.teacher.references_requested.subject"),
+    )
+  end
+
   private
 
   def teacher

--- a/app/views/referee_mailer/reference_reminder.text.erb
+++ b/app/views/referee_mailer/reference_reminder.text.erb
@@ -1,0 +1,14 @@
+Dear <%= @work_history.contact_name %>
+
+We still need you to confirm some information about <%= application_form_full_name(@application_form) %> as part of their application for qualified teacher status (QTS) in England.
+
+We recently contacted you to ask you to help us confirm that the information [Applicant name] has provided about their work history and experience is accurate.
+
+Please follow the link below and answer the questions by <%= @reference_request.expired_at.strftime("%e %B %Y") %>. If we do not receive your response by this date, it could affect the outcome for the applicant.
+
+<%= teacher_interface_reference_request_url(@reference_request) %>
+
+It should take no longer than 5 minutes.
+
+Kind regards,
+The Teacher Qualifications Team (part of the Teaching Regulation Agency)

--- a/app/views/referee_mailer/reference_requested.text.erb
+++ b/app/views/referee_mailer/reference_requested.text.erb
@@ -1,0 +1,16 @@
+Dear <%= @work_history.contact_name %>
+
+We need you to confirm some information about <%= application_form_full_name(@application_form) %> as part of their application for qualified teacher status (QTS) in England.
+
+As part of the QTS application process, our assessors need to understand each applicant’s work history and experience.
+
+<%= application_form_full_name(@application_form) %> has given us your name and email address to help us confirm that the information they’ve provided about their work history and experience is accurate.
+
+Please follow the link below and answer the questions by <%= @reference_request.expired_at.strftime("%e %B %Y") %>.
+
+<%= teacher_interface_reference_request_url(@reference_request) %>
+
+It should take no longer than 5 minutes.
+
+Kind regards,
+The Teacher Qualifications Team (part of the Teaching Regulation Agency)

--- a/app/views/teacher_mailer/application_awarded.text.erb
+++ b/app/views/teacher_mailer/application_awarded.text.erb
@@ -1,10 +1,10 @@
-Dear <%= @name %>
+Dear <%= application_form_full_name(@application_form) %>
 
 # Your QTS application was successful
 
 Your reference number is:
 
-<%= @reference %>
+<%= @application_form.reference %>
 
 We’re pleased to tell you that the assessor has now completed their review of your application and you’ve been awarded qualified teacher status (QTS).
 

--- a/app/views/teacher_mailer/application_declined.text.erb
+++ b/app/views/teacher_mailer/application_declined.text.erb
@@ -1,10 +1,10 @@
-Dear <%= @name %>
+Dear <%= application_form_full_name(@application_form) %>
 
 # Your QTS application has been declined
 
 Your reference number is:
 
-<%= @reference %>
+<%= @application_form.reference %>
 
 Thank you for applying for qualified teacher status (QTS) and for your patience while we reviewed your application.
 

--- a/app/views/teacher_mailer/application_not_submitted.text.erb
+++ b/app/views/teacher_mailer/application_not_submitted.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @name %>
+Dear <%= application_form_full_name(@application_form) %>
 
 We’ve noticed that you have a draft application for qualified teacher status (QTS) that has not been submitted.
 

--- a/app/views/teacher_mailer/application_received.text.erb
+++ b/app/views/teacher_mailer/application_received.text.erb
@@ -1,10 +1,10 @@
-Dear <%= @name %>
+Dear <%= application_form_full_name(@application_form) %>
 
 # We’ve received your application for qualified teacher status (QTS)
 
 Your reference number is:
 
-<%= @reference %>
+<%= @application_form.reference %>
 
 # What happens next
 

--- a/app/views/teacher_mailer/further_information_received.text.erb
+++ b/app/views/teacher_mailer/further_information_received.text.erb
@@ -1,10 +1,10 @@
-Dear <%= @name %>
+Dear <%= application_form_full_name(@application_form) %>
 
 The assessor has now resumed their review of your QTS application.
 
 Your reference number is:
 
-<%= @reference %>
+<%= @application_form.reference %>
 
 Thanks for sending the additional information we requested.The assessor will now continue reviewing your application.
 

--- a/app/views/teacher_mailer/further_information_reminder.text.erb
+++ b/app/views/teacher_mailer/further_information_reminder.text.erb
@@ -1,10 +1,10 @@
-Dear <%= @name %>
+Dear <%= application_form_full_name(@application_form) %>
 
 # The assessor reviewing your QTS application needs more information
 
 Your reference number is:
 
-<%= @reference %>
+<%= @application_form.reference %>
 
 # What happens next
 

--- a/app/views/teacher_mailer/further_information_requested.text.erb
+++ b/app/views/teacher_mailer/further_information_requested.text.erb
@@ -1,4 +1,4 @@
-Dear <%= @name %>
+Dear <%= application_form_full_name(@application_form) %>
 
 The assessor reviewing your QTS application needs more information.
 

--- a/app/views/teacher_mailer/references_requested.text.erb
+++ b/app/views/teacher_mailer/references_requested.text.erb
@@ -1,0 +1,10 @@
+Dear <%= application_form_full_name(@application_form) %>
+
+# We’ve contacted the references you provided to verify your work history
+
+As part of your QTS application we’ve contacted the references that you provided.
+
+Once they reply, we’ll review the references and proceed with assessing your application.
+
+Kind regards,
+The Teacher Qualifications Team

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -1,5 +1,10 @@
 en:
   mailer:
+    referee:
+      reference_reminder:
+        subject: We still need you to verify %{name}’s application for qualified teacher status (QTS)
+      reference_requested:
+        subject: Please help us to verify %{name}’s application for qualified teacher status (QTS)
     teacher:
       application_awarded:
         subject: Your QTS application was successful

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -23,3 +23,5 @@ en:
         subject: We need some more information to progress your QTS application
       further_information_reminder:
         subject: We still need some more information to progress your QTS application
+      references_requested:
+        subject: Your qualified teacher status application – we’ve contacted your references

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe ApplicationFormHelper do
     subject(:full_name) { application_form_full_name(application_form) }
 
     it { is_expected.to eq("Given Family") }
+
+    context "without names" do
+      before { application_form.update!(given_names: "", family_name: "") }
+
+      it { is_expected.to eq("applicant") }
+    end
   end
 
   describe "#application_form_summary_rows" do

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RefereeMailer, type: :mailer do
+  let(:application_form) do
+    create(:application_form, given_names: "First", family_name: "Last")
+  end
+
+  let(:assessment) { create(:assessment, application_form:) }
+  let(:work_history) do
+    create(
+      :work_history,
+      application_form:,
+      contact_name: "Contact Name",
+      contact_email: "referee@school.com",
+    )
+  end
+
+  let(:reference_request) do
+    create(:reference_request, assessment:, work_history:)
+  end
+
+  describe "#reference_reminder" do
+    subject(:mail) do
+      described_class.with(reference_request:).reference_reminder
+    end
+
+    describe "#subject" do
+      subject(:subject) { mail.subject }
+
+      it do
+        is_expected.to eq(
+          "We still need you to verify First Last’s application for qualified teacher status (QTS)",
+        )
+      end
+    end
+
+    describe "#to" do
+      subject(:to) { mail.to }
+
+      it { is_expected.to eq(["referee@school.com"]) }
+    end
+
+    describe "#body" do
+      subject(:body) { mail.body.encoded }
+
+      it { is_expected.to include("Dear Contact Name") }
+      it do
+        is_expected.to include(
+          "We still need you to confirm some information about First Last",
+        )
+      end
+      it do
+        is_expected.to include(
+          "http://localhost:3000/teacher/references/#{reference_request.id}",
+        )
+      end
+    end
+
+    it_behaves_like "an observable mailer", "reference_reminder"
+  end
+
+  describe "#reference_requested" do
+    subject(:mail) do
+      described_class.with(reference_request:).reference_requested
+    end
+
+    describe "#subject" do
+      subject(:subject) { mail.subject }
+
+      it do
+        is_expected.to eq(
+          "Please help us to verify First Last’s application for qualified teacher status (QTS)",
+        )
+      end
+    end
+
+    describe "#to" do
+      subject(:to) { mail.to }
+
+      it { is_expected.to eq(["referee@school.com"]) }
+    end
+
+    describe "#body" do
+      subject(:body) { mail.body.encoded }
+
+      it { is_expected.to include("Dear Contact Name") }
+      it do
+        is_expected.to include(
+          "We need you to confirm some information about First Last",
+        )
+      end
+      it do
+        is_expected.to include(
+          "http://localhost:3000/teacher/references/#{reference_request.id}",
+        )
+      end
+    end
+
+    it_behaves_like "an observable mailer", "reference_requested"
+  end
+end

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe TeacherMailer, type: :mailer do

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -280,4 +280,37 @@ RSpec.describe TeacherMailer, type: :mailer do
 
     it_behaves_like "an observable mailer", "further_information_reminder"
   end
+
+  describe "#references_requested" do
+    subject(:mail) { described_class.with(teacher:).references_requested }
+
+    describe "#subject" do
+      subject(:subject) { mail.subject }
+
+      it do
+        is_expected.to eq(
+          "Your qualified teacher status application – we’ve contacted your references",
+        )
+      end
+    end
+
+    describe "#to" do
+      subject(:to) { mail.to }
+
+      it { is_expected.to eq(["teacher@example.com"]) }
+    end
+
+    describe "#body" do
+      subject(:body) { mail.body.encoded }
+
+      it { is_expected.to include("Dear First Last") }
+      it do
+        is_expected.to include(
+          "We’ve contacted the references you provided to verify your work history",
+        )
+      end
+    end
+
+    it_behaves_like "an observable mailer", "references_requested"
+  end
 end


### PR DESCRIPTION
This adds two new emails which we send in relation to references, one to the referee and one to the teacher.

I've also refactored the mailers to make better use of helpers for common code.

Depends on #921 and #922

[Trello Card](https://trello.com/c/ipsDiRoR/1340-send-automatic-emails-to-referees)