### PR TITLE
Awaiting third-party professional standing

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -1,12 +1,12 @@
 <div class="moj-timeline__item">
   <div class="moj-timeline__header">
-    <h2 class="moj-timeline__title"><%= t("components.timeline_entry.title.#{timeline_event.event_type}") %></h2>
+    <h2 class="moj-timeline__title"><%= title %></h2>
     <p class="moj-timeline__byline">by <%= creator %></p>
   </div>
 
   <p class="moj-timeline__date">
   <time datetime="<%= timeline_event.created_at.iso8601 %>">
-    <%= timeline_event.created_at.strftime("%e %B %Y at %l:%M %P") %>
+    <%= timeline_event.created_at.to_fs(:date_and_time) %>
   </time>
   </p>
 
@@ -52,9 +52,7 @@
         <% end %>
       <% end %>
     <% else %>
-      <p class="govuk-body">
-        <%= simple_format t("components.timeline_entry.description.#{timeline_event.event_type}", **description_vars).html_safe %>
-      </p>
+      <p class="govuk-body"><%= simple_format description.html_safe %></p>
     <% end %>
   </div>
 </div>

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -136,6 +136,7 @@ module TimelineEntry
       {
         requested_at:
           timeline_event.requestable.created_at.to_fs(:date_and_time),
+        location_note: timeline_event.requestable.try(:location_note),
       }
     end
 

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -13,6 +13,28 @@ module TimelineEntry
         timeline_event.creator.email
     end
 
+    def title
+      locale_key =
+        if timeline_event.requestable_event_type?
+          "components.timeline_entry.title.#{timeline_event.event_type}.#{timeline_event.requestable.class.name}"
+        else
+          "components.timeline_entry.title.#{timeline_event.event_type}"
+        end
+
+      I18n.t(locale_key)
+    end
+
+    def description
+      locale_key =
+        if timeline_event.requestable_event_type?
+          "components.timeline_entry.description.#{timeline_event.event_type}.#{timeline_event.requestable.class.name}"
+        else
+          "components.timeline_entry.description.#{timeline_event.event_type}"
+        end
+
+      I18n.t(locale_key, **description_vars)
+    end
+
     def description_vars
       send("#{timeline_event.event_type}_vars")
     end
@@ -78,8 +100,8 @@ module TimelineEntry
       {
         further_information_request: timeline_event.further_information_request,
         date_requested:
-          timeline_event.further_information_request.created_at.strftime(
-            "%e %B %Y at %l:%M %P",
+          timeline_event.further_information_request.created_at.to_fs(
+            :date_and_time,
           ),
       }
     end
@@ -105,5 +127,18 @@ module TimelineEntry
         subjects_note: assessment.subjects_note,
       }
     end
+
+    def requestable_requested_vars
+      {}
+    end
+
+    def requestable_received_vars
+      {
+        requested_at:
+          timeline_event.requestable.created_at.to_fs(:date_and_time),
+      }
+    end
+
+    alias_method :requestable_expired_vars, :requestable_received_vars
   end
 end

--- a/app/controllers/assessor_interface/base_controller.rb
+++ b/app/controllers/assessor_interface/base_controller.rb
@@ -12,5 +12,9 @@ class AssessorInterface::BaseController < ApplicationController
     authorize :assessor
   end
 
+  def authorize_note
+    authorize :note
+  end
+
   alias_method :pundit_user, :current_staff
 end

--- a/app/controllers/assessor_interface/notes_controller.rb
+++ b/app/controllers/assessor_interface/notes_controller.rb
@@ -26,10 +26,6 @@ module AssessorInterface
 
     private
 
-    def authorize_note
-      authorize :note
-    end
-
     def application_form
       @application_form ||= ApplicationForm.find(params[:application_form_id])
     end

--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module AssessorInterface
+  class ProfessionalStandingRequestsController < BaseController
+    before_action :authorize_note
+
+    def edit
+      @professional_standing_request_form =
+        ProfessionalStandingRequestForm.new(
+          professional_standing_request:,
+          user: current_staff,
+          received: professional_standing_request.received?,
+          location_note: professional_standing_request.location_note,
+        )
+    end
+
+    def update
+      @professional_standing_request_form =
+        ProfessionalStandingRequestForm.new(
+          professional_standing_request_form.merge(
+            professional_standing_request:,
+            user: current_staff,
+          ),
+        )
+
+      if @professional_standing_request_form.save
+        redirect_to [:assessor_interface, application_form]
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def professional_standing_request_form
+      params.require(
+        :assessor_interface_professional_standing_request_form,
+      ).permit(:received, :location_note)
+    end
+
+    def application_form
+      @application_form ||=
+        ApplicationForm.includes(
+          assessment: :professional_standing_request,
+        ).find(params[:application_form_id])
+    end
+
+    delegate :professional_standing_request, to: :assessment
+    delegate :assessment, to: :application_form
+  end
+end

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -24,7 +24,10 @@ module TeacherInterface
     end
 
     def update
-      reference_request.received! if reference_request.responses_given?
+      SubmitReferenceRequest.call(
+        reference_request:,
+        user: reference_request.work_history.contact_name,
+      )
 
       redirect_to teacher_interface_reference_request_path
     end

--- a/app/forms/assessor_interface/professional_standing_request_form.rb
+++ b/app/forms/assessor_interface/professional_standing_request_form.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class AssessorInterface::ProfessionalStandingRequestForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :professional_standing_request, :user
+  validates :professional_standing_request, :user, presence: true
+
+  attribute :received, :boolean
+
+  attribute :location_note, :string
+  validates :location_note, presence: true, if: -> { received.present? }
+
+  def save
+    return false unless valid?
+
+    ActiveRecord::Base.transaction do
+      professional_standing_request.update!(location_note:)
+
+      if received.present? && !professional_standing_request.received?
+        receive_professional_standing
+      elsif received.blank? && professional_standing_request.received?
+        request_professional_standing
+      end
+
+      ApplicationFormStatusUpdater.call(application_form:, user:)
+    end
+
+    true
+  end
+
+  delegate :application_form, to: :professional_standing_request
+
+  private
+
+  def receive_professional_standing
+    professional_standing_request.received!
+
+    TimelineEvent.create!(
+      event_type: "requestable_received",
+      application_form:,
+      creator: user,
+      requestable: professional_standing_request,
+    )
+  end
+
+  def request_professional_standing
+    professional_standing_request.requested!
+
+    TimelineEvent
+      .requestable_received
+      .where(requestable: professional_standing_request)
+      .destroy_all
+  end
+end

--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -69,12 +69,12 @@ class ApplicationFormStatusUpdater
       elsif waiting_on_professional_standing ||
             waiting_on_further_information || waiting_on_reference
         "waiting_on"
-      elsif received_professional_standing || received_further_information ||
-            received_reference
+      elsif received_further_information || received_reference
         "received"
       elsif assessment&.started?
         "initial_assessment"
-      elsif application_form.submitted_at.present?
+      elsif application_form.submitted_at.present? ||
+            received_professional_standing
         "submitted"
       else
         "draft"
@@ -84,7 +84,9 @@ class ApplicationFormStatusUpdater
   delegate :assessment, :dqt_trn_request, :teacher, to: :application_form
 
   def professional_standing_requests
-    @professional_standing_requests ||= []
+    @professional_standing_requests ||= [
+      assessment&.professional_standing_request,
+    ].compact
   end
 
   def further_information_requests

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -33,6 +33,7 @@ class Assessment < ApplicationRecord
 
   has_many :sections, class_name: "AssessmentSection", dependent: :destroy
   has_many :further_information_requests, dependent: :destroy
+  has_one :professional_standing_request, dependent: :destroy, required: false
   has_many :reference_requests, dependent: :destroy
 
   enum :recommendation,

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -4,6 +4,8 @@ module Requestable
   extend ActiveSupport::Concern
 
   included do
+    belongs_to :assessment
+
     enum :state,
          { requested: "requested", received: "received", expired: "expired" },
          default: "requested"

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -20,7 +20,6 @@
 class FurtherInformationRequest < ApplicationRecord
   include Requestable
 
-  belongs_to :assessment
   has_many :items,
            class_name: "FurtherInformationRequestItem",
            inverse_of: :further_information_request,

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: professional_standing_requests
+#
+#  id            :bigint           not null, primary key
+#  location_note :text             default(""), not null
+#  received_at   :datetime
+#  state         :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  assessment_id :bigint           not null
+#
+# Indexes
+#
+#  index_professional_standing_requests_on_assessment_id  (assessment_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#
+class ProfessionalStandingRequest < ApplicationRecord
+  include Requestable
+
+  with_options if: :received? do
+    validates :location_note, presence: true
+  end
+end

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -26,4 +26,6 @@ class ProfessionalStandingRequest < ApplicationRecord
   with_options if: :received? do
     validates :location_note, presence: true
   end
+
+  delegate :application_form, to: :assessment
 end

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -35,7 +35,6 @@ class ReferenceRequest < ApplicationRecord
 
   has_secure_token :slug
 
-  belongs_to :assessment
   belongs_to :work_history
 
   with_options if: :received? do

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -139,8 +139,6 @@ class TimelineEvent < ApplicationRecord
             absence: true,
             unless: :requestable_event_type?
 
-  private
-
   def requestable_event_type?
     requestable_requested? || requestable_received? || requestable_expired?
   end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -132,7 +132,11 @@ class TimelineEvent < ApplicationRecord
   validates :requestable_id, presence: true, if: :requestable_event_type?
   validates :requestable_type,
             presence: true,
-            inclusion: %w[FurtherInformationRequest ReferenceRequest],
+            inclusion: %w[
+              FurtherInformationRequest
+              ProfessionalStandingRequest
+              ReferenceRequest
+            ],
             if: :requestable_event_type?
   validates :requestable_id,
             :requestable_type,

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -66,6 +66,9 @@ class TimelineEvent < ApplicationRecord
          age_range_subjects_verified: "age_range_subjects_verified",
          further_information_request_expired:
            "further_information_request_expired",
+         requestable_requested: "requestable_requested",
+         requestable_received: "requestable_received",
+         requestable_expired: "requestable_expired",
        }
   validates :event_type, inclusion: { in: event_types.values }
 
@@ -124,4 +127,21 @@ class TimelineEvent < ApplicationRecord
   belongs_to :assessment, optional: true
   validates :assessment, presence: true, if: :age_range_subjects_verified?
   validates :assessment, absence: true, unless: :age_range_subjects_verified?
+
+  belongs_to :requestable, polymorphic: true, optional: true
+  validates :requestable_id, presence: true, if: :requestable_event_type?
+  validates :requestable_type,
+            presence: true,
+            inclusion: %w[FurtherInformationRequest ReferenceRequest],
+            if: :requestable_event_type?
+  validates :requestable_id,
+            :requestable_type,
+            absence: true,
+            unless: :requestable_event_type?
+
+  private
+
+  def requestable_event_type?
+    requestable_requested? || requestable_received? || requestable_expired?
+  end
 end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -14,6 +14,7 @@
 #  message_subject                :string           default(""), not null
 #  new_state                      :string           default(""), not null
 #  old_state                      :string           default(""), not null
+#  requestable_type               :string
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
 #  application_form_id            :bigint           not null
@@ -23,6 +24,7 @@
 #  creator_id                     :integer
 #  further_information_request_id :bigint
 #  note_id                        :bigint
+#  requestable_id                 :bigint
 #
 # Indexes
 #
@@ -32,6 +34,7 @@
 #  index_timeline_events_on_assignee_id                     (assignee_id)
 #  index_timeline_events_on_further_information_request_id  (further_information_request_id)
 #  index_timeline_events_on_note_id                         (note_id)
+#  index_timeline_events_on_requestable                     (requestable_type,requestable_id)
 #
 # Foreign Keys
 #

--- a/app/services/create_further_information_request.rb
+++ b/app/services/create_further_information_request.rb
@@ -21,6 +21,8 @@ class CreateFurtherInformationRequest
 
         ApplicationFormStatusUpdater.call(application_form:, user:)
 
+        create_timeline_event(request)
+
         request
       end
 
@@ -39,5 +41,14 @@ class CreateFurtherInformationRequest
 
   def teacher
     @teacher ||= application_form.teacher
+  end
+
+  def create_timeline_event(further_information_request)
+    TimelineEvent.create!(
+      application_form:,
+      creator: user,
+      event_type: "requestable_requested",
+      requestable: further_information_request,
+    )
   end
 end

--- a/app/services/further_information_request_expirer.rb
+++ b/app/services/further_information_request_expirer.rb
@@ -45,8 +45,8 @@ class FurtherInformationRequestExpirer
     TimelineEvent.create!(
       application_form:,
       creator_name: "Expirer",
-      further_information_request:,
-      event_type: "further_information_request_expired",
+      event_type: "requestable_expired",
+      requestable: further_information_request,
     )
   end
 end

--- a/app/services/submit_further_information_request.rb
+++ b/app/services/submit_further_information_request.rb
@@ -14,6 +14,8 @@ class SubmitFurtherInformationRequest
     ActiveRecord::Base.transaction do
       further_information_request.received!
 
+      create_timeline_event
+
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end
 
@@ -33,4 +35,13 @@ class SubmitFurtherInformationRequest
   end
 
   delegate :teacher, to: :application_form
+
+  def create_timeline_event
+    TimelineEvent.create!(
+      application_form:,
+      creator: user,
+      event_type: "requestable_received",
+      requestable: further_information_request,
+    )
+  end
 end

--- a/app/services/submit_reference_request.rb
+++ b/app/services/submit_reference_request.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class SubmitReferenceRequest
+  include ServicePattern
+
+  def initialize(reference_request:, user:)
+    @reference_request = reference_request
+    @user = user
+  end
+
+  def call
+    raise AlreadySubmitted if reference_request.received?
+
+    ActiveRecord::Base.transaction do
+      reference_request.received!
+      create_timeline_event
+      ApplicationFormStatusUpdater.call(application_form:, user:)
+    end
+  end
+
+  class AlreadySubmitted < StandardError
+  end
+
+  private
+
+  attr_reader :reference_request, :user
+
+  delegate :application_form, to: :reference_request
+
+  def create_timeline_event
+    TimelineEvent.create!(
+      application_form:,
+      creator_name: user,
+      event_type: "requestable_received",
+      requestable: reference_request,
+    )
+  end
+end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -47,7 +47,9 @@ class AssessorInterface::ApplicationFormsShowViewObject
   def assessment_task_path(section, item, index)
     case section
     when :pre_assessment_tasks
-      nil
+      url_helpers.edit_assessor_interface_application_form_professional_standing_request_path(
+        application_form,
+      )
     when :submitted_details
       return nil unless professional_standing_request_received?
 

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -20,7 +20,7 @@ module AssessorInterface
     end
 
     delegate :assessment, to: :assessment_section
-    delegate :application_form, to: :assessment
+    delegate :application_form, :professional_standing_request, to: :assessment
     delegate :registration_number, to: :application_form
     delegate :checks, to: :assessment_section
     delegate :region, :country, to: :application_form

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -51,6 +51,20 @@
                application_form: @assessment_section_view_object.application_form,
                changeable: false %>
   <% end %>
+
+  <% if (professional_standing_request = @assessment_section_view_object.professional_standing_request).present? %>
+    <%= render(CheckYourAnswersSummary::Component.new(
+      id: "professional-standing-request",
+      model: professional_standing_request,
+      title: t(".professional_standing_request"),
+      fields: {
+        note: {
+          title: "Written statement",
+          value: "<p class=\"govuk-body\">The competent authority has sent the letter of professional standing directly to the TRA. Follow the instructions below to locate it.</p>#{simple_format(professional_standing_request.note)}".html_safe,
+        },
+      },
+    )) %>
+  <% end %>
 <% end %>
 
 <% if @assessment_section_view_object.application_form.created_under_new_regulations? && @assessment_section_view_object.work_history? %>

--- a/app/views/assessor_interface/professional_standing_requests/edit.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title, "#{"Error: " if @professional_standing_request_form.errors.any?}#{t(".title")}" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@professional_standing_request_form.application_form) %>
+
+<%= form_with model: @professional_standing_request_form, url: [:assessor_interface, @professional_standing_request_form.application_form, :professional_standing_request], method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
+
+  <p class="govuk-body">Only use this screen when the letter of professional standing has been received.</p>
+
+  <p class="govuk-body">This screen is not an assessment of professional standing, it just confirms that it has been received.</p>
+
+  <%= f.govuk_check_boxes_fieldset :received, multiple: false, legend: nil do %>
+    <%= f.govuk_check_box :received, true, false, multiple: false, link_errors: true,
+                          label: { text: t("helpers.label.assessor_interface_professional_standing_request_form.received") } %>
+  <% end %>
+
+  <%= f.govuk_text_area :location_note %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -312,6 +312,8 @@
     - mailer_action_name
     - message_subject
     - assessment_id
+    - requestable_type
+    - requestable_id
   :uploads:
     - id
     - document_id

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -188,6 +188,14 @@
     - text
     - created_at
     - updated_at
+  :professional_standing_requests:
+    - id
+    - assessment_id
+    - state
+    - received_at
+    - location_note
+    - created_at
+    - updated_at
   :qualifications:
     - id
     - application_form_id

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -23,6 +23,8 @@
     - response
   :notes:
     - text
+  :professional_standing_requests:
+    - location_note
   :qualifications:
     - title
     - institution_name

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
 Date::DATE_FORMATS[:long_ordinal_uk] = "%-d %B %Y"
+
+Time::DATE_FORMATS[:date_and_time] = "%e %B %Y at %l:%M %P"

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -149,6 +149,7 @@ en:
           true:
             GB-SCT: Provisional registration
             GB-NIR: "No"
+        professional_standing_request: Third-party professional standing
 
     further_information_requests:
       edit:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -155,6 +155,10 @@ en:
         title: Review further information from applicant
         check_your_answers: Further information requested
 
+    professional_standing_requests:
+      edit:
+        title: Third-party professional standing – response received
+
   activemodel:
     errors:
       models:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -13,9 +13,11 @@ en:
       show:
         assessment_tasks:
           sections:
+            pre_assessment_tasks: Pre-assessment tasks
             submitted_details: Check submitted details
             recommendation: Your recommendation
           items:
+            professional_standing_request: Awaiting third-party professional standing
             personal_information: Check personal information
             qualifications: Check qualifications
             age_range_subjects: Verify age range and subjects

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -259,3 +259,7 @@ en:
           attributes:
             induction_required:
               inclusion: Select whether the teacher requires induction
+        assessor_interface/professional_standing_request_form:
+          attributes:
+            note:
+              blank: Enter where the assessor can find it

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -34,12 +34,15 @@ en:
         age_range_subjects_verified: Age range and subjects verified
         requestable_requested:
           FurtherInformationRequest: Further information requested
+          ProfessionalStandingRequest: Professional standing requested
           ReferenceRequest: Reference requested
         requestable_received:
           FurtherInformationRequest: Further information received
+          ProfessionalStandingRequest: Professional standing received
           ReferenceRequest: Reference received
         requestable_expired:
           FurtherInformationRequest: Further information expired
+          ProfessionalStandingRequest: Professional standing expired
           ReferenceRequest: Reference expired
       description:
         assessor_assigned: "%{assignee_name} is assigned as the assessor."
@@ -51,10 +54,13 @@ en:
         email_sent: "%{subject}"
         requestable_requested:
           FurtherInformationRequest: Further information has been requested.
+          ProfessionalStandingRequest: The professional standing has been requested.
           ReferenceRequest: A reference has been requested.
         requestable_received:
           FurtherInformationRequest: Further information requested on %{requested_at} has been received.
+          ProfessionalStandingRequest: "The professional standing has been received: %{location_note}"
           ReferenceRequest: A reference has been received.
         requestable_expired:
           FurtherInformationRequest: Further information requested on %{requested_at} has expired. Application has been declined.
+          ProfessionalStandingRequest: The professional standing request has expired.
           ReferenceRequest: A reference has expired.

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -32,6 +32,15 @@ en:
         further_information_request_expired: Further information expired
         email_sent: Email sent
         age_range_subjects_verified: Age range and subjects verified
+        requestable_requested:
+          FurtherInformationRequest: Further information requested
+          ReferenceRequest: Reference requested
+        requestable_received:
+          FurtherInformationRequest: Further information received
+          ReferenceRequest: Reference received
+        requestable_expired:
+          FurtherInformationRequest: Further information expired
+          ReferenceRequest: Reference expired
       description:
         assessor_assigned: "%{assignee_name} is assigned as the assessor."
         reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
@@ -40,3 +49,12 @@ en:
         further_information_request_assessed: Further information request has been assessed.
         further_information_request_expired: "Further information requested on %{date_requested} has expired. Application has been declined."
         email_sent: "%{subject}"
+        requestable_requested:
+          FurtherInformationRequest: Further information has been requested.
+          ReferenceRequest: A reference has been requested.
+        requestable_received:
+          FurtherInformationRequest: Further information requested on %{requested_at} has been received.
+          ReferenceRequest: A reference has been received.
+        requestable_expired:
+          FurtherInformationRequest: Further information requested on %{requested_at} has expired. Application has been declined.
+          ReferenceRequest: A reference has expired.

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -73,6 +73,9 @@ en:
           true: "Yes"
           false: "No"
         failure_assessor_note: Explain why this section is not completed to your satisfaction
+      assessor_interface_professional_standing_request_form:
+        received: The letter of professional standing has been received.
+        note: Where can the assessor find it?
       eligibility_interface_country_form:
         location: In which country are you currently recognised as a teacher?
       eligibility_interface_work_experience_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,10 @@ Rails.application.routes.draw do
       resources :notes, only: %i[new create]
       resources :timeline_events, only: :index
 
+      resource :professional_standing_request,
+               path: "/professional-standing-request",
+               only: %i[edit update]
+
       resources :assessments, only: %i[edit update] do
         member do
           post "declare", to: "assessments#declare"

--- a/db/migrate/20230123123703_create_professional_standing_request.rb
+++ b/db/migrate/20230123123703_create_professional_standing_request.rb
@@ -1,0 +1,11 @@
+class CreateProfessionalStandingRequest < ActiveRecord::Migration[7.0]
+  def change
+    create_table :professional_standing_requests do |t|
+      t.references :assessment, null: false, foreign_key: true
+      t.string :state, null: false
+      t.datetime :received_at
+      t.text :location_note, null: false, default: ""
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230124130023_add_requestable_to_timeline_events.rb
+++ b/db/migrate/20230124130023_add_requestable_to_timeline_events.rb
@@ -1,0 +1,5 @@
+class AddRequestableToTimelineEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :timeline_events, :requestable, polymorphic: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_23_103414) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_24_130023) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -84,9 +84,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_103414) do
     t.bigint "english_language_provider_id"
     t.text "english_language_provider_reference", default: "", null: false
     t.datetime "awarded_at"
+    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "written_statement_confirmation", default: false, null: false
-    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "english_language_provider_other", default: false, null: false
     t.datetime "declined_at"
     t.boolean "waiting_on_professional_standing", default: false, null: false
@@ -295,8 +295,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_103414) do
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
-    t.text "qualifications_information", default: "", null: false
     t.boolean "application_form_skip_work_history", default: false, null: false
+    t.text "qualifications_information", default: "", null: false
     t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_requires_submission_email", default: false, null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
@@ -405,12 +405,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_103414) do
     t.bigint "assessment_id"
     t.string "message_subject", default: "", null: false
     t.string "mailer_class_name", default: "", null: false
+    t.string "requestable_type"
+    t.bigint "requestable_id"
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
     t.index ["assessment_id"], name: "index_timeline_events_on_assessment_id"
     t.index ["assessment_section_id"], name: "index_timeline_events_on_assessment_section_id"
     t.index ["assignee_id"], name: "index_timeline_events_on_assignee_id"
     t.index ["further_information_request_id"], name: "index_timeline_events_on_further_information_request_id"
     t.index ["note_id"], name: "index_timeline_events_on_note_id"
+    t.index ["requestable_type", "requestable_id"], name: "index_timeline_events_on_requestable"
   end
 
   create_table "uploads", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -243,6 +243,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_24_130023) do
     t.index ["author_id"], name: "index_notes_on_author_id"
   end
 
+  create_table "professional_standing_requests", force: :cascade do |t|
+    t.bigint "assessment_id", null: false
+    t.string "state", null: false
+    t.datetime "received_at"
+    t.text "location_note", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessment_id"], name: "index_professional_standing_requests_on_assessment_id"
+  end
+
   create_table "qualifications", force: :cascade do |t|
     t.bigint "application_form_id", null: false
     t.text "title", default: "", null: false
@@ -457,6 +467,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_24_130023) do
   add_foreign_key "eligibility_checks", "regions"
   add_foreign_key "notes", "application_forms"
   add_foreign_key "notes", "staff", column: "author_id"
+  add_foreign_key "professional_standing_requests", "assessments"
   add_foreign_key "qualifications", "application_forms"
   add_foreign_key "reference_requests", "assessments"
   add_foreign_key "reference_requests", "work_histories"

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -33,6 +33,7 @@ namespace :example_data do
     TimelineEvent.delete_all
     DQTTRNRequest.delete_all
     ReminderEmail.delete_all
+    ProfessionalStandingRequest.delete_all
     ReferenceRequest.delete_all
     FurtherInformationRequest.delete_all
     SelectedFailureReason.delete_all
@@ -148,13 +149,21 @@ def create_application_forms(new_regs:)
       assessment = AssessmentFactory.call(application_form:)
 
       if application_form.waiting_on?
-        FactoryBot.create(
-          :further_information_request,
-          :requested,
-          :with_items,
-          assessment:,
-        )
-      elsif (work_history = assessment.application_form.work_histories.first) &&
+        if application_form.needs_written_statement && rand(2).zero?
+          FactoryBot.create(
+            :professional_standing_request,
+            :requested,
+            assessment:,
+          )
+        else
+          FactoryBot.create(
+            :further_information_request,
+            :requested,
+            :with_items,
+            assessment:,
+          )
+        end
+      elsif (work_history = application_form.work_histories.first) &&
             rand(2).zero?
         reference_request_trait = ReferenceRequest.states.keys.sample
         FactoryBot.create(

--- a/lib/tasks/timeline_events.rake
+++ b/lib/tasks/timeline_events.rake
@@ -1,0 +1,12 @@
+namespace :timeline_events do
+  desc "Migrate the old further information request expired event type."
+  task migrate_further_information_request_expired: :environment do
+    TimelineEvent.further_information_request_expired.each do |timeline_event|
+      timeline_event.update!(
+        event_type: "requestable_expired",
+        requestable: timeline_event.further_information_request,
+        further_information_request: nil,
+      )
+    end
+  end
+end

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -210,4 +210,121 @@ RSpec.describe TimelineEntry::Component, type: :component do
       expect(component.text).to include(creator.name)
     end
   end
+
+  context "further information request requested" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_requested,
+        requestable: create(:further_information_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "Further information has been requested.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "reference request requested" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_requested,
+        requestable: create(:reference_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("A reference has been requested.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "further information request received" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_received,
+        requestable: create(:further_information_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "Further information requested on " \
+          "#{timeline_event.requestable.created_at.strftime("%e %B %Y at %l:%M %P")} has been received.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "reference request requested" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_received,
+        requestable: create(:reference_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("A reference has been received.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "further information request expired" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_expired,
+        requestable: create(:further_information_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "Further information requested on " \
+          "#{timeline_event.requestable.created_at.strftime("%e %B %Y at %l:%M %P")} has expired. " \
+          "Application has been declined.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "reference request requested" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_expired,
+        requestable: create(:reference_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("A reference has expired.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
 end

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -231,6 +231,26 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
   end
 
+  context "professional standing request requested" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_requested,
+        requestable: create(:professional_standing_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "The professional standing has been requested.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
   context "reference request requested" do
     let(:timeline_event) do
       create(
@@ -263,6 +283,31 @@ RSpec.describe TimelineEntry::Component, type: :component do
         "Further information requested on " \
           "#{timeline_event.requestable.created_at.strftime("%e %B %Y at %l:%M %P")} has been received.",
       )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "professional standing request requested" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_received,
+        requestable:
+          create(
+            :professional_standing_request,
+            location_note: "This is a note.",
+          ),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "The professional standing has been received:",
+      )
+      expect(component.text).to include("This is a note.")
     end
 
     it "attributes to the creator" do
@@ -310,7 +355,27 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
   end
 
-  context "reference request requested" do
+  context "professional standing request expired" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_expired,
+        requestable: create(:professional_standing_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "The professional standing request has expired.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "reference request expired" do
     let(:timeline_event) do
       create(
         :timeline_event,

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -54,6 +54,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_professional_standing_request do
+      after(:create) do |assessment, _evaluator|
+        create(:professional_standing_request, :requested, assessment:)
+      end
+    end
+
     trait :with_reference_request do
       after(:create) do |assessment, _evaluator|
         create(

--- a/spec/factories/professional_standing_requests.rb
+++ b/spec/factories/professional_standing_requests.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: professional_standing_requests
+#
+#  id            :bigint           not null, primary key
+#  location_note :text             default(""), not null
+#  received_at   :datetime
+#  state         :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  assessment_id :bigint           not null
+#
+# Indexes
+#
+#  index_professional_standing_requests_on_assessment_id  (assessment_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#
+FactoryBot.define do
+  factory :professional_standing_request do
+    association :assessment
+
+    trait :requested do
+      state { "requested" }
+    end
+
+    trait :received do
+      state { "received" }
+      received_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
+      receivable
+    end
+
+    trait :receivable do
+      location_note { Faker::Lorem.sentence }
+    end
+  end
+end

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -12,6 +12,7 @@
 #  message_subject                :string           default(""), not null
 #  new_state                      :string           default(""), not null
 #  old_state                      :string           default(""), not null
+#  requestable_type               :string
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
 #  application_form_id            :bigint           not null
@@ -21,6 +22,7 @@
 #  creator_id                     :integer
 #  further_information_request_id :bigint
 #  note_id                        :bigint
+#  requestable_id                 :bigint
 #
 # Indexes
 #
@@ -30,6 +32,7 @@
 #  index_timeline_events_on_assignee_id                     (assignee_id)
 #  index_timeline_events_on_further_information_request_id  (further_information_request_id)
 #  index_timeline_events_on_note_id                         (note_id)
+#  index_timeline_events_on_requestable                     (requestable_type,requestable_id)
 #
 # Foreign Keys
 #

--- a/spec/forms/assessor_interface/age_range_subjects_form_spec.rb
+++ b/spec/forms/assessor_interface/age_range_subjects_form_spec.rb
@@ -78,10 +78,11 @@ RSpec.describe AssessorInterface::AgeRangeSubjectsForm, type: :model do
         expect(assessment.subjects_note).to be_blank
       end
 
-      it "creates a timeline event" do
-        timeline_events = TimelineEvent.age_range_subjects_verified
-        expect { save }.to change(timeline_events, :count).by(1)
-        expect(timeline_events.last.assessment).to eq(assessment)
+      it "records a timeline event" do
+        expect { save }.to have_recorded_timeline_event(
+          :age_range_subjects_verified,
+          assessment:,
+        )
       end
     end
 
@@ -106,10 +107,11 @@ RSpec.describe AssessorInterface::AgeRangeSubjectsForm, type: :model do
         expect(assessment.subjects_note).to eq("Another note.")
       end
 
-      it "creates a timeline event" do
-        timeline_events = TimelineEvent.age_range_subjects_verified
-        expect { save }.to change(timeline_events, :count).by(1)
-        expect(timeline_events.last.assessment).to eq(assessment)
+      it "records a timeline event" do
+        expect { save }.to have_recorded_timeline_event(
+          :age_range_subjects_verified,
+          assessment:,
+        )
       end
     end
   end

--- a/spec/forms/assessor_interface/assessor_assignment_form_spec.rb
+++ b/spec/forms/assessor_interface/assessor_assignment_form_spec.rb
@@ -24,12 +24,11 @@ RSpec.describe AssessorInterface::AssessorAssignmentForm, type: :model do
       expect { save }.to change(application_form, :assessor_id).to(assessor_id)
     end
 
-    it "creates a timeline event" do
-      expect { save }.to change { TimelineEvent.count }.by(1)
-
-      created_event = TimelineEvent.last
-      expect(created_event.creator).to eq(staff)
-      expect(created_event).to be_assessor_assigned
+    it "records a timeline event" do
+      expect { save }.to have_recorded_timeline_event(
+        :assessor_assigned,
+        creator: staff,
+      )
     end
   end
 end

--- a/spec/forms/assessor_interface/create_note_form_spec.rb
+++ b/spec/forms/assessor_interface/create_note_form_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe AssessorInterface::CreateNoteForm, type: :model do
 
   describe "#save!" do
     let(:note) { Note.last }
-    let(:timeline_event) { TimelineEvent.last }
 
     it "creates a note" do
       expect { subject.save! }.to change { Note.count }.by(1)
@@ -25,12 +24,11 @@ RSpec.describe AssessorInterface::CreateNoteForm, type: :model do
       expect(note.text).to eq(text)
     end
 
-    it "creates a timeline event" do
-      expect { subject.save! }.to change { TimelineEvent.count }.by(1)
-
-      expect(timeline_event).to be_note_created
-      expect(timeline_event.creator).to eq(author)
-      expect(timeline_event.note).to eq(Note.last)
+    it "records a timeline event" do
+      expect { subject.save! }.to have_recorded_timeline_event(
+        :note_created,
+        creator: author,
+      )
     end
   end
 end

--- a/spec/forms/assessor_interface/further_information_request_form_spec.rb
+++ b/spec/forms/assessor_interface/further_information_request_form_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe AssessorInterface::FurtherInformationRequestForm, type: :model do
         ).to(true)
       end
 
-      it "creates a timeline event" do
-        expect { save }.to change {
-          TimelineEvent.further_information_request_assessed.count
-        }.by(1)
+      it "records a timeline event" do
+        expect { save }.to have_recorded_timeline_event(
+          :further_information_request_assessed,
+        )
       end
     end
   end

--- a/spec/forms/assessor_interface/professional_standing_form_spec.rb
+++ b/spec/forms/assessor_interface/professional_standing_form_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::ProfessionalStandingRequestForm,
+               type: :model do
+  let(:professional_standing_request) { create(:professional_standing_request) }
+  let(:user) { create(:staff) }
+
+  let(:received) { "" }
+  let(:location_note) { "" }
+
+  subject(:form) do
+    described_class.new(
+      professional_standing_request:,
+      user:,
+      received:,
+      location_note:,
+    )
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:professional_standing_request) }
+    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to allow_values(true, false).for(:received) }
+
+    context "when received" do
+      let(:received) { "true" }
+
+      it { is_expected.to validate_presence_of(:location_note) }
+    end
+
+    context "when not received" do
+      let(:received) { "" }
+
+      it { is_expected.to_not validate_presence_of(:location_note) }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    context "when not received" do
+      let(:received) { "" }
+
+      it { is_expected.to be true }
+
+      it "doesn't change the state" do
+        expect { save }.to_not change(professional_standing_request, :state)
+      end
+
+      it "doesn't record a timeline event" do
+        expect { save }.to_not have_recorded_timeline_event(
+          :requestable_received,
+        )
+      end
+    end
+
+    context "when received" do
+      let(:received) { "true" }
+      let(:location_note) { "Note." }
+
+      it { is_expected.to be true }
+
+      it "changes the state" do
+        expect { save }.to change(professional_standing_request, :state).to(
+          "received",
+        )
+      end
+
+      it "changes the note" do
+        expect { save }.to change(
+          professional_standing_request,
+          :location_note,
+        ).to("Note.")
+      end
+
+      it "records a timeline event" do
+        expect { save }.to have_recorded_timeline_event(
+          :requestable_received,
+          creator: user,
+          requestable: professional_standing_request,
+        )
+      end
+    end
+  end
+end

--- a/spec/forms/assessor_interface/reviewer_assignment_form_spec.rb
+++ b/spec/forms/assessor_interface/reviewer_assignment_form_spec.rb
@@ -24,12 +24,11 @@ RSpec.describe AssessorInterface::ReviewerAssignmentForm, type: :model do
       expect { save }.to change(application_form, :reviewer_id).to(reviewer_id)
     end
 
-    it "creates a timeline event" do
-      expect { save }.to change { TimelineEvent.count }.by(1)
-
-      created_event = TimelineEvent.last
-      expect(created_event.creator).to eq(staff)
-      expect(created_event).to be_reviewer_assigned
+    it "records a timeline event" do
+      expect { save }.to have_recorded_timeline_event(
+        :reviewer_assigned,
+        creator: staff,
+      )
     end
   end
 end

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe ApplicationFormStatusUpdater do
     end
 
     it "records a timeline event" do
-      expect { call }.to change(TimelineEvent.state_changed, :count).by(1)
-
-      timeline_event = TimelineEvent.state_changed.find_by(application_form:)
-
-      expect(timeline_event.creator).to eq(user)
-      expect(timeline_event.old_state).to eq("draft")
-      expect(timeline_event.new_state).to eq(new_status)
+      expect { call }.to have_recorded_timeline_event(
+        :state_changed,
+        creator: user,
+        application_form:,
+        old_state: "draft",
+        new_state: new_status,
+      )
     end
   end
 
@@ -155,8 +155,8 @@ RSpec.describe ApplicationFormStatusUpdater do
         expect { call }.to_not change(application_form, :status).from("draft")
       end
 
-      it "doesn't create a timeline event" do
-        expect { call }.to_not change(TimelineEvent.state_changed, :count)
+      it "doesn't record a timeline event" do
+        expect { call }.to_not have_recorded_timeline_event(:state_changed)
       end
     end
   end

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -65,6 +65,42 @@ RSpec.describe ApplicationFormStatusUpdater do
       include_examples "changes status", "awarded_pending_checks"
     end
 
+    context "with a requested profession standing request" do
+      let(:assessment) { create(:assessment, application_form:) }
+
+      before do
+        application_form.update!(submitted_at: Time.zone.now)
+        create(:professional_standing_request, :requested, assessment:)
+      end
+
+      include_examples "changes status", "waiting_on"
+
+      it "changes waiting_on_professional_standing" do
+        expect { call }.to change(
+          application_form,
+          :waiting_on_professional_standing,
+        ).from(false).to(true)
+      end
+    end
+
+    context "with a received profession standing request" do
+      let(:assessment) { create(:assessment, application_form:) }
+
+      before do
+        application_form.update!(submitted_at: Time.zone.now)
+        create(:professional_standing_request, :received, assessment:)
+      end
+
+      include_examples "changes status", "submitted"
+
+      it "changes waiting_on_professional_standing" do
+        expect { call }.to change(
+          application_form,
+          :received_professional_standing,
+        ).from(false).to(true)
+      end
+    end
+
     context "with a received FI request" do
       let(:assessment) { create(:assessment, application_form:) }
 

--- a/spec/lib/application_mailer_observer_spec.rb
+++ b/spec/lib/application_mailer_observer_spec.rb
@@ -9,19 +9,14 @@ RSpec.describe ApplicationMailerObserver do
 
   subject(:delivered_email) { described_class.delivered_email(message) }
 
-  it "creates a timeline event" do
-    expect { delivered_email }.to change(TimelineEvent, :count).by(1)
-  end
-
-  it "sets the attributes" do
-    timeline_event = delivered_email
-
-    expect(timeline_event.event_type).to eq("email_sent")
-    expect(timeline_event.application_form).to eq(application_form)
-    expect(timeline_event.mailer_class_name).to eq("TeacherMailer")
-    expect(timeline_event.mailer_action_name).to eq("application_received")
-    expect(timeline_event.message_subject).to eq(
-      "We’ve received your application for qualified teacher status (QTS)",
+  it "records a timeline event" do
+    expect { delivered_email }.to have_recorded_timeline_event(
+      :email_sent,
+      application_form:,
+      mailer_class_name: "TeacherMailer",
+      mailer_action_name: "application_received",
+      message_subject:
+        "We’ve received your application for qualified teacher status (QTS)",
     )
   end
 

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Assessment, type: :model do
 
   describe "associations" do
     it { is_expected.to have_many(:sections) }
+    it { is_expected.to have_one(:professional_standing_request).optional }
     it { is_expected.to have_many(:further_information_requests) }
   end
 

--- a/spec/models/professional_standing_request_spec.rb
+++ b/spec/models/professional_standing_request_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: professional_standing_requests
+#
+#  id            :bigint           not null, primary key
+#  location_note :text             default(""), not null
+#  received_at   :datetime
+#  state         :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  assessment_id :bigint           not null
+#
+# Indexes
+#
+#  index_professional_standing_requests_on_assessment_id  (assessment_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#
+require "rails_helper"
+
+RSpec.describe ProfessionalStandingRequest, type: :model do
+  it_behaves_like "a requestable" do
+    subject { build(:professional_standing_request, :receivable) }
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:assessment) }
+  end
+
+  describe "validations" do
+    context "when received" do
+      subject { build(:professional_standing_request, :received) }
+
+      it { is_expected.to validate_presence_of(:location_note) }
+    end
+  end
+end

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -12,6 +12,7 @@
 #  message_subject                :string           default(""), not null
 #  new_state                      :string           default(""), not null
 #  old_state                      :string           default(""), not null
+#  requestable_type               :string
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
 #  application_form_id            :bigint           not null
@@ -21,6 +22,7 @@
 #  creator_id                     :integer
 #  further_information_request_id :bigint
 #  note_id                        :bigint
+#  requestable_id                 :bigint
 #
 # Indexes
 #
@@ -30,6 +32,7 @@
 #  index_timeline_events_on_assignee_id                     (assignee_id)
 #  index_timeline_events_on_further_information_request_id  (further_information_request_id)
 #  index_timeline_events_on_note_id                         (note_id)
+#  index_timeline_events_on_requestable                     (requestable_type,requestable_id)
 #
 # Foreign Keys
 #

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -84,6 +84,9 @@ RSpec.describe TimelineEvent do
         age_range_subjects_verified: "age_range_subjects_verified",
         further_information_request_expired:
           "further_information_request_expired",
+        requestable_requested: "requestable_requested",
+        requestable_received: "requestable_received",
+        requestable_expired: "requestable_expired",
       ).backed_by_column_of_type(:string)
     end
 
@@ -100,6 +103,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with an reviewer assigned event type" do
@@ -115,6 +120,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with a state changed event type" do
@@ -130,6 +137,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with an assessment section recorded event type" do
@@ -145,6 +154,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with a note created event type" do
@@ -160,6 +171,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with a further information request assessed event type" do
@@ -177,6 +190,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with a further information request expired event type" do
@@ -194,6 +209,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with an email sent event type" do
@@ -209,6 +226,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:mailer_action_name) }
       it { is_expected.to validate_presence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with an age range subjects verified event type" do
@@ -224,6 +243,74 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_presence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
+    end
+
+    context "with a requestable requested event type" do
+      before { timeline_event.event_type = :requestable_received }
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
+      it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
+      it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
+      it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_presence_of(:requestable_id) }
+      it { is_expected.to validate_presence_of(:requestable_type) }
+      it do
+        is_expected.to validate_inclusion_of(:requestable_type).in_array(
+          %w[FurtherInformationRequest ReferenceRequest],
+        )
+      end
+    end
+
+    context "with a requestable received event type" do
+      before { timeline_event.event_type = :requestable_received }
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
+      it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
+      it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
+      it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_presence_of(:requestable_id) }
+      it { is_expected.to validate_presence_of(:requestable_type) }
+      it do
+        is_expected.to validate_inclusion_of(:requestable_type).in_array(
+          %w[FurtherInformationRequest ReferenceRequest],
+        )
+      end
+    end
+
+    context "with a requestable expired event type" do
+      before { timeline_event.event_type = :requestable_expired }
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
+      it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
+      it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
+      it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_presence_of(:requestable_id) }
+      it { is_expected.to validate_presence_of(:requestable_type) }
+      it do
+        is_expected.to validate_inclusion_of(:requestable_type).in_array(
+          %w[FurtherInformationRequest ReferenceRequest],
+        )
+      end
     end
   end
 end

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -264,7 +264,11 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:requestable_type) }
       it do
         is_expected.to validate_inclusion_of(:requestable_type).in_array(
-          %w[FurtherInformationRequest ReferenceRequest],
+          %w[
+            FurtherInformationRequest
+            ProfessionalStandingRequest
+            ReferenceRequest
+          ],
         )
       end
     end
@@ -286,7 +290,11 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:requestable_type) }
       it do
         is_expected.to validate_inclusion_of(:requestable_type).in_array(
-          %w[FurtherInformationRequest ReferenceRequest],
+          %w[
+            FurtherInformationRequest
+            ProfessionalStandingRequest
+            ReferenceRequest
+          ],
         )
       end
     end
@@ -308,7 +316,11 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:requestable_type) }
       it do
         is_expected.to validate_inclusion_of(:requestable_type).in_array(
-          %w[FurtherInformationRequest ReferenceRequest],
+          %w[
+            FurtherInformationRequest
+            ProfessionalStandingRequest
+            ReferenceRequest
+          ],
         )
       end
     end

--- a/spec/services/assign_application_form_assessor_spec.rb
+++ b/spec/services/assign_application_form_assessor_spec.rb
@@ -21,22 +21,11 @@ RSpec.describe AssignApplicationFormAssessor do
     end
   end
 
-  describe "record timeline event" do
-    subject(:timeline_event) do
-      TimelineEvent.assessor_assigned.find_by(application_form:)
-    end
-
-    it { is_expected.to be_nil }
-
-    context "after calling the service" do
-      before { call }
-
-      it { is_expected.to_not be_nil }
-
-      it "sets the attributes correctly" do
-        expect(timeline_event.creator).to eq(user)
-        expect(timeline_event.assignee).to eq(assessor)
-      end
-    end
+  it "records a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :assessor_assigned,
+      creator: user,
+      assignee: assessor,
+    )
   end
 end

--- a/spec/services/assign_application_form_reviewer_spec.rb
+++ b/spec/services/assign_application_form_reviewer_spec.rb
@@ -21,22 +21,11 @@ RSpec.describe AssignApplicationFormReviewer do
     end
   end
 
-  describe "record timeline event" do
-    subject(:timeline_event) do
-      TimelineEvent.reviewer_assigned.find_by(application_form:)
-    end
-
-    it { is_expected.to be_nil }
-
-    context "after calling the service" do
-      before { call }
-
-      it { is_expected.to_not be_nil }
-
-      it "sets the attributes correctly" do
-        expect(timeline_event.creator).to eq(user)
-        expect(timeline_event.assignee).to eq(reviewer)
-      end
-    end
+  it "records a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :reviewer_assigned,
+      creator: user,
+      assignee: reviewer,
+    )
   end
 end

--- a/spec/services/create_further_information_request_spec.rb
+++ b/spec/services/create_further_information_request_spec.rb
@@ -47,4 +47,8 @@ RSpec.describe CreateFurtherInformationRequest do
       )
     end
   end
+
+  it "records a requestable requested timeline event" do
+    expect { call }.to have_recorded_timeline_event(:requestable_requested)
+  end
 end

--- a/spec/services/create_note_spec.rb
+++ b/spec/services/create_note_spec.rb
@@ -25,22 +25,10 @@ RSpec.describe CreateNote do
     end
   end
 
-  describe "record timeline event" do
-    subject(:timeline_event) do
-      TimelineEvent.note_created.find_by(application_form:)
-    end
-
-    it { is_expected.to be_nil }
-
-    context "after calling the service" do
-      before { call }
-
-      it { is_expected.to_not be_nil }
-
-      it "sets the attributes correctly" do
-        expect(timeline_event.creator).to eq(author)
-        expect(timeline_event.note).to eq(Note.first)
-      end
-    end
+  it "records a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :note_created,
+      creator: author,
+    )
   end
 end

--- a/spec/services/destroy_application_form_spec.rb
+++ b/spec/services/destroy_application_form_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe DestroyApplicationForm do
         create(
           :assessment,
           :with_further_information_request,
+          :with_professional_standing_request,
           :with_reference_request,
           application_form:,
         )
@@ -45,9 +46,10 @@ RSpec.describe DestroyApplicationForm do
   include_examples "deletes model", Document, 16, 8
   include_examples "deletes model", FurtherInformationRequest
   include_examples "deletes model", FurtherInformationRequestItem, 4, 2
-  include_examples "deletes model", ReferenceRequest
   include_examples "deletes model", Note
+  include_examples "deletes model", ProfessionalStandingRequest
   include_examples "deletes model", Qualification
+  include_examples "deletes model", ReferenceRequest
   include_examples "deletes model", Teacher
   include_examples "deletes model", TimelineEvent
   include_examples "deletes model", Upload

--- a/spec/services/further_information_request_expirer_spec.rb
+++ b/spec/services/further_information_request_expirer_spec.rb
@@ -32,10 +32,8 @@ RSpec.describe FurtherInformationRequestExpirer do
         expect(subject.passed).to eq(false)
       end
 
-      it "creates the expiry timeline event" do
-        expect { subject }.to change {
-          TimelineEvent.where(further_information_request:).count
-        }.by(1)
+      it "records a requestable requested timeline event" do
+        expect { subject }.to have_recorded_timeline_event(:requestable_expired)
       end
     end
 

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -81,6 +81,50 @@ RSpec.describe SubmitApplicationForm do
     end
   end
 
+  describe "creating professional standing request" do
+    let(:assessment) { Assessment.find_by(application_form:) }
+
+    subject(:professional_standing_request) do
+      ProfessionalStandingRequest.find_by(assessment:)
+    end
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when teaching authority provides the written statement" do
+      before do
+        region.update!(teaching_authority_provides_written_statement: true)
+        call
+      end
+
+      it { is_expected.to_not be_nil }
+      it { is_expected.to be_requested }
+    end
+  end
+
+  describe "professional standing request timeline event" do
+    it "doesn't record a timeline event" do
+      expect { call }.to_not have_recorded_timeline_event(
+        :requestable_requested,
+      )
+    end
+
+    context "when teaching authority provides the written statement" do
+      before do
+        region.update!(teaching_authority_provides_written_statement: true)
+      end
+
+      it "records a timeline event" do
+        expect { call }.to have_recorded_timeline_event(:requestable_requested)
+      end
+    end
+  end
+
   describe "sending application received email" do
     it "queues an email job" do
       expect { call }.to have_enqueued_mail(

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -59,22 +59,14 @@ RSpec.describe SubmitApplicationForm do
     end
   end
 
-  describe "recording timeline event" do
-    subject(:timeline_event) { TimelineEvent.find_by(application_form:) }
-
-    it { is_expected.to be_nil }
-
-    context "after calling the service" do
-      before { call }
-
-      it { is_expected.to_not be_nil }
-
-      it "sets the attributes correctly" do
-        expect(timeline_event.creator).to eq(user)
-        expect(timeline_event.old_state).to eq("draft")
-        expect(timeline_event.new_state).to eq("submitted")
-      end
-    end
+  it "records a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :state_changed,
+      creator: user,
+      application_form:,
+      old_state: "draft",
+      new_state: "submitted",
+    )
   end
 
   describe "creating assessment" do

--- a/spec/services/submit_further_information_request_spec.rb
+++ b/spec/services/submit_further_information_request_spec.rb
@@ -50,21 +50,19 @@ RSpec.describe SubmitFurtherInformationRequest do
     )
   end
 
-  describe "recording timeline event" do
-    subject(:timeline_event) do
-      TimelineEvent.state_changed.where(application_form:).last
-    end
+  it "records a requestable received timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :requestable_received,
+      requestable: further_information_request,
+    )
+  end
 
-    context "after calling the service" do
-      before { call }
-
-      it { is_expected.to_not be_nil }
-
-      it "sets the attributes correctly" do
-        expect(timeline_event.creator).to eq(user)
-        expect(timeline_event.old_state).to eq("submitted")
-        expect(timeline_event.new_state).to eq("received")
-      end
-    end
+  it "records a state changed timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :state_changed,
+      creator: user,
+      old_state: "submitted",
+      new_state: "received",
+    )
   end
 end

--- a/spec/services/submit_reference_request_spec.rb
+++ b/spec/services/submit_reference_request_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubmitReferenceRequest do
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:reference_request) do
+    create(
+      :reference_request,
+      :requested,
+      :receivable,
+      assessment: create(:assessment, application_form:),
+    )
+  end
+  let(:user) { "John Smith" }
+
+  subject(:call) { described_class.call(reference_request:, user:) }
+
+  context "with an already received reference request" do
+    before { reference_request.received! }
+
+    it "raises an error" do
+      expect { call }.to raise_error(SubmitReferenceRequest::AlreadySubmitted)
+    end
+  end
+
+  it "changes the reference request state to received" do
+    expect { call }.to change(reference_request, :received?).from(false).to(
+      true,
+    )
+  end
+
+  it "changes the application form state to received" do
+    expect { call }.to change(application_form, :received?).from(false).to(true)
+  end
+
+  it "changes the reference request received at" do
+    freeze_time do
+      expect { call }.to change(reference_request, :received_at).from(nil).to(
+        Time.current,
+      )
+    end
+  end
+
+  it "records a requestable received timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :requestable_received,
+      requestable: reference_request,
+    )
+  end
+
+  it "records a state changed timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :state_changed,
+      creator_name: user,
+      old_state: "submitted",
+      new_state: "received",
+    )
+  end
+end

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe UpdateAssessmentSection do
       ).to(:completed)
     end
 
-    it "creates a timeline event" do
-      expect { subject }.to change {
-        TimelineEvent.assessment_section_recorded.count
-      }.by(1)
+    it "records a timeline event" do
+      expect { subject }.to have_recorded_timeline_event(
+        :assessment_section_recorded,
+      )
     end
 
     it "creates the assessment failure reason records" do
@@ -132,8 +132,10 @@ RSpec.describe UpdateAssessmentSection do
 
     it { is_expected.to be false }
 
-    it "doesn't create a timeline event" do
-      expect { subject }.to_not(change { TimelineEvent.count })
+    it "doesn't record a timeline event" do
+      expect { subject }.to_not have_recorded_timeline_event(
+        :assessment_section_recorded,
+      )
     end
 
     it "doesn't change the assessor" do
@@ -155,9 +157,9 @@ RSpec.describe UpdateAssessmentSection do
       described_class.call(assessment_section:, user:, params: other_params)
     end
 
-    it "doesn't create a timeline event" do
-      expect { subject }.to_not(
-        change { TimelineEvent.assessment_section_recorded.count },
+    it "doesn't record a timeline event" do
+      expect { subject }.to_not have_recorded_timeline_event(
+        :assessment_section_recorded,
       )
     end
   end

--- a/spec/services/update_further_information_request_spec.rb
+++ b/spec/services/update_further_information_request_spec.rb
@@ -23,26 +23,11 @@ RSpec.describe UpdateFurtherInformationRequest do
     end
   end
 
-  describe "record timeline event" do
-    subject(:timeline_event) do
-      TimelineEvent.further_information_request_assessed.find_by(
-        further_information_request:,
-      )
-    end
-
-    it { is_expected.to be_nil }
-
-    context "after calling the service" do
-      before { call }
-
-      it { is_expected.to_not be_nil }
-
-      it "sets the attributes correctly" do
-        expect(timeline_event.creator).to eq(user)
-        expect(timeline_event.further_information_request).to eq(
-          further_information_request,
-        )
-      end
-    end
+  it "records a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :further_information_request_assessed,
+      creator: user,
+      further_information_request:,
+    )
   end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -16,6 +16,10 @@ module PageObjects
 
       section :task_list, TaskList, ".app-task-list"
 
+      def awaiting_professional_standing_task
+        task_list.find_item("Awaiting third-party professional standing")
+      end
+
       def personal_information_task
         task_list.find_item("Check personal information")
       end

--- a/spec/support/autoload/page_objects/assessor_interface/edit_professional_standing_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/edit_professional_standing_request.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class EditProfessionalStandingRequest < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/professional-standing-request/edit"
+
+      section :form, "form" do
+        element :received_checkbox, ".govuk-checkboxes__input", visible: false
+        element :note_textarea, ".govuk-textarea"
+        element :continue_button, ".govuk-button"
+      end
+    end
+  end
+end

--- a/spec/support/matchers/have_recorded_timeline_event.rb
+++ b/spec/support/matchers/have_recorded_timeline_event.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rspec/expectations"
+
+RSpec::Matchers.define :have_recorded_timeline_event do |event_type, **attributes|
+  timeline_events = TimelineEvent.where(event_type:).order(:created_at)
+
+  match do |actual|
+    expect { actual.call }.to change(timeline_events, :count).by_at_least(1)
+
+    timeline_event = timeline_events.last
+
+    attributes.each do |key, value|
+      expect(timeline_event.send(key)).to eq(value)
+    end
+  end
+
+  match_when_negated do |actual|
+    expect { actual.call }.to_not change(timeline_events, :count)
+  end
+
+  supports_block_expectations
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -22,6 +22,11 @@ module PageHelpers
       PageObjects::AssessorInterface::ApplicationStatus.new
   end
 
+  def assessor_edit_professional_standing_request_page
+    @assessor_edit_professional_standing_request_page ||=
+      PageObjects::AssessorInterface::EditProfessionalStandingRequest.new
+  end
+
   def applications_page
     @applications_page ||= PageObjects::AssessorInterface::Applications.new
   end

--- a/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assessor awaiting professional standing", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_an_assessor_user
+    given_there_is_an_application_form_with_professional_standing_request
+  end
+
+  it "review complete" do
+    when_i_visit_the(:assessor_application_page, application_id:)
+    and_i_see_a_waiting_on_status
+    and_i_click_awaiting_professional_standing
+    then_i_see_the(
+      :assessor_edit_professional_standing_request_page,
+      application_id:,
+    )
+
+    when_i_fill_in_the_form
+    then_i_see_the(:assessor_application_page, application_id:)
+    and_i_see_a_not_started_status
+  end
+
+  private
+
+  def given_there_is_an_application_form_with_professional_standing_request
+    application_form
+  end
+
+  def and_i_see_a_waiting_on_status
+    expect(assessor_application_page.overview.status.text).to eq("WAITING ON")
+  end
+
+  def and_i_click_awaiting_professional_standing
+    assessor_application_page.awaiting_professional_standing_task.link.click
+  end
+
+  def when_i_fill_in_the_form
+    assessor_edit_professional_standing_request_page
+      .form
+      .received_checkbox
+      .click
+    assessor_edit_professional_standing_request_page.form.note_textarea.fill_in with:
+      "Note."
+    assessor_edit_professional_standing_request_page.form.continue_button.click
+  end
+
+  def and_i_see_a_not_started_status
+    expect(assessor_application_page.overview.status.text).to eq("NOT STARTED")
+  end
+
+  def application_form
+    @application_form ||=
+      create(
+        :application_form,
+        :waiting_on,
+        assessment: create(:assessment, :with_professional_standing_request),
+      )
+  end
+
+  def application_id
+    application_form.id
+  end
+end

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
 
     let(:params) { { id: application_form.id } }
 
+    describe "pre-assessment tasks" do
+      subject(:pre_assessment_tasks) { assessment_tasks[:pre_assessment_tasks] }
+
+      it { is_expected.to be_nil }
+
+      context "with a professional standing request" do
+        before { create(:professional_standing_request, assessment:) }
+
+        it { is_expected.to eq(%i[professional_standing_request]) }
+      end
+    end
+
     describe "submitted details" do
       subject(:submitted_details) { assessment_tasks.fetch(:submitted_details) }
 
@@ -91,6 +103,13 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
     let(:params) { { id: application_form.id } }
 
     let(:index) { 0 }
+
+    context "with pre-assessment tasks section" do
+      let(:section) { :pre_assessment_tasks }
+      let(:item) { :professional_standing }
+
+      it { is_expected.to be_nil }
+    end
 
     context "with submitted details section" do
       let(:section) { :submitted_details }

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -108,7 +108,11 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       let(:section) { :pre_assessment_tasks }
       let(:item) { :professional_standing }
 
-      it { is_expected.to be_nil }
+      it do
+        is_expected.to eq(
+          "/assessor/applications/#{application_form.id}/professional-standing-request/edit",
+        )
+      end
     end
 
     context "with submitted details section" do


### PR DESCRIPTION
This adds a new pre-assessment task allowing assessors to review professional standing when the teaching authority provides the written statement to the TRA directly.

Depends on #1009 and #998 

[Trello Card](https://trello.com/c/4Jy6n9Ek/1392-find-a-lopless-case-and-add-lops)

## Screenshots

<img width="714" alt="Screenshot 2023-01-23 at 22 10 15" src="https://user-images.githubusercontent.com/510498/214242746-be199034-e43f-47bb-8182-edab22bd175b.png">
<img width="714" alt="Screenshot 2023-01-23 at 22 16 04" src="https://user-images.githubusercontent.com/510498/214242753-4bbe848e-c54b-4c52-9ff6-d02dea3dba57.png">

![Screenshot 2023-01-24 at 11 51 57](https://user-images.githubusercontent.com/510498/214289729-738862ba-5f06-418e-be94-684feba7775a.png)

![Screenshot 2023-01-24 at 12 08 59](https://user-images.githubusercontent.com/510498/214289733-1397c002-10e7-4d5e-98ef-5949d6385193.png)
