### PR TITLE
Add toggle for providing written statement

### DIFF
--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -51,6 +51,7 @@ class SupportInterface::RegionsController < SupportInterface::BaseController
       :teaching_authority_status_information,
       :teaching_authority_other,
       :teaching_authority_online_checker_url,
+      :teaching_authority_provides_written_statement,
     )
   end
 end

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -23,6 +23,8 @@
 
   <%= render "shared/teaching_authority_form_fields", f: %>
 
+  <%= f.govuk_check_box :teaching_authority_provides_written_statement, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Teaching authority will only send written statement directly to TRA" } %>
+
   <%= f.govuk_submit "Save", prevent_double_click: false do %>
     <%= f.govuk_submit "Save and preview", prevent_double_click: false, name: "preview", value: "preview" %>
     <%= govuk_button_link_to "Ignore changes and preview", preview_support_interface_region_path(@region), secondary: true %>


### PR DESCRIPTION
Adds a toggle in the support console for controlling whether a teaching authority provides writtent statement or not