### PR TITLE
Add view object to qualifications update action

### DIFF
--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -100,6 +100,7 @@ module TeacherInterface
       @qualification = qualification
 
       @view_object = QualificationViewObject.new(qualification:)
+
       @qualification_form =
         QualificationForm.new(
           qualification:,
@@ -114,6 +115,8 @@ module TeacherInterface
 
     def update
       @qualification = qualification
+
+      @view_object = QualificationViewObject.new(qualification:)
 
       @qualification_form =
         QualificationForm.new(qualification_form_params.merge(qualification:))


### PR DESCRIPTION
This should resolve an issue where the view object isn't there if an error occurs.

https://sentry.io/organizations/dfe-teacher-services/issues/3875709077/