### PR TITLE
Fix issue where form for further information is missing

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -50,8 +50,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
     when :further_information
       further_information_request = further_information_requests[index]
 
-      if further_information_request.received? &&
-           assessment.request_further_information?
+      if further_information_request.received?
         url_helpers.edit_assessor_interface_application_form_assessment_further_information_request_path(
           application_form,
           assessment,

--- a/app/view_objects/assessor_interface/further_information_request_view_object.rb
+++ b/app/view_objects/assessor_interface/further_information_request_view_object.rb
@@ -19,8 +19,7 @@ class AssessorInterface::FurtherInformationRequestViewObject
         .find(params[:id])
   end
 
-  delegate :assessment, to: :further_information_request
-  delegate :application_form, to: :assessment
+  delegate :application_form, :assessment, to: :further_information_request
 
   def review_items
     further_information_request
@@ -49,6 +48,11 @@ class AssessorInterface::FurtherInformationRequestViewObject
           },
         }
       end
+  end
+
+  def can_update?
+    further_information_request.passed.nil? ||
+      assessment.request_further_information?
   end
 
   private

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -9,7 +9,7 @@
   <%= render(CheckYourAnswersSummary::Component.new(**item.fetch(:check_your_answers))) %>
 <% end %>
 
-<% if policy(:assessor).update? && @view_object.further_information_request.passed.nil? %>
+<% if policy(:assessor).update? && @view_object.can_update? %>
   <%= form_with model: @further_information_request_form, url: [:assessor_interface, @view_object.application_form, @view_object.assessment, @view_object.further_information_request], method: :put do |f| %>
     <%= f.govuk_error_summary %>
 

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -42,8 +42,9 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     and_i_see_a_decline_qts_option
   end
 
-  it "further information request passed" do
-    @further_information_request.update!(passed: true)
+  it "further information request passed and assessment finished" do
+    further_information_request.update!(passed: true)
+    further_information_request.assessment.award!
 
     when_i_visit_the(:assessor_application_page, application_id:)
     and_i_click_review_requested_information

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -132,31 +132,12 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
         let!(:further_information_request) do
           create(:further_information_request, :received, assessment:)
         end
-
-        before do
-          assessment.update!(recommendation: "request_further_information")
-        end
-
         it do
           is_expected.to eq(
             "/assessor/applications/#{application_form.id}/assessments/#{assessment.id}" \
               "/further-information-requests/#{further_information_request.id}/edit",
           )
         end
-      end
-
-      context "and a passed further information request" do
-        let!(:further_information_request) do
-          create(:further_information_request, :received, :passed, assessment:)
-        end
-        it { is_expected.to be_nil }
-      end
-
-      context "and a failed further information request" do
-        let!(:further_information_request) do
-          create(:further_information_request, :received, :failed, assessment:)
-        end
-        it { is_expected.to be_nil }
       end
     end
   end

--- a/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
@@ -79,4 +79,40 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
       )
     end
   end
+
+  describe "#can_update?" do
+    subject(:can_update?) { view_object.can_update? }
+
+    context "when not passed and not recommended" do
+      before do
+        further_information_request.update!(passed: nil)
+        assessment.request_further_information!
+      end
+      it { is_expected.to be true }
+    end
+
+    context "when passed and not recommended" do
+      before do
+        further_information_request.update!(passed: true)
+        assessment.request_further_information!
+      end
+      it { is_expected.to be true }
+    end
+
+    context "when not passed and recommended" do
+      before do
+        further_information_request.update!(passed: nil)
+        assessment.award!
+      end
+      it { is_expected.to be true }
+    end
+
+    context "when passed and recommended" do
+      before do
+        further_information_request.update!(passed: true)
+        assessment.award!
+      end
+      it { is_expected.to be false }
+    end
+  end
 end


### PR DESCRIPTION
This makes a slight change to the logic to decide whether the form on the edit further information page for an assessor appears. This should fix a bug where the form disappears after the pass/fail has been selected, but the rest of the flow hasn't been followed through yet.