### PR TITLE
Validate declined at date

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -94,6 +94,9 @@ class ApplicationForm < ApplicationRecord
 
   validates :submitted_at, presence: true, unless: :draft?
   validates :awarded_at, presence: true, if: :awarded?
+  validates :awarded_at, absence: true, if: :declined?
+  validates :declined_at, presence: true, if: :declined?
+  validates :declined_at, absence: true, if: :awarded?
 
   enum :english_language_proof_method,
        { medium_of_instruction: "medium_of_instruction", provider: "provider" },

--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -15,19 +15,4 @@ namespace :application_forms do
     puts "There were #{original_count} draft applications and there are now #{new_count}."
     puts "There are #{ApplicationForm.count} applications overall."
   end
-
-  desc "Generate a countries CSV file for analytics dashboards."
-  task set_declined_at: :environment do
-    ApplicationForm
-      .declined
-      .where(declined_at: nil)
-      .each do |application_form|
-        timeline_event =
-          TimelineEvent.state_changed.find_by(
-            application_form:,
-            new_state: "declined",
-          )
-        application_form.update!(declined_at: timeline_event.created_at)
-      end
-  end
 end

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -146,6 +146,7 @@ FactoryBot.define do
     trait :declined do
       state { "declined" }
       submitted_at { Time.zone.now }
+      declined_at { Time.zone.now }
     end
 
     trait :potential_duplicate_in_dqt do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -277,6 +277,23 @@ RSpec.describe ApplicationForm, type: :model do
         it { is_expected.to be_valid }
       end
     end
+
+    context "when declined" do
+      before do
+        application_form.assign_attributes(
+          state: "declined",
+          submitted_at: Time.zone.now,
+        )
+      end
+
+      it { is_expected.to_not be_valid }
+
+      context "with declined_at" do
+        before { application_form.declined_at = Time.zone.now }
+
+        it { is_expected.to be_valid }
+      end
+    end
   end
 
   describe "scopes" do


### PR DESCRIPTION
This ensures that if the state is declined, the declined_at date is set, and also checks that awarded_at isn't set. I've also removed the Rake task which has now been run in all environments.