### PR TITLE
Further fixes to "skip questions" flow

### DIFF
--- a/app/controllers/eligibility_interface/qualifications_controller.rb
+++ b/app/controllers/eligibility_interface/qualifications_controller.rb
@@ -28,12 +28,9 @@ module EligibilityInterface
     end
 
     def next_path
-      if eligibility_check.skip_additional_questions?
-        if eligibility_check.eligible?
-          eligibility_interface_eligible_path
-        else
-          eligibility_interface_ineligible_path
-        end
+      if eligibility_check.skip_additional_questions? &&
+           eligibility_check.eligible?
+        eligibility_interface_eligible_path
       else
         paths[:degree]
       end

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -216,7 +216,7 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the_legacy_service
   end
 
-  it "can skip questions" do
+  it "can skip questions with qualification" do
     when_i_visit_the(:start_page)
     when_i_press_start_now
     when_i_select_a_skip_questions_country
@@ -224,6 +224,29 @@ RSpec.describe "Eligibility check", type: :system do
 
     when_i_have_a_qualification
     then_i_see_the(:eligible_page)
+  end
+
+  it "can skip questions without qualification" do
+    when_i_visit_the(:start_page)
+    when_i_press_start_now
+    when_i_select_a_skip_questions_country
+    then_i_see_the(:qualification_page)
+
+    when_i_dont_have_a_qualification
+    then_i_see_the(:degree_page)
+
+    when_i_dont_have_a_degree
+    then_i_see_the(:teach_children_page)
+
+    when_i_cant_teach_children
+    then_i_see_the(:misconduct_page)
+
+    when_i_have_a_misconduct_record
+    then_i_see_the(:ineligible_page)
+    and_i_see_the_ineligible_degree_text
+    and_i_see_the_ineligible_qualification_text
+    and_i_see_the_ineligible_teach_children_text
+    and_i_see_the_ineligible_misconduct_text
   end
 
   it "handles countries with multiple regions" do


### PR DESCRIPTION
This follows on from https://github.com/DFE-Digital/apply-for-qualified-teacher-status/commit/30c778dce76a2e6f9b00d2a2397baf20971f2d27 to further improve the "skip questions" flow. The requirements are that we only skip the additional questions if the applicant is eligible, otherwise they go through the normal flow (so they can see all the reasons they might have been ineligible).

This is rebased off #933 as it only affects Scotland and Northern Ireland at the moment.

[Trello Card](https://trello.com/c/J9btT0qS/1341-scotland-ni-eligibility-flow)