### PR TITLE
Show work history number of months

### DIFF
--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -33,6 +33,10 @@ module AssessorInterface
       application_form.work_histories.ordered
     end
 
+    def work_history_months_count
+      @months_count = WorkHistoryDuration.new(application_form:).count_months
+    end
+
     def show_registration_number_summary
       application_form.needs_registration_number?
     end
@@ -57,6 +61,10 @@ module AssessorInterface
       @online_checker_url ||=
         region.teaching_authority_online_checker_url.presence ||
           region.country.teaching_authority_online_checker_url
+    end
+
+    def work_history?
+      assessment_section.key == "work_history"
     end
 
     def professional_standing?

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -53,7 +53,11 @@
   <% end %>
 <% end %>
 
-<% if @assessment_section_view_object.professional_standing? %>
+<% if @assessment_section_view_object.application_form.created_under_new_regulations? && @assessment_section_view_object.work_history? %>
+  <h2 class="govuk-heading-m">
+    This applicant has provided <%= @assessment_section_view_object.work_history_months_count %> months of work experience in total.
+  </h2>
+<% elsif @assessment_section_view_object.professional_standing? %>
   <%= govuk_accordion do |accordion| %>
     <% if (online_checker_url = @assessment_section_view_object.online_checker_url).present? %>
       <% accordion.section(heading_text: "Online checker") do %>


### PR DESCRIPTION
When an assessor is checking the work history, it now includes a sentence showing the number of months they've provided.

[Trello Card](https://trello.com/c/ZgCRHmHc/1411-add-number-of-months-of-work-history-to-assessment-spoke)

## Screenshots

<img width="711" alt="Screenshot 2023-01-18 at 08 57 00" src="https://user-images.githubusercontent.com/510498/213129931-9c0486c1-06ae-4d32-9175-b98d2171762a.png">
