### PR TITLE
Add written statement confirmation page

### DIFF
--- a/app/controllers/teacher_interface/written_statements_controller.rb
+++ b/app/controllers/teacher_interface/written_statements_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class WrittenStatementsController < BaseController
+    include HandleApplicationFormSection
+    include HistoryTrackable
+
+    before_action :redirect_unless_application_form_is_draft
+    before_action :load_application_form
+
+    def edit
+      @form =
+        WrittenStatementConfirmationForm.new(
+          application_form:,
+          written_statement_confirmation:
+            application_form.written_statement_confirmation,
+        )
+    end
+
+    def update
+      @form =
+        WrittenStatementConfirmationForm.new(
+          written_statement_confirmation_form_params.merge(application_form:),
+        )
+
+      handle_application_form_section(form: @form)
+    end
+
+    private
+
+    def written_statement_confirmation_form_params
+      params.fetch(
+        :teacher_interface_written_statement_confirmation_form,
+        {},
+      ).permit(:written_statement_confirmation)
+    end
+  end
+end

--- a/app/forms/teacher_interface/written_statement_confirmation_form.rb
+++ b/app/forms/teacher_interface/written_statement_confirmation_form.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class WrittenStatementConfirmationForm < BaseForm
+    attr_accessor :application_form
+    attribute :written_statement_confirmation
+
+    validates :application_form, presence: true
+    validates :written_statement_confirmation, presence: true
+
+    private
+
+    def update_model
+      application_form.update!(written_statement_confirmation:)
+    end
+  end
+end

--- a/app/lib/application_form_factory.rb
+++ b/app/lib/application_form_factory.rb
@@ -14,6 +14,7 @@ class ApplicationFormFactory
       region:,
       needs_work_history:,
       needs_written_statement:,
+      teaching_authority_provides_written_statement:,
       needs_registration_number:,
     )
   end
@@ -33,6 +34,8 @@ class ApplicationFormFactory
   def needs_written_statement
     region.status_check_written? || region.sanction_check_written?
   end
+
+  delegate :teaching_authority_provides_written_statement, to: :region
 
   def needs_registration_number
     region.status_check_online? || region.sanction_check_online?

--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -47,6 +47,8 @@ class ApplicationFormStatusUpdater
            :has_work_history,
            :work_histories,
            :registration_number,
+           :teaching_authority_provides_written_statement,
+           :written_statement_confirmation,
            :written_statement_document,
            to: :application_form
 
@@ -180,7 +182,14 @@ class ApplicationFormStatusUpdater
   end
 
   def written_statement_status
-    written_statement_document.uploaded? ? :completed : :not_started
+    completed =
+      if teaching_authority_provides_written_statement
+        written_statement_confirmation
+      else
+        written_statement_document.uploaded?
+      end
+
+    completed ? :completed : :not_started
   end
 
   def status_for_values(*values)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -2,47 +2,49 @@
 #
 # Table name: application_forms
 #
-#  id                                    :bigint           not null, primary key
-#  age_range_max                         :integer
-#  age_range_min                         :integer
-#  age_range_status                      :string           default("not_started"), not null
-#  alternative_family_name               :text             default(""), not null
-#  alternative_given_names               :text             default(""), not null
-#  awarded_at                            :datetime
-#  confirmed_no_sanctions                :boolean          default(FALSE)
-#  date_of_birth                         :date
-#  english_language_citizenship_exempt   :boolean
-#  english_language_proof_method         :string
-#  english_language_provider_reference   :text             default(""), not null
-#  english_language_qualification_exempt :boolean
-#  english_language_status               :string           default("not_started"), not null
-#  family_name                           :text             default(""), not null
-#  given_names                           :text             default(""), not null
-#  has_alternative_name                  :boolean
-#  has_work_history                      :boolean
-#  identification_document_status        :string           default("not_started"), not null
-#  needs_registration_number             :boolean          not null
-#  needs_work_history                    :boolean          not null
-#  needs_written_statement               :boolean          not null
-#  personal_information_status           :string           default("not_started"), not null
-#  qualifications_status                 :string           default("not_started"), not null
-#  reference                             :string(31)       not null
-#  registration_number                   :text
-#  registration_number_status            :string           default("not_started"), not null
-#  state                                 :string           default("draft"), not null
-#  subjects                              :text             default([]), not null, is an Array
-#  subjects_status                       :string           default("not_started"), not null
-#  submitted_at                          :datetime
-#  work_history_status                   :string           default("not_started"), not null
-#  working_days_since_submission         :integer
-#  written_statement_status              :string           default("not_started"), not null
-#  created_at                            :datetime         not null
-#  updated_at                            :datetime         not null
-#  assessor_id                           :bigint
-#  english_language_provider_id          :bigint
-#  region_id                             :bigint           not null
-#  reviewer_id                           :bigint
-#  teacher_id                            :bigint           not null
+#  id                                            :bigint           not null, primary key
+#  age_range_max                                 :integer
+#  age_range_min                                 :integer
+#  age_range_status                              :string           default("not_started"), not null
+#  alternative_family_name                       :text             default(""), not null
+#  alternative_given_names                       :text             default(""), not null
+#  awarded_at                                    :datetime
+#  confirmed_no_sanctions                        :boolean          default(FALSE)
+#  date_of_birth                                 :date
+#  english_language_citizenship_exempt           :boolean
+#  english_language_proof_method                 :string
+#  english_language_provider_reference           :text             default(""), not null
+#  english_language_qualification_exempt         :boolean
+#  english_language_status                       :string           default("not_started"), not null
+#  family_name                                   :text             default(""), not null
+#  given_names                                   :text             default(""), not null
+#  has_alternative_name                          :boolean
+#  has_work_history                              :boolean
+#  identification_document_status                :string           default("not_started"), not null
+#  needs_registration_number                     :boolean          not null
+#  needs_work_history                            :boolean          not null
+#  needs_written_statement                       :boolean          not null
+#  personal_information_status                   :string           default("not_started"), not null
+#  qualifications_status                         :string           default("not_started"), not null
+#  reference                                     :string(31)       not null
+#  registration_number                           :text
+#  registration_number_status                    :string           default("not_started"), not null
+#  state                                         :string           default("draft"), not null
+#  subjects                                      :text             default([]), not null, is an Array
+#  subjects_status                               :string           default("not_started"), not null
+#  submitted_at                                  :datetime
+#  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
+#  work_history_status                           :string           default("not_started"), not null
+#  working_days_since_submission                 :integer
+#  written_statement_confirmation                :boolean          default(FALSE), not null
+#  written_statement_status                      :string           default("not_started"), not null
+#  created_at                                    :datetime         not null
+#  updated_at                                    :datetime         not null
+#  assessor_id                                   :bigint
+#  english_language_provider_id                  :bigint
+#  region_id                                     :bigint           not null
+#  reviewer_id                                   :bigint
+#  teacher_id                                    :bigint           not null
 #
 # Indexes
 #

--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -62,6 +62,18 @@ class TeacherInterface::ApplicationFormShowViewObject
     completed_task_sections.count == tasks.count
   end
 
+  def text_for_task_item(key)
+    if key == :written_statement
+      if application_form.teaching_authority_provides_written_statement
+        I18n.t("application_form.tasks.items.written_statement.provide")
+      else
+        I18n.t("application_form.tasks.items.written_statement.upload")
+      end
+    else
+      I18n.t("application_form.tasks.items.#{key}")
+    end
+  end
+
   def path_for_task_item(key)
     case key
     when :identification_document
@@ -69,9 +81,13 @@ class TeacherInterface::ApplicationFormShowViewObject
         application_form.identification_document,
       )
     when :written_statement
-      url_helpers.teacher_interface_application_form_document_path(
-        application_form.written_statement_document,
-      )
+      if application_form.teaching_authority_provides_written_statement
+        url_helpers.edit_teacher_interface_application_form_written_statement_path
+      else
+        url_helpers.teacher_interface_application_form_document_path(
+          application_form.written_statement_document,
+        )
+      end
     when :work_history
       if FeatureFlags::FeatureFlag.active?(:application_work_history)
         url_helpers.teacher_interface_application_form_new_regs_work_histories_path

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -65,7 +65,7 @@
     <% accordion.section(heading_text: "Competent authority information shown to applicant") do %>
       <%= render "shared/eligible_region_content_components/professional_recognition",
                  region: @assessment_section_view_object.region,
-                 teaching_authority_provides_written_statement: @assessment_section_view_object.region.teaching_authority_provides_written_statement %>
+                 teaching_authority_provides_written_statement: @assessment_section_view_object.application_form.teaching_authority_provides_written_statement %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/shared/application_form/_written_statement_summary.html.erb
+++ b/app/views/shared/application_form/_written_statement_summary.html.erb
@@ -1,12 +1,27 @@
-<%= render(CheckYourAnswersSummary::Component.new(
-  id: "written-statement",
-  model: application_form,
-  title: I18n.t("application_form.tasks.items.written_statement"),
-  fields: {
-    written_statement_document: {
-      title: "Written statement",
-      href: [:teacher_interface, :application_form, application_form.written_statement_document]
+<% if application_form.teaching_authority_provides_written_statement %>
+  <%= render(CheckYourAnswersSummary::Component.new(
+    id: "written-statement",
+    model: application_form,
+    title: I18n.t("application_form.tasks.items.written_statement.provide"),
+    fields: {
+      written_statement_confirmation: {
+        title: "Written statement confirmed",
+        href: [:edit, :teacher_interface, :application_form, :written_statement]
+      },
     },
-  },
-  changeable:
-)) %>
+    changeable:
+  )) %>
+<% else %>
+  <%= render(CheckYourAnswersSummary::Component.new(
+    id: "written-statement",
+    model: application_form,
+    title: I18n.t("application_form.tasks.items.written_statement.upload"),
+    fields: {
+      written_statement_document: {
+        title: "Written statement",
+        href: [:teacher_interface, :application_form, application_form.written_statement_document]
+      },
+    },
+    changeable:
+  )) %>
+<% end %>

--- a/app/views/shared/eligible_region_content_components/_professional_recognition.html.erb
+++ b/app/views/shared/eligible_region_content_components/_professional_recognition.html.erb
@@ -34,7 +34,7 @@
     </p>
 
     <p class="govuk-body">
-      You cannot provide this document yourself – instead, you must contact <%= region_teaching_authority_name_phrase(region) %> and ask them to send it directly to us at <a class="govuk-link" href="mailto:<%= t("service.email") %>"><%= t("service.email") %></a>.
+      You cannot send this document yourself – instead, you must contact <%= region_teaching_authority_name_phrase(region) %> and ask them to send it directly to us at <a class="govuk-link" href="mailto:<%= t("service.email") %>"><%= t("service.email") %></a>.
     </p>
   <% end %>
 

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -29,7 +29,7 @@
           <% items.each do |item| %>
             <li class="app-task-list__item">
               <span class="app-task-list__task-name">
-                <%= link_to I18n.t("application_form.tasks.items.#{item}"),
+                <%= link_to @view_object.text_for_task_item(item),
                             @view_object.path_for_task_item(item),
                             aria: { describedby: "#{item}-status" } %>
               </span>

--- a/app/views/teacher_interface/written_statements/edit.html.erb
+++ b/app/views/teacher_interface/written_statements/edit.html.erb
@@ -1,0 +1,31 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("application_form.tasks.items.written_statement.provide")}" %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
+
+<%= form_with model: @form, url: %i[teacher_interface application_form written_statement], method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l"><%= t("application_form.tasks.sections.proof_of_recognition") %></span>
+  <h1 class="govuk-heading-l"><%= t("application_form.tasks.items.written_statement.provide") %></h1>
+
+  <%= render "shared/eligible_region_content_components/professional_recognition",
+             region: @application_form.region,
+             teaching_authority_provides_written_statement: @application_form.teaching_authority_provides_written_statement %>
+
+  <p class="govuk-body">
+    Check the box below to confirm you understand that it’s your responsibility to request this document.
+  </p>
+
+  <%= f.govuk_check_boxes_fieldset :written_statement_confirmation, legend: nil, small: true do %>
+    <%= f.govuk_check_box :written_statement_confirmation,
+                          true,
+                          false,
+                          multiple: false,
+                          link_errors: true,
+                          label: {
+                            text: "I understand that it’s my responsibility to request written evidence from #{region_teaching_authority_name_phrase(@application_form.region)} to be sent directly to #{govuk_link_to t("service.email"), "mailto:#{t("service.email")}"}.".html_safe,
+                            size: "s",
+                          } %>
+  <% end %>
+
+  <%= render "shared/save_submit_buttons", f: %>
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -56,6 +56,7 @@
     - needs_work_history
     - needs_written_statement
     - needs_registration_number
+    - teaching_authority_provides_written_statement
     - confirmed_no_sanctions
     - english_language_status
     - english_language_citizenship_exempt
@@ -63,6 +64,7 @@
     - english_language_proof_method
     - english_language_provider_id
     - english_language_provider_reference
+    - written_statement_confirmation
   :assessment_sections:
     - id
     - assessment_id

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -71,7 +71,9 @@ en:
         english_language: Verify your English language proficiency
         work_history: Add your work history
         registration_number: Enter your registration number
-        written_statement: Upload your written statement
+        written_statement:
+          upload: Upload your written statement
+          provide: Provide your written statement
     qualifications:
       heading:
         title:
@@ -348,3 +350,7 @@ en:
               invalid: Enter the end date in the format 3 1980
               future: End date must be in the past
               comparison: End date must be after start date
+        teacher_interface/written_statement_confirmation_form:
+          attributes:
+            written_statement_confirmation:
+              blank: You must confirm that you understand that it’s your responsibility to request written evidence

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,6 +233,8 @@ Rails.application.routes.draw do
         end
       end
 
+      resource :written_statement, only: %i[edit update]
+
       resources :documents, only: %i[show edit update] do
         resources :uploads, only: %i[new create destroy] do
           get "delete", on: :member

--- a/db/migrate/20230113094131_add_written_statement_confirmation_to_application_forms.rb
+++ b/db/migrate/20230113094131_add_written_statement_confirmation_to_application_forms.rb
@@ -1,0 +1,12 @@
+class AddWrittenStatementConfirmationToApplicationForms < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    change_table :application_forms, bulk: true do |t|
+      t.boolean :teaching_authority_provides_written_statement,
+                default: false,
+                null: false
+      t.boolean :written_statement_confirmation, default: false, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_12_093403) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_13_094131) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -84,6 +84,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_12_093403) do
     t.bigint "english_language_provider_id"
     t.text "english_language_provider_reference", default: "", null: false
     t.datetime "awarded_at"
+    t.boolean "teaching_authority_provides_written_statement", default: false, null: false
+    t.boolean "written_statement_confirmation", default: false, null: false
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["english_language_provider_id"], name: "index_application_forms_on_english_language_provider_id"
     t.index ["family_name"], name: "index_application_forms_on_family_name"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -2,47 +2,49 @@
 #
 # Table name: application_forms
 #
-#  id                                    :bigint           not null, primary key
-#  age_range_max                         :integer
-#  age_range_min                         :integer
-#  age_range_status                      :string           default("not_started"), not null
-#  alternative_family_name               :text             default(""), not null
-#  alternative_given_names               :text             default(""), not null
-#  awarded_at                            :datetime
-#  confirmed_no_sanctions                :boolean          default(FALSE)
-#  date_of_birth                         :date
-#  english_language_citizenship_exempt   :boolean
-#  english_language_proof_method         :string
-#  english_language_provider_reference   :text             default(""), not null
-#  english_language_qualification_exempt :boolean
-#  english_language_status               :string           default("not_started"), not null
-#  family_name                           :text             default(""), not null
-#  given_names                           :text             default(""), not null
-#  has_alternative_name                  :boolean
-#  has_work_history                      :boolean
-#  identification_document_status        :string           default("not_started"), not null
-#  needs_registration_number             :boolean          not null
-#  needs_work_history                    :boolean          not null
-#  needs_written_statement               :boolean          not null
-#  personal_information_status           :string           default("not_started"), not null
-#  qualifications_status                 :string           default("not_started"), not null
-#  reference                             :string(31)       not null
-#  registration_number                   :text
-#  registration_number_status            :string           default("not_started"), not null
-#  state                                 :string           default("draft"), not null
-#  subjects                              :text             default([]), not null, is an Array
-#  subjects_status                       :string           default("not_started"), not null
-#  submitted_at                          :datetime
-#  work_history_status                   :string           default("not_started"), not null
-#  working_days_since_submission         :integer
-#  written_statement_status              :string           default("not_started"), not null
-#  created_at                            :datetime         not null
-#  updated_at                            :datetime         not null
-#  assessor_id                           :bigint
-#  english_language_provider_id          :bigint
-#  region_id                             :bigint           not null
-#  reviewer_id                           :bigint
-#  teacher_id                            :bigint           not null
+#  id                                            :bigint           not null, primary key
+#  age_range_max                                 :integer
+#  age_range_min                                 :integer
+#  age_range_status                              :string           default("not_started"), not null
+#  alternative_family_name                       :text             default(""), not null
+#  alternative_given_names                       :text             default(""), not null
+#  awarded_at                                    :datetime
+#  confirmed_no_sanctions                        :boolean          default(FALSE)
+#  date_of_birth                                 :date
+#  english_language_citizenship_exempt           :boolean
+#  english_language_proof_method                 :string
+#  english_language_provider_reference           :text             default(""), not null
+#  english_language_qualification_exempt         :boolean
+#  english_language_status                       :string           default("not_started"), not null
+#  family_name                                   :text             default(""), not null
+#  given_names                                   :text             default(""), not null
+#  has_alternative_name                          :boolean
+#  has_work_history                              :boolean
+#  identification_document_status                :string           default("not_started"), not null
+#  needs_registration_number                     :boolean          not null
+#  needs_work_history                            :boolean          not null
+#  needs_written_statement                       :boolean          not null
+#  personal_information_status                   :string           default("not_started"), not null
+#  qualifications_status                         :string           default("not_started"), not null
+#  reference                                     :string(31)       not null
+#  registration_number                           :text
+#  registration_number_status                    :string           default("not_started"), not null
+#  state                                         :string           default("draft"), not null
+#  subjects                                      :text             default([]), not null, is an Array
+#  subjects_status                               :string           default("not_started"), not null
+#  submitted_at                                  :datetime
+#  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
+#  work_history_status                           :string           default("not_started"), not null
+#  working_days_since_submission                 :integer
+#  written_statement_confirmation                :boolean          default(FALSE), not null
+#  written_statement_status                      :string           default("not_started"), not null
+#  created_at                                    :datetime         not null
+#  updated_at                                    :datetime         not null
+#  assessor_id                                   :bigint
+#  english_language_provider_id                  :bigint
+#  region_id                                     :bigint           not null
+#  reviewer_id                                   :bigint
+#  teacher_id                                    :bigint           not null
 #
 # Indexes
 #
@@ -243,11 +245,19 @@ FactoryBot.define do
       end
     end
 
+    trait :teaching_authority_provides_written_statement do
+      teaching_authority_provides_written_statement { true }
+    end
+
     trait :with_written_statement do
       needs_written_statement { true }
 
       after(:create) do |application_form, _evaluator|
-        create(:upload, document: application_form.written_statement_document)
+        if application_form.teaching_authority_provides_written_statement
+          application_form.update!(written_statement_confirmation: true)
+        else
+          create(:upload, document: application_form.written_statement_document)
+        end
       end
     end
 

--- a/spec/forms/teacher_interface/written_statement_confirmation_form_spec.rb
+++ b/spec/forms/teacher_interface/written_statement_confirmation_form_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::WrittenStatementConfirmationForm,
+               type: :model do
+  let(:application_form) { build(:application_form) }
+
+  subject(:form) do
+    described_class.new(application_form:, written_statement_confirmation:)
+  end
+
+  describe "validations" do
+    let(:written_statement_confirmation) { "" }
+
+    it { is_expected.to validate_presence_of(:application_form) }
+    it { is_expected.to validate_presence_of(:written_statement_confirmation) }
+  end
+
+  describe "#save" do
+    let(:written_statement_confirmation) { "true" }
+
+    before { form.save(validate: true) }
+
+    it "updates the application form" do
+      expect(application_form).to be_written_statement_confirmation
+    end
+  end
+end

--- a/spec/lib/application_form_factory_spec.rb
+++ b/spec/lib/application_form_factory_spec.rb
@@ -76,7 +76,23 @@ RSpec.describe ApplicationFormFactory do
         application_form = call
         expect(application_form.needs_work_history).to be false
         expect(application_form.needs_written_statement).to be true
+        expect(
+          application_form.teaching_authority_provides_written_statement,
+        ).to be false
         expect(application_form.needs_registration_number).to be false
+      end
+
+      context "when teaching authority provides the written statement" do
+        before do
+          region.update!(teaching_authority_provides_written_statement: true)
+        end
+
+        it "sets the rules" do
+          application_form = call
+          expect(
+            application_form.teaching_authority_provides_written_statement,
+          ).to be true
+        end
       end
     end
 

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -311,16 +311,41 @@ RSpec.describe ApplicationFormStatusUpdater do
         application_form.written_statement_status
       end
 
-      context "with no upload" do
-        let(:application_form) { create(:application_form) }
-        it { is_expected.to eq("not_started") }
+      context "when teaching authority provides the written statement" do
+        context "without confirmation" do
+          let(:application_form) do
+            create(
+              :application_form,
+              :teaching_authority_provides_written_statement,
+              :with_written_statement,
+            )
+          end
+          it { is_expected.to eq("completed") }
+        end
+
+        context "with confirmation" do
+          let(:application_form) do
+            create(
+              :application_form,
+              :teaching_authority_provides_written_statement,
+            )
+          end
+          it { is_expected.to eq("not_started") }
+        end
       end
 
-      context "with an upload" do
-        let(:application_form) do
-          create(:application_form, :with_written_statement)
+      context "when teacher provides the written statement" do
+        context "with no upload" do
+          let(:application_form) { create(:application_form) }
+          it { is_expected.to eq("not_started") }
         end
-        it { is_expected.to eq("completed") }
+
+        context "with an upload" do
+          let(:application_form) do
+            create(:application_form, :with_written_statement)
+          end
+          it { is_expected.to eq("completed") }
+        end
       end
     end
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -2,47 +2,49 @@
 #
 # Table name: application_forms
 #
-#  id                                    :bigint           not null, primary key
-#  age_range_max                         :integer
-#  age_range_min                         :integer
-#  age_range_status                      :string           default("not_started"), not null
-#  alternative_family_name               :text             default(""), not null
-#  alternative_given_names               :text             default(""), not null
-#  awarded_at                            :datetime
-#  confirmed_no_sanctions                :boolean          default(FALSE)
-#  date_of_birth                         :date
-#  english_language_citizenship_exempt   :boolean
-#  english_language_proof_method         :string
-#  english_language_provider_reference   :text             default(""), not null
-#  english_language_qualification_exempt :boolean
-#  english_language_status               :string           default("not_started"), not null
-#  family_name                           :text             default(""), not null
-#  given_names                           :text             default(""), not null
-#  has_alternative_name                  :boolean
-#  has_work_history                      :boolean
-#  identification_document_status        :string           default("not_started"), not null
-#  needs_registration_number             :boolean          not null
-#  needs_work_history                    :boolean          not null
-#  needs_written_statement               :boolean          not null
-#  personal_information_status           :string           default("not_started"), not null
-#  qualifications_status                 :string           default("not_started"), not null
-#  reference                             :string(31)       not null
-#  registration_number                   :text
-#  registration_number_status            :string           default("not_started"), not null
-#  state                                 :string           default("draft"), not null
-#  subjects                              :text             default([]), not null, is an Array
-#  subjects_status                       :string           default("not_started"), not null
-#  submitted_at                          :datetime
-#  work_history_status                   :string           default("not_started"), not null
-#  working_days_since_submission         :integer
-#  written_statement_status              :string           default("not_started"), not null
-#  created_at                            :datetime         not null
-#  updated_at                            :datetime         not null
-#  assessor_id                           :bigint
-#  english_language_provider_id          :bigint
-#  region_id                             :bigint           not null
-#  reviewer_id                           :bigint
-#  teacher_id                            :bigint           not null
+#  id                                            :bigint           not null, primary key
+#  age_range_max                                 :integer
+#  age_range_min                                 :integer
+#  age_range_status                              :string           default("not_started"), not null
+#  alternative_family_name                       :text             default(""), not null
+#  alternative_given_names                       :text             default(""), not null
+#  awarded_at                                    :datetime
+#  confirmed_no_sanctions                        :boolean          default(FALSE)
+#  date_of_birth                                 :date
+#  english_language_citizenship_exempt           :boolean
+#  english_language_proof_method                 :string
+#  english_language_provider_reference           :text             default(""), not null
+#  english_language_qualification_exempt         :boolean
+#  english_language_status                       :string           default("not_started"), not null
+#  family_name                                   :text             default(""), not null
+#  given_names                                   :text             default(""), not null
+#  has_alternative_name                          :boolean
+#  has_work_history                              :boolean
+#  identification_document_status                :string           default("not_started"), not null
+#  needs_registration_number                     :boolean          not null
+#  needs_work_history                            :boolean          not null
+#  needs_written_statement                       :boolean          not null
+#  personal_information_status                   :string           default("not_started"), not null
+#  qualifications_status                         :string           default("not_started"), not null
+#  reference                                     :string(31)       not null
+#  registration_number                           :text
+#  registration_number_status                    :string           default("not_started"), not null
+#  state                                         :string           default("draft"), not null
+#  subjects                                      :text             default([]), not null, is an Array
+#  subjects_status                               :string           default("not_started"), not null
+#  submitted_at                                  :datetime
+#  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
+#  work_history_status                           :string           default("not_started"), not null
+#  working_days_since_submission                 :integer
+#  written_statement_confirmation                :boolean          default(FALSE), not null
+#  written_statement_status                      :string           default("not_started"), not null
+#  created_at                                    :datetime         not null
+#  updated_at                                    :datetime         not null
+#  assessor_id                                   :bigint
+#  english_language_provider_id                  :bigint
+#  region_id                                     :bigint           not null
+#  reviewer_id                                   :bigint
+#  teacher_id                                    :bigint           not null
 #
 # Indexes
 #

--- a/spec/support/autoload/page_objects/govuk_checkbox_item.rb
+++ b/spec/support/autoload/page_objects/govuk_checkbox_item.rb
@@ -2,5 +2,7 @@ module PageObjects
   class GovukCheckboxItem < SitePrism::Section
     element :label, "label"
     element :checkbox, "input", visible: false
+
+    def_delegator :checkbox, :click
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/application.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/application.rb
@@ -23,6 +23,14 @@ module PageObjects
       def work_history_task_item
         task_list.find_item("Add your work history")
       end
+
+      def upload_written_statement_task_item
+        task_list.find_item("Upload your written statement")
+      end
+
+      def provide_written_statement_task_item
+        task_list.find_item("Provide your written statement")
+      end
     end
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/edit_written_statement.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/edit_written_statement.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class EditWrittenStatement < SitePrism::Page
+      set_url "/teacher/application/written_statement/edit"
+
+      section :form, "form" do
+        section :written_statement_confirmation_checkbox,
+                GovukCheckboxItem,
+                ".govuk-checkboxes__item"
+
+        element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
+        element :save_and_come_back_later_button,
+                ".govuk-button.govuk-button--secondary"
+      end
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -273,6 +273,11 @@ module PageHelpers
       PageObjects::TeacherInterface::EditWorkHistorySchool.new
   end
 
+  def teacher_edit_written_statement_page
+    @teacher_edit_written_statement_page ||=
+      PageObjects::TeacherInterface::EditWrittenStatement.new
+  end
+
   def teacher_english_language_exemption_page
     @teacher_english_language_exemption_page ||=
       PageObjects::TeacherInterface::EnglishLanguageExemption.new

--- a/spec/system/teacher_interface/written_statement_spec.rb
+++ b/spec/system/teacher_interface/written_statement_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Teacher written statement", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_a_user(teacher)
+    given_an_application_form_exists
+  end
+
+  it "teacher provides document" do
+    when_i_visit_the(:teacher_application_page)
+    then_i_see_the(:teacher_application_page)
+    and_i_see_the_upload_written_statement_task
+
+    when_i_click_the_upload_written_statement_task
+    then_i_see_the(:teacher_upload_document_page)
+
+    when_i_upload_a_file
+    then_i_see_the(:teacher_check_document_page)
+
+    when_i_dont_need_to_upload_another_file
+    then_i_see_the(:teacher_application_page)
+    and_i_see_the_upload_written_statement_task_is_completed
+  end
+
+  it "teaching authority provides document" do
+    given_the_teaching_authority_provides_written_statement
+
+    when_i_visit_the(:teacher_application_page)
+    then_i_see_the(:teacher_application_page)
+    and_i_see_the_provide_written_statement_task
+
+    when_i_click_the_provide_written_statement_task
+    then_i_see_the(:teacher_edit_written_statement_page)
+
+    when_i_confirm_written_statement
+    then_i_see_the(:teacher_application_page)
+    and_i_see_the_provide_written_statement_task_is_completed
+  end
+
+  private
+
+  def given_an_application_form_exists
+    application_form
+  end
+
+  def given_the_teaching_authority_provides_written_statement
+    application_form.update!(
+      teaching_authority_provides_written_statement: true,
+    )
+  end
+
+  def and_i_see_the_upload_written_statement_task
+    expect(
+      teacher_application_page.upload_written_statement_task_item,
+    ).to_not be_nil
+  end
+
+  def when_i_click_the_upload_written_statement_task
+    teacher_application_page.upload_written_statement_task_item.click
+  end
+
+  def when_i_upload_a_file
+    teacher_upload_document_page.form.original_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
+    )
+    teacher_upload_document_page.form.continue_button.click
+  end
+
+  def when_i_dont_need_to_upload_another_file
+    teacher_check_document_page.form.no_radio_item.input.click
+    teacher_check_document_page.form.continue_button.click
+  end
+
+  def and_i_see_the_upload_written_statement_task_is_completed
+    expect(
+      teacher_application_page
+        .upload_written_statement_task_item
+        .status_tag
+        .text,
+    ).to eq("COMPLETED")
+  end
+
+  def and_i_see_the_provide_written_statement_task
+    expect(
+      teacher_application_page.provide_written_statement_task_item,
+    ).to_not be_nil
+  end
+
+  def when_i_click_the_provide_written_statement_task
+    teacher_application_page.provide_written_statement_task_item.click
+  end
+
+  def when_i_confirm_written_statement
+    teacher_edit_written_statement_page
+      .form
+      .written_statement_confirmation_checkbox
+      .click
+    teacher_edit_written_statement_page.form.continue_button.click
+  end
+
+  def and_i_see_the_provide_written_statement_task_is_completed
+    expect(
+      teacher_application_page
+        .provide_written_statement_task_item
+        .status_tag
+        .text,
+    ).to eq("COMPLETED")
+  end
+
+  def teacher
+    @teacher ||= create(:teacher)
+  end
+
+  def application_form
+    @application_form ||=
+      create(
+        :application_form,
+        teacher:,
+        region: create(:region, :written_checks),
+      )
+  end
+end


### PR DESCRIPTION
This adds a new page to the application form asking the teacher to confirm that they need to get their teaching authority to send us their written statement if required.

[Trello Card](https://trello.com/c/4fa45iNN/1355-lopless-application-form)

## Screenshot

![Screenshot 2023-01-13 at 14 58 27](https://user-images.githubusercontent.com/510498/212353798-f1a59194-9bff-409d-8375-7cc7302e0b6b.png)
