### PR TITLE
Change email address for verification

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,5 @@
 class ApplicationMailer < Mail::Notify::Mailer
-  default from: "qts.enquiries@education.gov.uk"
+  default from: I18n.t("service.email.enquiries")
 
   GOVUK_NOTIFY_TEMPLATE_ID =
     ENV.fetch(

--- a/app/views/eligibility_interface/finish/ineligible.html.erb
+++ b/app/views/eligibility_interface/finish/ineligible.html.erb
@@ -48,5 +48,5 @@
   <%= render "shared/help_us_to_improve_this_service" %>
 <% else %>
   <p class="govuk-body">If you have any questions about QTS contact the help team at:</p>
-  <p class="govuk-body"><a class="govuk-link" href="mailto:<%= I18n.t("service.email") %>"><%= I18n.t("service.email") %></a></p>
+  <p class="govuk-body"><%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %></p>
 <% end %>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -8,7 +8,7 @@
   If you reached this page after submitting information then it has not
   been saved. You’ll need to enter it again when the service is available.
 </p>
+
 <p class="govuk-body">
-  If you have any questions, please email us at <a class="govuk-link"
-    href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.
+  If you have any questions, please email us at <%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %>.
 </p>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -11,8 +11,7 @@
 </p>
 
 <p class="govuk-body">
-  If the web address is correct or you selected a link or button and you
-  need to speak to someone about this problem, contact the <%=
-  t(current_namespace, scope: %i[service name]) %> team: <a class="govuk-link" href="mailto:<%=
-  t('service.email') %>"><%= t('service.email') %></a>.
+  If the web address is correct or you selected a link or button and you need to speak to someone about this problem,
+  contact the <%= t(current_namespace, scope: %i[service name]) %> team:
+  <%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %>
 </p>

--- a/app/views/errors/too_many_requests.html.erb
+++ b/app/views/errors/too_many_requests.html.erb
@@ -10,6 +10,5 @@
 </p>
 
 <p class="govuk-body">
-  If you have any questions, please email us at
-  <a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.
+  If you have any questions, please email us at <%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %>.
 </p>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -5,6 +5,6 @@
 <p class="govuk-body">Try again later.</p>
 
 <p class="govuk-body">
-  If you continue to see this error contact the <%= t(current_namespace, scope: %i[service name]) %>
-  team: <a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a>.
+  If you continue to see this error contact the <%= t(current_namespace, scope: %i[service name]) %> team:
+  <%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %>
 </p>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -52,7 +52,7 @@
     </div>
 
     <%= govuk_footer(
-        meta_items_title: 'Footer links', 
+        meta_items_title: 'Footer links',
         meta_items: {
           'Accessibility': '/accessibility',
           'Cookies': '/cookies',
@@ -61,9 +61,12 @@
       <% footer.navigation do %>
         <% if current_teacher %>
           <div class="govuk-footer__section">
-            <h3 style = "margin-left: 100px">Get help</h3>
-            <p>If you‘re having difficulty completing your application form, contact: <a class="govuk-link"
-            href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a> for support.</p>
+            <h3 style="margin-left: 100px">Get help</h3>
+            <p>
+              If you‘re having difficulty completing your application form, contact:
+              <%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %>
+              for support.
+            </p>
             <p>We‘ll aim to respond to you within 2 working days.</p>
           </div>
         <% end %>

--- a/app/views/shared/eligible_region_content_components/_professional_recognition.html.erb
+++ b/app/views/shared/eligible_region_content_components/_professional_recognition.html.erb
@@ -34,7 +34,7 @@
     </p>
 
     <p class="govuk-body">
-      You cannot send this document yourself – instead, you must contact <%= region_teaching_authority_name_phrase(region) %> and ask them to send it directly to us at <a class="govuk-link" href="mailto:<%= t("service.email") %>"><%= t("service.email") %></a>.
+      You cannot send this document yourself – instead, you must contact <%= region_teaching_authority_name_phrase(region) %> and ask them to send it directly to us at <a class="govuk-link" href="mailto:<%= t("service.email.verification") %>"><%= t("service.email.verification") %></a>.
     </p>
   <% end %>
 

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -128,7 +128,7 @@
     <p class="govuk-body">You have the right of appeal to the Head of Teacher Qualifications and/or the County Court against this decision.</p>
   <% end %>
 
-  <p class="govuk-body">If you want to appeal, you should contact <a class="govuk-link" href="mailto:<%= t("service.email") %>"><%= t("service.email") %></a> and do so within 4 months of this notification.</p>
+  <p class="govuk-body">If you want to appeal, you should contact <%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %> and do so within 4 months of this notification.</p>
 <% elsif @view_object.application_form.awarded? %>
   <h2 class="govuk-heading-l">Your QTS application was successful</h2>
 
@@ -192,5 +192,5 @@
   <p class="govuk-body">If you match our search criteria, we'll invite you to take part in research.</p>
 
   <h2 class="govuk-heading-s">If you have any questions, contact:</h2>
-  <p class="govuk-body"><a class="govuk-link" href="mailto:<%= t('service.email') %>"><%= t('service.email') %></a></p>
+  <p class="govuk-body"><%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %></p>
 <% end %>

--- a/app/views/teacher_interface/written_statements/edit.html.erb
+++ b/app/views/teacher_interface/written_statements/edit.html.erb
@@ -22,7 +22,7 @@
                           multiple: false,
                           link_errors: true,
                           label: {
-                            text: "I understand that it’s my responsibility to request written evidence from #{region_teaching_authority_name_phrase(@application_form.region)} to be sent directly to #{govuk_link_to t("service.email"), "mailto:#{t("service.email")}"}.".html_safe,
+                            text: "I understand that it’s my responsibility to request written evidence from #{region_teaching_authority_name_phrase(@application_form.region)} to be sent directly to #{govuk_link_to t("service.email.verification"), "mailto:#{t("service.email.verification")}"}.".html_safe,
                             size: "s",
                           } %>
   <% end %>

--- a/app/views/teacher_mailer/application_received.text.erb
+++ b/app/views/teacher_mailer/application_received.text.erb
@@ -12,8 +12,7 @@ Your application is in the queue to be assigned to a QTS assessor, which can tak
 
 We aim to reach a final decision on QTS applications within 80 working days (4 months) of submission.
 
-If you have any questions, contact:
-qts.enquiries@education.gov.uk
+If you have any questions, contact: <%= t("service.email.enquiries") %>
 
 <%= render "shared/teacher_mailer/help_us_to_improve_this_service" %>
 

--- a/app/views/teacher_mailer/further_information_received.text.erb
+++ b/app/views/teacher_mailer/further_information_received.text.erb
@@ -12,8 +12,7 @@ Thanks for sending the additional information we requested.The assessor will now
 
 We aim to reach a final decision on QTS applications within 80 working days (4 months) of submission.
 
-If you have any questions, contact:
-qts.enquiries@education.gov.uk
+If you have any questions, contact: <%= t("service.email.enquiries") %>
 
 Kind regards,
 The Teacher Qualifications Team

--- a/app/views/teacher_mailer/further_information_reminder.text.erb
+++ b/app/views/teacher_mailer/further_information_reminder.text.erb
@@ -16,8 +16,7 @@ You can sign in to add the requested information to your application at:
 
 <%= new_teacher_session_url %>
 
-If you have any questions, contact:
-qts.enquiries@education.gov.uk
+If you have any questions, contact: <%= t("service.email.enquiries") %>
 
 Kind regards,
 The Teacher Qualifications Team

--- a/app/views/teacher_mailer/further_information_requested.text.erb
+++ b/app/views/teacher_mailer/further_information_requested.text.erb
@@ -12,8 +12,7 @@ You can sign in to add the requested information to your application at:
 
 <%= new_teacher_session_url %>
 
-If you have any questions, contact:
-qts.enquiries@education.gov.uk
+If you have any questions, contact: <%= t("service.email.enquiries") %>
 
 <%= render "shared/teacher_mailer/help_us_to_improve_this_service" %>
 

--- a/app/views/teaching_authority_mailer/application_submitted.text.erb
+++ b/app/views/teaching_authority_mailer/application_submitted.text.erb
@@ -17,7 +17,7 @@ They’ve told us that they’re qualified to teach children <%= @application_fo
 
 We’d be grateful if you could provide written evidence of their professional standing as a teacher in <%= CountryName.from_region(@region, with_definite_article: true) %>, and email it to us at:
 
-ApplyQTS.Verification@education.gov.uk
+<%= t("service.email.verification") %>
 
 Please include their QTS application reference number <%= @application_form.reference %>.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,7 +11,10 @@ en:
       support: Support for qualified teacher services (QTS)
       teacher: Apply for qualified teacher status (QTS) in England
 
-    email: qts.enquiries@education.gov.uk
+    email:
+      enquiries: QTS.Enquiries@education.gov.uk
+      verification: ApplyQTS.Verification@education.gov.uk
+
     url: https://apply-for-qts-in-england.education.gov.uk
     phase_banner_text: This is a new service – <a href="https://docs.google.com/forms/d/e/1FAIpQLSePiIC7xO1Dt6oxvIdL6jcGrlUkRDJDS1kxOcqvK-uspBED9w/viewform">your feedback will help us to improve it</a>.
 


### PR DESCRIPTION
This changes the email address on written statement pages to show the verification email address rather than the general enquiries ones. I've also refactored where we render the email address to use the `govuk_link_to` helper.

[Trello Card](https://trello.com/c/8tKQPf3Y/1384-change-email-address-that-lops-get-sent-to-in-lopless-journey)