### PR TITLE
Record potential duplicates in the DQT TRN requests

### DIFF
--- a/app/jobs/update_dqt_trn_request_job.rb
+++ b/app/jobs/update_dqt_trn_request_job.rb
@@ -20,7 +20,12 @@ class UpdateDQTTRNRequestJob < ApplicationJob
 
     dqt_trn_request.pending! if dqt_trn_request.initial?
 
-    if response[:potential_duplicate]
+    potential_duplicate = response[:potential_duplicate]
+    if potential_duplicate != dqt_trn_request.potential_duplicate
+      dqt_trn_request.update!(potential_duplicate:)
+    end
+
+    if potential_duplicate
       ChangeApplicationFormState.call(
         application_form:,
         user: "DQT",

--- a/app/models/dqt_trn_request.rb
+++ b/app/models/dqt_trn_request.rb
@@ -3,6 +3,7 @@
 # Table name: dqt_trn_requests
 #
 #  id                  :bigint           not null, primary key
+#  potential_duplicate :boolean
 #  state               :string           default("initial"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -125,6 +125,7 @@
     - application_form_id
     - request_id
     - state
+    - potential_duplicate
     - created_at
     - updated_at
   :eligibility_checks:

--- a/db/migrate/20230119115001_add_potential_duplicate_to_dqt_trn_request.rb
+++ b/db/migrate/20230119115001_add_potential_duplicate_to_dqt_trn_request.rb
@@ -1,0 +1,15 @@
+class AddPotentialDuplicateToDQTTRNRequest < ActiveRecord::Migration[7.0]
+  def up
+    add_column :dqt_trn_requests, :potential_duplicate, :boolean
+
+    DQTTRNRequest.complete.update_all(potential_duplicate: false)
+
+    ApplicationForm.potential_duplicate_in_dqt.each do |application_form|
+      application_form.dqt_trn_request.update!(potential_duplicate: true)
+    end
+  end
+
+  def down
+    remove_column :dqt_trn_requests, :potential_duplicate
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -168,6 +168,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_20_100710) do
     t.string "state", default: "pending", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "potential_duplicate"
     t.index ["application_form_id"], name: "index_dqt_trn_requests_on_application_form_id"
   end
 

--- a/spec/factories/dqt_trn_requests.rb
+++ b/spec/factories/dqt_trn_requests.rb
@@ -3,6 +3,7 @@
 # Table name: dqt_trn_requests
 #
 #  id                  :bigint           not null, primary key
+#  potential_duplicate :boolean
 #  state               :string           default("initial"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/spec/jobs/update_dqt_trn_request_job_spec.rb
+++ b/spec/jobs/update_dqt_trn_request_job_spec.rb
@@ -25,8 +25,14 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
         end
 
         it "marks the request as complete" do
-          perform
-          expect(dqt_trn_request.reload.state).to eq("complete")
+          expect { perform }.to change(dqt_trn_request, :complete?).to(true)
+        end
+
+        it "sets potential duplicate" do
+          expect { perform }.to change(
+            dqt_trn_request,
+            :potential_duplicate,
+          ).to(false)
         end
 
         it "awards QTS" do
@@ -51,8 +57,17 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
         end
 
         it "leaves the request as initial" do
-          perform_rescue_exception
-          expect(dqt_trn_request.reload.state).to eq("initial")
+          expect { perform_rescue_exception }.to_not change(
+            dqt_trn_request,
+            :state,
+          )
+        end
+
+        it "leaves the potential duplicate" do
+          expect { perform_rescue_exception }.to_not change(
+            dqt_trn_request,
+            :potential_duplicate,
+          )
         end
 
         it "doesn't award QTS" do
@@ -78,8 +93,14 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
         end
 
         it "marks the request as pending" do
-          perform
-          expect(dqt_trn_request.reload.state).to eq("pending")
+          expect { perform }.to change(dqt_trn_request, :pending?).to(true)
+        end
+
+        it "sets potential duplicate" do
+          expect { perform }.to change(
+            dqt_trn_request,
+            :potential_duplicate,
+          ).to(true)
         end
 
         it "doesn't award QTS" do
@@ -113,8 +134,14 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
         end
 
         it "marks the request as complete" do
-          perform
-          expect(dqt_trn_request.reload.state).to eq("complete")
+          expect { perform }.to change(dqt_trn_request, :complete?).to(true)
+        end
+
+        it "sets potential duplicate" do
+          expect { perform }.to change(
+            dqt_trn_request,
+            :potential_duplicate,
+          ).to(false)
         end
 
         it "awards QTS" do
@@ -139,8 +166,17 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
         end
 
         it "leaves the request as pending" do
-          perform_rescue_exception
-          expect(dqt_trn_request.reload.state).to eq("pending")
+          expect { perform_rescue_exception }.to_not change(
+            dqt_trn_request,
+            :state,
+          )
+        end
+
+        it "leaves the potential duplicate" do
+          expect { perform_rescue_exception }.to_not change(
+            dqt_trn_request,
+            :potential_duplicate,
+          )
         end
 
         it "doesn't award QTS" do
@@ -165,9 +201,18 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
           )
         end
 
-        it "marks the request as pending" do
-          perform
-          expect(dqt_trn_request.reload.state).to eq("pending")
+        it "leaves the request as pending" do
+          expect { perform_rescue_exception }.to_not change(
+            dqt_trn_request,
+            :state,
+          )
+        end
+
+        it "sets potential duplicate" do
+          expect { perform }.to change(
+            dqt_trn_request,
+            :potential_duplicate,
+          ).to(true)
         end
 
         it "doesn't award QTS" do
@@ -193,9 +238,18 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
     context "with a complete request" do
       let(:dqt_trn_request) { create(:dqt_trn_request, :complete) }
 
-      it "leaves the request as complete" do
-        perform
-        expect(dqt_trn_request.reload.state).to eq("complete")
+      it "leaves the request as pending" do
+        expect { perform_rescue_exception }.to_not change(
+          dqt_trn_request,
+          :state,
+        )
+      end
+
+      it "leaves the potential duplicate" do
+        expect { perform_rescue_exception }.to_not change(
+          dqt_trn_request,
+          :potential_duplicate,
+        )
       end
 
       it "doesn't award QTS" do

--- a/spec/models/dqt_trn_request_spec.rb
+++ b/spec/models/dqt_trn_request_spec.rb
@@ -5,6 +5,7 @@
 # Table name: dqt_trn_requests
 #
 #  id                  :bigint           not null, primary key
+#  potential_duplicate :boolean
 #  state               :string           default("initial"), not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null


### PR DESCRIPTION
This adds a new column to the DQT TRN Request which will store whether or not the request returned with a potential duplicate in DQT. We'll be storing this so the overall status of an application can be determined dynamically from this information.

[Trello Card](https://trello.com/c/tchqfcUF/1400-spike-waiting-on-state)