### PR TITLE
Check exact value of still_employed in work history

### DIFF
--- a/app/forms/teacher_interface/work_history_form.rb
+++ b/app/forms/teacher_interface/work_history_form.rb
@@ -22,9 +22,9 @@ module TeacherInterface
     validates :contact_name, presence: true
     validates :contact_email, presence: true, valid_for_notify: true
     validates :start_date, date: true
-    validates :end_date, date: true, unless: :still_employed
     validates :still_employed, inclusion: [true, false]
-    validates_with DateComparisonValidator, unless: :still_employed
+    validates :end_date, date: true, if: -> { still_employed == false }
+    validates_with DateComparisonValidator, if: -> { still_employed == false }
 
     def initialize(values)
       if (country_code = values.delete(:country_code))

--- a/app/forms/teacher_interface/work_history_school_form.rb
+++ b/app/forms/teacher_interface/work_history_school_form.rb
@@ -25,8 +25,8 @@ module TeacherInterface
     validates :hours_per_week, presence: true
     validates :start_date, date: true
     validates :still_employed, inclusion: [true, false]
-    validates :end_date, date: true, unless: :still_employed
-    validates_with DateComparisonValidator, unless: :still_employed
+    validates :end_date, date: true, if: -> { still_employed == false }
+    validates_with DateComparisonValidator, if: -> { still_employed == false }
 
     def initialize(values)
       if (country_code = values.delete(:country_code))


### PR DESCRIPTION
This prevents validation on the end date before the user has selected if they are still employed.

[Trello Card](https://trello.com/c/aKTRYRB1/1418-work-history-employment-end-date-validation)