### PR TITLE
Render qualifications information as markdown

### DIFF
--- a/app/view_objects/teacher_interface/qualification_view_object.rb
+++ b/app/view_objects/teacher_interface/qualification_view_object.rb
@@ -10,9 +10,9 @@ class TeacherInterface::QualificationViewObject
   def qualifications_information
     region = qualification.application_form.region
 
-    (
-      region.qualifications_information.presence ||
-        region.country.qualifications_information
-    )
+    [
+      region.qualifications_information,
+      region.country.qualifications_information,
+    ].compact_blank.join("\n\n")
   end
 end

--- a/app/views/shared/eligible_region_content_components/_proof_of_qualifications.html.erb
+++ b/app/views/shared/eligible_region_content_components/_proof_of_qualifications.html.erb
@@ -15,4 +15,10 @@
   </p>
 <% end %>
 
-<p class="govuk-body"><%= region.qualifications_information %></p>
+<% if region.qualifications_information.present? %>
+  <%= raw GovukMarkdown.render(region.qualifications_information) %>
+<% end %>
+
+<% if region.country.qualifications_information.present? %>
+  <%= raw GovukMarkdown.render(region.country.qualifications_information) %>
+<% end %>

--- a/app/views/support_interface/countries/confirm_edit.html.erb
+++ b/app/views/support_interface/countries/confirm_edit.html.erb
@@ -21,7 +21,7 @@
 <% if @country.qualifications_information_changed? %>
   <h3 class="govuk-heading-s">Qualifications information</h3>
 
-  <p class="govuk-body"><%= @country.qualifications_information %></p>
+  <%= raw GovukMarkdown.render(@country.qualifications_information) %>
 <% end %>
 
 <% if @diff_actions.present? %>

--- a/app/views/teacher_interface/qualifications/_heading.html.erb
+++ b/app/views/teacher_interface/qualifications/_heading.html.erb
@@ -1,6 +1,9 @@
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 <h1 class="govuk-heading-l"><%= I18n.t("application_form.qualifications.heading.title.#{view_object.qualification.locale_key}") %></h1>
 <p class="govuk-body-l"><%= I18n.t("application_form.qualifications.heading.description.#{view_object.qualification.locale_key}") %></p>
+
 <% if view_object.qualifications_information.present? %>
-  <p class="govuk-body-l"><%= view_object.qualifications_information %></p>
+  <section id="app-qualifications-information">
+    <%= raw GovukMarkdown.render(view_object.qualifications_information) %>
+  </section>
 <% end %>

--- a/spec/support/autoload/page_objects/teacher_interface/qualifications_form.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/qualifications_form.rb
@@ -2,7 +2,8 @@ module PageObjects
   module TeacherInterface
     class QualificationsForm < SitePrism::Page
       element :heading, "h1"
-      elements :body, ".govuk-body-l"
+      element :body, ".govuk-body-l"
+      element :qualifications_information, "#app-qualifications-information"
 
       section :form, "form" do
         element :title, "#teacher-interface-qualification-form-title-field"

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -820,10 +820,10 @@ RSpec.describe "Teacher application", type: :system do
     expect(qualifications_form_page.heading.text).to eq(
       "Your teaching qualification",
     )
-    expect(qualifications_form_page.body.first).to have_content(
+    expect(qualifications_form_page.body).to have_content(
       "This is the qualification that led to you being recognised as a teacher.",
     )
-    expect(qualifications_form_page.body.last).to have_content(
+    expect(qualifications_form_page.qualifications_information).to have_content(
       "Qualifications information",
     )
   end
@@ -831,7 +831,7 @@ RSpec.describe "Teacher application", type: :system do
   def then_i_see_the_university_degree_form
     expect(qualifications_form_page).to have_title("Your qualifications")
     expect(qualifications_form_page.heading.text).to eq("University degree")
-    expect(qualifications_form_page.body.first).to have_content(
+    expect(qualifications_form_page.body).to have_content(
       "Tell us about your university degree qualification.",
     )
   end
@@ -839,7 +839,7 @@ RSpec.describe "Teacher application", type: :system do
   def then_i_see_the_degree_qualifications_form
     expect(qualifications_form_page).to have_title("Your qualifications")
     expect(qualifications_form_page.heading.text).to eq("University degree")
-    expect(qualifications_form_page.body.first).to have_content(
+    expect(qualifications_form_page.body).to have_content(
       "Tell us about your university degree qualification.",
     )
   end

--- a/spec/view_objects/teacher_interface/qualification_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/qualification_view_object_spec.rb
@@ -15,19 +15,23 @@ RSpec.describe TeacherInterface::QualificationViewObject do
         qualification.application_form.region.country.update!(
           qualifications_information: info,
         )
-        expect(view_object.qualifications_information).to eq(info)
+        expect(view_object.qualifications_information).to eq(
+          "Qualifications info",
+        )
       end
     end
 
     context "when region has qualifications information" do
-      it "returns qualifications info for the country" do
+      it "returns qualifications info for the country and the region" do
         qualification.application_form.region.country.update!(
           qualifications_information: "Country specific info",
         )
         qualification.application_form.region.update!(
           qualifications_information: info,
         )
-        expect(view_object.qualifications_information).to eq(info)
+        expect(view_object.qualifications_information).to eq(
+          "Qualifications info\n\nCountry specific info",
+        )
       end
     end
 


### PR DESCRIPTION
This allows us to put formatting in such as bullet points, paragraphs, etc as has been requested.

[Trello Card](https://trello.com/c/1eWdJ3TM/1441-content-in-qualifications-info-support-console-field-losing-para-formatting)