### PR TITLE
Add reduced evidence journey option

### DIFF
--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -41,6 +41,7 @@ class SupportInterface::RegionsController < SupportInterface::BaseController
       :legacy,
       :application_form_enabled,
       :application_form_skip_work_history,
+      :reduced_evidence_accepted,
       :qualifications_information,
       :sanction_check,
       :status_check,

--- a/app/lib/application_form_factory.rb
+++ b/app/lib/application_form_factory.rb
@@ -16,12 +16,15 @@ class ApplicationFormFactory
       needs_written_statement:,
       teaching_authority_provides_written_statement:,
       needs_registration_number:,
+      reduced_evidence_accepted:,
     )
   end
 
   private
 
   attr_reader :teacher, :region
+
+  delegate :reduced_evidence_accepted, to: :region
 
   def needs_work_history
     if FeatureFlags::FeatureFlag.active?(:application_work_history)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -26,6 +26,7 @@
 #  needs_written_statement                       :boolean          not null
 #  personal_information_status                   :string           default("not_started"), not null
 #  qualifications_status                         :string           default("not_started"), not null
+#  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  reference                                     :string(31)       not null
 #  registration_number                           :text
 #  registration_number_status                    :string           default("not_started"), not null

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -6,8 +6,9 @@
 #  application_form_enabled                      :boolean          default(FALSE)
 #  application_form_skip_work_history            :boolean          default(FALSE), not null
 #  legacy                                        :boolean          default(TRUE), not null
-#  qualifications_information                    :text             default(""), not null
 #  name                                          :string           default(""), not null
+#  qualifications_information                    :text             default(""), not null
+#  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  sanction_check                                :string           default("none"), not null
 #  status_check                                  :string           default("none"), not null
 #  teaching_authority_address                    :text             default(""), not null

--- a/app/views/support_interface/countries/index.html.erb
+++ b/app/views/support_interface/countries/index.html.erb
@@ -12,6 +12,16 @@
               <h2 class="govuk-heading-m">
                 <%= govuk_link_to CountryName.from_country(country), edit_support_interface_country_path(country) %>
                 <code class="govuk-tag app-country-code-tag govuk-!-margin-left-2"><%= country.code %></code>
+
+                <% if country.eligibility_enabled %>
+                  <%= govuk_tag(text: "Eligible", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
+                <% else %>
+                  <%= govuk_tag(text: "Ineligible", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
+                <% end %>
+
+                <% if country.eligibility_skip_questions %>
+                  <%= govuk_tag(text: "Skips questions", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
+                <% end %>
               </h2>
             </th>
           </tr>
@@ -30,25 +40,24 @@
                     <% end %>
                   </a>
                 </td>
-                <td class="govuk-table__cell">
-                  <% if country.eligibility_enabled %>
-                    <%= govuk_tag(text: "Eligibility enabled", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
 
-                    <% if country.eligibility_skip_questions || region.legacy %>
-                      <%= govuk_tag(text: "Skips questions", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
+                <td class="govuk-table__cell">
+                  <% if region.legacy && !country.eligibility_skip_questions %>
+                    <%= govuk_tag(text: "Skips questions", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
+                  <% end %>
+
+                  <% if region.application_form_enabled %>
+                    <%= govuk_tag(text: "Applications enabled", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
+
+                    <% if region.application_form_skip_work_history %>
+                      <%= govuk_tag(text: "Skips work history", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
                     <% end %>
 
-                    <% if region.application_form_enabled %>
-                      <%= govuk_tag(text: "Applications enabled", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
-
-                      <% if region.application_form_skip_work_history %>
-                        <%= govuk_tag(text: "Skips work history", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
-                      <% end %>
-                    <% else %>
-                      <%= govuk_tag(text: "Applications disabled", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
+                    <% if region.reduced_evidence_accepted %>
+                      <%= govuk_tag(text: "Accepts reduced evidence", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
                     <% end %>
                   <% else %>
-                    <%= govuk_tag(text: "Eligibility disabled", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
+                    <%= govuk_tag(text: "Applications disabled", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
                   <% end %>
                 </td>
               </tr>

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -9,6 +9,7 @@
 
   <%= f.govuk_check_box :application_form_enabled, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Application form enabled" } %>
   <%= f.govuk_check_box :application_form_skip_work_history, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Skip work history" } %>
+  <%= f.govuk_check_box :reduced_evidence_accepted, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Accept reduced evidence" } %>
 
   <%= f.govuk_collection_select :sanction_check, [
     OpenStruct.new(id: 'online', name: 'Online'),

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -57,6 +57,7 @@
     - needs_written_statement
     - needs_registration_number
     - teaching_authority_provides_written_statement
+    - written_statement_confirmation
     - confirmed_no_sanctions
     - english_language_status
     - english_language_citizenship_exempt
@@ -64,7 +65,7 @@
     - english_language_proof_method
     - english_language_provider_id
     - english_language_provider_reference
-    - written_statement_confirmation
+    - reduced_evidence_accepted
   :assessment_sections:
     - id
     - assessment_id
@@ -216,6 +217,7 @@
     - legacy
     - application_form_enabled
     - application_form_skip_work_history
+    - reduced_evidence_accepted
     - teaching_authority_address
     - teaching_authority_emails
     - teaching_authority_websites

--- a/db/migrate/20230113152013_add_reduced_evidence_accepted.rb
+++ b/db/migrate/20230113152013_add_reduced_evidence_accepted.rb
@@ -1,0 +1,14 @@
+class AddReducedEvidenceAccepted < ActiveRecord::Migration[7.0]
+  def change
+    add_column :regions,
+               :reduced_evidence_accepted,
+               :boolean,
+               default: false,
+               null: false
+    add_column :application_forms,
+               :reduced_evidence_accepted,
+               :boolean,
+               default: false,
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_13_094131) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_13_152013) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_13_094131) do
     t.bigint "english_language_provider_id"
     t.text "english_language_provider_reference", default: "", null: false
     t.datetime "awarded_at"
+    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "written_statement_confirmation", default: false, null: false
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
@@ -287,6 +288,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_13_094131) do
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "application_form_skip_work_history", default: false, null: false
     t.text "qualifications_information", default: "", null: false
+    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
     t.index ["country_id"], name: "index_regions_on_country_id"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -256,7 +256,7 @@ COUNTRIES = {
   ],
   "SG" => [],
   "ZA" => [],
-  "UA" => [],
+  "UA" => [{ reduced_evidence_accepted: true }],
   "ZW" => [],
 }.freeze
 

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -26,6 +26,7 @@
 #  needs_written_statement                       :boolean          not null
 #  personal_information_status                   :string           default("not_started"), not null
 #  qualifications_status                         :string           default("not_started"), not null
+#  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  reference                                     :string(31)       not null
 #  registration_number                           :text
 #  registration_number_status                    :string           default("not_started"), not null
@@ -83,6 +84,7 @@ FactoryBot.define do
     needs_registration_number do
       region.status_check_online? || region.sanction_check_online?
     end
+    reduced_evidence_accepted { region.reduced_evidence_accepted }
 
     trait :completed do
       personal_information_status { "completed" }

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -8,6 +8,7 @@
 #  legacy                                        :boolean          default(TRUE), not null
 #  name                                          :string           default(""), not null
 #  qualifications_information                    :text             default(""), not null
+#  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  sanction_check                                :string           default("none"), not null
 #  status_check                                  :string           default("none"), not null
 #  teaching_authority_address                    :text             default(""), not null
@@ -50,6 +51,10 @@ FactoryBot.define do
 
     trait :application_form_enabled do
       application_form_enabled { true }
+    end
+
+    trait :reduced_evidence_accepted do
+      reduced_evidence_accepted { true }
     end
 
     trait :online_checks do

--- a/spec/lib/application_form_factory_spec.rb
+++ b/spec/lib/application_form_factory_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe ApplicationFormFactory do
         expect(application_form.needs_work_history).to be true
         expect(application_form.needs_written_statement).to be false
         expect(application_form.needs_registration_number).to be false
+        expect(application_form.reduced_evidence_accepted).to be false
       end
     end
 
@@ -44,6 +45,7 @@ RSpec.describe ApplicationFormFactory do
           expect(application_form.needs_work_history).to be true
           expect(application_form.needs_written_statement).to be false
           expect(application_form.needs_registration_number).to be false
+          expect(application_form.reduced_evidence_accepted).to be false
         end
       end
 
@@ -61,6 +63,7 @@ RSpec.describe ApplicationFormFactory do
           expect(application_form.needs_work_history).to be false
           expect(application_form.needs_written_statement).to be false
           expect(application_form.needs_registration_number).to be false
+          expect(application_form.reduced_evidence_accepted).to be false
         end
       end
     end
@@ -80,6 +83,7 @@ RSpec.describe ApplicationFormFactory do
           application_form.teaching_authority_provides_written_statement,
         ).to be false
         expect(application_form.needs_registration_number).to be false
+        expect(application_form.reduced_evidence_accepted).to be false
       end
 
       context "when teaching authority provides the written statement" do
@@ -108,6 +112,20 @@ RSpec.describe ApplicationFormFactory do
         expect(application_form.needs_work_history).to be false
         expect(application_form.needs_written_statement).to be false
         expect(application_form.needs_registration_number).to be true
+        expect(application_form.reduced_evidence_accepted).to be false
+      end
+    end
+
+    context "when reduced evidence is accepted" do
+      let(:region) { create(:region, :reduced_evidence_accepted) }
+
+      it "creates an application form" do
+        expect { call }.to change(ApplicationForm, :count).by(1)
+      end
+
+      it "sets the rules" do
+        application_form = call
+        expect(application_form.reduced_evidence_accepted).to be true
       end
     end
   end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -26,6 +26,7 @@
 #  needs_written_statement                       :boolean          not null
 #  personal_information_status                   :string           default("not_started"), not null
 #  qualifications_status                         :string           default("not_started"), not null
+#  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  reference                                     :string(31)       not null
 #  registration_number                           :text
 #  registration_number_status                    :string           default("not_started"), not null

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -8,6 +8,7 @@
 #  legacy                                        :boolean          default(TRUE), not null
 #  name                                          :string           default(""), not null
 #  qualifications_information                    :text             default(""), not null
+#  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  sanction_check                                :string           default("none"), not null
 #  status_check                                  :string           default("none"), not null
 #  teaching_authority_address                    :text             default(""), not null


### PR DESCRIPTION
This adds the option of a reduced evidence journey to regions in the support console in preparation for building the flow.

[Trello Card](https://trello.com/c/FAZeRZuL/1377-trigger-reduced-evidence-journey-in-support-console)

## Screenshots

![Screenshot 2023-01-13 at 15 34 27](https://user-images.githubusercontent.com/510498/212360350-0926bfdd-c11a-45ee-82b1-7c093cccd968.png)
![Screenshot 2023-01-13 at 15 38 41](https://user-images.githubusercontent.com/510498/212360354-6acef2e9-be9d-4045-8442-79a51e04758d.png)
