### PR TITLE
Update content for written statement

### DIFF
--- a/app/helpers/proof_of_recognition_helper.rb
+++ b/app/helpers/proof_of_recognition_helper.rb
@@ -13,12 +13,11 @@ module ProofOfRecognitionHelper
   end
 
   def proof_of_recognition_description_for(region:)
-    if region.status_check_written?
-      return(
-        "The authority or territory that recognises you as a teacher must confirm:"
-      )
-    end
-    if region.sanction_check_written?
+    if region.teaching_authority_provides_written_statement?
+      "The document must confirm:"
+    elsif region.status_check_written?
+      "The authority or territory that recognises you as a teacher must confirm:"
+    elsif region.sanction_check_written?
       "The education department or authority must also confirm in writing:"
     end
   end

--- a/app/helpers/region_helper.rb
+++ b/app/helpers/region_helper.rb
@@ -8,4 +8,21 @@ module RegionHelper
         "letter that proves you’re recognised as a teacher"
     "#{certificate.indefinite_article} #{tag.span(certificate, lang: region.country.code)}".html_safe
   end
+
+  def region_teaching_authority_name_phrase(region)
+    name =
+      region.teaching_authority_name.presence ||
+        region.country.teaching_authority_name.presence || "teaching authority"
+    "the #{name}"
+  end
+
+  def region_teaching_authority_emails_phrase(region)
+    emails =
+      region.teaching_authority_emails +
+        region.country.teaching_authority_emails
+    emails
+      .map { |email| govuk_link_to email, "mailto:#{email}" }
+      .to_sentence
+      .html_safe
+  end
 end

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -63,7 +63,9 @@
     <% end %>
 
     <% accordion.section(heading_text: "Competent authority information shown to applicant") do %>
-      <%= render "shared/eligible_region_content_components/professional_recognition", region: @assessment_section_view_object.region %>
+      <%= render "shared/eligible_region_content_components/professional_recognition",
+                 region: @assessment_section_view_object.region,
+                 teaching_authority_provides_written_statement: @assessment_section_view_object.region.teaching_authority_provides_written_statement %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -36,7 +36,9 @@
     <% end %>
 
     <% accordion.section(heading_text: "Proof that you’re recognised as a teacher") do %>
-      <%= render "shared/eligible_region_content_components/professional_recognition", region: %>
+      <%= render "shared/eligible_region_content_components/professional_recognition",
+                 region:,
+                 teaching_authority_provides_written_statement: region.teaching_authority_provides_written_statement %>
     <% end %>
 
     <% if FeatureFlags::FeatureFlag.active?(:application_work_history) && !region.application_form_skip_work_history %>

--- a/app/views/shared/eligible_region_content_components/_professional_recognition.html.erb
+++ b/app/views/shared/eligible_region_content_components/_professional_recognition.html.erb
@@ -3,6 +3,7 @@
     As your education department or authority has an online register of teachers,
     you’ll need to provide any registration numbers we need to check your record.
   </p>
+
   <% if region.teaching_authority_status_information.present?%>
     <%= raw GovukMarkdown.render(region.teaching_authority_status_information) %>
   <% end %>
@@ -22,36 +23,55 @@
   <% end %>
 <% end %>
 
-<p class="govuk-body">
-  <%= proof_of_recognition_description_for(region:) %>
-</p>
-<ul class="govuk-list govuk-list--bullet">
-  <%- proof_of_recognition_requirements_for(region:).each do |requirement|%>
-    <li><%= requirement %></li>
-  <%- end -%>
-</ul>
-
 <% if region.status_check_written? || region.sanction_check_written? %>
-  <p class="govuk-body">
-    You’ll need to provide <%= region_certificate_phrase(region) %>, which you can obtain by contacting:
-  </p>
+  <% if teaching_authority_provides_written_statement %>
+    <p class="govuk-body">
+      We need a document called <%= region_certificate_phrase(region) %> from <%= region_teaching_authority_name_phrase(region) %>.
+    </p>
 
-  <%= render "shared/teaching_authority_contact_information", region: %>
+    <p class="govuk-body">
+      You should request it by emailing <%= region_teaching_authority_emails_phrase(region) %>.
+    </p>
+
+    <p class="govuk-body">
+      You cannot provide this document yourself – instead, you must contact <%= region_teaching_authority_name_phrase(region) %> and ask them to send it directly to us at <a class="govuk-link" href="mailto:<%= t("service.email") %>"><%= t("service.email") %></a>.
+    </p>
+  <% end %>
+
+  <p class="govuk-body"><%= proof_of_recognition_description_for(region:) %></p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <%- proof_of_recognition_requirements_for(region:).each do |requirement|%>
+      <li><%= requirement %></li>
+    <%- end -%>
+  </ul>
+
+  <% if teaching_authority_provides_written_statement %>
+    <p class="govuk-body">
+      If we do not receive the document within 90 days of the date that you submit your application, we’ll need to close your application.
+    </p>
+  <% else %>
+    <p class="govuk-body">
+      You’ll need to provide <%= region_certificate_phrase(region) %>, which you can obtain by contacting:
+    </p>
+
+    <%= render "shared/teaching_authority_contact_information", region: %>
+  <% end %>
 <% end %>
 
 <% if region.status_check_written? %>
-  <% if region.teaching_authority_status_information.present?%>
+  <% if region.teaching_authority_status_information.present? %>
     <%= raw GovukMarkdown.render(region.teaching_authority_status_information) %>
   <% end %>
 
-  <% if region.country.teaching_authority_status_information.present?%>
+  <% if region.country.teaching_authority_status_information.present? %>
     <%= raw GovukMarkdown.render(region.country.teaching_authority_status_information) %>
   <% end %>
-  
+
 <% end %>
 
 <% if region.sanction_check_written? %>
-  <% if region.teaching_authority_sanction_information.present?%> 
+  <% if region.teaching_authority_sanction_information.present?%>
     <%= raw GovukMarkdown.render(region.teaching_authority_sanction_information) %>
   <% end %>
 
@@ -80,6 +100,7 @@
 <% if region.teaching_authority_other.present? %>
   <%= raw GovukMarkdown.render(region.teaching_authority_other) %>
 <% end %>
+
 <% if region.country.teaching_authority_other.present?%>
   <%= raw GovukMarkdown.render(region.country.teaching_authority_other) %>
 <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -243,7 +243,17 @@ COUNTRIES = {
   "HK" => [],
   "IN" => [],
   "JM" => [],
-  "NG" => [],
+  "NG" => [
+    {
+      status_check: "written",
+      sanction_check: "written",
+      teaching_authority_provides_written_statement: true,
+      teaching_authority_name:
+        "Teachers Registration Council of Nigeria (TRCN)",
+      teaching_authority_certificate: "Letter of Professional Standing",
+      teaching_authority_emails: %w[LoPs@trcn.gov.ng],
+    },
+  ],
   "SG" => [],
   "ZA" => [],
   "UA" => [],

--- a/spec/helpers/proof_of_recognition_helper_spec.rb
+++ b/spec/helpers/proof_of_recognition_helper_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe ProofOfRecognitionHelper do
       name: "Region Name",
       status_check_written?: status,
       sanction_check_written?: sanction,
+      teaching_authority_provides_written_statement?:
+        teaching_authority_provides_written_statement,
       application_form_skip_work_history?: application_form_skip_work_history,
       country:
         double(
@@ -16,6 +18,7 @@ RSpec.describe ProofOfRecognitionHelper do
   end
   let(:status) { false }
   let(:sanction) { false }
+  let(:teaching_authority_provides_written_statement) { false }
   let(:application_form_skip_work_history) { false }
   let(:teaching_authority_checks_sanctions) { true }
 
@@ -121,6 +124,12 @@ RSpec.describe ProofOfRecognitionHelper do
           "The authority or territory that recognises you as a teacher must confirm:",
         )
       end
+    end
+
+    context "a country which provides the written statement" do
+      let(:teaching_authority_provides_written_statement) { true }
+
+      it { is_expected.to eq("The document must confirm:") }
     end
   end
 end


### PR DESCRIPTION
If the teaching authority provides the written statement directly to the TRA, we want to include some specific content.

[Trello Card](https://trello.com/c/zWaU0Dgz/1330-lopless-eligibility-checker-content-changes)

## Screenshots

<img width="680" alt="Screenshot 2023-01-13 at 12 49 07" src="https://user-images.githubusercontent.com/510498/212324231-bdd537dd-4266-4545-8eaf-9738d29d5a94.png">
