### PR TITLE
Add waiting on and received statuses (part 1 of 2)

### DIFF
--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -37,9 +37,10 @@ module StatusTag
       initial_assessment: "blue",
       not_started: "grey",
       potential_duplicate_in_dqt: "red",
-      received: "purple",
-      requested: "yellow",
+      received: "yellow",
+      requested: "purple",
       submitted: "grey",
+      waiting_on: "purple",
     }.freeze
 
     def colour

--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -49,7 +49,7 @@ class PersonasController < ApplicationController
     %w[online written none]
       .product(
         %w[online written none],
-        %w[draft submitted further_information_requested awarded declined],
+        %w[draft submitted waiting_on awarded declined],
         [true, false],
       )
       .tap { |personas| personas.insert(2, *personas.slice!(8, 2)) }

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -112,11 +112,27 @@ class ApplicationForm < ApplicationRecord
          initial_assessment: "initial_assessment",
          further_information_requested: "further_information_requested",
          further_information_received: "further_information_received",
+         waiting_on: "waiting_on",
+         received: "received",
          awarded_pending_checks: "awarded_pending_checks",
          awarded: "awarded",
          declined: "declined",
          potential_duplicate_in_dqt: "potential_duplicate_in_dqt",
        }
+
+  scope :waiting_on,
+        -> { where(state: %w[further_information_requested waiting_on]) }
+
+  def waiting_on?
+    %w[further_information_requested waiting_on].include?(state)
+  end
+
+  scope :received,
+        -> { where(state: %w[further_information_received received]) }
+
+  def received?
+    %w[further_information_received received].include?(state)
+  end
 
   delegate :country, to: :region, allow_nil: true
 

--- a/app/services/create_further_information_request.rb
+++ b/app/services/create_further_information_request.rb
@@ -14,7 +14,7 @@ class CreateFurtherInformationRequest
         ChangeApplicationFormState.call(
           application_form:,
           user:,
-          new_state: :further_information_requested,
+          new_state: "waiting_on",
         )
 
         assessment.further_information_requests.create!(

--- a/app/services/submit_further_information_request.rb
+++ b/app/services/submit_further_information_request.rb
@@ -17,7 +17,7 @@ class SubmitFurtherInformationRequest
       ChangeApplicationFormState.call(
         application_form:,
         user:,
-        new_state: :further_information_received,
+        new_state: "received",
       )
     end
 

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -40,6 +40,8 @@ class AssessorInterface::ApplicationFormsIndexViewObject
       initial_assessment
       further_information_requested
       further_information_received
+      waiting_on
+      received
       awarded_pending_checks
       awarded
       declined

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -61,18 +61,6 @@
     <%- end -%>
     <%= govuk_button_link_to "Save and sign out", destroy_teacher_session_path, secondary: true %>
   </div>
-<% elsif @view_object.application_form.further_information_requested? %>
-  <h2 class="govuk-heading-m">We need some more information</h2>
-  <p class="govuk-body">The status of your qualified teacher status application is currently:</p>
-  <p class="govuk-body"><%= render(StatusTag::Component.new(key: "state", status: @view_object.application_form.state)) %></p>
-  <h3 class="govuk-heading-m">What you need to do</h3>
-  <p class="govuk-body">The assessor needs you to provide some additional information so they can continue reviewing your application.</p>
-  <div class="govuk-inset-text">
-    You may need to upload 1 or more documents. Make sure any files you upload clearly show the whole document or page, and that any text is easy to read.
-  </div>
-  <p class="govuk-body">You must add all of the requested information, so the assessor can continue reviewing your QTS application.</p>
-  <p class="govuk-body">The next screen will take you to the first section you need to complete.</p>
-  <%= govuk_start_button(text: "Start now", href: teacher_interface_application_form_further_information_request_path(@view_object.further_information_request)) %>
 <% elsif @view_object.application_form.declined? %>
   <h2 class="govuk-heading-l">Your QTS application has been declined</h2>
 
@@ -154,14 +142,26 @@
 
   <p class="govuk-body">If you’re applying for a secondary school maths, physics or modern foreign languages teaching role in England, use the Get into Teaching service for one-to-one support with your application through <a href="https://adviser-getintoteaching.education.gov.uk" class="govuk-link">Get an advisor</a>.</p>
   <p class="govuk-body">Your adviser can help with writing a personal statement, preparing for an interview and accessing courses to enhance your subject knowledge.</p>
+<% elsif @view_object.further_information_request&.requested? %>
+  <h2 class="govuk-heading-m">We need some more information</h2>
+  <p class="govuk-body">The status of your qualified teacher status application is currently:</p>
+  <p class="govuk-body"><%= render(StatusTag::Component.new(key: "state", status: @view_object.application_form.state)) %></p>
+  <h3 class="govuk-heading-m">What you need to do</h3>
+  <p class="govuk-body">The assessor needs you to provide some additional information so they can continue reviewing your application.</p>
+  <div class="govuk-inset-text">
+    You may need to upload 1 or more documents. Make sure any files you upload clearly show the whole document or page, and that any text is easy to read.
+  </div>
+  <p class="govuk-body">You must add all of the requested information, so the assessor can continue reviewing your QTS application.</p>
+  <p class="govuk-body">The next screen will take you to the first section you need to complete.</p>
+  <%= govuk_start_button(text: "Start now", href: teacher_interface_application_form_further_information_request_path(@view_object.further_information_request)) %>
 <% else %>
-  <%= govuk_panel(title_text: @view_object.application_form.further_information_received? ? "Further information successfully submitted" : "Application complete") do %>
+  <%= govuk_panel(title_text: @view_object.further_information_request&.received? ? "Further information successfully submitted" : "Application complete") do %>
     Your reference number
     <br />
     <strong><%= @view_object.application_form.reference %></strong>
   <% end %>
 
-  <% if @view_object.application_form.further_information_received? %>
+  <% if @view_object.further_information_request&.received? %>
     <h3 class="govuk-heading-m">You’ve successfully submitted your further information</h3>
     <p class="govuk-body">We’ve sent you an email to confirm that we’ve received it.</p>
     <p class="govuk-body">Once the assessor has checked the documents to make sure you’ve provided all of the requested information, they’ll continue reviewing your QTS application.</p>

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -20,6 +20,7 @@ en:
       submitted:
         assessor: Not started
         teacher: Submitted
+      waiting_on: Waiting on
 
     timeline_entry:
       title:

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -127,7 +127,7 @@ def application_form_traits_for(region, new_regs)
       with_identification_document
       with_age_range
       with_subjects
-    ] + evidential_traits << :submitted << :further_information_requested,
+    ] + evidential_traits << :submitted << :waiting_on,
   ]
 end
 
@@ -147,7 +147,7 @@ def create_application_forms(new_regs:)
 
       assessment = AssessmentFactory.call(application_form:)
 
-      if application_form.further_information_requested?
+      if application_form.waiting_on?
         FactoryBot.create(
           :further_information_request,
           :requested,

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -132,6 +132,16 @@ FactoryBot.define do
       submitted_at { Time.zone.now }
     end
 
+    trait :waiting_on do
+      state { "waiting_on" }
+      submitted_at { Time.zone.now }
+    end
+
+    trait :received do
+      state { "received" }
+      submitted_at { Time.zone.now }
+    end
+
     trait :awarded_pending_checks do
       state { "awarded_pending_checks" }
       submitted_at { Time.zone.now }

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -89,6 +89,8 @@ RSpec.describe ApplicationForm, type: :model do
         initial_assessment: "initial_assessment",
         further_information_requested: "further_information_requested",
         further_information_received: "further_information_received",
+        waiting_on: "waiting_on",
+        received: "received",
         awarded: "awarded",
         awarded_pending_checks: "awarded_pending_checks",
         declined: "declined",

--- a/spec/services/create_further_information_request_spec.rb
+++ b/spec/services/create_further_information_request_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CreateFurtherInformationRequest do
     context "after calling the service" do
       before { call }
 
-      it { is_expected.to eq("further_information_requested") }
+      it { is_expected.to eq("waiting_on") }
     end
   end
 

--- a/spec/services/submit_further_information_request_spec.rb
+++ b/spec/services/submit_further_information_request_spec.rb
@@ -31,11 +31,8 @@ RSpec.describe SubmitFurtherInformationRequest do
     ).to(true)
   end
 
-  it "changes the application form state to further information received" do
-    expect { call }.to change(
-      application_form,
-      :further_information_received?,
-    ).from(false).to(true)
+  it "changes the application form state to received" do
+    expect { call }.to change(application_form, :received?).from(false).to(true)
   end
 
   it "changes the further information request received at" do
@@ -66,7 +63,7 @@ RSpec.describe SubmitFurtherInformationRequest do
       it "sets the attributes correctly" do
         expect(timeline_event.creator).to eq(user)
         expect(timeline_event.old_state).to eq("submitted")
-        expect(timeline_event.new_state).to eq("further_information_received")
+        expect(timeline_event.new_state).to eq("received")
       end
     end
   end

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -167,6 +167,8 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
             id: "further_information_received",
             label: "Further information received (0)",
           ),
+          OpenStruct.new(id: "waiting_on", label: "Waiting on (0)"),
+          OpenStruct.new(id: "received", label: "Received (0)"),
           OpenStruct.new(
             id: "awarded_pending_checks",
             label: "Awarded pending checks (0)",
@@ -187,6 +189,8 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
         create_list(:application_form, 2, :initial_assessment)
         create_list(:application_form, 3, :further_information_requested)
         create_list(:application_form, 4, :further_information_received)
+        create_list(:application_form, 3, :waiting_on)
+        create_list(:application_form, 4, :received)
         create_list(:application_form, 5, :awarded_pending_checks)
         create_list(:application_form, 6, :awarded)
         create_list(:application_form, 7, :declined)
@@ -209,6 +213,8 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
               id: "further_information_received",
               label: "Further information received (4)",
             ),
+            OpenStruct.new(id: "waiting_on", label: "Waiting on (3)"),
+            OpenStruct.new(id: "received", label: "Received (4)"),
             OpenStruct.new(
               id: "awarded_pending_checks",
               label: "Awarded pending checks (5)",


### PR DESCRIPTION
This adds two new statuses to the application form which will be used to represent when an application form is being waited on for some information (further information, or references, for example) and one where the information has been received and the application can be progressed.

See also #975

[Trello Card](https://trello.com/c/tchqfcUF/1400-spike-waiting-on-state)

## Screenshots

![Screenshot 2023-01-19 at 13 26 31](https://user-images.githubusercontent.com/510498/213454604-388a7da5-7e81-4f89-afd5-d9b03c2f0ccb.png)

![Screenshot 2023-01-19 at 13 26 34](https://user-images.githubusercontent.com/510498/213454611-a83e86e2-8ae2-4bd6-96ad-0757c31b0f7a.png)
