### PR TITLE
Update medium of instruction summary content

### DIFF
--- a/app/views/shared/application_form/_english_language_summary.html.erb
+++ b/app/views/shared/application_form/_english_language_summary.html.erb
@@ -17,7 +17,7 @@
       href: %i[proof_method teacher_interface application_form english_language]
     } : nil,
     english_language_medium_of_instruction_document: !application_form.english_language_exempt? && application_form.english_language_proof_method_medium_of_instruction? ? {
-      title: "Medium of instruction",
+      title: "Medium of instruction document",
       href: [:teacher_interface, :application_form, application_form.english_language_medium_of_instruction_document]
     } : nil,
     english_language_provider: !application_form.english_language_exempt? && application_form.english_language_proof_method_provider? ? {

--- a/spec/system/teacher_interface/english_language_spec.rb
+++ b/spec/system/teacher_interface/english_language_spec.rb
@@ -254,7 +254,9 @@ RSpec.describe "Teacher English language", type: :system do
 
     document_summary_list_row =
       teacher_check_english_language_page.summary_list.rows.fourth
-    expect(document_summary_list_row.key.text).to eq("Medium of instruction")
+    expect(document_summary_list_row.key.text).to eq(
+      "Medium of instruction document",
+    )
     expect(document_summary_list_row.value.text).to eq(
       "upload.pdf (opens in a new tab)",
     )


### PR DESCRIPTION
We want to add the phrase "document" to be consistent with other check your answers.