### PR TITLE
Allow countries to skip eligibility questions

### DIFF
--- a/app/controllers/eligibility_interface/countries_controller.rb
+++ b/app/controllers/eligibility_interface/countries_controller.rb
@@ -22,7 +22,7 @@ module EligibilityInterface
       {
         eligible: eligibility_interface_qualifications_path,
         ineligible: eligibility_interface_ineligible_path,
-        legacy: eligibility_interface_eligible_path,
+        skip_questions: eligibility_interface_eligible_path,
         region: eligibility_interface_region_path,
       }.fetch(eligibility_check.country_eligibility_status)
     end

--- a/app/controllers/support_interface/countries_controller.rb
+++ b/app/controllers/support_interface/countries_controller.rb
@@ -65,6 +65,8 @@ class SupportInterface::CountriesController < SupportInterface::BaseController
 
   def country_params
     params.require(:country).permit(
+      :eligibility_enabled,
+      :eligibility_skip_questions,
       :teaching_authority_name,
       :teaching_authority_address,
       :teaching_authority_emails_string,
@@ -75,7 +77,6 @@ class SupportInterface::CountriesController < SupportInterface::BaseController
       :teaching_authority_status_information,
       :teaching_authority_checks_sanctions,
       :teaching_authority_online_checker_url,
-      :eligibility_enabled,
     )
   end
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -5,6 +5,7 @@
 #  id                                      :bigint           not null, primary key
 #  code                                    :string           not null
 #  eligibility_enabled                     :boolean          default(TRUE), not null
+#  eligibility_skip_questions              :boolean          default(FALSE), not null
 #  teaching_authority_address              :text             default(""), not null
 #  teaching_authority_certificate          :text             default(""), not null
 #  teaching_authority_checks_sanctions     :boolean          default(TRUE), not null

--- a/app/views/support_interface/countries/confirm_edit.html.erb
+++ b/app/views/support_interface/countries/confirm_edit.html.erb
@@ -50,6 +50,8 @@
 
 <%= form_with model: [:support_interface, @country] do |f| %>
   <%= f.hidden_field :all_regions, value: @all_regions %>
+  <%= f.hidden_field :eligibility_enabled, value: @country.eligibility_enabled %>
+  <%= f.hidden_field :eligibility_skip_questions, value: @country.eligibility_skip_questions %>
   <%= f.hidden_field :teaching_authority_name, value: @country.teaching_authority_name %>
   <%= f.hidden_field :teaching_authority_address, value: @country.teaching_authority_address %>
   <%= f.hidden_field :teaching_authority_emails_string, value: @country.teaching_authority_emails_string %>
@@ -60,6 +62,5 @@
   <%= f.hidden_field :teaching_authority_other, value: @country.teaching_authority_other %>
   <%= f.hidden_field :teaching_authority_online_checker_url, value: @country.teaching_authority_online_checker_url %>
   <%= f.hidden_field :teaching_authority_checks_sanctions, value: @country.teaching_authority_checks_sanctions %>
-  <%= f.hidden_field :eligibility_enabled, value: @country.eligibility_enabled %>
   <%= f.govuk_submit "Confirm save", prevent_double_click: false %>
 <% end %>

--- a/app/views/support_interface/countries/edit.html.erb
+++ b/app/views/support_interface/countries/edit.html.erb
@@ -5,11 +5,12 @@
 <%= form_with model: @country, url: confirm_edit_support_interface_country_path(@country), method: "POST" do |f| %>
   <%= f.govuk_error_summary %>
 
+  <%= f.govuk_check_box :eligibility_enabled, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Eligible" }%>
+  <%= f.govuk_check_box :eligibility_skip_questions, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Skip eligibility questions" }%>
+
   <%= render "shared/teaching_authority_form_fields", f: %>
 
   <%= f.govuk_check_box :teaching_authority_checks_sanctions, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Teaching authority checks sanctions" } %>
-
-  <%= f.govuk_check_box :eligibility_enabled, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Eligible country" }%>
 
   <%= f.govuk_text_area :all_regions,
                         value: @all_regions,

--- a/app/views/support_interface/countries/index.html.erb
+++ b/app/views/support_interface/countries/index.html.erb
@@ -31,15 +31,20 @@
                   </a>
                 </td>
                 <td class="govuk-table__cell">
-                  <% if region.legacy %>
-                    <%= govuk_tag(text: "Eligibility Inactive", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
+                  <% if country.eligibility_enabled %>
+                    <%= govuk_tag(text: "Eligibility enabled", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
+
+                    <% if country.eligibility_skip_questions || region.legacy %>
+                      <%= govuk_tag(text: "Skips questions", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
+                    <% end %>
+
+                    <% if region.application_form_enabled %>
+                      <%= govuk_tag(text: "Applications enabled", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
+                    <% else %>
+                      <%= govuk_tag(text: "Applications disabled", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
+                    <% end %>
                   <% else %>
-                    <%= govuk_tag(text: "Eligibility Active", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
-                  <% end %>
-                  <% if region.application_form_enabled? %>
-                    <%= govuk_tag(text: "Application Form Active", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
-                  <% else %>
-                    <%= govuk_tag(text: "Application Form Inactive", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
+                    <%= govuk_tag(text: "Eligibility disabled", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
                   <% end %>
                 </td>
               </tr>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -93,8 +93,9 @@
     - id
     - code
     - created_at
-    - eligibility_enabled
     - updated_at
+    - eligibility_enabled
+    - eligibility_skip_questions
     - teaching_authority_address
     - teaching_authority_emails
     - teaching_authority_websites

--- a/db/migrate/20230111112551_add_eligibility_skip_questions_to_countries.rb
+++ b/db/migrate/20230111112551_add_eligibility_skip_questions_to_countries.rb
@@ -1,0 +1,9 @@
+class AddEligibilitySkipQuestionsToCountries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :countries,
+               :eligibility_skip_questions,
+               :boolean,
+               default: false,
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_11_102451) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_11_112551) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -141,6 +141,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_11_102451) do
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "eligibility_enabled", default: true, null: false
+    t.boolean "eligibility_skip_questions", default: false, null: false
     t.index ["code"], name: "index_countries_on_code", unique: true
   end
 

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -5,6 +5,7 @@
 #  id                                      :bigint           not null, primary key
 #  code                                    :string           not null
 #  eligibility_enabled                     :boolean          default(TRUE), not null
+#  eligibility_skip_questions              :boolean          default(FALSE), not null
 #  teaching_authority_address              :text             default(""), not null
 #  teaching_authority_certificate          :text             default(""), not null
 #  teaching_authority_checks_sanctions     :boolean          default(TRUE), not null

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -5,6 +5,7 @@
 #  id                                      :bigint           not null, primary key
 #  code                                    :string           not null
 #  eligibility_enabled                     :boolean          default(TRUE), not null
+#  eligibility_skip_questions              :boolean          default(FALSE), not null
 #  teaching_authority_address              :text             default(""), not null
 #  teaching_authority_certificate          :text             default(""), not null
 #  teaching_authority_checks_sanctions     :boolean          default(TRUE), not null

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -216,6 +216,13 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the_legacy_service
   end
 
+  it "can skip questions" do
+    when_i_visit_the(:start_page)
+    when_i_press_start_now
+    when_i_select_a_skip_questions_country
+    then_i_see_the(:eligible_page)
+  end
+
   it "handles countries with multiple regions" do
     when_i_visit_the(:start_page)
     when_i_press_start_now
@@ -275,6 +282,12 @@ RSpec.describe "Eligibility check", type: :system do
   def given_countries_exist
     create(:country, :with_national_region, code: "GB-SCT")
     create(:country, :with_legacy_region, code: "FR")
+    create(
+      :country,
+      :with_national_region,
+      code: "PT",
+      eligibility_skip_questions: true,
+    )
 
     it = create(:country, code: "IT")
     create(:region, country: it, name: "Region")
@@ -299,6 +312,10 @@ RSpec.describe "Eligibility check", type: :system do
 
   def when_i_select_a_legacy_country
     country_page.submit(country: "France")
+  end
+
+  def when_i_select_a_skip_questions_country
+    country_page.submit(country: "Portugal")
   end
 
   def when_i_select_a_multiple_region_country


### PR DESCRIPTION
This adds a new boolean field to countries allowing some countries to skip the eligibility questions. At the moment we only know of Scotland and Northern Ireland where this will be the case, but I've implemented this as a field on the country model following the same pattern for other customisations like this.

[Trello Card](https://trello.com/c/J9btT0qS/1341-scotland-ni-eligibility-flow)

## Screenshots

![Screenshot 2023-01-11 at 12 12 00](https://user-images.githubusercontent.com/510498/211803975-6eacf2b3-2c20-4096-93ac-c14df1014165.png)
![Screenshot 2023-01-11 at 12 12 12](https://user-images.githubusercontent.com/510498/211803980-129f8dd0-d79a-44e4-a9e0-b8eb46887877.png)
![Screenshot 2023-01-11 at 12 12 16](https://user-images.githubusercontent.com/510498/211803982-bec5a26f-01cd-4213-89e1-778e2bc68457.png)
