### PR TITLE
Restrict applications to eligible countries

### DIFF
--- a/app/controllers/teachers/registrations_controller.rb
+++ b/app/controllers/teachers/registrations_controller.rb
@@ -43,7 +43,8 @@ class Teachers::RegistrationsController < Devise::RegistrationsController
   end
 
   def valid_eligibility_check?
-    eligibility_check.present? && eligibility_check.region.present?
+    eligibility_check.present? && eligibility_check.region.present? &&
+      eligibility_check.country.eligibility_enabled?
   end
 
   def eligibility_check

--- a/app/forms/teacher_interface/country_region_form.rb
+++ b/app/forms/teacher_interface/country_region_form.rb
@@ -16,7 +16,10 @@ module TeacherInterface
     end
 
     def regions
-      Region.joins(:country).where(country: { code: country_code }).order(:name)
+      Region
+        .joins(:country)
+        .where(country: { code: country_code, eligibility_enabled: true })
+        .order(:name)
     end
 
     def needs_region?

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -61,6 +61,8 @@ class EligibilityCheck < ApplicationRecord
           )
         }
 
+  delegate :country, to: :region, allow_nil: true
+
   def country_code=(value)
     super(value)
     regions =
@@ -82,7 +84,7 @@ class EligibilityCheck < ApplicationRecord
   end
 
   def skip_additional_questions?
-    region&.country&.eligibility_skip_questions || false
+    country&.eligibility_skip_questions || false
   end
 
   def ineligible_reasons


### PR DESCRIPTION
If a user starts an application via the registration page (skipping the eligibility checker) we don't check if the country they select is eligible at the moment. This needs to be fixed to prevent users from starting applications for ineligible countries.