### PR TITLE
Send submission emails to teaching authorities

### DIFF
--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -55,6 +55,7 @@ class SupportInterface::RegionsController < SupportInterface::BaseController
       :teaching_authority_other,
       :teaching_authority_online_checker_url,
       :teaching_authority_provides_written_statement,
+      :teaching_authority_requires_submission_email,
     )
   end
 end

--- a/app/helpers/region_helper.rb
+++ b/app/helpers/region_helper.rb
@@ -9,11 +9,13 @@ module RegionHelper
     "#{certificate.indefinite_article} #{tag.span(certificate, lang: region.country.code)}".html_safe
   end
 
+  def region_teaching_authority_name(region)
+    region.teaching_authority_name.presence ||
+      region.country.teaching_authority_name.presence || "teaching authority"
+  end
+
   def region_teaching_authority_name_phrase(region)
-    name =
-      region.teaching_authority_name.presence ||
-        region.country.teaching_authority_name.presence || "teaching authority"
-    "the #{name}"
+    "the #{region_teaching_authority_name(region)}"
   end
 
   def region_teaching_authority_emails_phrase(region)

--- a/app/mailers/teaching_authority_mailer.rb
+++ b/app/mailers/teaching_authority_mailer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class TeachingAuthorityMailer < ApplicationMailer
+  include ApplicationFormHelper
+
+  before_action :set_application_form, :set_qualification, :set_region
+
+  helper :application_form, :qualification, :region
+
+  def application_submitted
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: region.teaching_authority_emails + country.teaching_authority_emails,
+      subject:
+        I18n.t(
+          "mailer.teaching_authority.application_submitted.subject",
+          name: application_form_full_name(application_form),
+        ),
+    )
+  end
+
+  private
+
+  def application_form
+    params[:application_form]
+  end
+
+  delegate :region, :country, to: :application_form
+
+  def set_application_form
+    @application_form = application_form
+  end
+
+  def set_qualification
+    @qualification = application_form.teaching_qualification
+  end
+
+  def set_region
+    @region = application_form.region
+  end
+end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -18,6 +18,7 @@
 #  teaching_authority_online_checker_url         :string           default(""), not null
 #  teaching_authority_other                      :text             default(""), not null
 #  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
+#  teaching_authority_requires_submission_email  :boolean          default(FALSE), not null
 #  teaching_authority_sanction_information       :string           default(""), not null
 #  teaching_authority_status_information         :string           default(""), not null
 #  teaching_authority_websites                   :text             default([]), not null, is an Array

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -25,9 +25,18 @@ class SubmitApplicationForm
       .with(teacher: application_form.teacher)
       .application_received
       .deliver_later
+
+    if region.teaching_authority_requires_submission_email
+      TeachingAuthorityMailer
+        .with(application_form:)
+        .application_submitted
+        .deliver_later
+    end
   end
 
   private
 
   attr_reader :application_form, :user
+
+  delegate :region, to: :application_form
 end

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -24,9 +24,11 @@
   ], :id, :name, label: { text: "Status check" } %>
 
   <%= render "shared/teaching_authority_form_fields", f: %>
-  <%= render "shared/qualifications_information_form_fields", f: %>
 
   <%= f.govuk_check_box :teaching_authority_provides_written_statement, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Teaching authority will only send written statement directly to TRA" } %>
+  <%= f.govuk_check_box :teaching_authority_requires_submission_email, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Teaching authority requires an email when an application is submitted" } %>
+
+  <%= render "shared/qualifications_information_form_fields", f: %>
 
   <%= f.govuk_submit "Save", prevent_double_click: false do %>
     <%= f.govuk_submit "Save and preview", prevent_double_click: false, name: "preview", value: "preview" %>

--- a/app/views/teaching_authority_mailer/application_submitted.text.erb
+++ b/app/views/teaching_authority_mailer/application_submitted.text.erb
@@ -1,0 +1,27 @@
+Dear <%= region_teaching_authority_name(@region) %>
+
+We can confirm that the following person has made an application to us for qualified teacher status (QTS) in England:
+
+<%= application_form_full_name(@application_form) %>
+
+Date of birth: <%= @application_form.date_of_birth.to_fs(:long_ordinal_uk) %>
+
+The applicant has provided us with the following details about their teaching qualification:
+
+Title: <%= qualification_title(@qualification) %>
+Institution studied at: <%= @qualification.institution_name %>
+Date started: <%= @qualification.start_date.to_fs(:long_ordinal_uk) %>
+Date ended: <%= @qualification.complete_date.to_fs(:long_ordinal_uk) %>
+
+They’ve told us that they’re qualified to teach children <%= @application_form.subjects.to_sentence %> from age <%= @application_form.age_range_min %> to <%= @application_form.age_range_max %> years old.
+
+We’d be grateful if you could provide written evidence of their professional standing as a teacher in <%= CountryName.from_region(@region, with_definite_article: true) %>, and email it to us at:
+
+ApplyQTS.Verification@education.gov.uk
+
+Please include their QTS application reference number <%= @application_form.reference %>.
+
+Kind regards,
+Teaching Regulation Agency (TRA)
+
+TRA is an executive agency, sponsored by the Department for Education. We have responsibility for the regulation of the teaching profession in England.

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -229,6 +229,7 @@
     - teaching_authority_status_information
     - teaching_authority_sanction_information
     - teaching_authority_provides_written_statement
+    - teaching_authority_requires_submission_email
     - qualifications_information
   :reminder_emails:
     - id

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Date::DATE_FORMATS[:long_ordinal_uk] = "%-d %B %Y"

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -25,3 +25,6 @@ en:
         subject: We still need some more information to progress your QTS application
       references_requested:
         subject: Your qualified teacher status application – we’ve contacted your references
+    teaching_authority:
+      application_submitted:
+        subject: "%{name} has made an application for qualified teacher status (QTS) in England"

--- a/db/migrate/20230117211010_add_teaching_authority_requires_submission_email_to_regions.rb
+++ b/db/migrate/20230117211010_add_teaching_authority_requires_submission_email_to_regions.rb
@@ -1,0 +1,11 @@
+class AddTeachingAuthorityRequiresSubmissionEmailToRegions < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    add_column :regions,
+               :teaching_authority_requires_submission_email,
+               :boolean,
+               default: false,
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_16_135601) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_17_211010) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -290,6 +290,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_16_135601) do
     t.boolean "application_form_skip_work_history", default: false, null: false
     t.text "qualifications_information", default: "", null: false
     t.boolean "reduced_evidence_accepted", default: false, null: false
+    t.boolean "teaching_authority_requires_submission_email", default: false, null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
     t.index ["country_id"], name: "index_regions_on_country_id"
   end

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -18,6 +18,7 @@
 #  teaching_authority_online_checker_url         :string           default(""), not null
 #  teaching_authority_other                      :text             default(""), not null
 #  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
+#  teaching_authority_requires_submission_email  :boolean          default(FALSE), not null
 #  teaching_authority_sanction_information       :string           default(""), not null
 #  teaching_authority_status_information         :string           default(""), not null
 #  teaching_authority_websites                   :text             default([]), not null, is an Array

--- a/spec/mailers/teaching_authority_mailer_spec.rb
+++ b/spec/mailers/teaching_authority_mailer_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeachingAuthorityMailer, type: :mailer do
+  let(:region) do
+    create(
+      :region,
+      name: "Region Name",
+      teaching_authority_name: "Teaching Authority",
+      teaching_authority_emails: ["authority@government.com"],
+    )
+  end
+
+  let(:application_form) do
+    create(
+      :application_form,
+      region:,
+      reference: "abc",
+      given_names: "First",
+      family_name: "Last",
+      date_of_birth: Date.new(1990, 1, 1),
+      subjects: %w[Maths French],
+      age_range_min: 8,
+      age_range_max: 11,
+    )
+  end
+
+  before do
+    create(
+      :qualification,
+      application_form:,
+      title: "Qualification Title",
+      institution_name: "Institution",
+      start_date: Date.new(2010, 1, 1),
+      complete_date: Date.new(2015, 1, 1),
+    )
+  end
+
+  describe "#application_submitted" do
+    subject(:mail) do
+      described_class.with(application_form:).application_submitted
+    end
+
+    describe "#subject" do
+      subject(:subject) { mail.subject }
+
+      it do
+        is_expected.to eq(
+          "First Last has made an application for qualified teacher status (QTS) in England",
+        )
+      end
+    end
+
+    describe "#to" do
+      subject(:to) { mail.to }
+
+      it { is_expected.to eq(["authority@government.com"]) }
+    end
+
+    describe "#body" do
+      subject(:body) { mail.body.encoded.gsub("\r", "") }
+
+      it { is_expected.to eq(<<-EMAIL) }
+Dear Teaching Authority
+
+We can confirm that the following person has made an application to us for qualified teacher status (QTS) in England:
+
+First Last
+
+Date of birth: 1 January 1990
+
+The applicant has provided us with the following details about their teaching qualification:
+
+Title: Qualification Title
+Institution studied at: Institution
+Date started: 1 January 2010
+Date ended: 1 January 2015
+
+They’ve told us that they’re qualified to teach children Maths and French from age 8 to 11 years old.
+
+We’d be grateful if you could provide written evidence of their professional standing as a teacher in Region Name, and email it to us at:
+
+ApplyQTS.Verification@education.gov.uk
+
+Please include their QTS application reference number abc.
+
+Kind regards,
+Teaching Regulation Agency (TRA)
+
+TRA is an executive agency, sponsored by the Department for Education. We have responsibility for the regulation of the teaching profession in England.
+      EMAIL
+    end
+
+    it_behaves_like "an observable mailer", "application_submitted"
+  end
+end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -18,6 +18,7 @@
 #  teaching_authority_online_checker_url         :string           default(""), not null
 #  teaching_authority_other                      :text             default(""), not null
 #  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
+#  teaching_authority_requires_submission_email  :boolean          default(FALSE), not null
 #  teaching_authority_sanction_information       :string           default(""), not null
 #  teaching_authority_status_information         :string           default(""), not null
 #  teaching_authority_websites                   :text             default([]), not null, is an Array

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_status_information
     when_i_fill_teaching_authority_certificate
     when_i_fill_teaching_authority_online_checker_url
+    when_i_check_teaching_authority_requires_submission_email
     when_i_fill_qualifications_information
     and_i_save_and_preview
     then_i_see_the_preview
@@ -217,6 +218,11 @@ RSpec.describe "Countries support", type: :system do
   rescue Capybara::ElementNotFound
     fill_in "country-teaching-authority-status-information-field",
             with: "Status information"
+  end
+
+  def when_i_check_teaching_authority_requires_submission_email
+    check "region-teaching-authority-requires-submission-email-1-field",
+          visible: false
   end
 
   def when_i_fill_qualifications_information


### PR DESCRIPTION
This adds a new email which is sent to teaching authorities when an application is submitted and the teaching authority requires an email.

[Trello Card](https://trello.com/c/DNbG6bWE/1363-notify-a-teaching-authority-that-we-will-need-a-lops)

## Screenshots

<img width="618" alt="Screenshot 2023-01-18 at 07 30 47" src="https://user-images.githubusercontent.com/510498/213110324-0107963e-ff76-4b17-91d6-d9210656a8b7.png">
<img width="661" alt="Screenshot 2023-01-18 at 07 31 23" src="https://user-images.githubusercontent.com/510498/213110341-5f8d0377-c8f3-4cc7-a527-ffcabcf36249.png">
