### PR TITLE
Add view object to qualifications create action

### DIFF
--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -50,6 +50,8 @@ module TeacherInterface
     def create
       qualification = Qualification.new(application_form:)
 
+      @view_object = QualificationViewObject.new(qualification:)
+
       @qualification_form =
         QualificationForm.new(qualification_form_params.merge(qualification:))
 


### PR DESCRIPTION
This should resolve an issue where the view object isn't there if an error occurs.

https://sentry.io/organizations/dfe-teacher-services/issues/3873347359/