### PR TITLE
Organise statuses

### DIFF
--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -22,7 +22,7 @@ module StatusTag
 
     COLOURS = {
       awarded: "green",
-      awarded_pending_checks: "green",
+      awarded_pending_checks: "turquoise",
       cannot_start: "grey",
       completed: {
         assessor: "green",
@@ -34,7 +34,7 @@ module StatusTag
       initial_assessment: "blue",
       invalid: "red",
       not_started: "grey",
-      potential_duplicate_in_dqt: "red",
+      potential_duplicate_in_dqt: "pink",
       received: "purple",
       requested: "yellow",
       submitted: "grey",

--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -29,7 +29,7 @@ module StatusTag
       },
       declined: "red",
       draft: "grey",
-      expired: "red",
+      expired: "pink",
       in_progress: "blue",
       initial_assessment: "blue",
       invalid: "red",

--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -35,10 +35,10 @@ module StatusTag
       invalid: "red",
       not_started: "grey",
       potential_duplicate_in_dqt: "red",
-      received: "yellow",
-      requested: "purple",
+      received: "purple",
+      requested: "yellow",
       submitted: "grey",
-      waiting_on: "purple",
+      waiting_on: "yellow",
     }.freeze
 
     def colour

--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -21,7 +21,6 @@ module StatusTag
     end
 
     COLOURS = {
-      action_required: "red",
       awarded: "green",
       awarded_pending_checks: "green",
       cannot_start_yet: "grey",
@@ -33,6 +32,7 @@ module StatusTag
       expired: "red",
       in_progress: "blue",
       initial_assessment: "blue",
+      invalid: "red",
       not_started: "grey",
       potential_duplicate_in_dqt: "red",
       received: "yellow",

--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -24,9 +24,6 @@ module StatusTag
       awarded: "green",
       awarded_pending_checks: "turquoise",
       cannot_start: "grey",
-      completed: {
-        assessor: "green",
-      },
       declined: "red",
       draft: "grey",
       expired: "pink",
@@ -38,6 +35,7 @@ module StatusTag
       received: "purple",
       requested: "yellow",
       submitted: "grey",
+      valid: "green",
       waiting_on: "yellow",
     }.freeze
 

--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -23,7 +23,7 @@ module StatusTag
     COLOURS = {
       awarded: "green",
       awarded_pending_checks: "green",
-      cannot_start_yet: "grey",
+      cannot_start: "grey",
       completed: {
         assessor: "green",
       },

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -51,7 +51,7 @@ class Assessment < ApplicationRecord
             }
 
   def started?
-    sections.any? { |section| section.state != :not_started }
+    sections.any?(&:finished?)
   end
 
   def finished?
@@ -59,11 +59,11 @@ class Assessment < ApplicationRecord
   end
 
   def sections_finished?
-    sections.none? { |section| section.state == :not_started }
+    sections.all?(&:finished?)
   end
 
   def can_award?
-    sections_complete? || further_information_requests_passed?
+    sections_passed? || further_information_requests_passed?
   end
 
   def can_decline?
@@ -71,7 +71,8 @@ class Assessment < ApplicationRecord
   end
 
   def can_request_further_information?
-    action_required? && cannot_decline? && further_information_requests.empty?
+    sections_not_passed? && cannot_decline? &&
+      further_information_requests.empty?
   end
 
   def available_recommendations
@@ -86,8 +87,8 @@ class Assessment < ApplicationRecord
 
   private
 
-  def sections_complete?
-    sections.all? { |section| section.state == :completed }
+  def sections_passed?
+    sections.all?(&:passed)
   end
 
   def further_information_requests_passed?
@@ -95,8 +96,8 @@ class Assessment < ApplicationRecord
       further_information_requests.all?(&:passed)
   end
 
-  def action_required?
-    sections.any? { |section| section.state == :action_required }
+  def sections_not_passed?
+    sections.any? { |section| section.passed == false }
   end
 
   def cannot_decline?

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -53,7 +53,7 @@ class AssessmentSection < ApplicationRecord
     !passed.nil?
   end
 
-  def state
+  def status
     finished? ? :completed : :not_started
   end
 

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -49,9 +49,12 @@ class AssessmentSection < ApplicationRecord
             absence: true,
             if: -> { passed || passed.nil? }
 
+  def finished?
+    !passed.nil?
+  end
+
   def state
-    return :not_started if passed.nil?
-    passed ? :completed : :action_required
+    finished? ? :completed : :not_started
   end
 
   def declines_assessment?

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -11,7 +11,7 @@ class UpdateAssessmentSection
   end
 
   def call
-    old_state = assessment_section.state
+    old_state = assessment_section.status
 
     ActiveRecord::Base.transaction do
       selected_keys = selected_failure_reasons.keys
@@ -57,7 +57,7 @@ class UpdateAssessmentSection
   end
 
   def create_timeline_event(old_state:)
-    new_state = assessment_section.state
+    new_state = assessment_section.status
     return if old_state == new_state
 
     TimelineEvent.create!(

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -63,7 +63,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
   def assessment_task_status(section, item, index)
     case section
     when :submitted_details
-      assessment.sections.find { |s| s.key == item.to_s }.state
+      assessment.sections.find { |s| s.key == item.to_s }.status
     when :recommendation
       return :cannot_start unless assessment.sections_finished?
       return :not_started if assessment.unknown?

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -65,13 +65,13 @@ class AssessorInterface::ApplicationFormsShowViewObject
     when :submitted_details
       assessment.sections.find { |s| s.key == item.to_s }.state
     when :recommendation
-      return :cannot_start_yet unless assessment.sections_finished?
+      return :cannot_start unless assessment.sections_finished?
       return :not_started if assessment.unknown?
       return :in_progress if assessment_editable?
       :completed
     when :further_information
       further_information_request = further_information_requests[index]
-      return :cannot_start_yet if further_information_request.requested?
+      return :cannot_start if further_information_request.requested?
       return :not_started if further_information_request.passed.nil?
       return :in_progress if assessment.request_further_information?
       :completed

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -1,7 +1,6 @@
 en:
   components:
     status_tag:
-      action_required: Action required
       awarded: Awarded
       awarded_pending_checks: Awarded pending checks
       cannot_start_yet: Cannot start yet
@@ -11,6 +10,7 @@ en:
       expired: Expired
       in_progress: In progress
       initial_assessment: Initial assessment
+      invalid: Invalid
       not_started: Not started
       potential_duplicate_in_dqt: Potential duplicate in DQT
       received: Received

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -18,6 +18,7 @@ en:
       submitted:
         assessor: Not started
         teacher: Submitted
+      valid: Valid
       waiting_on: Waiting on
 
     timeline_entry:

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -3,7 +3,7 @@ en:
     status_tag:
       awarded: Awarded
       awarded_pending_checks: Awarded pending checks
-      cannot_start_yet: Cannot start yet
+      cannot_start: Cannot start
       completed: Completed
       declined: Declined
       draft: Draft

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -14,7 +14,7 @@ en:
       not_started: Not started
       potential_duplicate_in_dqt: Potential duplicate in DQT
       received: Received
-      requested: Requested
+      requested: Waiting on
       submitted:
         assessor: Not started
         teacher: Submitted

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -7,7 +7,7 @@ en:
       completed: Completed
       declined: Declined
       draft: Draft
-      expired: Expired
+      expired: Overdue
       in_progress: In progress
       initial_assessment: Assessment in progress
       invalid: Invalid

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -2,17 +2,17 @@ en:
   components:
     status_tag:
       awarded: Awarded
-      awarded_pending_checks: Awarded pending checks
+      awarded_pending_checks: Award pending
       cannot_start: Cannot start
       completed: Completed
       declined: Declined
       draft: Draft
       expired: Expired
       in_progress: In progress
-      initial_assessment: Initial assessment
+      initial_assessment: Assessment in progress
       invalid: Invalid
       not_started: Not started
-      potential_duplicate_in_dqt: Potential duplicate in DQT
+      potential_duplicate_in_dqt: Potential duplication in DQT
       received: Received
       requested: Waiting on
       submitted:

--- a/spec/components/status_tag_spec.rb
+++ b/spec/components/status_tag_spec.rb
@@ -53,18 +53,10 @@ RSpec.describe StatusTag::Component, type: :component do
       it { is_expected.to eq("govuk-tag govuk-tag--blue app-task-list__tag") }
     end
 
-    context "with a 'completed' status and teacher context" do
+    context "with a 'completed' status" do
       let(:status) { :completed }
-      let(:context) { :teacher }
 
       it { is_expected.to eq("govuk-tag app-task-list__tag") }
-    end
-
-    context "with a 'completed' status and assessor context" do
-      let(:status) { :completed }
-      let(:context) { :assessor }
-
-      it { is_expected.to eq("govuk-tag govuk-tag--green app-task-list__tag") }
     end
 
     context "with an 'initial_assessment' status" do

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -72,8 +72,8 @@ FactoryBot.define do
           assessment: build(:assessment, application_form:),
         )
       end
-      old_state { %i[not_started action_required completed].sample }
-      new_state { %i[not_started action_required completed].sample }
+      old_state { %i[not_started invalid completed].sample }
+      new_state { %i[not_started invalid completed].sample }
     end
 
     trait :note_created do

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe AssessmentSection, type: :model do
     end
   end
 
-  describe "#state" do
-    subject(:state) { assessment_section.state }
+  describe "#status" do
+    subject(:status) { assessment_section.status }
 
     context "with a passed assessment" do
       before { assessment_section.passed = true }

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe AssessmentSection, type: :model do
 
     context "with a failed assessment" do
       before { assessment_section.passed = false }
-      it { is_expected.to eq(:action_required) }
+      it { is_expected.to eq(:completed) }
     end
 
     context "with no assessment yet" do

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe UpdateAssessmentSection do
     it { is_expected.to be true }
 
     it "sets the state" do
-      expect { subject }.to change { assessment_section.state }.from(
+      expect { subject }.to change(assessment_section, :status).from(
         :not_started,
       ).to(:completed)
     end

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe UpdateAssessmentSection do
     it "sets the state" do
       expect { subject }.to change { assessment_section.state }.from(
         :not_started,
-      ).to(:action_required)
+      ).to(:completed)
     end
 
     it "creates a timeline event" do

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
     when_i_choose_check_personal_information_no
     then_i_see_the(:assessor_application_page, application_id:)
-    and_i_see_check_personal_information_action_required
+    and_i_see_check_personal_information_completed
   end
 
   it "allows passing the qualifications" do
@@ -56,7 +56,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
     when_i_choose_check_qualifications_no
     then_i_see_the(:assessor_application_page, application_id:)
-    and_i_see_check_qualifications_action_required
+    and_i_see_check_qualifications_completed
   end
 
   it "allows passing the age range and subjects" do
@@ -86,7 +86,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     and_i_fill_in_subjects
     and_i_choose_verify_age_range_subjects_no
     then_i_see_the(:assessor_application_page, application_id:)
-    and_i_see_verify_age_range_subjects_action_required
+    and_i_see_verify_age_range_subjects_completed
   end
 
   it "allows passing the work history" do
@@ -104,7 +104,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
     when_i_choose_check_work_history_no
     then_i_see_the(:assessor_application_page, application_id:)
-    and_i_see_check_work_history_action_required
+    and_i_see_check_work_history_completed
   end
 
   it "allows passing the professional standing" do
@@ -130,7 +130,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
     when_i_choose_check_professional_standing_no
     then_i_see_the(:assessor_application_page, application_id:)
-    and_i_see_check_professional_standing_action_required
+    and_i_see_check_professional_standing_completed
   end
 
   it "allows passing the professional standing without work history" do
@@ -203,12 +203,6 @@ RSpec.describe "Assessor check submitted details", type: :system do
     check_personal_information_page.form.continue_button.click
   end
 
-  def and_i_see_check_personal_information_action_required
-    expect(
-      assessor_application_page.personal_information_task.status_tag.text,
-    ).to eq("ACTION REQUIRED")
-  end
-
   def then_i_see_the_qualifications
     teaching_qualification =
       application_form.qualifications.find(&:is_teaching_qualification?)
@@ -240,12 +234,6 @@ RSpec.describe "Assessor check submitted details", type: :system do
   def and_i_see_check_qualifications_completed
     expect(assessor_application_page.qualifications_task.status_tag.text).to eq(
       "COMPLETED",
-    )
-  end
-
-  def and_i_see_check_qualifications_action_required
-    expect(assessor_application_page.qualifications_task.status_tag.text).to eq(
-      "ACTION REQUIRED",
     )
   end
 
@@ -297,12 +285,6 @@ RSpec.describe "Assessor check submitted details", type: :system do
     ).to eq("COMPLETED")
   end
 
-  def and_i_see_verify_age_range_subjects_action_required
-    expect(
-      assessor_application_page.age_range_subjects_task.status_tag.text,
-    ).to eq("ACTION REQUIRED")
-  end
-
   def then_i_see_the_work_history
     most_recent_role = application_form.work_histories.first
     expect(check_work_history_page.most_recent_role.school_name.text).to eq(
@@ -334,12 +316,6 @@ RSpec.describe "Assessor check submitted details", type: :system do
       .failure_reason_note_textareas
       .first.fill_in with: "Note."
     check_work_history_page.form.continue_button.click
-  end
-
-  def and_i_see_check_work_history_action_required
-    expect(assessor_application_page.work_history_task.status_tag.text).to eq(
-      "ACTION REQUIRED",
-    )
   end
 
   def then_i_see_the_professional_standing
@@ -385,12 +361,6 @@ RSpec.describe "Assessor check submitted details", type: :system do
       .failure_reason_note_textareas
       .first.fill_in with: "Note."
     check_professional_standing_page.form.continue_button.click
-  end
-
-  def and_i_see_check_professional_standing_action_required
-    expect(
-      assessor_application_page.professional_standing_task.status_tag.text,
-    ).to eq("ACTION REQUIRED")
   end
 
   def application_form

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -157,19 +157,19 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
           OpenStruct.new(id: "submitted", label: "Not started (0)"),
           OpenStruct.new(
             id: "initial_assessment",
-            label: "Initial assessment (0)",
+            label: "Assessment in progress (0)",
           ),
           OpenStruct.new(id: "waiting_on", label: "Waiting on (0)"),
           OpenStruct.new(id: "received", label: "Received (0)"),
           OpenStruct.new(
             id: "awarded_pending_checks",
-            label: "Awarded pending checks (0)",
+            label: "Award pending (0)",
           ),
           OpenStruct.new(id: "awarded", label: "Awarded (0)"),
           OpenStruct.new(id: "declined", label: "Declined (0)"),
           OpenStruct.new(
             id: "potential_duplicate_in_dqt",
-            label: "Potential duplicate in DQT (0)",
+            label: "Potential duplication in DQT (0)",
           ),
         ],
       )
@@ -193,19 +193,19 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
             OpenStruct.new(id: "submitted", label: "Not started (1)"),
             OpenStruct.new(
               id: "initial_assessment",
-              label: "Initial assessment (2)",
+              label: "Assessment in progress (2)",
             ),
             OpenStruct.new(id: "waiting_on", label: "Waiting on (3)"),
             OpenStruct.new(id: "received", label: "Received (4)"),
             OpenStruct.new(
               id: "awarded_pending_checks",
-              label: "Awarded pending checks (5)",
+              label: "Award pending (5)",
             ),
             OpenStruct.new(id: "awarded", label: "Awarded (6)"),
             OpenStruct.new(id: "declined", label: "Declined (7)"),
             OpenStruct.new(
               id: "potential_duplicate_in_dqt",
-              label: "Potential duplicate in DQT (1)",
+              label: "Potential duplication in DQT (1)",
             ),
           ],
         )

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
         let(:item) { :initial_assessment }
 
         context "with unfinished assessment sections" do
-          it { is_expected.to eq(:cannot_start_yet) }
+          it { is_expected.to eq(:cannot_start) }
         end
 
         context "with finished assessment sections" do
@@ -209,7 +209,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
 
       context "and a requested further information request" do
         before { create(:further_information_request, :requested, assessment:) }
-        it { is_expected.to eq(:cannot_start_yet) }
+        it { is_expected.to eq(:cannot_start) }
       end
 
       context "and a received further information request" do


### PR DESCRIPTION
This organises the various statuses according to the ones we've got in the new designs.

[Trello Card](https://trello.com/c/7zKGIxme/1406-build-new-status-into-application)

## Screenshots

![image](https://user-images.githubusercontent.com/510498/214114186-a7dd5f01-5eaf-47de-a20e-bbc7dfd62848.png)

![Screenshot 2023-01-24 at 09 55 47](https://user-images.githubusercontent.com/510498/214261757-13f368f7-e4b1-45ea-b5f1-e8bb7de399ed.png)
