### PR TITLE
Add declined_at column to application form

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -11,6 +11,7 @@
 #  awarded_at                                    :datetime
 #  confirmed_no_sanctions                        :boolean          default(FALSE)
 #  date_of_birth                                 :date
+#  declined_at                                   :datetime
 #  english_language_citizenship_exempt           :boolean
 #  english_language_proof_method                 :string
 #  english_language_provider_other               :boolean          default(FALSE), not null

--- a/app/services/decline_qts.rb
+++ b/app/services/decline_qts.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class DeclineQTS
+  include ServicePattern
+
+  def initialize(application_form:, user:)
+    @application_form = application_form
+    @user = user
+  end
+
+  def call
+    return if application_form.declined?
+
+    ActiveRecord::Base.transaction do
+      application_form.update!(declined_at: Time.zone.now)
+
+      ChangeApplicationFormState.call(
+        application_form:,
+        user:,
+        new_state: "declined",
+      )
+    end
+
+    TeacherMailer.with(teacher:).application_declined.deliver_later
+  end
+
+  private
+
+  attr_reader :application_form, :user
+
+  delegate :teacher, to: :application_form
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -52,6 +52,7 @@
     - reviewer_id
     - submitted_at
     - awarded_at
+    - declined_at
     - working_days_since_submission
     - needs_work_history
     - needs_written_statement

--- a/db/migrate/20230120100710_add_declined_at_to_application_forms.rb
+++ b/db/migrate/20230120100710_add_declined_at_to_application_forms.rb
@@ -1,0 +1,5 @@
+class AddDeclinedAtToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_forms, :declined_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_17_211010) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_20_100710) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -84,10 +84,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_17_211010) do
     t.bigint "english_language_provider_id"
     t.text "english_language_provider_reference", default: "", null: false
     t.datetime "awarded_at"
+    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "written_statement_confirmation", default: false, null: false
     t.boolean "english_language_provider_other", default: false, null: false
-    t.boolean "reduced_evidence_accepted", default: false, null: false
+    t.datetime "declined_at"
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["english_language_provider_id"], name: "index_application_forms_on_english_language_provider_id"
     t.index ["family_name"], name: "index_application_forms_on_family_name"
@@ -287,8 +288,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_17_211010) do
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
-    t.text "qualifications_information", default: "", null: false
     t.boolean "application_form_skip_work_history", default: false, null: false
+    t.text "qualifications_information", default: "", null: false
     t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_requires_submission_email", default: false, null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true

--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -15,4 +15,19 @@ namespace :application_forms do
     puts "There were #{original_count} draft applications and there are now #{new_count}."
     puts "There are #{ApplicationForm.count} applications overall."
   end
+
+  desc "Generate a countries CSV file for analytics dashboards."
+  task set_declined_at: :environment do
+    ApplicationForm
+      .declined
+      .where(declined_at: nil)
+      .each do |application_form|
+        timeline_event =
+          TimelineEvent.state_changed.find_by(
+            application_form:,
+            new_state: "declined",
+          )
+        application_form.update!(declined_at: timeline_event.created_at)
+      end
+  end
 end

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -11,6 +11,7 @@
 #  awarded_at                                    :datetime
 #  confirmed_no_sanctions                        :boolean          default(FALSE)
 #  date_of_birth                                 :date
+#  declined_at                                   :datetime
 #  english_language_citizenship_exempt           :boolean
 #  english_language_proof_method                 :string
 #  english_language_provider_other               :boolean          default(FALSE), not null

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -11,6 +11,7 @@
 #  awarded_at                                    :datetime
 #  confirmed_no_sanctions                        :boolean          default(FALSE)
 #  date_of_birth                                 :date
+#  declined_at                                   :datetime
 #  english_language_citizenship_exempt           :boolean
 #  english_language_proof_method                 :string
 #  english_language_provider_other               :boolean          default(FALSE), not null

--- a/spec/services/decline_qts_spec.rb
+++ b/spec/services/decline_qts_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DeclineQTS do
+  let(:teacher) { create(:teacher) }
+  let(:user) { create(:staff, :confirmed) }
+
+  subject(:call) { described_class.call(application_form:, user:) }
+
+  context "with an application form" do
+    let(:application_form) { create(:application_form, :submitted, teacher:) }
+
+    it "sends an email" do
+      expect { call }.to have_enqueued_mail(
+        TeacherMailer,
+        :application_declined,
+      ).with(params: { teacher: }, args: [])
+    end
+
+    it "changes the status" do
+      expect(ChangeApplicationFormState).to receive(:call).with(
+        application_form:,
+        user:,
+        new_state: "declined",
+      )
+      call
+    end
+
+    it "sets the declined at date" do
+      freeze_time do
+        expect { call }.to change(application_form, :declined_at).to(
+          Time.zone.now,
+        )
+      end
+    end
+  end
+
+  context "with a declined application form" do
+    let(:application_form) { create(:application_form, :declined, teacher:) }
+
+    it "doesn't send an email" do
+      expect { call }.to_not have_enqueued_mail(
+        TeacherMailer,
+        :application_declined,
+      )
+    end
+
+    it "doesn't change the status" do
+      expect(ChangeApplicationFormState).to_not receive(:call)
+      call
+    end
+
+    it "doesn't change the declined at date" do
+      expect { call }.to_not change(application_form, :declined_at)
+    end
+  end
+end


### PR DESCRIPTION
This adds a new column to the application form which captures the time when an application was declined, we'll use this as the source of truth as to whether an application is declined or not rather than the status, and it's useful for analytics.

[Trello Card](https://trello.com/c/tchqfcUF/1400-spike-waiting-on-state)