### PR TITLE
Improve work history ordering and flows

### DIFF
--- a/app/controllers/teacher_interface/new_regs/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/new_regs/work_histories_controller.rb
@@ -106,15 +106,30 @@ module TeacherInterface
               check: true,
             )
 
-            redirect_to new_teacher_interface_application_form_new_regs_work_history_path
-          else
             redirect_to %i[
-                          check
+                          new
                           teacher_interface
                           application_form
                           new_regs
-                          work_histories
+                          work_history
                         ]
+          else
+            came_from_check_collection =
+              history_stack.last_entry&.fetch(:path) ==
+                check_teacher_interface_application_form_new_regs_work_histories_path
+
+            if came_from_check_collection ||
+                 application_form.work_histories.count == 1
+              redirect_to %i[teacher_interface application_form]
+            else
+              redirect_to %i[
+                            check
+                            teacher_interface
+                            application_form
+                            new_regs
+                            work_histories
+                          ]
+            end
           end
         else
           render :add_another, status: :unprocessable_entity

--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -92,7 +92,21 @@ module TeacherInterface
 
         redirect_to %i[new teacher_interface application_form qualification]
       else
-        redirect_to %i[check teacher_interface application_form qualifications]
+        came_from_check_collection =
+          history_stack.last_entry&.fetch(:path) ==
+            check_teacher_interface_application_form_qualifications_path
+
+        if came_from_check_collection ||
+             application_form.qualifications.count == 1
+          redirect_to %i[teacher_interface application_form]
+        else
+          redirect_to %i[
+                        check
+                        teacher_interface
+                        application_form
+                        qualifications
+                      ]
+        end
       end
     end
 

--- a/app/controllers/teacher_interface/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/work_histories_controller.rb
@@ -77,7 +77,21 @@ module TeacherInterface
 
         redirect_to %i[new teacher_interface application_form work_history]
       else
-        redirect_to %i[check teacher_interface application_form work_histories]
+        came_from_check_collection =
+          history_stack.last_entry&.fetch(:path) ==
+            check_teacher_interface_application_form_work_histories_path
+
+        if came_from_check_collection ||
+             application_form.work_histories.count == 1
+          redirect_to %i[teacher_interface application_form]
+        else
+          redirect_to %i[
+                        check
+                        teacher_interface
+                        application_form
+                        work_histories
+                      ]
+        end
       end
     end
 

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -31,7 +31,7 @@
 class WorkHistory < ApplicationRecord
   belongs_to :application_form
 
-  scope :ordered, -> { order(start_date: :desc, created_at: :desc) }
+  scope :ordered, -> { order(created_at: :asc) }
 
   def current_or_most_recent_role?
     application_form.work_histories.empty? ||

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -138,6 +138,7 @@ def create_application_forms(new_regs:)
   Region.all.each do |region|
     application_form_traits_for(region, new_regs).each do |traits|
       created_at = new_regs ? new_regs_date : old_regs_date
+      traits.insert(0, :new_regs) if new_regs
 
       application_form =
         FactoryBot.create(:application_form, *traits, region:, created_at:)

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -154,7 +154,7 @@ FactoryBot.define do
 
     trait :new_regs do
       created_at { Date.new(2023, 2, 1) }
-      needs_work_history { true }
+      needs_work_history { !region.application_form_skip_work_history }
     end
 
     trait :with_assessment do

--- a/spec/models/work_history_spec.rb
+++ b/spec/models/work_history_spec.rb
@@ -38,16 +38,11 @@ RSpec.describe WorkHistory, type: :model do
   end
 
   describe "#ordered" do
-    let(:newest) { create(:work_history, start_date: 1.week.ago) }
-    let(:oldest) { create(:work_history, start_date: 1.month.ago) }
-
-    before do
-      oldest
-      newest
-    end
+    let!(:newest) { create(:work_history, created_at: 1.week.ago) }
+    let!(:oldest) { create(:work_history, created_at: 1.month.ago) }
 
     it "orders in reverse order of start date" do
-      expect(described_class.ordered).to eq([newest, oldest])
+      expect(described_class.ordered).to eq([oldest, newest])
     end
   end
 

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -134,9 +134,6 @@ RSpec.describe "Teacher application", type: :system do
     when_i_click_continue
     and_i_choose_no
     and_i_click_continue
-    then_i_see_the(:teacher_check_work_histories_page)
-
-    when_i_click_continue
     then_i_see_completed_work_history_section
 
     when_i_click_check_your_answers
@@ -221,9 +218,6 @@ RSpec.describe "Teacher application", type: :system do
     when_i_click_continue
     and_i_choose_no
     and_i_click_continue
-    then_i_see_the(:teacher_check_qualifications_page)
-
-    when_i_click_continue
     then_i_see_completed_qualifications_section
 
     when_i_click_age_range
@@ -330,9 +324,6 @@ RSpec.describe "Teacher application", type: :system do
     when_i_click_continue
     and_i_choose_no
     and_i_click_continue
-    then_i_see_the(:teacher_check_qualifications_page)
-
-    when_i_click_continue
     then_i_see_completed_qualifications_section
 
     when_i_click_age_range
@@ -394,6 +385,9 @@ RSpec.describe "Teacher application", type: :system do
     when_i_click_continue
     and_i_choose_no
     and_i_click_continue
+    then_i_see_the(:teacher_application_page)
+
+    when_i_click_work_history
     then_i_see_the(:teacher_check_work_histories_page)
 
     when_i_click_delete

--- a/spec/system/teacher_interface/work_history_spec.rb
+++ b/spec/system/teacher_interface/work_history_spec.rb
@@ -32,9 +32,6 @@ RSpec.describe "Teacher work history", type: :system do
     and_i_see_the_heading_with_the_number_of_months
 
     when_i_dont_add_another_work_history
-    then_i_see_the(:teacher_check_work_histories_page)
-
-    when_i_click_continue
     then_i_see_the(:teacher_application_page)
   end
 
@@ -57,9 +54,6 @@ RSpec.describe "Teacher work history", type: :system do
     and_i_see_the_heading_with_the_number_of_months
 
     when_i_dont_add_another_work_history
-    then_i_see_the(:teacher_check_work_histories_page)
-
-    when_i_click_continue
     then_i_see_the(:teacher_application_page)
   end
 


### PR DESCRIPTION
This makes some improvements to the work history (and qualification) flow on the application form that was spotted in a snagging session. See individual commits for more details.

[Trello Card](https://trello.com/c/7Gq9XLzH/1416-order-add-another-role-by-created-date)
[Trello Card](https://trello.com/c/zmLUtXPg/1415-add-another-role-loop)