### PR TITLE
Provide 'qualifications information' on a per region or country basis

### DIFF
--- a/app/controllers/support_interface/countries_controller.rb
+++ b/app/controllers/support_interface/countries_controller.rb
@@ -67,6 +67,7 @@ class SupportInterface::CountriesController < SupportInterface::BaseController
     params.require(:country).permit(
       :eligibility_enabled,
       :eligibility_skip_questions,
+      :qualifications_information,
       :teaching_authority_name,
       :teaching_authority_address,
       :teaching_authority_emails_string,

--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -41,6 +41,7 @@ class SupportInterface::RegionsController < SupportInterface::BaseController
       :legacy,
       :application_form_enabled,
       :application_form_skip_work_history,
+      :qualifications_information,
       :sanction_check,
       :status_check,
       :teaching_authority_name,

--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -42,10 +42,9 @@ module TeacherInterface
     end
 
     def new
-      @qualification_form =
-        QualificationForm.new(
-          qualification: Qualification.new(application_form:),
-        )
+      qualification = Qualification.new(application_form:)
+      @view_object = QualificationViewObject.new(qualification:)
+      @qualification_form = QualificationForm.new(qualification:)
     end
 
     def create
@@ -98,6 +97,7 @@ module TeacherInterface
     def edit
       @qualification = qualification
 
+      @view_object = QualificationViewObject.new(qualification:)
       @qualification_form =
         QualificationForm.new(
           qualification:,

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -6,6 +6,7 @@
 #  code                                    :string           not null
 #  eligibility_enabled                     :boolean          default(TRUE), not null
 #  eligibility_skip_questions              :boolean          default(FALSE), not null
+#  qualifications_information              :text             default(""), not null
 #  teaching_authority_address              :text             default(""), not null
 #  teaching_authority_certificate          :text             default(""), not null
 #  teaching_authority_checks_sanctions     :boolean          default(TRUE), not null

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -6,6 +6,7 @@
 #  application_form_enabled                      :boolean          default(FALSE)
 #  application_form_skip_work_history            :boolean          default(FALSE), not null
 #  legacy                                        :boolean          default(TRUE), not null
+#  qualifications_information                    :text             default(""), not null
 #  name                                          :string           default(""), not null
 #  sanction_check                                :string           default("none"), not null
 #  status_check                                  :string           default("none"), not null

--- a/app/view_objects/teacher_interface/qualification_view_object.rb
+++ b/app/view_objects/teacher_interface/qualification_view_object.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class TeacherInterface::QualificationViewObject
+  attr_reader :qualification
+
+  def initialize(qualification:)
+    @qualification = qualification
+  end
+
+  def qualifications_information
+    region = qualification.application_form.region
+
+    (
+      region.qualifications_information.presence ||
+        region.country.qualifications_information
+    )
+  end
+end

--- a/app/views/shared/_qualifications_information_form_fields.html.erb
+++ b/app/views/shared/_qualifications_information_form_fields.html.erb
@@ -1,0 +1,1 @@
+<%= f.govuk_text_area :qualifications_information, label: { text: "Qualifications information" } %>

--- a/app/views/shared/eligible_region_content_components/_proof_of_qualifications.html.erb
+++ b/app/views/shared/eligible_region_content_components/_proof_of_qualifications.html.erb
@@ -7,3 +7,5 @@
   A transcript is a document from the institution where you studied. It lists all the modules or subjects you studied in each year, and the marks or grades you were awarded.
   Note that you must have completed all of your teaching qualification in <%= CountryName.from_country(region.country, with_definite_article: true) %>.
 </p>
+
+<p class="govuk-body"><%= region.qualifications_information %></p>

--- a/app/views/support_interface/countries/confirm_edit.html.erb
+++ b/app/views/support_interface/countries/confirm_edit.html.erb
@@ -4,7 +4,7 @@
 
 <h2 class="govuk-heading-m">Review and confirm the following changes:</h2>
 
-<% if @country.changed? %>
+<% if @country.changes.keys.select { |k| k.starts_with?("teaching_authority_") }.any? %>
   <h3 class="govuk-heading-s">Teaching authority</h3>
 
   <%= render "shared/teaching_authority_contactable", contactable: @country %>
@@ -16,6 +16,12 @@
   <p class="govuk-body"><%= @country.teaching_authority_certificate %></p>
 
   <p class="govuk-body"><%= @country.teaching_authority_online_checker_url %></p>
+<% end %>
+
+<% if @country.qualifications_information_changed? %>
+  <h3 class="govuk-heading-s">Qualifications information</h3>
+
+  <p class="govuk-body"><%= @country.qualifications_information %></p>
 <% end %>
 
 <% if @diff_actions.present? %>
@@ -52,6 +58,7 @@
   <%= f.hidden_field :all_regions, value: @all_regions %>
   <%= f.hidden_field :eligibility_enabled, value: @country.eligibility_enabled %>
   <%= f.hidden_field :eligibility_skip_questions, value: @country.eligibility_skip_questions %>
+  <%= f.hidden_field :qualifications_information, value: @country.qualifications_information %>
   <%= f.hidden_field :teaching_authority_name, value: @country.teaching_authority_name %>
   <%= f.hidden_field :teaching_authority_address, value: @country.teaching_authority_address %>
   <%= f.hidden_field :teaching_authority_emails_string, value: @country.teaching_authority_emails_string %>

--- a/app/views/support_interface/countries/edit.html.erb
+++ b/app/views/support_interface/countries/edit.html.erb
@@ -9,6 +9,7 @@
   <%= f.govuk_check_box :eligibility_skip_questions, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Skip additional eligibility questions (keep qualification question)" }%>
 
   <%= render "shared/teaching_authority_form_fields", f: %>
+  <%= render "shared/qualifications_information_form_fields", f: %>
 
   <%= f.govuk_check_box :teaching_authority_checks_sanctions, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Teaching authority checks sanctions" } %>
 

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -23,6 +23,7 @@
   ], :id, :name, label: { text: "Status check" } %>
 
   <%= render "shared/teaching_authority_form_fields", f: %>
+  <%= render "shared/qualifications_information_form_fields", f: %>
 
   <%= f.govuk_check_box :teaching_authority_provides_written_statement, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Teaching authority will only send written statement directly to TRA" } %>
 

--- a/app/views/teacher_interface/qualifications/_heading.html.erb
+++ b/app/views/teacher_interface/qualifications/_heading.html.erb
@@ -1,3 +1,6 @@
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
-<h1 class="govuk-heading-l"><%= I18n.t("application_form.qualifications.heading.title.#{qualification.locale_key}") %></h1>
-<p class="govuk-body-l"><%= I18n.t("application_form.qualifications.heading.description.#{qualification.locale_key}") %></p>
+<h1 class="govuk-heading-l"><%= I18n.t("application_form.qualifications.heading.title.#{view_object.qualification.locale_key}") %></h1>
+<p class="govuk-body-l"><%= I18n.t("application_form.qualifications.heading.description.#{view_object.qualification.locale_key}") %></p>
+<% if view_object.qualifications_information.present? %>
+  <p class="govuk-body-l"><%= view_object.qualifications_information %></p>
+<% end %>

--- a/app/views/teacher_interface/qualifications/edit.html.erb
+++ b/app/views/teacher_interface/qualifications/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "#{"Error: " if @qualification_form.errors.any?}#{t("application_form.tasks.sections.qualifications")}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
-<%= render "heading", qualification: @qualification %>
+<%= render "heading", view_object: @view_object %>
 
 <%= render "form", qualification_form: @qualification_form, qualification: @qualification %>

--- a/app/views/teacher_interface/qualifications/new.html.erb
+++ b/app/views/teacher_interface/qualifications/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :page_title, "#{"Error: " if @qualification_form.errors.any?}#{t("application_form.tasks.sections.qualifications")}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
-<%= render "heading", qualification: @qualification_form.qualification %>
+<%= render "heading", view_object: @view_object %>
 
 <%= render "form", qualification_form: @qualification_form, qualification: @qualification_form.qualification %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -106,6 +106,7 @@
     - teaching_authority_online_checker_url
     - teaching_authority_status_information
     - teaching_authority_sanction_information
+    - qualifications_information
   :documents:
     - id
     - document_type
@@ -222,6 +223,7 @@
     - teaching_authority_status_information
     - teaching_authority_sanction_information
     - teaching_authority_provides_written_statement
+    - qualifications_information
   :reminder_emails:
     - id
     - created_at

--- a/db/migrate/20230111105740_add_qualifications_information_to_countries_and_regions.rb
+++ b/db/migrate/20230111105740_add_qualifications_information_to_countries_and_regions.rb
@@ -1,0 +1,16 @@
+class AddQualificationsInformationToCountriesAndRegions < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    add_column :countries,
+               :qualifications_information,
+               :text,
+               default: "",
+               null: false
+    add_column :regions,
+               :qualifications_information,
+               :text,
+               default: "",
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -142,6 +142,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_11_124208) do
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "eligibility_enabled", default: true, null: false
     t.boolean "eligibility_skip_questions", default: false, null: false
+    t.text "qualifications_information", default: "", null: false
     t.index ["code"], name: "index_countries_on_code", unique: true
   end
 
@@ -282,6 +283,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_11_124208) do
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "application_form_skip_work_history", default: false, null: false
+    t.text "qualifications_information", default: "", null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
     t.index ["country_id"], name: "index_regions_on_country_id"
   end

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -6,6 +6,7 @@
 #  code                                    :string           not null
 #  eligibility_enabled                     :boolean          default(TRUE), not null
 #  eligibility_skip_questions              :boolean          default(FALSE), not null
+#  qualifications_information              :text             default(""), not null
 #  teaching_authority_address              :text             default(""), not null
 #  teaching_authority_certificate          :text             default(""), not null
 #  teaching_authority_checks_sanctions     :boolean          default(TRUE), not null

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -7,6 +7,7 @@
 #  application_form_skip_work_history            :boolean          default(FALSE), not null
 #  legacy                                        :boolean          default(TRUE), not null
 #  name                                          :string           default(""), not null
+#  qualifications_information                    :text             default(""), not null
 #  sanction_check                                :string           default("none"), not null
 #  status_check                                  :string           default("none"), not null
 #  teaching_authority_address                    :text             default(""), not null

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -6,6 +6,7 @@
 #  code                                    :string           not null
 #  eligibility_enabled                     :boolean          default(TRUE), not null
 #  eligibility_skip_questions              :boolean          default(FALSE), not null
+#  qualifications_information              :text             default(""), not null
 #  teaching_authority_address              :text             default(""), not null
 #  teaching_authority_certificate          :text             default(""), not null
 #  teaching_authority_checks_sanctions     :boolean          default(TRUE), not null

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -7,6 +7,7 @@
 #  application_form_skip_work_history            :boolean          default(FALSE), not null
 #  legacy                                        :boolean          default(TRUE), not null
 #  name                                          :string           default(""), not null
+#  qualifications_information                    :text             default(""), not null
 #  sanction_check                                :string           default("none"), not null
 #  status_check                                  :string           default("none"), not null
 #  teaching_authority_address                    :text             default(""), not null

--- a/spec/support/autoload/page_objects/teacher_interface/qualifications_form.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/qualifications_form.rb
@@ -2,7 +2,7 @@ module PageObjects
   module TeacherInterface
     class QualificationsForm < SitePrism::Page
       element :heading, "h1"
-      element :body, ".govuk-body-l"
+      elements :body, ".govuk-body-l"
 
       section :form, "form" do
         element :title, "#teacher-interface-qualification-form-title-field"

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -18,6 +18,7 @@ module SystemHelpers
     country = create(:country, :with_national_region, code: "GB-SCT")
     country.regions.first.update!(
       application_form_enabled: true,
+      qualifications_information: "Qualifications information",
       status_check: country_check,
       sanction_check: country_check,
       teaching_authority_status_information: "Status information",

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_certificate
     when_i_fill_teaching_authority_online_checker_url
     when_i_fill_teaching_authority_checks_sanctions
+    when_i_fill_qualifications_information
     when_i_fill_regions
     and_i_save
     then_i_see_country_contact_preview
@@ -51,6 +52,7 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_status_information
     when_i_fill_teaching_authority_certificate
     when_i_fill_teaching_authority_online_checker_url
+    when_i_fill_qualifications_information
     and_i_save_and_preview
     then_i_see_the_preview
     and_i_see_a_success_banner
@@ -110,6 +112,7 @@ RSpec.describe "Countries support", type: :system do
     expect(page).to have_content("Website")
     expect(page).to have_content("Certificate")
     expect(page).to have_content("Other")
+    expect(page).to have_content("Qualifications information")
   end
 
   def then_i_see_region_changes_confirmation
@@ -130,6 +133,8 @@ RSpec.describe "Countries support", type: :system do
     expect(page).to have_content("You’re eligible to apply")
     expect(page).to have_content("Preparing to apply")
     expect(page).to have_content("Certified translations")
+    click_on "Proof of qualifications"
+    expect(page).to have_content("Qualifications information")
   end
 
   def when_i_fill_regions
@@ -212,6 +217,14 @@ RSpec.describe "Countries support", type: :system do
   rescue Capybara::ElementNotFound
     fill_in "country-teaching-authority-status-information-field",
             with: "Status information"
+  end
+
+  def when_i_fill_qualifications_information
+    fill_in "region-qualifications-information-field",
+            with: "Qualifications information"
+  rescue Capybara::ElementNotFound
+    fill_in "country-qualifications-information-field",
+            with: "Qualifications information"
   end
 
   def and_i_save

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -826,15 +826,18 @@ RSpec.describe "Teacher application", type: :system do
     expect(qualifications_form_page.heading.text).to eq(
       "Your teaching qualification",
     )
-    expect(qualifications_form_page.body).to have_content(
+    expect(qualifications_form_page.body.first).to have_content(
       "This is the qualification that led to you being recognised as a teacher.",
+    )
+    expect(qualifications_form_page.body.last).to have_content(
+      "Qualifications information",
     )
   end
 
   def then_i_see_the_university_degree_form
     expect(qualifications_form_page).to have_title("Your qualifications")
     expect(qualifications_form_page.heading.text).to eq("University degree")
-    expect(qualifications_form_page.body).to have_content(
+    expect(qualifications_form_page.body.first).to have_content(
       "Tell us about your university degree qualification.",
     )
   end
@@ -842,7 +845,7 @@ RSpec.describe "Teacher application", type: :system do
   def then_i_see_the_degree_qualifications_form
     expect(qualifications_form_page).to have_title("Your qualifications")
     expect(qualifications_form_page.heading.text).to eq("University degree")
-    expect(qualifications_form_page.body).to have_content(
+    expect(qualifications_form_page.body.first).to have_content(
       "Tell us about your university degree qualification.",
     )
   end

--- a/spec/view_objects/teacher_interface/qualification_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/qualification_view_object_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::QualificationViewObject do
+  subject(:view_object) { described_class.new(qualification:) }
+
+  let(:qualification) { create(:qualification) }
+
+  describe "#qualifications_information" do
+    let(:info) { "Qualifications info" }
+
+    context "when country has qualifications information" do
+      it "returns qualifications info for the country" do
+        qualification.application_form.region.country.update!(
+          qualifications_information: info,
+        )
+        expect(view_object.qualifications_information).to eq(info)
+      end
+    end
+
+    context "when region has qualifications information" do
+      it "returns qualifications info for the country" do
+        qualification.application_form.region.country.update!(
+          qualifications_information: "Country specific info",
+        )
+        qualification.application_form.region.update!(
+          qualifications_information: info,
+        )
+        expect(view_object.qualifications_information).to eq(info)
+      end
+    end
+
+    context "with no qualifications information" do
+      it "returns blank" do
+        expect(view_object.qualifications_information).to be_blank
+      end
+    end
+  end
+end

--- a/spec/views/shared/eligible_region_content_spec.rb
+++ b/spec/views/shared/eligible_region_content_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe "Eligible region content", type: :view do
         teaching_authority_status_information: "Status information",
         teaching_authority_sanction_information: "Sanction information",
         teaching_authority_address: "address",
+        qualifications_information: "qualifications info",
       )
     end
 
@@ -37,6 +38,7 @@ RSpec.describe "Eligible region content", type: :view do
     it { is_expected.to match(/You’ll need to provide a/) }
     it { is_expected.to match(/certificate/) }
     it { is_expected.to match(/address/) }
+    it { is_expected.to match(/qualifications info/) }
   end
 
   context "with an online status check and written sanction check" do


### PR DESCRIPTION
## Trello

https://trello.com/c/Jyzrctlo/1332-what-qualifications-we-cannot-accept-by-country

## Context / Changes

We'd like to provide tailored content on a per region or per country basis which is appended to the **Proof of qualifications** section visible in the eligibility screener. The content should be editable via the support UI for each country or region where applicable.

- Add `qualifications_information` to `countries` and `regions` tables
- Add form fields in Support UI to capture qualifications information
- Present qualifications information on support preview screens and relevant eligibility screener page

#### Support UI

![image](https://user-images.githubusercontent.com/93511/211857564-c32356ee-2d6f-43f7-912d-3c913a0c94dd.png)

#### Rendered in content
 
![image](https://user-images.githubusercontent.com/93511/211857688-40a3b53f-8f8b-464f-9119-c29618899492.png)

#### Rendered in application form (qualifications section)

![image](https://user-images.githubusercontent.com/93511/212090708-633ae5e9-1b3f-4a8e-b09f-35c6a5c6b081.png)
