### PR TITLE
Move English language form errors to the top of pages

### DIFF
--- a/app/views/teacher_interface/english_language/edit_exemption.html.erb
+++ b/app/views/teacher_interface/english_language/edit_exemption.html.erb
@@ -1,26 +1,26 @@
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t(".#{@exemption_field}.heading")}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
-<span class="govuk-caption-l"><%= t("application_form.tasks.sections.english_language") %></span>
-<h1 class="govuk-heading-l"><%= t(".#{@exemption_field}.heading") %></h1>
-
-<p class="govuk-body"><%= t(".#{@exemption_field}.description") %></p>
-<p class="govuk-body"><%= t(".#{@exemption_field}.evidence") %></p>
-
-<div class="govuk-grid-row">
-  <% english_language_exempt_countries.in_groups(2, false) do |exempt_countries| %>
-    <div class="govuk-grid-column-one-half">
-      <ul class="govuk-list govuk-list--bullet">
-        <% exempt_countries.each do |exempt_country| %>
-          <li><%= exempt_country %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-</div>
-
 <%= form_with model: @form, url: exemption_teacher_interface_application_form_english_language_path(@exemption_field) do |f| %>
   <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l"><%= t("application_form.tasks.sections.english_language") %></span>
+  <h1 class="govuk-heading-l"><%= t(".#{@exemption_field}.heading") %></h1>
+
+  <p class="govuk-body"><%= t(".#{@exemption_field}.description") %></p>
+  <p class="govuk-body"><%= t(".#{@exemption_field}.evidence") %></p>
+
+  <div class="govuk-grid-row">
+    <% english_language_exempt_countries.in_groups(2, false) do |exempt_countries| %>
+      <div class="govuk-grid-column-one-half">
+        <ul class="govuk-list govuk-list--bullet">
+          <% exempt_countries.each do |exempt_country| %>
+            <li><%= exempt_country %></li>
+          <% end %>
+        </ul>
+      </div>
+    <% end %>
+  </div>
 
   <%= f.govuk_collection_radio_buttons :exempt,
                                        [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],

--- a/app/views/teacher_interface/english_language/edit_provider.html.erb
+++ b/app/views/teacher_interface/english_language/edit_provider.html.erb
@@ -1,12 +1,12 @@
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t(".heading")}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
-<span class="govuk-caption-l"><%= t("application_form.tasks.sections.english_language") %></span>
-<h1 class="govuk-heading-l"><%= t(".heading") %></h1>
-<p class="govuk-body"><%= t(".description") %></p>
-
 <%= form_with model: @form, url: %i[provider teacher_interface application_form english_language] do |f| %>
   <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l"><%= t("application_form.tasks.sections.english_language") %></span>
+  <h1 class="govuk-heading-l"><%= t(".heading") %></h1>
+  <p class="govuk-body"><%= t(".description") %></p>
 
   <%= f.govuk_collection_radio_buttons :provider_id,
                                        @form.providers,

--- a/app/views/teacher_interface/english_language/edit_provider_reference.html.erb
+++ b/app/views/teacher_interface/english_language/edit_provider_reference.html.erb
@@ -1,12 +1,12 @@
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t(".heading")} – #{@provider.name}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
-<span class="govuk-caption-l"><%= t("application_form.tasks.sections.english_language") %></span>
-<h1 class="govuk-heading-l"><%= t(".heading") %> – <%= @provider.name %></h1>
-<p class="govuk-body">For <%= @provider.name %>, B2 level requires <%= @provider.b2_level_requirement %> in all 4 disciplines (reading, writing, listening and speaking).</p>
-
 <%= form_with model: @form, url: %i[provider_reference teacher_interface application_form english_language] do |f| %>
   <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l"><%= t("application_form.tasks.sections.english_language") %></span>
+  <h1 class="govuk-heading-l"><%= t(".heading") %> – <%= @provider.name %></h1>
+  <p class="govuk-body">For <%= @provider.name %>, B2 level requires <%= @provider.b2_level_requirement %> in all 4 disciplines (reading, writing, listening and speaking).</p>
 
   <%= f.govuk_text_field :reference,
                          label: { text: "Enter your #{@provider.reference_name}", size: "m" },


### PR DESCRIPTION
This is how the errors should appear on the page to match the GOV.UK designs.

[Trello Card](https://trello.com/c/4qsMQW8f/1420-exemption-errors-not-at-top-of-page)