### PR TITLE
Hide proof of recognition if unnecessary

### DIFF
--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -39,10 +39,12 @@
       <% end %>
     <% end %>
 
-    <% accordion.section(heading_text: "Proof that you’re recognised as a teacher") do %>
-      <%= render "shared/eligible_region_content_components/professional_recognition",
-                 region:,
-                 teaching_authority_provides_written_statement: region.teaching_authority_provides_written_statement %>
+    <% unless FeatureFlags::FeatureFlag.active?(:application_work_history) && region.status_check_none? && region.sanction_check_none? %>
+      <% accordion.section(heading_text: "Proof that you’re recognised as a teacher") do %>
+        <%= render "shared/eligible_region_content_components/professional_recognition",
+                   region:,
+                   teaching_authority_provides_written_statement: region.teaching_authority_provides_written_statement %>
+      <% end %>
     <% end %>
 
     <% if FeatureFlags::FeatureFlag.active?(:application_work_history) && !region.application_form_skip_work_history %>

--- a/spec/factories/eligibility_checks.rb
+++ b/spec/factories/eligibility_checks.rb
@@ -48,5 +48,9 @@ FactoryBot.define do
     trait :ineligible do
       degree { false }
     end
+
+    trait :new_regs do
+      created_at { Date.new(2023, 2, 1) }
+    end
   end
 end

--- a/spec/views/shared/eligible_region_content_spec.rb
+++ b/spec/views/shared/eligible_region_content_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Eligible region content", type: :view do
       create(:region, status_check: :online, sanction_check: :online)
     end
 
+    it { is_expected.to match(/Proof that you’re recognised as a teacher/) }
     it { is_expected.to match(/has an online register of teachers/) }
   end
 
@@ -34,6 +35,7 @@ RSpec.describe "Eligible region content", type: :view do
       )
     end
 
+    it { is_expected.to match(/Proof that you’re recognised as a teacher/) }
     it { is_expected.to match(/recognises you as a teacher must confirm/) }
     it { is_expected.to match(/You’ll need to provide a/) }
     it { is_expected.to match(/certificate/) }
@@ -53,6 +55,7 @@ RSpec.describe "Eligible region content", type: :view do
       )
     end
 
+    it { is_expected.to match(/Proof that you’re recognised as a teacher/) }
     it { is_expected.to match(/has an online register of teachers/) }
     it { is_expected.to match(/must also confirm in writing/) }
     it { is_expected.to match(/You’ll need to provide a/) }
@@ -72,6 +75,7 @@ RSpec.describe "Eligible region content", type: :view do
       )
     end
 
+    it { is_expected.to match(/Proof that you’re recognised as a teacher/) }
     it { is_expected.to match(/recognises you as a teacher must confirm/) }
     it { is_expected.to match(/You’ll need to provide a/) }
     it { is_expected.to match(/certificate/) }
@@ -82,6 +86,7 @@ RSpec.describe "Eligible region content", type: :view do
   context "with no status check and no sanction check" do
     let(:region) { create(:region, status_check: :none, sanction_check: :none) }
 
+    it { is_expected.to match(/Proof that you’re recognised as a teacher/) }
     it { is_expected.to match(/show evidence of your work history/) }
   end
 
@@ -139,6 +144,16 @@ RSpec.describe "Eligible region content", type: :view do
 
       it do
         is_expected.to_not match(/You’ll need to show you’ve been employed/)
+      end
+    end
+
+    context "with no status check and no sanction check" do
+      let(:region) do
+        create(:region, status_check: :none, sanction_check: :none)
+      end
+
+      it do
+        is_expected.to_not match(/Proof that you’re recognised as a teacher/)
       end
     end
   end


### PR DESCRIPTION
This hides this section of the eligibility checker if the new work history feature is enabled as the status and sanction check is both none, since there's no proof of recognition required.

[Trello Card](https://trello.com/c/yXm8evVC/1402-status-sanctionnone-remove-proof-you-are-recognised-as-a-teacher)