### PR TITLE
Don't skip English language flow when changing answers

### DIFF
--- a/app/controllers/teacher_interface/english_language_controller.rb
+++ b/app/controllers/teacher_interface/english_language_controller.rb
@@ -84,22 +84,16 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @form,
-        if_success_then_redirect: ->(check_path) do
-          check_path ||
-            if @form.exempt
-              %i[check teacher_interface application_form english_language]
-            elsif @form.citizenship?
-              exemption_teacher_interface_application_form_english_language_path(
-                "qualification",
-              )
-            else
-              %i[
-                proof_method
-                teacher_interface
-                application_form
-                english_language
-              ]
-            end
+        if_success_then_redirect: ->(_check_path) do
+          if @form.exempt
+            %i[check teacher_interface application_form english_language]
+          elsif @form.citizenship?
+            exemption_teacher_interface_application_form_english_language_path(
+              "qualification",
+            )
+          else
+            %i[proof_method teacher_interface application_form english_language]
+          end
         end,
         if_failure_then_render: :edit_exemption,
       )
@@ -121,17 +115,16 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @form,
-        if_success_then_redirect: ->(check_path) do
-          check_path ||
-            if @form.medium_of_instruction?
-              [
-                :teacher_interface,
-                :application_form,
-                application_form.english_language_medium_of_instruction_document,
-              ]
-            else
-              %i[provider teacher_interface application_form english_language]
-            end
+        if_success_then_redirect: ->(_check_path) do
+          if @form.medium_of_instruction?
+            [
+              :teacher_interface,
+              :application_form,
+              application_form.english_language_medium_of_instruction_document,
+            ]
+          else
+            %i[provider teacher_interface application_form english_language]
+          end
         end,
         if_failure_then_render: :edit_proof_method,
       )
@@ -154,22 +147,21 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @form,
-        if_success_then_redirect: ->(check_path) do
-          check_path ||
-            if @form.other?
-              [
-                :teacher_interface,
-                :application_form,
-                application_form.english_language_proficiency_document,
-              ]
-            else
-              %i[
-                provider_reference
-                teacher_interface
-                application_form
-                english_language
-              ]
-            end
+        if_success_then_redirect: ->(_check_path) do
+          if @form.other?
+            [
+              :teacher_interface,
+              :application_form,
+              application_form.english_language_proficiency_document,
+            ]
+          else
+            %i[
+              provider_reference
+              teacher_interface
+              application_form
+              english_language
+            ]
+          end
         end,
         if_failure_then_render: :edit_provider,
       )

--- a/app/forms/teacher_interface/english_language_exemption_form.rb
+++ b/app/forms/teacher_interface/english_language_exemption_form.rb
@@ -13,6 +13,29 @@ module TeacherInterface
       application_form.update!(
         { "english_language_#{exemption_field}_exempt": exempt },
       )
+
+      if exempt
+        application_form.update!(
+          english_language_proof_method: nil,
+          english_language_provider_id: nil,
+          english_language_provider_other: false,
+          english_language_provider_reference: "",
+        )
+
+        application_form
+          .english_language_medium_of_instruction_document
+          .uploads
+          .destroy_all
+
+        application_form
+          .english_language_proficiency_document
+          .uploads
+          .destroy_all
+      end
+
+      if exempt && citizenship?
+        application_form.update!(english_language_qualification_exempt: nil)
+      end
     end
 
     def citizenship?

--- a/app/forms/teacher_interface/english_language_proof_method_form.rb
+++ b/app/forms/teacher_interface/english_language_proof_method_form.rb
@@ -12,6 +12,24 @@ module TeacherInterface
 
     def update_model
       application_form.update!(english_language_proof_method: proof_method)
+
+      if medium_of_instruction?
+        application_form.update!(
+          english_language_provider_id: nil,
+          english_language_provider_other: false,
+          english_language_provider_reference: "",
+        )
+
+        application_form
+          .english_language_proficiency_document
+          .uploads
+          .destroy_all
+      else
+        application_form
+          .english_language_medium_of_instruction_document
+          .uploads
+          .destroy_all
+      end
     end
 
     def medium_of_instruction?

--- a/app/forms/teacher_interface/english_language_provider_form.rb
+++ b/app/forms/teacher_interface/english_language_provider_form.rb
@@ -23,12 +23,22 @@ module TeacherInterface
         application_form.update!(
           english_language_provider_id: nil,
           english_language_provider_other: true,
+          english_language_provider_reference: "",
         )
       else
+        if provider_id != application_form.english_language_provider_id
+          application_form.update!(english_language_provider_reference: "")
+        end
+
         application_form.update!(
           english_language_provider_id: provider_id,
           english_language_provider_other: false,
         )
+
+        application_form
+          .english_language_proficiency_document
+          .uploads
+          .destroy_all
       end
     end
 

--- a/app/forms/teacher_interface/english_language_provider_reference_form.rb
+++ b/app/forms/teacher_interface/english_language_provider_reference_form.rb
@@ -9,7 +9,10 @@ module TeacherInterface
     validates :reference, presence: true
 
     def update_model
-      application_form.update!(english_language_provider_reference: reference)
+      application_form.update!(
+        english_language_provider_reference: reference,
+        english_language_provider_other: false,
+      )
     end
   end
 end

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -250,6 +250,18 @@ FactoryBot.define do
       english_language_provider_reference { "reference" }
     end
 
+    trait :with_english_language_other_provider do
+      english_language_proof_method { "provider" }
+      english_language_provider_other { true }
+
+      after(:create) do |application_form, _evaluator|
+        create(
+          :upload,
+          document: application_form.english_language_proficiency_document,
+        )
+      end
+    end
+
     trait :with_work_history do
       needs_work_history { true }
       has_work_history { true }

--- a/spec/forms/teacher_interface/english_language_exemption_form_spec.rb
+++ b/spec/forms/teacher_interface/english_language_exemption_form_spec.rb
@@ -29,5 +29,18 @@ RSpec.describe TeacherInterface::EnglishLanguageExemptionForm, type: :model do
         :english_language_citizenship_exempt,
       ).to(true)
     end
+
+    context "with an existing English language provider" do
+      let(:application_form) do
+        create(:application_form, :with_english_language_provider)
+      end
+
+      it "clears the provider" do
+        expect { save }.to change(
+          application_form,
+          :english_language_provider,
+        ).to(nil)
+      end
+    end
   end
 end

--- a/spec/forms/teacher_interface/english_language_proof_method_form_spec.rb
+++ b/spec/forms/teacher_interface/english_language_proof_method_form_spec.rb
@@ -30,5 +30,18 @@ RSpec.describe TeacherInterface::EnglishLanguageProofMethodForm, type: :model do
         :english_language_proof_method_provider?,
       ).to(true)
     end
+
+    context "with an existing English language medium of instruction" do
+      let(:application_form) do
+        create(:application_form, :with_english_language_medium_of_instruction)
+      end
+
+      it "clears the documents" do
+        expect { save }.to change(
+          application_form.english_language_medium_of_instruction_document.uploads,
+          :count,
+        ).to(0)
+      end
+    end
   end
 end

--- a/spec/forms/teacher_interface/english_language_provider_form_spec.rb
+++ b/spec/forms/teacher_interface/english_language_provider_form_spec.rb
@@ -42,6 +42,19 @@ RSpec.describe TeacherInterface::EnglishLanguageProviderForm, type: :model do
           :english_language_provider,
         ).to(providers.first)
       end
+
+      context "with an existing English language provider" do
+        let(:application_form) do
+          create(:application_form, :with_english_language_provider)
+        end
+
+        it "clears the reference" do
+          expect { save }.to change(
+            application_form,
+            :english_language_provider_reference,
+          ).to("")
+        end
+      end
     end
 
     context "when other is selected" do
@@ -54,6 +67,19 @@ RSpec.describe TeacherInterface::EnglishLanguageProviderForm, type: :model do
           application_form,
           :english_language_provider_other,
         ).to(true)
+      end
+
+      context "with an existing English language provider" do
+        let(:application_form) do
+          create(:application_form, :with_english_language_provider)
+        end
+
+        it "clears the reference" do
+          expect { save }.to change(
+            application_form,
+            :english_language_provider_reference,
+          ).to("")
+        end
       end
     end
   end

--- a/spec/forms/teacher_interface/english_language_provider_reference_form_spec.rb
+++ b/spec/forms/teacher_interface/english_language_provider_reference_form_spec.rb
@@ -26,5 +26,18 @@ RSpec.describe TeacherInterface::EnglishLanguageProviderReferenceForm,
         :english_language_provider_reference,
       ).to("reference")
     end
+
+    context "with an existing other provider" do
+      let(:application_form) do
+        create(:application_form, :with_english_language_other_provider)
+      end
+
+      it "clears the reference" do
+        expect { save }.to change(
+          application_form,
+          :english_language_provider_other,
+        ).to(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
The answers to future questions are dependent on the ones to earlier questions so rather than taking the user to the "Change your answers" screen as it does normally we will always take the user back through the flow.

[Trello Card](https://trello.com/c/junEFb2T/1421-changing-elp-answers-continues-flow)