### PR TITLE
Add induction required form where necessary

### DIFF
--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -40,10 +40,6 @@ module AssessorInterface
         AssessmentSectionViewObject.new(params:)
     end
 
-    def assessment_section
-      assessment_section_view_object.assessment_section
-    end
-
     def assessment_section_form
       assessment_section_form_class.for_assessment_section(assessment_section)
     end
@@ -51,6 +47,10 @@ module AssessorInterface
     def assessment_section_form_class
       if assessment_section.age_range_subjects?
         AgeRangeSubjectsForm
+      elsif assessment_section.professional_standing? &&
+            application_form.created_under_new_regulations? &&
+            !application_form.needs_work_history
+        InductionRequiredForm
       else
         AssessmentSectionForm
       end
@@ -61,5 +61,9 @@ module AssessorInterface
         params.require(:assessor_interface_assessment_section_form),
       )
     end
+
+    delegate :assessment_section,
+             :application_form,
+             to: :assessment_section_view_object
   end
 end

--- a/app/forms/assessor_interface/induction_required_form.rb
+++ b/app/forms/assessor_interface/induction_required_form.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class AssessorInterface::InductionRequiredForm < AssessorInterface::AssessmentSectionForm
+  attribute :induction_required, :boolean
+
+  validates :induction_required, inclusion: [true, false], if: :passed
+
+  def save
+    return false unless valid?
+
+    ActiveRecord::Base.transaction do
+      assessment.update!(induction_required:)
+      super
+    end
+
+    true
+  end
+
+  class << self
+    def initial_attributes(assessment_section)
+      assessment = assessment_section.assessment
+      super.merge(induction_required: assessment.induction_required)
+    end
+
+    def permittable_parameters
+      args, kwargs = super
+      args += %i[induction_required]
+      [args, kwargs]
+    end
+  end
+
+  delegate :assessment, to: :assessment_section
+end

--- a/app/lib/dqt/trn_request_params.rb
+++ b/app/lib/dqt/trn_request_params.rb
@@ -28,7 +28,7 @@ module DQT
             application_form.region.country.code,
           ),
         qtsDate: qts_decision_at.to_date.iso8601,
-        inductionRequired: false,
+        inductionRequired: induction_required,
       }
     end
 
@@ -84,6 +84,14 @@ module DQT
         application_form.awarded_at
       else
         application_form.submitted_at
+      end
+    end
+
+    def induction_required
+      if application_form.created_under_new_regulations?
+        assessment.induction_required
+      else
+        false
       end
     end
   end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -6,6 +6,7 @@
 #  age_range_max                             :integer
 #  age_range_min                             :integer
 #  age_range_note                            :text             default(""), not null
+#  induction_required                        :boolean
 #  recommendation                            :string           default("unknown"), not null
 #  recommended_at                            :datetime
 #  started_at                                :datetime

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -23,7 +23,7 @@ module AssessorInterface
     delegate :application_form, to: :assessment
     delegate :registration_number, to: :application_form
     delegate :checks, to: :assessment_section
-    delegate :region, to: :application_form
+    delegate :region, :country, to: :application_form
 
     def qualifications
       application_form.qualifications.ordered

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -81,7 +81,7 @@
   ), method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
-  <% if @assessment_section_view_object.assessment_section.age_range_subjects? %>
+  <% if @assessment_section_form.is_a?(AssessorInterface::AgeRangeSubjectsForm) %>
     <h2 class="govuk-heading-m">What age range is the applicant qualified to teach?</h2>
     <p class="govuk-body">Based on the evidence the applicant has provided, you can either copy the age range they entered if you agree, or enter a new range.</p>
 
@@ -110,7 +110,18 @@
     <%= f.govuk_text_area :subjects_note %>
   <% end %>
 
-  <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "Has the applicant completed this section to your satisfaction?", size: "s" } do %>
+  <% if @assessment_section_form.is_a?(AssessorInterface::InductionRequiredForm) %>
+    <%= f.govuk_collection_radio_buttons :induction_required,
+                                         [
+                                           OpenStruct.new(value: :false, label: t(".induction_required.false.#{@assessment_section_view_object.country.code}")),
+                                           OpenStruct.new(value: :true, label: t(".induction_required.true.#{@assessment_section_view_object.country.code}"))
+                                         ],
+                                         :value,
+                                         :label,
+                                         legend: { text: t(".induction_required.legend.#{@assessment_section_view_object.country.code}") } %>
+  <% end %>
+
+  <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "Has the applicant completed this section to your satisfaction?" } do %>
     <%= f.govuk_radio_button :passed, true, label: { text: "Yes" }, link_errors: true %>
     <%= f.govuk_radio_button :passed, false, label: { text: "No" } do %>
       <%= f.govuk_check_boxes_fieldset :selected_failure_reasons, legend: { size: "s" }  do %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -85,6 +85,7 @@
     - subjects
     - subjects_note
     - recommended_at
+    - induction_required
     - working_days_since_started
     - working_days_submission_to_recommendation
     - working_days_submission_to_started

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -137,6 +137,16 @@ en:
           work_history_break: We need more information about a break in the applicant’s work history.
           written_statement_illegible: The letter from the country or state’s authority is illegible or in a format that we cannot accept.
           written_statement_recent: The letter from the country or state’s authority was not issued within the last 3 months.
+        induction_required:
+          legend:
+            GB-SCT: What level of registration does the applicant have?
+            GB-NIR: Has applicant completed Induction?
+          false:
+            GB-SCT: Full registration
+            GB-NIR: "Yes"
+          true:
+            GB-SCT: Provisional registration
+            GB-NIR: "No"
 
     further_information_requests:
       edit:
@@ -243,3 +253,7 @@ en:
               inclusion: Select whether the applicant completed this section to your satisfaction
             failure_assessor_note:
               blank: Enter why this section is not completed to your satisfaction
+        assessor_interface/induction_required_form:
+          attributes:
+            induction_required:
+              inclusion: Select whether the teacher requires induction

--- a/db/migrate/20230112093403_add_induction_required_to_assessments.rb
+++ b/db/migrate/20230112093403_add_induction_required_to_assessments.rb
@@ -1,0 +1,5 @@
+class AddInductionRequiredToAssessments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :assessments, :induction_required, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_11_124208) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_12_093403) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -123,6 +123,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_11_124208) do
     t.integer "working_days_submission_to_recommendation"
     t.integer "working_days_submission_to_started"
     t.integer "working_days_since_started"
+    t.boolean "induction_required"
     t.index ["application_form_id"], name: "index_assessments_on_application_form_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,11 +25,23 @@ COUNTRIES = {
   "GI" => [],
   "GB-SCT" => {
     eligibility_skip_questions: true,
-    regions: [{ application_form_skip_work_history: true }],
+    regions: [
+      {
+        status_check: "online",
+        sanction_check: "written",
+        application_form_skip_work_history: true,
+      },
+    ],
   },
   "GB-NIR" => {
     eligibility_skip_questions: true,
-    regions: [{ application_form_skip_work_history: true }],
+    regions: [
+      {
+        status_check: "online",
+        sanction_check: "written",
+        application_form_skip_work_history: true,
+      },
+    ],
   },
   "AT" => [],
   "CH" => [],

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -89,19 +89,21 @@ def helpdesk_users
   ]
 end
 
-def evidential_traits_for(status_check, sanction_check)
-  args = [status_check, sanction_check]
+def evidential_traits_for(region, new_regs)
+  checks = [region.status_check, region.sanction_check]
 
   [].tap do |traits|
-    traits << :with_work_history if args.include?("none")
-    traits << :with_written_statement if args.include?("written")
-    traits << :with_registration_number if args.include?("online")
+    if (checks.include?("none") || new_regs) &&
+         !region.application_form_skip_work_history
+      traits << :with_work_history
+    end
+    traits << :with_written_statement if checks.include?("written")
+    traits << :with_registration_number if checks.include?("online")
   end
 end
 
-def application_form_traits_for(region)
-  evidential_traits =
-    evidential_traits_for(region.status_check, region.sanction_check)
+def application_form_traits_for(region, new_regs)
+  evidential_traits = evidential_traits_for(region, new_regs)
 
   [
     [],
@@ -134,9 +136,7 @@ def create_application_forms(new_regs:)
   old_regs_date = new_regs_date - 1.day
 
   Region.all.each do |region|
-    application_form_traits_for(region).each do |traits|
-      traits << :new_regs if new_regs
-
+    application_form_traits_for(region, new_regs).each do |traits|
       created_at = new_regs ? new_regs_date : old_regs_date
 
       application_form =

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -72,7 +72,8 @@ FactoryBot.define do
     association :region
 
     needs_work_history do
-      region.status_check_none? || region.sanction_check_none?
+      (region.status_check_none? || region.sanction_check_none?) &&
+        !region.application_form_skip_work_history
     end
     needs_written_statement do
       region.status_check_written? || region.sanction_check_written?

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -6,6 +6,7 @@
 #  age_range_max                             :integer
 #  age_range_min                             :integer
 #  age_range_note                            :text             default(""), not null
+#  induction_required                        :boolean
 #  recommendation                            :string           default("unknown"), not null
 #  recommended_at                            :datetime
 #  started_at                                :datetime

--- a/spec/forms/assessor_interface/induction_required_form_spec.rb
+++ b/spec/forms/assessor_interface/induction_required_form_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::InductionRequiredForm, type: :model do
+  let(:assessment_section) do
+    create(:assessment_section, :professional_standing)
+  end
+  let(:user) { create(:staff, :confirmed) }
+  let(:attributes) { {} }
+
+  subject(:form) do
+    described_class.for_assessment_section(assessment_section).new(
+      assessment_section:,
+      user:,
+      **attributes,
+    )
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:assessment_section) }
+    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to allow_values(true, false).for(:passed) }
+
+    it do
+      is_expected.to allow_values(nil, true, false).for(:induction_required)
+    end
+
+    context "when passed" do
+      let(:attributes) { { passed: "true" } }
+
+      it { is_expected.to_not allow_values(nil).for(:induction_required) }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    let(:assessment) { assessment_section.assessment }
+
+    describe "when invalid attributes" do
+      it { is_expected.to be false }
+    end
+
+    describe "with valid attributes" do
+      let(:attributes) { { passed: true, induction_required: true } }
+
+      it { is_expected.to be true }
+
+      it "sets the attributes" do
+        save # rubocop:disable Rails/SaveBang
+
+        expect(assessment.induction_required).to be true
+      end
+    end
+  end
+end

--- a/spec/lib/dqt/trn_request_params_spec.rb
+++ b/spec/lib/dqt/trn_request_params_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe DQT::TRNRequestParams do
       )
     end
 
-    before do
+    let!(:assessment) do
       create(
         :assessment,
         :award,
@@ -30,7 +30,9 @@ RSpec.describe DQT::TRNRequestParams do
         age_range_max: 11,
         subjects: %w[physics french_language],
       )
+    end
 
+    before do
       create(
         :qualification,
         :completed,
@@ -89,6 +91,22 @@ RSpec.describe DQT::TRNRequestParams do
 
       it "should use the assessed date" do
         expect(call[:qtsDate]).to eq("2020-01-07")
+      end
+
+      describe "induction required" do
+        subject(:induction_required) { call[:inductionRequired] }
+
+        it { is_expected.to be_nil }
+
+        context "when induction is required" do
+          before { assessment.update!(induction_required: true) }
+          it { is_expected.to be true }
+        end
+
+        context "when induction is not required" do
+          before { assessment.update!(induction_required: false) }
+          it { is_expected.to be false }
+        end
       end
     end
   end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -8,6 +8,7 @@
 #  age_range_max                             :integer
 #  age_range_min                             :integer
 #  age_range_note                            :text             default(""), not null
+#  induction_required                        :boolean
 #  recommendation                            :string           default("unknown"), not null
 #  recommended_at                            :datetime
 #  started_at                                :datetime

--- a/spec/support/autoload/page_objects/assessor_interface/assessment_section.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/assessment_section.rb
@@ -4,12 +4,12 @@ module PageObjects
       element :heading, "h1"
 
       section :form, "form" do
-        section :yes_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(1)"
-        section :no_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(2)"
+        element :yes_radio_item,
+                "#assessor-interface-assessment-section-form-passed-true-field",
+                visible: false
+        element :no_radio_item,
+                "#assessor-interface-assessment-section-form-passed-field",
+                visible: false
         sections :failure_reason_checkbox_items,
                  PageObjects::GovukCheckboxItem,
                  ".govuk-checkboxes__item"

--- a/spec/support/autoload/page_objects/assessor_interface/check_professional_standing.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_professional_standing.rb
@@ -11,6 +11,15 @@ module PageObjects
 
       sections :cards, ProfessionalStandingCard, ".govuk-summary-list__card"
 
+      section :induction_required_form, "form" do
+        element :no_radio_item,
+                "#assessor-interface-assessment-section-form-induction-required-false-field",
+                visible: false
+        element :yes_radio_item,
+                "#assessor-interface-assessment-section-form-induction-required-true-field",
+                visible: false
+      end
+
       def proof_of_recognition
         cards&.first
       end

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -133,10 +133,33 @@ RSpec.describe "Assessor check submitted details", type: :system do
     and_i_see_check_professional_standing_action_required
   end
 
+  it "allows passing the professional standing without work history" do
+    given_application_form_doesnt_need_work_history
+
+    when_i_visit_the(
+      :check_professional_standing_page,
+      application_id:,
+      assessment_id:,
+    )
+    then_i_see_the_professional_standing
+
+    when_i_choose_full_registration
+    and_i_choose_check_professional_standing_yes
+    then_i_see_the(:assessor_application_page, application_id:)
+    and_i_see_check_professional_standing_completed
+  end
+
   private
 
   def given_there_is_an_application_form
     application_form
+  end
+
+  def given_application_form_doesnt_need_work_history
+    application_form.update!(
+      needs_work_history: false,
+      created_at: Date.new(2023, 2, 1),
+    )
   end
 
   def then_i_see_the_personal_information
@@ -149,7 +172,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def when_i_choose_check_personal_information_yes
-    check_personal_information_page.form.yes_radio_item.input.click
+    check_personal_information_page.form.yes_radio_item.choose
     check_personal_information_page.form.continue_button.click
   end
 
@@ -166,7 +189,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def when_i_choose_check_personal_information_no
-    check_personal_information_page.form.no_radio_item.input.click
+    check_personal_information_page.form.no_radio_item.choose
     check_personal_information_page
       .form
       .failure_reason_checkbox_items
@@ -195,12 +218,12 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def when_i_choose_check_qualifications_yes
-    check_qualifications_page.form.yes_radio_item.input.click
+    check_qualifications_page.form.yes_radio_item.choose
     check_qualifications_page.form.continue_button.click
   end
 
   def when_i_choose_check_qualifications_no
-    check_qualifications_page.form.no_radio_item.input.click
+    check_qualifications_page.form.no_radio_item.choose
     check_qualifications_page
       .form
       .failure_reason_checkbox_items
@@ -249,12 +272,12 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def and_i_choose_verify_age_range_subjects_yes
-    verify_age_range_subjects_page.form.yes_radio_item.input.click
+    verify_age_range_subjects_page.form.yes_radio_item.choose
     verify_age_range_subjects_page.form.continue_button.click
   end
 
   def and_i_choose_verify_age_range_subjects_no
-    verify_age_range_subjects_page.form.no_radio_item.input.click
+    verify_age_range_subjects_page.form.no_radio_item.choose
     verify_age_range_subjects_page
       .form
       .failure_reason_checkbox_items
@@ -288,7 +311,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def when_i_choose_check_work_history_yes
-    check_work_history_page.form.yes_radio_item.input.click
+    check_work_history_page.form.yes_radio_item.choose
     check_work_history_page.form.continue_button.click
   end
 
@@ -299,7 +322,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def when_i_choose_check_work_history_no
-    check_work_history_page.form.no_radio_item.input.click
+    check_work_history_page.form.no_radio_item.choose
     check_work_history_page
       .form
       .failure_reason_checkbox_items
@@ -329,8 +352,18 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def when_i_choose_check_professional_standing_yes
-    check_professional_standing_page.form.yes_radio_item.input.click
+    check_professional_standing_page.form.yes_radio_item.choose
     check_professional_standing_page.form.continue_button.click
+  end
+
+  alias_method :and_i_choose_check_professional_standing_yes,
+               :when_i_choose_check_professional_standing_yes
+
+  def when_i_choose_full_registration
+    check_professional_standing_page
+      .induction_required_form
+      .no_radio_item
+      .choose
   end
 
   def and_i_see_check_professional_standing_completed
@@ -340,7 +373,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def when_i_choose_check_professional_standing_no
-    check_professional_standing_page.form.no_radio_item.input.click
+    check_professional_standing_page.form.no_radio_item.choose
     check_professional_standing_page
       .form
       .failure_reason_checkbox_items
@@ -372,6 +405,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
             :with_personal_information,
             :submitted,
             :with_assessment,
+            region: create(:region, :in_country, country_code: "GB-SCT"),
           )
 
         create(


### PR DESCRIPTION
This adds a new "induction required" form to the check professional standing assessor spoke if the application form is under the new regulations and didn't require work history (and therefore has no way of determining the induction required status other than asking the assessor).

This is only needed for Scotland and Northern Ireland at the moment but I've implemented it in a generic way that means we could apply it to other countries in the future if we needed to.

[Trello Card](https://trello.com/c/ZDTTxczS/1344-scotland-ni-assessor)

## Screenshots

### Scotland

![Screenshot 2023-01-12 at 10 58 49](https://user-images.githubusercontent.com/510498/212056908-f29a900d-3521-402f-bc09-b092eae5267f.png)

### Northern Ireland

![Screenshot 2023-01-12 at 11 09 50](https://user-images.githubusercontent.com/510498/212056913-a1ce2cea-5954-4fcb-9072-19e11ec6fb2d.png)
