### PR TITLE
Always show qualification question

### DIFF
--- a/app/controllers/eligibility_interface/countries_controller.rb
+++ b/app/controllers/eligibility_interface/countries_controller.rb
@@ -22,7 +22,7 @@ module EligibilityInterface
       {
         eligible: eligibility_interface_qualifications_path,
         ineligible: eligibility_interface_ineligible_path,
-        skip_questions: eligibility_interface_eligible_path,
+        legacy: eligibility_interface_eligible_path,
         region: eligibility_interface_region_path,
       }.fetch(eligibility_check.country_eligibility_status)
     end

--- a/app/controllers/eligibility_interface/qualifications_controller.rb
+++ b/app/controllers/eligibility_interface/qualifications_controller.rb
@@ -13,7 +13,7 @@ module EligibilityInterface
           qualification_form_params.merge(eligibility_check:),
         )
       if @qualification_form.save
-        redirect_to paths[:degree]
+        redirect_to next_path
       else
         render :new, status: :unprocessable_entity
       end
@@ -25,6 +25,18 @@ module EligibilityInterface
       params.require(:eligibility_interface_qualification_form).permit(
         :qualification,
       )
+    end
+
+    def next_path
+      if eligibility_check.skip_additional_questions?
+        if eligibility_check.eligible?
+          eligibility_interface_eligible_path
+        else
+          eligibility_interface_ineligible_path
+        end
+      else
+        paths[:degree]
+      end
     end
   end
 end

--- a/app/views/support_interface/countries/edit.html.erb
+++ b/app/views/support_interface/countries/edit.html.erb
@@ -6,7 +6,7 @@
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_check_box :eligibility_enabled, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Eligible" }%>
-  <%= f.govuk_check_box :eligibility_skip_questions, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Skip eligibility questions" }%>
+  <%= f.govuk_check_box :eligibility_skip_questions, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Skip additional eligibility questions (keep qualification question)" }%>
 
   <%= render "shared/teaching_authority_form_fields", f: %>
 

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe EligibilityCheck, type: :model do
     context "when the region exists and is legacy" do
       before { eligibility_check.region = create(:region, :legacy) }
 
-      it { is_expected.to eq(:skip_questions) }
+      it { is_expected.to eq(:legacy) }
     end
 
     context "when the region exists and country skips questions" do
@@ -192,7 +192,7 @@ RSpec.describe EligibilityCheck, type: :model do
 
       before { eligibility_check.country_code = country.code }
 
-      it { is_expected.to eq(:skip_questions) }
+      it { is_expected.to eq(:eligible) }
     end
 
     context "when the country doesn't exist" do
@@ -216,7 +216,7 @@ RSpec.describe EligibilityCheck, type: :model do
     context "when the region exists and is legacy" do
       before { eligibility_check.region = create(:region, :legacy) }
 
-      it { is_expected.to eq(:skip_questions) }
+      it { is_expected.to eq(:legacy) }
     end
 
     context "when the region exists and country skips questions" do
@@ -228,7 +228,7 @@ RSpec.describe EligibilityCheck, type: :model do
           )
       end
 
-      it { is_expected.to eq(:skip_questions) }
+      it { is_expected.to eq(:eligible) }
     end
   end
 

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -220,6 +220,9 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_visit_the(:start_page)
     when_i_press_start_now
     when_i_select_a_skip_questions_country
+    then_i_see_the(:qualification_page)
+
+    when_i_have_a_qualification
     then_i_see_the(:eligible_page)
   end
 


### PR DESCRIPTION
This changes the logic behind the "skips question" field on countries to show the qualification question, but none other than that. This was missed in 0466c7e13fbe04216cfabc317cca184e129e86db where this field was added.

I did consider renaming the field, but I thought it was okay to keep it for now and I've changed the label in the support console (the field didn't say which questions it skips in the first place). If we do want to rename it, we'll need to do it in steps anyway so it'll come in a separate PR.

[Trello Card](https://trello.com/c/J9btT0qS/1341-scotland-ni-eligibility-flow)