### PR TITLE
Track what is being waiting on and received

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -28,6 +28,9 @@
 #  needs_written_statement                       :boolean          not null
 #  personal_information_status                   :string           default("not_started"), not null
 #  qualifications_status                         :string           default("not_started"), not null
+#  received_further_information                  :boolean          default(FALSE), not null
+#  received_professional_standing                :boolean          default(FALSE), not null
+#  received_reference                            :boolean          default(FALSE), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  reference                                     :string(31)       not null
 #  registration_number                           :text
@@ -37,6 +40,9 @@
 #  subjects_status                               :string           default("not_started"), not null
 #  submitted_at                                  :datetime
 #  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
+#  waiting_on_further_information                :boolean          default(FALSE), not null
+#  waiting_on_professional_standing              :boolean          default(FALSE), not null
+#  waiting_on_reference                          :boolean          default(FALSE), not null
 #  work_history_status                           :string           default("not_started"), not null
 #  working_days_since_submission                 :integer
 #  written_statement_confirmation                :boolean          default(FALSE), not null

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -25,6 +25,12 @@
     - id
     - reference
     - state
+    - waiting_on_professional_standing
+    - received_professional_standing
+    - waiting_on_further_information
+    - received_further_information
+    - waiting_on_reference
+    - received_reference
     - personal_information_status
     - identification_document_status
     - qualifications_status

--- a/db/migrate/20230123103414_add_waiting_on_and_received_to_application_forms.rb
+++ b/db/migrate/20230123103414_add_waiting_on_and_received_to_application_forms.rb
@@ -1,0 +1,14 @@
+class AddWaitingOnAndReceivedToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    change_table :application_forms, bulk: true do |t|
+      t.boolean :waiting_on_professional_standing, null: false, default: false
+      t.boolean :received_professional_standing, null: false, default: false
+
+      t.boolean :waiting_on_further_information, null: false, default: false
+      t.boolean :received_further_information, null: false, default: false
+
+      t.boolean :waiting_on_reference, null: false, default: false
+      t.boolean :received_reference, null: false, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_20_100710) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_23_103414) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -89,6 +89,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_20_100710) do
     t.boolean "written_statement_confirmation", default: false, null: false
     t.boolean "english_language_provider_other", default: false, null: false
     t.datetime "declined_at"
+    t.boolean "waiting_on_professional_standing", default: false, null: false
+    t.boolean "received_professional_standing", default: false, null: false
+    t.boolean "waiting_on_further_information", default: false, null: false
+    t.boolean "received_further_information", default: false, null: false
+    t.boolean "waiting_on_reference", default: false, null: false
+    t.boolean "received_reference", default: false, null: false
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["english_language_provider_id"], name: "index_application_forms_on_english_language_provider_id"
     t.index ["family_name"], name: "index_application_forms_on_family_name"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -28,6 +28,9 @@
 #  needs_written_statement                       :boolean          not null
 #  personal_information_status                   :string           default("not_started"), not null
 #  qualifications_status                         :string           default("not_started"), not null
+#  received_further_information                  :boolean          default(FALSE), not null
+#  received_professional_standing                :boolean          default(FALSE), not null
+#  received_reference                            :boolean          default(FALSE), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  reference                                     :string(31)       not null
 #  registration_number                           :text
@@ -37,6 +40,9 @@
 #  subjects_status                               :string           default("not_started"), not null
 #  submitted_at                                  :datetime
 #  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
+#  waiting_on_further_information                :boolean          default(FALSE), not null
+#  waiting_on_professional_standing              :boolean          default(FALSE), not null
+#  waiting_on_reference                          :boolean          default(FALSE), not null
 #  work_history_status                           :string           default("not_started"), not null
 #  working_days_since_submission                 :integer
 #  written_statement_confirmation                :boolean          default(FALSE), not null

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -74,6 +74,13 @@ RSpec.describe ApplicationFormStatusUpdater do
       end
 
       include_examples "changes status", "received"
+
+      it "changes received_further_information" do
+        expect { call }.to change(
+          application_form,
+          :received_further_information,
+        ).from(false).to(true)
+      end
     end
 
     context "with a requested FI request" do
@@ -85,6 +92,47 @@ RSpec.describe ApplicationFormStatusUpdater do
       end
 
       include_examples "changes status", "waiting_on"
+
+      it "changes waiting_on_further_information" do
+        expect { call }.to change(
+          application_form,
+          :waiting_on_further_information,
+        ).from(false).to(true)
+      end
+    end
+
+    context "with a received reference request" do
+      let(:assessment) { create(:assessment, application_form:) }
+
+      before do
+        application_form.update!(submitted_at: Time.zone.now)
+        create(:reference_request, :received, assessment:)
+      end
+
+      include_examples "changes status", "received"
+
+      it "changes received_reference" do
+        expect { call }.to change(application_form, :received_reference).from(
+          false,
+        ).to(true)
+      end
+    end
+
+    context "with a requested reference request" do
+      let(:assessment) { create(:assessment, application_form:) }
+
+      before do
+        application_form.update!(submitted_at: Time.zone.now)
+        create(:reference_request, :requested, assessment:)
+      end
+
+      include_examples "changes status", "waiting_on"
+
+      it "changes waiting_on_reference" do
+        expect { call }.to change(application_form, :waiting_on_reference).from(
+          false,
+        ).to(true)
+      end
     end
 
     context "with a started assessment" do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -28,6 +28,9 @@
 #  needs_written_statement                       :boolean          not null
 #  personal_information_status                   :string           default("not_started"), not null
 #  qualifications_status                         :string           default("not_started"), not null
+#  received_further_information                  :boolean          default(FALSE), not null
+#  received_professional_standing                :boolean          default(FALSE), not null
+#  received_reference                            :boolean          default(FALSE), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  reference                                     :string(31)       not null
 #  registration_number                           :text
@@ -37,6 +40,9 @@
 #  subjects_status                               :string           default("not_started"), not null
 #  submitted_at                                  :datetime
 #  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
+#  waiting_on_further_information                :boolean          default(FALSE), not null
+#  waiting_on_professional_standing              :boolean          default(FALSE), not null
+#  waiting_on_reference                          :boolean          default(FALSE), not null
 #  work_history_status                           :string           default("not_started"), not null
 #  working_days_since_submission                 :integer
 #  written_statement_confirmation                :boolean          default(FALSE), not null


### PR DESCRIPTION
This adds new fields for tracking what type of thing we're waiting on and we've received, useful for analytics and filtering.

[Trello Card](https://trello.com/c/tchqfcUF/1400-spike-waiting-on-state)