### PR TITLE
Add steps to set up cf cli in db restore job

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -137,6 +137,20 @@ jobs:
           echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
           echo "PAAS_SPACE=$(jq -r '.paas_space' ${tf_vars_file})" >> $GITHUB_ENV
 
+      - uses: Azure/get-keyvault-secrets@v1
+        id: get_secrets
+        with:
+          keyvault: ${{ env.KEY_VAULT_NAME }}
+          secrets: "PAAS-USER,PAAS-PASSWORD"
+
+      - name: Setup cf cli
+        uses: DFE-Digital/github-actions/setup-cf-cli@master
+        with:
+          CF_USERNAME: ${{ steps.get_secrets.outputs.PAAS-USER }}
+          CF_PASSWORD: ${{ steps.get_secrets.outputs.PAAS-PASSWORD }}
+          CF_SPACE_NAME: ${{ env.PAAS_SPACE }}
+          INSTALL_CONDUIT: true
+
       - name: Download Sanitised Backup
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
### Context

The restore job in the database-backup workflow is failing nightly as the cf cli is not installed.

### Changes made in this PR

Add steps to set up cf cli

### Guidance to review

Review [logs](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/actions/runs/3985539452) on manually triggered run