### PR TITLE
Rename application form state to status (part 2 of 2)

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -35,7 +35,7 @@
 #  reference                                     :string(31)       not null
 #  registration_number                           :text
 #  registration_number_status                    :string           default("not_started"), not null
-#  state                                         :string           default("draft"), not null
+#  status                                        :string           default("draft"), not null
 #  subjects                                      :text             default([]), not null, is an Array
 #  subjects_status                               :string           default("not_started"), not null
 #  submitted_at                                  :datetime
@@ -64,7 +64,7 @@
 #  index_application_forms_on_reference                     (reference) UNIQUE
 #  index_application_forms_on_region_id                     (region_id)
 #  index_application_forms_on_reviewer_id                   (reviewer_id)
-#  index_application_forms_on_state                         (state)
+#  index_application_forms_on_status                        (status)
 #  index_application_forms_on_teacher_id                    (teacher_id)
 #
 # Foreign Keys
@@ -112,7 +112,7 @@ class ApplicationForm < ApplicationRecord
             absence: true,
             if: :english_language_provider_other
 
-  enum state: {
+  enum status: {
          draft: "draft",
          submitted: "submitted",
          initial_assessment: "initial_assessment",
@@ -123,8 +123,6 @@ class ApplicationForm < ApplicationRecord
          declined: "declined",
          potential_duplicate_in_dqt: "potential_duplicate_in_dqt",
        }
-
-  alias_attribute :status, :state
 
   delegate :country, to: :region, allow_nil: true
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -24,7 +24,7 @@
   :application_forms:
     - id
     - reference
-    - state
+    - status
     - waiting_on_professional_standing
     - received_professional_standing
     - waiting_on_further_information

--- a/db/migrate/20230119115001_add_potential_duplicate_to_dqt_trn_request.rb
+++ b/db/migrate/20230119115001_add_potential_duplicate_to_dqt_trn_request.rb
@@ -1,15 +1,5 @@
 class AddPotentialDuplicateToDQTTRNRequest < ActiveRecord::Migration[7.0]
-  def up
+  def change
     add_column :dqt_trn_requests, :potential_duplicate, :boolean
-
-    DQTTRNRequest.complete.update_all(potential_duplicate: false)
-
-    ApplicationForm.potential_duplicate_in_dqt.each do |application_form|
-      application_form.dqt_trn_request.update!(potential_duplicate: true)
-    end
-  end
-
-  def down
-    remove_column :dqt_trn_requests, :potential_duplicate
   end
 end

--- a/db/migrate/20230121114913_rename_application_form_state_to_status.rb
+++ b/db/migrate/20230121114913_rename_application_form_state_to_status.rb
@@ -1,0 +1,5 @@
+class RenameApplicationFormStateToStatus < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :application_forms, :state, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_103414) do
     t.text "subjects", default: [], null: false, array: true
     t.bigint "assessor_id"
     t.bigint "reviewer_id"
-    t.string "state", default: "draft", null: false
+    t.string "status", default: "draft", null: false
     t.datetime "submitted_at"
     t.boolean "needs_work_history", null: false
     t.boolean "needs_written_statement", null: false
@@ -102,7 +102,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_103414) do
     t.index ["reference"], name: "index_application_forms_on_reference", unique: true
     t.index ["region_id"], name: "index_application_forms_on_region_id"
     t.index ["reviewer_id"], name: "index_application_forms_on_reviewer_id"
-    t.index ["state"], name: "index_application_forms_on_state"
+    t.index ["status"], name: "index_application_forms_on_status"
     t.index ["teacher_id"], name: "index_application_forms_on_teacher_id"
   end
 

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -35,7 +35,7 @@
 #  reference                                     :string(31)       not null
 #  registration_number                           :text
 #  registration_number_status                    :string           default("not_started"), not null
-#  state                                         :string           default("draft"), not null
+#  status                                        :string           default("draft"), not null
 #  subjects                                      :text             default([]), not null, is an Array
 #  subjects_status                               :string           default("not_started"), not null
 #  submitted_at                                  :datetime
@@ -64,7 +64,7 @@
 #  index_application_forms_on_reference                     (reference) UNIQUE
 #  index_application_forms_on_region_id                     (region_id)
 #  index_application_forms_on_reviewer_id                   (reviewer_id)
-#  index_application_forms_on_state                         (state)
+#  index_application_forms_on_status                        (status)
 #  index_application_forms_on_teacher_id                    (teacher_id)
 #
 # Foreign Keys
@@ -78,7 +78,7 @@
 FactoryBot.define do
   factory :application_form do
     sequence(:reference) { |n| n.to_s.rjust(7, "0") }
-    state { "draft" }
+    status { "draft" }
     association :teacher
     association :region
 
@@ -107,7 +107,7 @@ FactoryBot.define do
     end
 
     trait :submitted do
-      state { "submitted" }
+      status { "submitted" }
       submitted_at { Time.zone.now }
       working_days_since_submission { 0 }
 
@@ -124,39 +124,39 @@ FactoryBot.define do
     end
 
     trait :initial_assessment do
-      state { "initial_assessment" }
+      status { "initial_assessment" }
       submitted_at { Time.zone.now }
     end
 
     trait :waiting_on do
-      state { "waiting_on" }
+      status { "waiting_on" }
       submitted_at { Time.zone.now }
     end
 
     trait :received do
-      state { "received" }
+      status { "received" }
       submitted_at { Time.zone.now }
     end
 
     trait :awarded_pending_checks do
-      state { "awarded_pending_checks" }
+      status { "awarded_pending_checks" }
       submitted_at { Time.zone.now }
     end
 
     trait :awarded do
-      state { "awarded" }
+      status { "awarded" }
       submitted_at { Time.zone.now }
       awarded_at { Time.zone.now }
     end
 
     trait :declined do
-      state { "declined" }
+      status { "declined" }
       submitted_at { Time.zone.now }
       declined_at { Time.zone.now }
     end
 
     trait :potential_duplicate_in_dqt do
-      state { "potential_duplicate_in_dqt" }
+      status { "potential_duplicate_in_dqt" }
       submitted_at { Time.zone.now }
     end
 

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -58,8 +58,8 @@ FactoryBot.define do
 
     trait :state_changed do
       event_type { "state_changed" }
-      old_state { ApplicationForm.states.keys.sample }
-      new_state { ApplicationForm.states.keys.sample }
+      old_state { ApplicationForm.statuses.keys.sample }
+      new_state { ApplicationForm.statuses.keys.sample }
     end
 
     trait :assessment_section_recorded do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -35,7 +35,7 @@
 #  reference                                     :string(31)       not null
 #  registration_number                           :text
 #  registration_number_status                    :string           default("not_started"), not null
-#  state                                         :string           default("draft"), not null
+#  status                                        :string           default("draft"), not null
 #  subjects                                      :text             default([]), not null, is an Array
 #  subjects_status                               :string           default("not_started"), not null
 #  submitted_at                                  :datetime
@@ -64,7 +64,7 @@
 #  index_application_forms_on_reference                     (reference) UNIQUE
 #  index_application_forms_on_region_id                     (region_id)
 #  index_application_forms_on_reviewer_id                   (reviewer_id)
-#  index_application_forms_on_state                         (state)
+#  index_application_forms_on_status                        (status)
 #  index_application_forms_on_teacher_id                    (teacher_id)
 #
 # Foreign Keys
@@ -89,7 +89,7 @@ RSpec.describe ApplicationForm, type: :model do
 
   describe "columns" do
     it do
-      is_expected.to define_enum_for(:state).with_values(
+      is_expected.to define_enum_for(:status).with_values(
         draft: "draft",
         submitted: "submitted",
         initial_assessment: "initial_assessment",


### PR DESCRIPTION
This renames the state field to status to make it clearer that it's generated dynamically. I'd like to rename it to be clearer that "status" is something dynamically generated based on the "state" of other objects.

Depends on #996 

[Trello Card](https://trello.com/c/tchqfcUF/1400-spike-waiting-on-state)