### PR TITLE
Cap hours per week to 30

### DIFF
--- a/app/lib/work_history_duration.rb
+++ b/app/lib/work_history_duration.rb
@@ -39,7 +39,7 @@ class WorkHistoryDuration
   end
 
   def work_history_hours_per_month(work_history)
-    work_history.hours_per_week * AVERAGE_WEEKS_PER_MONTH
+    [work_history.hours_per_week, 30].min * AVERAGE_WEEKS_PER_MONTH
   end
 
   def work_history_number_of_months(work_history)

--- a/spec/lib/work_history_duration_spec.rb
+++ b/spec/lib/work_history_duration_spec.rb
@@ -30,6 +30,20 @@ RSpec.describe WorkHistoryDuration do
       it { is_expected.to eq(12) }
     end
 
+    context "with a finished full time work history with extra hours" do
+      before do
+        create(
+          :work_history,
+          application_form:,
+          start_date: Date.new(2020, 1, 1),
+          end_date: Date.new(2020, 12, 31),
+          hours_per_week: 40,
+        )
+      end
+
+      it { is_expected.to eq(12) }
+    end
+
     context "with a finished part time work history" do
       before do
         create(


### PR DESCRIPTION
We don't want to treat a number any higher than 30 as more than full time, so we'll cap the number at 30.

[Trello Card](https://trello.com/c/cI8WKnoo/1417-cap-work-history-hours-at-30-hour-week)