### PR TITLE
Update deadline content for new regulations 

### DIFF
--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -50,12 +50,14 @@ class Teachers::SessionsController < Devise::SessionsController
   end
 
   def destroy
+    teacher = current_teacher
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
     yield if block_given?
-    respond_to_on_destroy
+    redirect_to after_sign_out_path_for(teacher)
   end
 
   def signed_out
+    @duration = params[:new_regulations] == "true" ? "6 months" : "60 days"
   end
 
   protected
@@ -64,7 +66,12 @@ class Teachers::SessionsController < Devise::SessionsController
     stored_location_for(resource) || teacher_interface_root_path
   end
 
-  def after_sign_out_path_for(_resource)
-    teacher_signed_out_path
+  def after_sign_out_path_for(resource)
+    return teacher_signed_out_path unless resource.is_a?(Teacher)
+
+    teacher_signed_out_path(
+      new_regulations:
+        resource.application_form&.created_under_new_regulations?,
+    )
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -68,6 +68,8 @@
 #  fk_rails_...  (teacher_id => teachers.id)
 #
 class ApplicationForm < ApplicationRecord
+  include Regulated
+
   belongs_to :teacher
   belongs_to :region
   belongs_to :english_language_provider, optional: true
@@ -170,10 +172,6 @@ class ApplicationForm < ApplicationRecord
 
   def english_language_exempt?
     english_language_citizenship_exempt || english_language_qualification_exempt
-  end
-
-  def created_under_new_regulations?
-    created_at >= Date.parse(ENV.fetch("NEW_REGS_DATE", "2023-02-01"))
   end
 
   private

--- a/app/models/concerns/regulated.rb
+++ b/app/models/concerns/regulated.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Regulated
+  extend ActiveSupport::Concern
+
+  def created_under_new_regulations?
+    created_at >= Date.parse(ENV.fetch("NEW_REGS_DATE", "2023-02-01"))
+  end
+end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -20,6 +20,8 @@
 #  fk_rails_...  (region_id => regions.id)
 #
 class EligibilityCheck < ApplicationRecord
+  include Regulated
+
   belongs_to :region, optional: true
   has_one :application
 

--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -22,6 +22,14 @@ class TeacherInterface::ApplicationFormShowViewObject
       assessment&.further_information_requests&.first
   end
 
+  def started_at
+    application_form.created_at.strftime("%e %B %Y")
+  end
+
+  def expires_at
+    (application_form.created_at + 6.months).strftime("%e %B %Y")
+  end
+
   def tasks
     hash = {}
     hash.merge!(about_you: %i[personal_information identification_document])

--- a/app/views/eligibility_interface/finish/eligible.html.erb
+++ b/app/views/eligibility_interface/finish/eligible.html.erb
@@ -3,7 +3,9 @@
 
 <%= render "shared/eligible_region_content", region: @region, eligibility_check: @eligibility_check %>
 
-<%= render "shared/apply_by_february_2023" %>
+<% unless @eligibility_check.created_under_new_regulations? %>
+  <%= render "shared/apply_by_february_2023" %>
+<% end %>
 
 <% if FeatureFlags::FeatureFlag.active?(:teacher_applications) && @region && @region.application_form_enabled %>
   <p class="govuk-body">Use our new application form to apply for QTS.</p>

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -9,10 +9,14 @@
 </p>
 
 <%= govuk_inset_text do %>
+  <% if eligibility_check&.created_under_new_regulations? %>
+    <p class="govuk-body">Once you start your application you’ll need to complete it within 6 months.</p>
+  <% end %>
+
+  <p class="govuk-body">You may want to spend some time gathering all the documents you need before you start.</p>
+
   <% if FeatureFlags::FeatureFlag.active?(:teacher_applications) && region && region.application_form_enabled %>
-    You may want to spend some time gathering all the documents you need before you begin your application. Once you start your application, we’ll sign you out if you’re inactive for 60 minutes.
-  <% else %>
-    You may want to spend some time gathering all the documents you need before you begin your application.
+    <p class="govuk-body">Once you start your application, we’ll sign you out if you’re inactive for 60 minutes.</p>
   <% end %>
 <% end %>
 

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -2,8 +2,6 @@
 
 <h1 class="govuk-heading-xl">Apply for qualified teacher status (QTS)</h1>
 
-<%= render "shared/apply_by_february_2023" %>
-
 <% if @view_object.application_form.draft? %>
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2">
     <% if @view_object.can_submit? %>
@@ -16,6 +14,17 @@
   <p class="govuk-body govuk-!-margin-bottom-7">
     You have completed <%= @view_object.completed_task_sections.count %> of <%= @view_object.tasks.count %> sections.
   </p>
+
+  <% if @view_object.application_form.created_under_new_regulations? %>
+    <%= govuk_inset_text do %>
+      <p class="govuk-body">
+        You started this application on <%= @view_object.started_at %>.
+        Applications must be completed within 6 months, so you’ll need to complete it before <%= @view_object.expires_at %>.
+      </p>
+    <% end %>
+  <% else %>
+    <%= render "shared/apply_by_february_2023" %>
+  <% end %>
 
   <ol class="app-task-list">
     <% @view_object.tasks.each_with_index do |(section, items), index| %>

--- a/app/views/teachers/sessions/signed_out.html.erb
+++ b/app/views/teachers/sessions/signed_out.html.erb
@@ -11,15 +11,19 @@
 </p>
 
 <p class="govuk-body">
-  We’ll keep your in-progress application open for 60 days. During that time you can continue your application using the link below.
+  We’ll keep your in-progress application open for <%= @duration %> from the date you started it.
+  If you do not complete it within this time, you’ll need to make a new application.
 </p>
 
+<h2 class="govuk-heading-m">Continuing your application</h2>
+
 <p class="govuk-body">
+  You can get back to your application (and see how long you have left to complete it) using the link below.
   The link will take you to the beginning of the service, but you can use your email address to sign in and continue your application.
 </p>
 
 <p class="govuk-body"><%= govuk_link_to new_teacher_session_url, new_teacher_session_url %></p>
 
 <p class="govuk-body">
-  If you do not continue your application within 60 days you’ll need to start a new application.
+  If you do not continue your application within <%= @duration %> you’ll need to start a new application.
 </p>

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -408,4 +408,46 @@ RSpec.describe EligibilityCheck, type: :model do
       it { is_expected.to eq(:eligibility) }
     end
   end
+
+  describe "#created_under_new_regulations?" do
+    subject(:created_under_new_regulations?) do
+      eligibility_check.created_under_new_regulations?
+    end
+
+    context "with default new regulations date" do
+      context "with an old eligibility check" do
+        let(:eligibility_check) do
+          create(:eligibility_check, created_at: Date.new(2020, 1, 1))
+        end
+        it { is_expected.to be false }
+      end
+
+      context "with a new eligibility check" do
+        let(:eligibility_check) do
+          create(:eligibility_check, created_at: Date.new(2024, 1, 1))
+        end
+        it { is_expected.to be true }
+      end
+    end
+
+    context "with a custom new regulations date" do
+      around do |example|
+        ClimateControl.modify(NEW_REGS_DATE: "2023-01-01") { example.run }
+      end
+
+      context "with an old eligibility check" do
+        let(:eligibility_check) do
+          create(:eligibility_check, created_at: Date.new(2021, 12, 31))
+        end
+        it { is_expected.to be false }
+      end
+
+      context "with a new eligibility check" do
+        let(:eligibility_check) do
+          create(:eligibility_check, created_at: Date.new(2023, 1, 1))
+        end
+        it { is_expected.to be true }
+      end
+    end
+  end
 end


### PR DESCRIPTION
This updates the content in various places to tell the user that under the new regulations they've got 6 months to complete their application, compared to the existing 60 days.

[Trello Card](https://trello.com/c/mRU9DlWZ/1007-you-have-6months-to-complete-your-application)

## Screenshots

<img width="668" alt="Screenshot 2023-01-17 at 08 54 35" src="https://user-images.githubusercontent.com/510498/212852852-3f8d54ba-d223-460f-bbd3-bcabd4bc38ca.png">

<img width="673" alt="Screenshot 2023-01-17 at 08 56 09" src="https://user-images.githubusercontent.com/510498/212853171-1a944d79-3a77-49a6-b5f9-6012dc0a1e7c.png">

<img width="666" alt="Screenshot 2023-01-17 at 08 56 56" src="https://user-images.githubusercontent.com/510498/212853332-31d01f1d-5a94-498e-ada1-7c43a75ddb64.png">
