### PR TITLE
Move the "Why we ask this" details

### DIFF
--- a/app/view_objects/teacher_interface/qualification_view_object.rb
+++ b/app/view_objects/teacher_interface/qualification_view_object.rb
@@ -10,9 +10,9 @@ class TeacherInterface::QualificationViewObject
   def qualifications_information
     region = qualification.application_form.region
 
-    (
-      region.qualifications_information.presence ||
-        region.country.qualifications_information
-    )
+    [
+      region.qualifications_information,
+      region.country.qualifications_information,
+    ].compact_blank.join("\n\n")
   end
 end

--- a/app/views/eligibility_interface/degrees/new.html.erb
+++ b/app/views/eligibility_interface/degrees/new.html.erb
@@ -3,6 +3,7 @@
 
 <%= form_with model: @degree_form, url: eligibility_interface_degree_url, method: :post do |f| %>
   <%= f.govuk_error_summary %>
+
   <%= f.govuk_collection_radio_buttons(
     :degree,
     [OpenStruct.new(label: 'Yes', value: true), OpenStruct.new(label: 'No', value: false)],
@@ -11,9 +12,11 @@
     legend: { size: 'l', tag: 'h1', text: 'Do you have a university degree?' },
     hint: { text: 'Your degree could include your teaching qualification, or it could be a degree in another subject.' }
   ) %>
+
+  <%= govuk_details(
+    summary_text: "Why we ask this",
+    text: "Teaching is a graduate-level profession in England, which means you must be able to show that you’ve completed a university degree."
+  ) %>
+
   <%= f.govuk_submit prevent_double_click: false %>
 <% end %>
-<%= govuk_details(
-  summary_text: "Why we ask this",
-  text: "Teaching is a graduate-level profession in England, which means you must be able to show that you’ve completed a university degree."
-) %>

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -9,7 +9,6 @@
 </p>
 
 <%= govuk_inset_text do %>
-
   <p class="govuk-body">You may want to spend some time gathering all the documents you need before you start your application.</p>
 
   <% if FeatureFlags::FeatureFlag.active?(:teacher_applications) && region && region.application_form_enabled %>
@@ -19,7 +18,6 @@
   <% if eligibility_check&.created_under_new_regulations? %>
     <p class="govuk-body">You’ll need to complete your application within 6 months of starting it.</p>
   <% end %>
-
 <% end %>
 
 <% if region && !region.legacy %>

--- a/app/views/shared/eligible_region_content_components/_professional_recognition.html.erb
+++ b/app/views/shared/eligible_region_content_components/_professional_recognition.html.erb
@@ -1,3 +1,5 @@
+<%# Written information %>
+
 <% if region.status_check_written? || region.sanction_check_written? %>
   <% if teaching_authority_provides_written_statement %>
     <p class="govuk-body">
@@ -18,10 +20,11 @@
   <% end %>
 
   <%= render "shared/teaching_authority_contact_information", region: %>
-  
+
   <% if region.sanction_check_none? && region.status_check_written? %>
     <p class="govuk-body"><%= t("eligibility_interface.three_months_before_applying") %></p>
   <% end %>
+
   <p class="govuk-body"><%= proof_of_recognition_description_for(region:) %></p>
 
   <ul class="govuk-list govuk-list--bullet">
@@ -30,22 +33,15 @@
     <%- end -%>
   </ul>
 
+  <% unless region.sanction_check_none? && region.status_check_written? %>
+    <p class="govuk-body"><%= t("eligibility_interface.three_months_before_applying") %></p>
+  <% end %>
+
   <% if teaching_authority_provides_written_statement %>
     <p class="govuk-body">
       If we do not receive the document within 90 days of the date that you submit your application, we’ll need to close your application.
     </p>
   <% end %>
-<% end %>
-
-<% if region.sanction_check_written? %>
-  <p class="govuk-body"><%= t("eligibility_interface.three_months_before_applying") %></p>
-<% end %>
-
-<% if region.status_check_online? || region.sanction_check_online? %>
-  <p class="govuk-body">
-    As your education department or authority has an online register of teachers,
-    you’ll also need to provide any reference numbers we need to check your record.
-  </p>
 <% end %>
 
 <% if region.status_check_written? %>
@@ -68,6 +64,15 @@
   <% end %>
 <% end %>
 
+<%# Online information %>
+
+<% if region.status_check_online? || region.sanction_check_online? %>
+  <p class="govuk-body">
+    As your education department or authority has an online register of teachers,
+    you’ll also need to provide any reference numbers we need to check your record.
+  </p>
+<% end %>
+
 <% if region.status_check_online? %>
   <% if region.teaching_authority_status_information.present?%>
     <%= raw GovukMarkdown.render(region.teaching_authority_status_information) %>
@@ -88,16 +93,27 @@
   <% end %>
 <% end %>
 
-<% unless FeatureFlags::FeatureFlag.active?(:application_work_history) && !region.application_form_skip_work_history %> 
-  <p class="govuk-body"><%= proof_of_recognition_description_for(region:) %></p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li>school name</li>
-    <li>school city</li>
-    <li>school country</li>
-    <li>your job role</li>
-    <li>start date</li>
-    <li>end date</li>
-  </ul>
+<%# "None" information %>
+
+<% unless FeatureFlags::FeatureFlag.active?(:application_work_history) && !region.application_form_skip_work_history %>
+  <% if region.sanction_check_none? || region.status_check_none? %>
+    <p class="govuk-body">
+      You also need to show evidence of your work history.
+    </p>
+
+    <p class="govuk-body">
+      For each school this should include:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <li>school name</li>
+      <li>school city</li>
+      <li>school country</li>
+      <li>your job role</li>
+      <li>start date</li>
+      <li>end date</li>
+    </ul>
+  <% end %>
 <% end %>
 
 <% if region.teaching_authority_other.present? %>

--- a/app/views/shared/eligible_region_content_components/_professional_recognition.html.erb
+++ b/app/views/shared/eligible_region_content_components/_professional_recognition.html.erb
@@ -15,13 +15,13 @@
     <p class="govuk-body">
       You’ll need to provide <%= region_certificate_phrase(region) %>, which you can get by contacting:
     </p>
-    <% if region.sanction_check_none? && region.status_check_written? %>
-      <p class="govuk-body"><%= t("eligibility_interface.three_months_before_applying") %></p>
-    <% end %>
   <% end %>
 
-    <%= render "shared/teaching_authority_contact_information", region: %>
-    
+  <%= render "shared/teaching_authority_contact_information", region: %>
+  
+  <% if region.sanction_check_none? && region.status_check_written? %>
+    <p class="govuk-body"><%= t("eligibility_interface.three_months_before_applying") %></p>
+  <% end %>
   <p class="govuk-body"><%= proof_of_recognition_description_for(region:) %></p>
 
   <ul class="govuk-list govuk-list--bullet">
@@ -37,6 +37,17 @@
   <% end %>
 <% end %>
 
+<% if region.sanction_check_written? %>
+  <p class="govuk-body"><%= t("eligibility_interface.three_months_before_applying") %></p>
+<% end %>
+
+<% if region.status_check_online? || region.sanction_check_online? %>
+  <p class="govuk-body">
+    As your education department or authority has an online register of teachers,
+    you’ll also need to provide any reference numbers we need to check your record.
+  </p>
+<% end %>
+
 <% if region.status_check_written? %>
   <% if region.teaching_authority_status_information.present? %>
     <%= raw GovukMarkdown.render(region.teaching_authority_status_information) %>
@@ -45,7 +56,6 @@
   <% if region.country.teaching_authority_status_information.present? %>
     <%= raw GovukMarkdown.render(region.country.teaching_authority_status_information) %>
   <% end %>
-
 <% end %>
 
 <% if region.sanction_check_written? %>
@@ -56,19 +66,6 @@
   <% if region.country.teaching_authority_sanction_information.present?%>
     <%= raw GovukMarkdown.render(region.country.teaching_authority_sanction_information) %>
   <% end %>
-<% end %>
-
-<% if region.sanction_check_written? %>
-  <p class="govuk-body"><%= t("eligibility_interface.three_months_before_applying") %></p>
-<% end %>
-
-<%= render "shared/teaching_authority_contact_information", region: %>
-
-<% if region.status_check_online? || region.sanction_check_online? %>
-  <p class="govuk-body">
-    As your education department or authority has an online register of teachers,
-    you’ll also need to provide any reference numbers we need to check your record.
-  </p>
 <% end %>
 
 <% if region.status_check_online? %>
@@ -92,6 +89,7 @@
 <% end %>
 
 <% unless FeatureFlags::FeatureFlag.active?(:application_work_history) && !region.application_form_skip_work_history %> 
+  <p class="govuk-body"><%= proof_of_recognition_description_for(region:) %></p>
   <ul class="govuk-list govuk-list--bullet">
     <li>school name</li>
     <li>school city</li>

--- a/app/views/shared/eligible_region_content_components/_proof_of_qualifications.html.erb
+++ b/app/views/shared/eligible_region_content_components/_proof_of_qualifications.html.erb
@@ -15,4 +15,10 @@
   </p>
 <% end %>
 
-<p class="govuk-body"><%= region.qualifications_information %></p>
+<% if region.qualifications_information.present? %>
+  <%= raw GovukMarkdown.render(region.qualifications_information) %>
+<% end %>
+
+<% if region.country.qualifications_information.present? %>
+  <%= raw GovukMarkdown.render(region.country.qualifications_information) %>
+<% end %>

--- a/app/views/support_interface/countries/confirm_edit.html.erb
+++ b/app/views/support_interface/countries/confirm_edit.html.erb
@@ -21,7 +21,7 @@
 <% if @country.qualifications_information_changed? %>
   <h3 class="govuk-heading-s">Qualifications information</h3>
 
-  <p class="govuk-body"><%= @country.qualifications_information %></p>
+  <%= raw GovukMarkdown.render(@country.qualifications_information) %>
 <% end %>
 
 <% if @diff_actions.present? %>

--- a/app/views/teacher_interface/qualifications/_heading.html.erb
+++ b/app/views/teacher_interface/qualifications/_heading.html.erb
@@ -1,6 +1,9 @@
 <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
 <h1 class="govuk-heading-l"><%= I18n.t("application_form.qualifications.heading.title.#{view_object.qualification.locale_key}") %></h1>
 <p class="govuk-body-l"><%= I18n.t("application_form.qualifications.heading.description.#{view_object.qualification.locale_key}") %></p>
+
 <% if view_object.qualifications_information.present? %>
-  <p class="govuk-body-l"><%= view_object.qualifications_information %></p>
+  <section id="app-qualifications-information">
+    <%= raw GovukMarkdown.render(view_object.qualifications_information) %>
+  </section>
 <% end %>

--- a/spec/support/autoload/page_objects/teacher_interface/qualifications_form.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/qualifications_form.rb
@@ -2,7 +2,8 @@ module PageObjects
   module TeacherInterface
     class QualificationsForm < SitePrism::Page
       element :heading, "h1"
-      elements :body, ".govuk-body-l"
+      element :body, ".govuk-body-l"
+      element :qualifications_information, "#app-qualifications-information"
 
       section :form, "form" do
         element :title, "#teacher-interface-qualification-form-title-field"

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -820,10 +820,10 @@ RSpec.describe "Teacher application", type: :system do
     expect(qualifications_form_page.heading.text).to eq(
       "Your teaching qualification",
     )
-    expect(qualifications_form_page.body.first).to have_content(
+    expect(qualifications_form_page.body).to have_content(
       "This is the qualification that led to you being recognised as a teacher.",
     )
-    expect(qualifications_form_page.body.last).to have_content(
+    expect(qualifications_form_page.qualifications_information).to have_content(
       "Qualifications information",
     )
   end
@@ -831,7 +831,7 @@ RSpec.describe "Teacher application", type: :system do
   def then_i_see_the_university_degree_form
     expect(qualifications_form_page).to have_title("Your qualifications")
     expect(qualifications_form_page.heading.text).to eq("University degree")
-    expect(qualifications_form_page.body.first).to have_content(
+    expect(qualifications_form_page.body).to have_content(
       "Tell us about your university degree qualification.",
     )
   end
@@ -839,7 +839,7 @@ RSpec.describe "Teacher application", type: :system do
   def then_i_see_the_degree_qualifications_form
     expect(qualifications_form_page).to have_title("Your qualifications")
     expect(qualifications_form_page.heading.text).to eq("University degree")
-    expect(qualifications_form_page.body.first).to have_content(
+    expect(qualifications_form_page.body).to have_content(
       "Tell us about your university degree qualification.",
     )
   end

--- a/spec/view_objects/teacher_interface/qualification_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/qualification_view_object_spec.rb
@@ -15,19 +15,23 @@ RSpec.describe TeacherInterface::QualificationViewObject do
         qualification.application_form.region.country.update!(
           qualifications_information: info,
         )
-        expect(view_object.qualifications_information).to eq(info)
+        expect(view_object.qualifications_information).to eq(
+          "Qualifications info",
+        )
       end
     end
 
     context "when region has qualifications information" do
-      it "returns qualifications info for the country" do
+      it "returns qualifications info for the country and the region" do
         qualification.application_form.region.country.update!(
           qualifications_information: "Country specific info",
         )
         qualification.application_form.region.update!(
           qualifications_information: info,
         )
-        expect(view_object.qualifications_information).to eq(info)
+        expect(view_object.qualifications_information).to eq(
+          "Qualifications info\n\nCountry specific info",
+        )
       end
     end
 


### PR DESCRIPTION
This should go above the continue button rather than below it.

[Trello Card](https://trello.com/c/DdKMtAhd/1437-move-why-we-ask-this-link)