### PR TITLE
Remove further information statuses (part 2 of 2)

### DIFF
--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -31,8 +31,6 @@ module StatusTag
       declined: "red",
       draft: "grey",
       expired: "red",
-      further_information_received: "purple",
-      further_information_requested: "yellow",
       in_progress: "blue",
       initial_assessment: "blue",
       not_started: "grey",

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -110,8 +110,6 @@ class ApplicationForm < ApplicationRecord
          draft: "draft",
          submitted: "submitted",
          initial_assessment: "initial_assessment",
-         further_information_requested: "further_information_requested",
-         further_information_received: "further_information_received",
          waiting_on: "waiting_on",
          received: "received",
          awarded_pending_checks: "awarded_pending_checks",
@@ -119,20 +117,6 @@ class ApplicationForm < ApplicationRecord
          declined: "declined",
          potential_duplicate_in_dqt: "potential_duplicate_in_dqt",
        }
-
-  scope :waiting_on,
-        -> { where(state: %w[further_information_requested waiting_on]) }
-
-  def waiting_on?
-    %w[further_information_requested waiting_on].include?(state)
-  end
-
-  scope :received,
-        -> { where(state: %w[further_information_received received]) }
-
-  def received?
-    %w[further_information_received received].include?(state)
-  end
 
   delegate :country, to: :region, allow_nil: true
 

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -38,8 +38,6 @@ class AssessorInterface::ApplicationFormsIndexViewObject
     states = %w[
       submitted
       initial_assessment
-      further_information_requested
-      further_information_received
       waiting_on
       received
       awarded_pending_checks

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -9,8 +9,6 @@ en:
       declined: Declined
       draft: Draft
       expired: Expired
-      further_information_received: Further information received
-      further_information_requested: Further information requested
       in_progress: In progress
       initial_assessment: Initial assessment
       not_started: Not started

--- a/db/migrate/20230119114035_remove_application_form_further_information_states.rb
+++ b/db/migrate/20230119114035_remove_application_form_further_information_states.rb
@@ -1,0 +1,12 @@
+class RemoveApplicationFormFurtherInformationStates < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    ApplicationForm.where(state: "further_information_requested").update_all(
+      state: "waiting_on",
+    )
+    ApplicationForm.where(state: "further_information_received").update_all(
+      state: "received",
+    )
+  end
+end

--- a/spec/components/status_tag_spec.rb
+++ b/spec/components/status_tag_spec.rb
@@ -73,18 +73,6 @@ RSpec.describe StatusTag::Component, type: :component do
       it { is_expected.to eq("govuk-tag govuk-tag--blue app-task-list__tag") }
     end
 
-    context "with a 'further_information_requested' status" do
-      let(:status) { :further_information_requested }
-
-      it { is_expected.to eq("govuk-tag govuk-tag--yellow app-task-list__tag") }
-    end
-
-    context "with a 'further_information_received' status" do
-      let(:status) { :further_information_received }
-
-      it { is_expected.to eq("govuk-tag govuk-tag--purple app-task-list__tag") }
-    end
-
     context "with an 'awarded' status" do
       let(:status) { :awarded }
 

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -122,16 +122,6 @@ FactoryBot.define do
       submitted_at { Time.zone.now }
     end
 
-    trait :further_information_requested do
-      state { "further_information_requested" }
-      submitted_at { Time.zone.now }
-    end
-
-    trait :further_information_received do
-      state { "further_information_received" }
-      submitted_at { Time.zone.now }
-    end
-
     trait :waiting_on do
       state { "waiting_on" }
       submitted_at { Time.zone.now }

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -87,8 +87,6 @@ RSpec.describe ApplicationForm, type: :model do
         draft: "draft",
         submitted: "submitted",
         initial_assessment: "initial_assessment",
-        further_information_requested: "further_information_requested",
-        further_information_received: "further_information_received",
         waiting_on: "waiting_on",
         received: "received",
         awarded: "awarded",

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -176,8 +176,7 @@ RSpec.describe "Teacher further information", type: :system do
   def application_form
     @application_form ||=
       begin
-        application_form =
-          create(:application_form, :further_information_requested, teacher:)
+        application_form = create(:application_form, :waiting_on, teacher:)
         create(
           :assessment,
           :with_further_information_request,

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -159,14 +159,6 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
             id: "initial_assessment",
             label: "Initial assessment (0)",
           ),
-          OpenStruct.new(
-            id: "further_information_requested",
-            label: "Further information requested (0)",
-          ),
-          OpenStruct.new(
-            id: "further_information_received",
-            label: "Further information received (0)",
-          ),
           OpenStruct.new(id: "waiting_on", label: "Waiting on (0)"),
           OpenStruct.new(id: "received", label: "Received (0)"),
           OpenStruct.new(
@@ -187,8 +179,6 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
       before do
         create_list(:application_form, 1, :submitted)
         create_list(:application_form, 2, :initial_assessment)
-        create_list(:application_form, 3, :further_information_requested)
-        create_list(:application_form, 4, :further_information_received)
         create_list(:application_form, 3, :waiting_on)
         create_list(:application_form, 4, :received)
         create_list(:application_form, 5, :awarded_pending_checks)
@@ -204,14 +194,6 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
             OpenStruct.new(
               id: "initial_assessment",
               label: "Initial assessment (2)",
-            ),
-            OpenStruct.new(
-              id: "further_information_requested",
-              label: "Further information requested (3)",
-            ),
-            OpenStruct.new(
-              id: "further_information_received",
-              label: "Further information received (4)",
             ),
             OpenStruct.new(id: "waiting_on", label: "Waiting on (3)"),
             OpenStruct.new(id: "received", label: "Received (4)"),


### PR DESCRIPTION
These statuses will be covered by the new waiting on and received statuses, and so we won't need dedicated statuses for further information.

See also #974 

[Trello Card](https://trello.com/c/tchqfcUF/1400-spike-waiting-on-state)

## Screenshot

![Screenshot 2023-01-19 at 13 28 40](https://user-images.githubusercontent.com/510498/213455005-a0eeba57-7653-487b-973d-2f751cf3420a.png)
