### PR TITLE
Allow regions to skip work history

### DIFF
--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -40,6 +40,7 @@ class SupportInterface::RegionsController < SupportInterface::BaseController
     params.require(:region).permit(
       :legacy,
       :application_form_enabled,
+      :application_form_skip_work_history,
       :sanction_check,
       :status_check,
       :teaching_authority_name,

--- a/app/helpers/proof_of_recognition_helper.rb
+++ b/app/helpers/proof_of_recognition_helper.rb
@@ -40,6 +40,10 @@ module ProofOfRecognitionHelper
         "that your authorisation to teach has never been suspended, barred, " \
           "cancelled, revoked or restricted, and that you have no sanctions against you",
       ]
+    elsif region.application_form_skip_work_history?
+      [
+        "if you have completed your induction in #{CountryName.from_region(region, with_definite_article: true)}",
+      ]
     else
       []
     end

--- a/app/lib/application_form_factory.rb
+++ b/app/lib/application_form_factory.rb
@@ -23,8 +23,11 @@ class ApplicationFormFactory
   attr_reader :teacher, :region
 
   def needs_work_history
-    FeatureFlags::FeatureFlag.active?(:application_work_history) ||
+    if FeatureFlags::FeatureFlag.active?(:application_work_history)
+      !region.application_form_skip_work_history
+    else
       region.status_check_none? || region.sanction_check_none?
+    end
   end
 
   def needs_written_statement

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -4,6 +4,7 @@
 #
 #  id                                            :bigint           not null, primary key
 #  application_form_enabled                      :boolean          default(FALSE)
+#  application_form_skip_work_history            :boolean          default(FALSE), not null
 #  legacy                                        :boolean          default(TRUE), not null
 #  name                                          :string           default(""), not null
 #  sanction_check                                :string           default("none"), not null

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -39,7 +39,7 @@
       <%= render "shared/eligible_region_content_components/professional_recognition", region: %>
     <% end %>
 
-    <% if FeatureFlags::FeatureFlag.active?(:eligibility_work_experience) %>
+    <% if FeatureFlags::FeatureFlag.active?(:application_work_history) && !region.application_form_skip_work_history %>
       <% accordion.section(heading_text: "Proof of work history") do %>
         <%= render "shared/eligible_region_content_components/proof_of_work_history", region:, eligibility_check: %>
       <% end %>

--- a/app/views/support_interface/countries/index.html.erb
+++ b/app/views/support_interface/countries/index.html.erb
@@ -40,6 +40,10 @@
 
                     <% if region.application_form_enabled %>
                       <%= govuk_tag(text: "Applications enabled", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
+
+                      <% if region.application_form_skip_work_history %>
+                        <%= govuk_tag(text: "Skips work history", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
+                      <% end %>
                     <% else %>
                       <%= govuk_tag(text: "Applications disabled", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
                     <% end %>

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -8,6 +8,7 @@
   <%= f.govuk_check_box :legacy, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Skip eligibility checker (legacy)" } %>
 
   <%= f.govuk_check_box :application_form_enabled, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Application form enabled" } %>
+  <%= f.govuk_check_box :application_form_skip_work_history, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Skip work history" } %>
 
   <%= f.govuk_collection_select :sanction_check, [
     OpenStruct.new(id: 'online', name: 'Online'),

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -209,15 +209,16 @@
     - updated_at
     - status_check
     - sanction_check
-    - teaching_authority_address
     - legacy
+    - application_form_enabled
+    - application_form_skip_work_history
+    - teaching_authority_address
     - teaching_authority_emails
     - teaching_authority_websites
     - teaching_authority_name
     - teaching_authority_other
     - teaching_authority_certificate
     - teaching_authority_online_checker_url
-    - application_form_enabled
     - teaching_authority_status_information
     - teaching_authority_sanction_information
     - teaching_authority_provides_written_statement

--- a/db/migrate/20230111124208_add_application_form_skip_work_history_to_regions.rb
+++ b/db/migrate/20230111124208_add_application_form_skip_work_history_to_regions.rb
@@ -1,0 +1,9 @@
+class AddApplicationFormSkipWorkHistoryToRegions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :regions,
+               :application_form_skip_work_history,
+               :boolean,
+               default: false,
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_11_112551) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_11_124208) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -281,6 +281,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_11_112551) do
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
+    t.boolean "application_form_skip_work_history", default: false, null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
     t.index ["country_id"], name: "index_regions_on_country_id"
   end

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -4,6 +4,7 @@
 #
 #  id                                            :bigint           not null, primary key
 #  application_form_enabled                      :boolean          default(FALSE)
+#  application_form_skip_work_history            :boolean          default(FALSE), not null
 #  legacy                                        :boolean          default(TRUE), not null
 #  name                                          :string           default(""), not null
 #  sanction_check                                :string           default("none"), not null

--- a/spec/helpers/proof_of_recognition_helper_spec.rb
+++ b/spec/helpers/proof_of_recognition_helper_spec.rb
@@ -3,8 +3,10 @@ require "rails_helper"
 RSpec.describe ProofOfRecognitionHelper do
   let(:region) do
     double(
+      name: "Region Name",
       status_check_written?: status,
       sanction_check_written?: sanction,
+      application_form_skip_work_history?: application_form_skip_work_history,
       country:
         double(
           teaching_authority_checks_sanctions?:
@@ -14,6 +16,7 @@ RSpec.describe ProofOfRecognitionHelper do
   end
   let(:status) { false }
   let(:sanction) { false }
+  let(:application_form_skip_work_history) { false }
   let(:teaching_authority_checks_sanctions) { true }
 
   describe "proof_of_recognition_requirements_for" do
@@ -66,11 +69,23 @@ RSpec.describe ProofOfRecognitionHelper do
       end
     end
 
-    context "with a country where authority doesn't change sanctions" do
+    context "with a country where authority doesn't check sanctions" do
       let(:sanction) { true }
       let(:teaching_authority_checks_sanctions) { false }
 
       it { is_expected.to be_empty }
+    end
+
+    context "with a country where authority doesn't check sanctions and the region skips work history" do
+      let(:sanction) { true }
+      let(:teaching_authority_checks_sanctions) { false }
+      let(:application_form_skip_work_history) { true }
+
+      it do
+        is_expected.to match_array(
+          ["if you have completed your induction in Region Name"],
+        )
+      end
     end
   end
 

--- a/spec/lib/application_form_factory_spec.rb
+++ b/spec/lib/application_form_factory_spec.rb
@@ -32,17 +32,36 @@ RSpec.describe ApplicationFormFactory do
         FeatureFlags::FeatureFlag.deactivate(:application_work_history)
       end
 
-      let(:region) { create(:region) }
+      context "with a region that doesn't skip work history" do
+        let(:region) { create(:region) }
 
-      it "creates an application form" do
-        expect { call }.to change(ApplicationForm, :count).by(1)
+        it "creates an application form" do
+          expect { call }.to change(ApplicationForm, :count).by(1)
+        end
+
+        it "sets the rules" do
+          application_form = call
+          expect(application_form.needs_work_history).to be true
+          expect(application_form.needs_written_statement).to be false
+          expect(application_form.needs_registration_number).to be false
+        end
       end
 
-      it "sets the rules" do
-        application_form = call
-        expect(application_form.needs_work_history).to be true
-        expect(application_form.needs_written_statement).to be false
-        expect(application_form.needs_registration_number).to be false
+      context "with a region which skips work history" do
+        let(:region) do
+          create(:region, application_form_skip_work_history: true)
+        end
+
+        it "creates an application form" do
+          expect { call }.to change(ApplicationForm, :count).by(1)
+        end
+
+        it "sets the rules" do
+          application_form = call
+          expect(application_form.needs_work_history).to be false
+          expect(application_form.needs_written_statement).to be false
+          expect(application_form.needs_registration_number).to be false
+        end
       end
     end
 

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                                            :bigint           not null, primary key
 #  application_form_enabled                      :boolean          default(FALSE)
+#  application_form_skip_work_history            :boolean          default(FALSE), not null
 #  legacy                                        :boolean          default(TRUE), not null
 #  name                                          :string           default(""), not null
 #  sanction_check                                :string           default("none"), not null

--- a/spec/views/shared/eligible_region_content_spec.rb
+++ b/spec/views/shared/eligible_region_content_spec.rb
@@ -108,7 +108,8 @@ RSpec.describe "Eligible region content", type: :view do
   end
 
   context "with work experience" do
-    before { FeatureFlags::FeatureFlag.activate(:eligibility_work_experience) }
+    before { FeatureFlags::FeatureFlag.activate(:application_work_history) }
+    after { FeatureFlags::FeatureFlag.deactivate(:application_work_history) }
 
     let(:region) { create(:region) }
 
@@ -128,6 +129,14 @@ RSpec.describe "Eligible region content", type: :view do
         is_expected.to match(
           /you’ll need to complete a 2-year ‘statutory induction’/,
         )
+      end
+    end
+
+    context "with a region which skips the work history" do
+      let(:region) { create(:region, application_form_skip_work_history: true) }
+
+      it do
+        is_expected.to_not match(/You’ll need to show you’ve been employed/)
       end
     end
   end


### PR DESCRIPTION
This adds a new boolean field to regions allowing some regions to skip the work history spoke of the application form. At the moment we only know of Scotland and Northern Ireland where this will be the case, but I've implemented this as a field on the country model following the same pattern for other customisations like this.

[Trello Card](https://trello.com/c/J9btT0qS/1341-scotland-ni-eligibility-flow)

## Screenshots

![Screenshot 2023-01-11 at 13 27 48](https://user-images.githubusercontent.com/510498/211820665-cd5f112d-668e-4fd7-a939-a6117d7375d0.png)
![Screenshot 2023-01-11 at 13 28 00](https://user-images.githubusercontent.com/510498/211820671-f75489d8-a757-4132-91f9-aa1e3eddd4a5.png)
![Screenshot 2023-01-11 at 13 37 48](https://user-images.githubusercontent.com/510498/211820675-116f7958-ecfd-4abb-b7b3-feae05be021c.png)
