### PR TITLE
Add timeline events for requestables

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -1,12 +1,12 @@
 <div class="moj-timeline__item">
   <div class="moj-timeline__header">
-    <h2 class="moj-timeline__title"><%= t("components.timeline_entry.title.#{timeline_event.event_type}") %></h2>
+    <h2 class="moj-timeline__title"><%= title %></h2>
     <p class="moj-timeline__byline">by <%= creator %></p>
   </div>
 
   <p class="moj-timeline__date">
   <time datetime="<%= timeline_event.created_at.iso8601 %>">
-    <%= timeline_event.created_at.strftime("%e %B %Y at %l:%M %P") %>
+    <%= timeline_event.created_at.to_fs(:date_and_time) %>
   </time>
   </p>
 
@@ -43,7 +43,7 @@
           <% end %>
         </ul>
       <% end %>
-    <% elsif timeline_event.further_information_request_assessed? %>
+    <% elsif timeline_event.further_information_request_assessed? || (timeline_event.requestable_assessed? && timeline_event.requestable.is_a?(FurtherInformationRequest)) %>
       <p class="govuk-body">Further information request has been assessed.</p>
 
       <% if (failure_assessor_note = description_vars[:failure_assessor_note]).present? %>
@@ -52,9 +52,7 @@
         <% end %>
       <% end %>
     <% else %>
-      <p class="govuk-body">
-        <%= simple_format t("components.timeline_entry.description.#{timeline_event.event_type}", **description_vars).html_safe %>
-      </p>
+      <p class="govuk-body"><%= simple_format description.html_safe %></p>
     <% end %>
   </div>
 </div>

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -13,6 +13,28 @@ module TimelineEntry
         timeline_event.creator.email
     end
 
+    def title
+      locale_key =
+        if timeline_event.requestable_event_type?
+          "components.timeline_entry.title.#{timeline_event.event_type}.#{timeline_event.requestable.class.name}"
+        else
+          "components.timeline_entry.title.#{timeline_event.event_type}"
+        end
+
+      I18n.t(locale_key)
+    end
+
+    def description
+      locale_key =
+        if timeline_event.requestable_event_type?
+          "components.timeline_entry.description.#{timeline_event.event_type}.#{timeline_event.requestable.class.name}"
+        else
+          "components.timeline_entry.description.#{timeline_event.event_type}"
+        end
+
+      I18n.t(locale_key, **description_vars)
+    end
+
     def description_vars
       send("#{timeline_event.event_type}_vars")
     end
@@ -78,8 +100,8 @@ module TimelineEntry
       {
         further_information_request: timeline_event.further_information_request,
         date_requested:
-          timeline_event.further_information_request.created_at.strftime(
-            "%e %B %Y at %l:%M %P",
+          timeline_event.further_information_request.created_at.to_fs(
+            :date_and_time,
           ),
       }
     end
@@ -104,6 +126,33 @@ module TimelineEntry
         subjects: Subject.find(assessment.subjects).map(&:name).join(", "),
         subjects_note: assessment.subjects_note,
       }
+    end
+
+    def requestable_requested_vars
+      {}
+    end
+
+    def requestable_received_vars
+      {
+        requested_at:
+          timeline_event.requestable.created_at.to_fs(:date_and_time),
+      }
+    end
+
+    alias_method :requestable_expired_vars, :requestable_received_vars
+
+    def requestable_assessed_vars
+      requestable = timeline_event.requestable
+
+      case requestable
+      when FurtherInformationRequest
+        {
+          passed: requestable.passed,
+          failure_assessor_note: requestable.failure_assessor_note,
+        }
+      else
+        {}
+      end
     end
   end
 end

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -24,7 +24,10 @@ module TeacherInterface
     end
 
     def update
-      reference_request.received! if reference_request.responses_given?
+      SubmitReferenceRequest.call(
+        reference_request:,
+        user: reference_request.work_history.contact_name,
+      )
 
       redirect_to teacher_interface_reference_request_path
     end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -66,6 +66,10 @@ class TimelineEvent < ApplicationRecord
          age_range_subjects_verified: "age_range_subjects_verified",
          further_information_request_expired:
            "further_information_request_expired",
+         requestable_requested: "requestable_requested",
+         requestable_received: "requestable_received",
+         requestable_expired: "requestable_expired",
+         requestable_assessed: "requestable_assessed",
        }
   validates :event_type, inclusion: { in: event_types.values }
 
@@ -124,4 +128,26 @@ class TimelineEvent < ApplicationRecord
   belongs_to :assessment, optional: true
   validates :assessment, presence: true, if: :age_range_subjects_verified?
   validates :assessment, absence: true, unless: :age_range_subjects_verified?
+
+  belongs_to :requestable, polymorphic: true, optional: true
+  validates :requestable_id, presence: true, if: :requestable_event_type?
+  validates :requestable_type,
+            presence: true,
+            inclusion: %w[
+              FurtherInformationRequest
+              QualificationRequest
+              ReferenceRequest
+            ],
+            if: :requestable_event_type?
+  validates :requestable_id,
+            :requestable_type,
+            absence: true,
+            unless: :requestable_event_type?
+
+  private
+
+  def requestable_event_type?
+    requestable_requested? || requestable_received? || requestable_expired? ||
+      requestable_assessed?
+  end
 end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -144,8 +144,6 @@ class TimelineEvent < ApplicationRecord
             absence: true,
             unless: :requestable_event_type?
 
-  private
-
   def requestable_event_type?
     requestable_requested? || requestable_received? || requestable_expired? ||
       requestable_assessed?

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -14,6 +14,7 @@
 #  message_subject                :string           default(""), not null
 #  new_state                      :string           default(""), not null
 #  old_state                      :string           default(""), not null
+#  requestable_type               :string
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
 #  application_form_id            :bigint           not null
@@ -23,6 +24,7 @@
 #  creator_id                     :integer
 #  further_information_request_id :bigint
 #  note_id                        :bigint
+#  requestable_id                 :bigint
 #
 # Indexes
 #
@@ -32,6 +34,7 @@
 #  index_timeline_events_on_assignee_id                     (assignee_id)
 #  index_timeline_events_on_further_information_request_id  (further_information_request_id)
 #  index_timeline_events_on_note_id                         (note_id)
+#  index_timeline_events_on_requestable                     (requestable_type,requestable_id)
 #
 # Foreign Keys
 #

--- a/app/services/create_further_information_request.rb
+++ b/app/services/create_further_information_request.rb
@@ -21,6 +21,8 @@ class CreateFurtherInformationRequest
 
         ApplicationFormStatusUpdater.call(application_form:, user:)
 
+        create_timeline_event(request)
+
         request
       end
 
@@ -39,5 +41,14 @@ class CreateFurtherInformationRequest
 
   def teacher
     @teacher ||= application_form.teacher
+  end
+
+  def create_timeline_event(further_information_request)
+    TimelineEvent.create!(
+      application_form:,
+      creator: user,
+      event_type: "requestable_requested",
+      requestable: further_information_request,
+    )
   end
 end

--- a/app/services/further_information_request_expirer.rb
+++ b/app/services/further_information_request_expirer.rb
@@ -45,8 +45,8 @@ class FurtherInformationRequestExpirer
     TimelineEvent.create!(
       application_form:,
       creator_name: "Expirer",
-      further_information_request:,
-      event_type: "further_information_request_expired",
+      event_type: "requestable_expired",
+      requestable: further_information_request,
     )
   end
 end

--- a/app/services/submit_further_information_request.rb
+++ b/app/services/submit_further_information_request.rb
@@ -14,6 +14,8 @@ class SubmitFurtherInformationRequest
     ActiveRecord::Base.transaction do
       further_information_request.received!
 
+      create_timeline_event
+
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end
 
@@ -33,4 +35,13 @@ class SubmitFurtherInformationRequest
   end
 
   delegate :teacher, to: :application_form
+
+  def create_timeline_event
+    TimelineEvent.create!(
+      application_form:,
+      creator: user,
+      event_type: "requestable_received",
+      requestable: further_information_request,
+    )
+  end
 end

--- a/app/services/submit_reference_request.rb
+++ b/app/services/submit_reference_request.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class SubmitReferenceRequest
+  include ServicePattern
+
+  def initialize(reference_request:, user:)
+    @reference_request = reference_request
+    @user = user
+  end
+
+  def call
+    raise AlreadySubmitted if reference_request.received?
+
+    ActiveRecord::Base.transaction do
+      reference_request.received!
+      create_timeline_event
+      ApplicationFormStatusUpdater.call(application_form:, user:)
+    end
+  end
+
+  class AlreadySubmitted < StandardError
+  end
+
+  private
+
+  attr_reader :reference_request, :user
+
+  delegate :application_form, to: :reference_request
+
+  def create_timeline_event
+    TimelineEvent.create!(
+      application_form:,
+      creator_name: user,
+      event_type: "requestable_received",
+      requestable: reference_request,
+    )
+  end
+end

--- a/app/services/update_further_information_request.rb
+++ b/app/services/update_further_information_request.rb
@@ -24,8 +24,8 @@ class UpdateFurtherInformationRequest
     unless further_information_request.passed.nil?
       TimelineEvent.create!(
         creator: user,
-        event_type: :further_information_request_assessed,
-        further_information_request:,
+        event_type: "requestable_assessed",
+        requestable: further_information_request,
         application_form:,
       )
     end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -321,6 +321,8 @@
     - mailer_action_name
     - message_subject
     - assessment_id
+    - requestable_type
+    - requestable_id
   :uploads:
     - id
     - document_id

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
 Date::DATE_FORMATS[:long_ordinal_uk] = "%-d %B %Y"
+
+Time::DATE_FORMATS[:date_and_time] = "%e %B %Y at %l:%M %P"

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -32,6 +32,22 @@ en:
         further_information_request_expired: Further information expired
         email_sent: Email sent
         age_range_subjects_verified: Age range and subjects verified
+        requestable_requested:
+          FurtherInformationRequest: Further information requested
+          QualificationRequest: Qualification requested
+          ReferenceRequest: Reference requested
+        requestable_received:
+          FurtherInformationRequest: Further information received
+          QualificationRequest: Qualification received
+          ReferenceRequest: Reference received
+        requestable_expired:
+          FurtherInformationRequest: Further information expired
+          QualificationRequest: Qualification expired
+          ReferenceRequest: Reference expired
+        requestable_assessed:
+          FurtherInformationRequest: Further information assessed
+          QualificationRequest: Qualification assessed
+          ReferenceRequest: Reference assessed
       description:
         assessor_assigned: "%{assignee_name} is assigned as the assessor."
         reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
@@ -40,3 +56,19 @@ en:
         further_information_request_assessed: Further information request has been assessed.
         further_information_request_expired: "Further information requested on %{date_requested} has expired. Application has been declined."
         email_sent: "%{subject}"
+        requestable_requested:
+          FurtherInformationRequest: Further information has been requested.
+          QualificationRequest: A qualification has been requested.
+          ReferenceRequest: A reference has been requested.
+        requestable_received:
+          FurtherInformationRequest: Further information requested on %{requested_at} has been received.
+          QualificationRequest: A qualification has been received.
+          ReferenceRequest: A reference has been received.
+        requestable_expired:
+          FurtherInformationRequest: Further information requested on %{requested_at} has expired. Application has been declined.
+          QualificationRequest: A qualification request has expired.
+          ReferenceRequest: A reference has expired.
+        requestable_assessed:
+          FurtherInformationRequest: Further information request has been assessed.
+          QualificationRequest: A qualification has been assessed.
+          ReferenceRequest: A reference has been assessed.

--- a/db/migrate/20230124130023_add_requestable_to_timeline_events.rb
+++ b/db/migrate/20230124130023_add_requestable_to_timeline_events.rb
@@ -1,0 +1,5 @@
+class AddRequestableToTimelineEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :timeline_events, :requestable, polymorphic: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -417,12 +417,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_161536) do
     t.bigint "assessment_id"
     t.string "message_subject", default: "", null: false
     t.string "mailer_class_name", default: "", null: false
+    t.string "requestable_type"
+    t.bigint "requestable_id"
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
     t.index ["assessment_id"], name: "index_timeline_events_on_assessment_id"
     t.index ["assessment_section_id"], name: "index_timeline_events_on_assessment_section_id"
     t.index ["assignee_id"], name: "index_timeline_events_on_assignee_id"
     t.index ["further_information_request_id"], name: "index_timeline_events_on_further_information_request_id"
     t.index ["note_id"], name: "index_timeline_events_on_note_id"
+    t.index ["requestable_type", "requestable_id"], name: "index_timeline_events_on_requestable"
   end
 
   create_table "uploads", force: :cascade do |t|

--- a/lib/tasks/timeline_events.rake
+++ b/lib/tasks/timeline_events.rake
@@ -1,0 +1,20 @@
+namespace :timeline_events do
+  desc "Migrate the old further information requests event type."
+  task migrate_further_information_requests: :environment do
+    TimelineEvent.further_information_request_expired.each do |timeline_event|
+      timeline_event.update!(
+        event_type: "requestable_expired",
+        requestable: timeline_event.further_information_request,
+        further_information_request: nil,
+      )
+    end
+
+    TimelineEvent.further_information_request_assessed.each do |timeline_event|
+      timeline_event.update!(
+        event_type: "requestable_assessed",
+        requestable: timeline_event.further_information_request,
+        further_information_request: nil,
+      )
+    end
+  end
+end

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -210,4 +210,239 @@ RSpec.describe TimelineEntry::Component, type: :component do
       expect(component.text).to include(creator.name)
     end
   end
+
+  context "further information request requested" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_requested,
+        requestable: create(:further_information_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "Further information has been requested.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "qualification request requested" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_requested,
+        requestable: create(:qualification_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("A qualification has been requested.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "reference request requested" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_requested,
+        requestable: create(:reference_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("A reference has been requested.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "further information request received" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_received,
+        requestable: create(:further_information_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "Further information requested on " \
+          "#{timeline_event.requestable.created_at.strftime("%e %B %Y at %l:%M %P")} has been received.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "qualification request received" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_received,
+        requestable: create(:qualification_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("A qualification has been received.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "reference request received" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_received,
+        requestable: create(:reference_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("A reference has been received.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "further information request expired" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_expired,
+        requestable: create(:further_information_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "Further information requested on " \
+          "#{timeline_event.requestable.created_at.strftime("%e %B %Y at %l:%M %P")} has expired. " \
+          "Application has been declined.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "qualification request expired" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_expired,
+        requestable: create(:qualification_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("A qualification request has expired.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "reference request expired" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_expired,
+        requestable: create(:reference_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("A reference has expired.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "further information request assessed" do
+    let(:further_information_request) do
+      create(
+        :further_information_request,
+        failure_assessor_note: "For this reason.",
+      )
+    end
+
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_assessed,
+        requestable: further_information_request,
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "Further information request has been assessed.",
+      )
+      expect(component.text).to include("For this reason.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "qualification request assessed" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_assessed,
+        requestable: create(:qualification_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("A qualification has been assessed.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "reference request assessed" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_assessed,
+        requestable: create(:reference_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("A reference has been assessed.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
 end

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -12,6 +12,7 @@
 #  message_subject                :string           default(""), not null
 #  new_state                      :string           default(""), not null
 #  old_state                      :string           default(""), not null
+#  requestable_type               :string
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
 #  application_form_id            :bigint           not null
@@ -21,6 +22,7 @@
 #  creator_id                     :integer
 #  further_information_request_id :bigint
 #  note_id                        :bigint
+#  requestable_id                 :bigint
 #
 # Indexes
 #
@@ -30,6 +32,7 @@
 #  index_timeline_events_on_assignee_id                     (assignee_id)
 #  index_timeline_events_on_further_information_request_id  (further_information_request_id)
 #  index_timeline_events_on_note_id                         (note_id)
+#  index_timeline_events_on_requestable                     (requestable_type,requestable_id)
 #
 # Foreign Keys
 #

--- a/spec/forms/assessor_interface/age_range_subjects_form_spec.rb
+++ b/spec/forms/assessor_interface/age_range_subjects_form_spec.rb
@@ -78,10 +78,11 @@ RSpec.describe AssessorInterface::AgeRangeSubjectsForm, type: :model do
         expect(assessment.subjects_note).to be_blank
       end
 
-      it "creates a timeline event" do
-        timeline_events = TimelineEvent.age_range_subjects_verified
-        expect { save }.to change(timeline_events, :count).by(1)
-        expect(timeline_events.last.assessment).to eq(assessment)
+      it "records a timeline event" do
+        expect { save }.to have_recorded_timeline_event(
+          :age_range_subjects_verified,
+          assessment:,
+        )
       end
     end
 
@@ -106,10 +107,11 @@ RSpec.describe AssessorInterface::AgeRangeSubjectsForm, type: :model do
         expect(assessment.subjects_note).to eq("Another note.")
       end
 
-      it "creates a timeline event" do
-        timeline_events = TimelineEvent.age_range_subjects_verified
-        expect { save }.to change(timeline_events, :count).by(1)
-        expect(timeline_events.last.assessment).to eq(assessment)
+      it "records a timeline event" do
+        expect { save }.to have_recorded_timeline_event(
+          :age_range_subjects_verified,
+          assessment:,
+        )
       end
     end
   end

--- a/spec/forms/assessor_interface/assessor_assignment_form_spec.rb
+++ b/spec/forms/assessor_interface/assessor_assignment_form_spec.rb
@@ -24,12 +24,11 @@ RSpec.describe AssessorInterface::AssessorAssignmentForm, type: :model do
       expect { save }.to change(application_form, :assessor_id).to(assessor_id)
     end
 
-    it "creates a timeline event" do
-      expect { save }.to change { TimelineEvent.count }.by(1)
-
-      created_event = TimelineEvent.last
-      expect(created_event.creator).to eq(staff)
-      expect(created_event).to be_assessor_assigned
+    it "records a timeline event" do
+      expect { save }.to have_recorded_timeline_event(
+        :assessor_assigned,
+        creator: staff,
+      )
     end
   end
 end

--- a/spec/forms/assessor_interface/create_note_form_spec.rb
+++ b/spec/forms/assessor_interface/create_note_form_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe AssessorInterface::CreateNoteForm, type: :model do
 
   describe "#save!" do
     let(:note) { Note.last }
-    let(:timeline_event) { TimelineEvent.last }
 
     it "creates a note" do
       expect { subject.save! }.to change { Note.count }.by(1)
@@ -25,12 +24,11 @@ RSpec.describe AssessorInterface::CreateNoteForm, type: :model do
       expect(note.text).to eq(text)
     end
 
-    it "creates a timeline event" do
-      expect { subject.save! }.to change { TimelineEvent.count }.by(1)
-
-      expect(timeline_event).to be_note_created
-      expect(timeline_event.creator).to eq(author)
-      expect(timeline_event.note).to eq(Note.last)
+    it "records a timeline event" do
+      expect { subject.save! }.to have_recorded_timeline_event(
+        :note_created,
+        creator: author,
+      )
     end
   end
 end

--- a/spec/forms/assessor_interface/further_information_request_form_spec.rb
+++ b/spec/forms/assessor_interface/further_information_request_form_spec.rb
@@ -43,10 +43,11 @@ RSpec.describe AssessorInterface::FurtherInformationRequestForm, type: :model do
         ).to(true)
       end
 
-      it "creates a timeline event" do
-        expect { save }.to change {
-          TimelineEvent.further_information_request_assessed.count
-        }.by(1)
+      it "records a timeline event" do
+        expect { save }.to have_recorded_timeline_event(
+          :requestable_assessed,
+          requestable: further_information_request,
+        )
       end
     end
   end

--- a/spec/forms/assessor_interface/reviewer_assignment_form_spec.rb
+++ b/spec/forms/assessor_interface/reviewer_assignment_form_spec.rb
@@ -24,12 +24,11 @@ RSpec.describe AssessorInterface::ReviewerAssignmentForm, type: :model do
       expect { save }.to change(application_form, :reviewer_id).to(reviewer_id)
     end
 
-    it "creates a timeline event" do
-      expect { save }.to change { TimelineEvent.count }.by(1)
-
-      created_event = TimelineEvent.last
-      expect(created_event.creator).to eq(staff)
-      expect(created_event).to be_reviewer_assigned
+    it "records a timeline event" do
+      expect { save }.to have_recorded_timeline_event(
+        :reviewer_assigned,
+        creator: staff,
+      )
     end
   end
 end

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe ApplicationFormStatusUpdater do
     end
 
     it "records a timeline event" do
-      expect { call }.to change(TimelineEvent.state_changed, :count).by(1)
-
-      timeline_event = TimelineEvent.state_changed.find_by(application_form:)
-
-      expect(timeline_event.creator).to eq(user)
-      expect(timeline_event.old_state).to eq("draft")
-      expect(timeline_event.new_state).to eq(new_status)
+      expect { call }.to have_recorded_timeline_event(
+        :state_changed,
+        creator: user,
+        application_form:,
+        old_state: "draft",
+        new_state: new_status,
+      )
     end
   end
 
@@ -155,8 +155,8 @@ RSpec.describe ApplicationFormStatusUpdater do
         expect { call }.to_not change(application_form, :status).from("draft")
       end
 
-      it "doesn't create a timeline event" do
-        expect { call }.to_not change(TimelineEvent.state_changed, :count)
+      it "doesn't record a timeline event" do
+        expect { call }.to_not have_recorded_timeline_event(:state_changed)
       end
     end
   end

--- a/spec/lib/application_mailer_observer_spec.rb
+++ b/spec/lib/application_mailer_observer_spec.rb
@@ -9,19 +9,14 @@ RSpec.describe ApplicationMailerObserver do
 
   subject(:delivered_email) { described_class.delivered_email(message) }
 
-  it "creates a timeline event" do
-    expect { delivered_email }.to change(TimelineEvent, :count).by(1)
-  end
-
-  it "sets the attributes" do
-    timeline_event = delivered_email
-
-    expect(timeline_event.event_type).to eq("email_sent")
-    expect(timeline_event.application_form).to eq(application_form)
-    expect(timeline_event.mailer_class_name).to eq("TeacherMailer")
-    expect(timeline_event.mailer_action_name).to eq("application_received")
-    expect(timeline_event.message_subject).to eq(
-      "We’ve received your application for qualified teacher status (QTS)",
+  it "records a timeline event" do
+    expect { delivered_email }.to have_recorded_timeline_event(
+      :email_sent,
+      application_form:,
+      mailer_class_name: "TeacherMailer",
+      mailer_action_name: "application_received",
+      message_subject:
+        "We’ve received your application for qualified teacher status (QTS)",
     )
   end
 

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -84,6 +84,10 @@ RSpec.describe TimelineEvent do
         age_range_subjects_verified: "age_range_subjects_verified",
         further_information_request_expired:
           "further_information_request_expired",
+        requestable_requested: "requestable_requested",
+        requestable_received: "requestable_received",
+        requestable_expired: "requestable_expired",
+        requestable_assessed: "requestable_assessed",
       ).backed_by_column_of_type(:string)
     end
 
@@ -100,6 +104,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with an reviewer assigned event type" do
@@ -115,6 +121,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with a state changed event type" do
@@ -130,6 +138,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with an assessment section recorded event type" do
@@ -145,6 +155,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with a note created event type" do
@@ -160,6 +172,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with a further information request assessed event type" do
@@ -177,6 +191,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with a further information request expired event type" do
@@ -194,6 +210,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with an email sent event type" do
@@ -209,6 +227,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:mailer_action_name) }
       it { is_expected.to validate_presence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
     end
 
     context "with an age range subjects verified event type" do
@@ -224,6 +244,96 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_presence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
+    end
+
+    context "with a requestable requested event type" do
+      before { timeline_event.event_type = :requestable_received }
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
+      it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
+      it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
+      it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_presence_of(:requestable_id) }
+      it { is_expected.to validate_presence_of(:requestable_type) }
+      it do
+        is_expected.to validate_inclusion_of(:requestable_type).in_array(
+          %w[FurtherInformationRequest ReferenceRequest],
+        )
+      end
+    end
+
+    context "with a requestable received event type" do
+      before { timeline_event.event_type = :requestable_received }
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
+      it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
+      it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
+      it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_presence_of(:requestable_id) }
+      it { is_expected.to validate_presence_of(:requestable_type) }
+      it do
+        is_expected.to validate_inclusion_of(:requestable_type).in_array(
+          %w[FurtherInformationRequest QualificationRequest ReferenceRequest],
+        )
+      end
+    end
+
+    context "with a requestable expired event type" do
+      before { timeline_event.event_type = :requestable_expired }
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
+      it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
+      it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
+      it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_presence_of(:requestable_id) }
+      it { is_expected.to validate_presence_of(:requestable_type) }
+      it do
+        is_expected.to validate_inclusion_of(:requestable_type).in_array(
+          %w[FurtherInformationRequest QualificationRequest ReferenceRequest],
+        )
+      end
+    end
+
+    context "with a requestable assessed event type" do
+      before { timeline_event.event_type = :requestable_assessed }
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
+      it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:further_information_request) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
+      it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
+      it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_presence_of(:requestable_id) }
+      it { is_expected.to validate_presence_of(:requestable_type) }
+      it do
+        is_expected.to validate_inclusion_of(:requestable_type).in_array(
+          %w[FurtherInformationRequest QualificationRequest ReferenceRequest],
+        )
+      end
     end
   end
 end

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -12,6 +12,7 @@
 #  message_subject                :string           default(""), not null
 #  new_state                      :string           default(""), not null
 #  old_state                      :string           default(""), not null
+#  requestable_type               :string
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null
 #  application_form_id            :bigint           not null
@@ -21,6 +22,7 @@
 #  creator_id                     :integer
 #  further_information_request_id :bigint
 #  note_id                        :bigint
+#  requestable_id                 :bigint
 #
 # Indexes
 #
@@ -30,6 +32,7 @@
 #  index_timeline_events_on_assignee_id                     (assignee_id)
 #  index_timeline_events_on_further_information_request_id  (further_information_request_id)
 #  index_timeline_events_on_note_id                         (note_id)
+#  index_timeline_events_on_requestable                     (requestable_type,requestable_id)
 #
 # Foreign Keys
 #

--- a/spec/services/assign_application_form_assessor_spec.rb
+++ b/spec/services/assign_application_form_assessor_spec.rb
@@ -21,22 +21,11 @@ RSpec.describe AssignApplicationFormAssessor do
     end
   end
 
-  describe "record timeline event" do
-    subject(:timeline_event) do
-      TimelineEvent.assessor_assigned.find_by(application_form:)
-    end
-
-    it { is_expected.to be_nil }
-
-    context "after calling the service" do
-      before { call }
-
-      it { is_expected.to_not be_nil }
-
-      it "sets the attributes correctly" do
-        expect(timeline_event.creator).to eq(user)
-        expect(timeline_event.assignee).to eq(assessor)
-      end
-    end
+  it "records a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :assessor_assigned,
+      creator: user,
+      assignee: assessor,
+    )
   end
 end

--- a/spec/services/assign_application_form_reviewer_spec.rb
+++ b/spec/services/assign_application_form_reviewer_spec.rb
@@ -21,22 +21,11 @@ RSpec.describe AssignApplicationFormReviewer do
     end
   end
 
-  describe "record timeline event" do
-    subject(:timeline_event) do
-      TimelineEvent.reviewer_assigned.find_by(application_form:)
-    end
-
-    it { is_expected.to be_nil }
-
-    context "after calling the service" do
-      before { call }
-
-      it { is_expected.to_not be_nil }
-
-      it "sets the attributes correctly" do
-        expect(timeline_event.creator).to eq(user)
-        expect(timeline_event.assignee).to eq(reviewer)
-      end
-    end
+  it "records a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :reviewer_assigned,
+      creator: user,
+      assignee: reviewer,
+    )
   end
 end

--- a/spec/services/create_further_information_request_spec.rb
+++ b/spec/services/create_further_information_request_spec.rb
@@ -47,4 +47,8 @@ RSpec.describe CreateFurtherInformationRequest do
       )
     end
   end
+
+  it "records a requestable requested timeline event" do
+    expect { call }.to have_recorded_timeline_event(:requestable_requested)
+  end
 end

--- a/spec/services/create_note_spec.rb
+++ b/spec/services/create_note_spec.rb
@@ -25,22 +25,10 @@ RSpec.describe CreateNote do
     end
   end
 
-  describe "record timeline event" do
-    subject(:timeline_event) do
-      TimelineEvent.note_created.find_by(application_form:)
-    end
-
-    it { is_expected.to be_nil }
-
-    context "after calling the service" do
-      before { call }
-
-      it { is_expected.to_not be_nil }
-
-      it "sets the attributes correctly" do
-        expect(timeline_event.creator).to eq(author)
-        expect(timeline_event.note).to eq(Note.first)
-      end
-    end
+  it "records a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :note_created,
+      creator: author,
+    )
   end
 end

--- a/spec/services/further_information_request_expirer_spec.rb
+++ b/spec/services/further_information_request_expirer_spec.rb
@@ -32,10 +32,8 @@ RSpec.describe FurtherInformationRequestExpirer do
         expect(subject.passed).to eq(false)
       end
 
-      it "creates the expiry timeline event" do
-        expect { subject }.to change {
-          TimelineEvent.where(further_information_request:).count
-        }.by(1)
+      it "records a requestable requested timeline event" do
+        expect { subject }.to have_recorded_timeline_event(:requestable_expired)
       end
     end
 

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -59,22 +59,14 @@ RSpec.describe SubmitApplicationForm do
     end
   end
 
-  describe "recording timeline event" do
-    subject(:timeline_event) { TimelineEvent.find_by(application_form:) }
-
-    it { is_expected.to be_nil }
-
-    context "after calling the service" do
-      before { call }
-
-      it { is_expected.to_not be_nil }
-
-      it "sets the attributes correctly" do
-        expect(timeline_event.creator).to eq(user)
-        expect(timeline_event.old_state).to eq("draft")
-        expect(timeline_event.new_state).to eq("submitted")
-      end
-    end
+  it "records a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :state_changed,
+      creator: user,
+      application_form:,
+      old_state: "draft",
+      new_state: "submitted",
+    )
   end
 
   describe "creating assessment" do

--- a/spec/services/submit_further_information_request_spec.rb
+++ b/spec/services/submit_further_information_request_spec.rb
@@ -50,21 +50,19 @@ RSpec.describe SubmitFurtherInformationRequest do
     )
   end
 
-  describe "recording timeline event" do
-    subject(:timeline_event) do
-      TimelineEvent.state_changed.where(application_form:).last
-    end
+  it "records a requestable received timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :requestable_received,
+      requestable: further_information_request,
+    )
+  end
 
-    context "after calling the service" do
-      before { call }
-
-      it { is_expected.to_not be_nil }
-
-      it "sets the attributes correctly" do
-        expect(timeline_event.creator).to eq(user)
-        expect(timeline_event.old_state).to eq("submitted")
-        expect(timeline_event.new_state).to eq("received")
-      end
-    end
+  it "records a state changed timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :state_changed,
+      creator: user,
+      old_state: "submitted",
+      new_state: "received",
+    )
   end
 end

--- a/spec/services/submit_reference_request_spec.rb
+++ b/spec/services/submit_reference_request_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SubmitReferenceRequest do
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:reference_request) do
+    create(
+      :reference_request,
+      :requested,
+      :receivable,
+      assessment: create(:assessment, application_form:),
+    )
+  end
+  let(:user) { "John Smith" }
+
+  subject(:call) { described_class.call(reference_request:, user:) }
+
+  context "with an already received reference request" do
+    before { reference_request.received! }
+
+    it "raises an error" do
+      expect { call }.to raise_error(SubmitReferenceRequest::AlreadySubmitted)
+    end
+  end
+
+  it "changes the reference request state to received" do
+    expect { call }.to change(reference_request, :received?).from(false).to(
+      true,
+    )
+  end
+
+  it "changes the application form state to received" do
+    expect { call }.to change(application_form, :received?).from(false).to(true)
+  end
+
+  it "changes the reference request received at" do
+    freeze_time do
+      expect { call }.to change(reference_request, :received_at).from(nil).to(
+        Time.current,
+      )
+    end
+  end
+
+  it "records a requestable received timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :requestable_received,
+      requestable: reference_request,
+    )
+  end
+
+  it "records a state changed timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :state_changed,
+      creator_name: user,
+      old_state: "submitted",
+      new_state: "received",
+    )
+  end
+end

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -27,10 +27,10 @@ RSpec.describe UpdateAssessmentSection do
       ).to(:completed)
     end
 
-    it "creates a timeline event" do
-      expect { subject }.to change {
-        TimelineEvent.assessment_section_recorded.count
-      }.by(1)
+    it "records a timeline event" do
+      expect { subject }.to have_recorded_timeline_event(
+        :assessment_section_recorded,
+      )
     end
 
     it "creates the assessment failure reason records" do
@@ -132,8 +132,10 @@ RSpec.describe UpdateAssessmentSection do
 
     it { is_expected.to be false }
 
-    it "doesn't create a timeline event" do
-      expect { subject }.to_not(change { TimelineEvent.count })
+    it "doesn't record a timeline event" do
+      expect { subject }.to_not have_recorded_timeline_event(
+        :assessment_section_recorded,
+      )
     end
 
     it "doesn't change the assessor" do
@@ -155,9 +157,9 @@ RSpec.describe UpdateAssessmentSection do
       described_class.call(assessment_section:, user:, params: other_params)
     end
 
-    it "doesn't create a timeline event" do
-      expect { subject }.to_not(
-        change { TimelineEvent.assessment_section_recorded.count },
+    it "doesn't record a timeline event" do
+      expect { subject }.to_not have_recorded_timeline_event(
+        :assessment_section_recorded,
       )
     end
   end

--- a/spec/services/update_further_information_request_spec.rb
+++ b/spec/services/update_further_information_request_spec.rb
@@ -23,26 +23,11 @@ RSpec.describe UpdateFurtherInformationRequest do
     end
   end
 
-  describe "record timeline event" do
-    subject(:timeline_event) do
-      TimelineEvent.further_information_request_assessed.find_by(
-        further_information_request:,
-      )
-    end
-
-    it { is_expected.to be_nil }
-
-    context "after calling the service" do
-      before { call }
-
-      it { is_expected.to_not be_nil }
-
-      it "sets the attributes correctly" do
-        expect(timeline_event.creator).to eq(user)
-        expect(timeline_event.further_information_request).to eq(
-          further_information_request,
-        )
-      end
-    end
+  it "records a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :requestable_assessed,
+      creator: user,
+      requestable: further_information_request,
+    )
   end
 end

--- a/spec/support/matchers/have_recorded_timeline_event.rb
+++ b/spec/support/matchers/have_recorded_timeline_event.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rspec/expectations"
+
+RSpec::Matchers.define :have_recorded_timeline_event do |event_type, **attributes|
+  timeline_events = TimelineEvent.where(event_type:).order(:created_at)
+
+  match do |actual|
+    expect { actual.call }.to change(timeline_events, :count).by_at_least(1)
+
+    timeline_event = timeline_events.last
+
+    attributes.each do |key, value|
+      expect(timeline_event.send(key)).to eq(value)
+    end
+  end
+
+  match_when_negated do |actual|
+    expect { actual.call }.to_not change(timeline_events, :count)
+  end
+
+  supports_block_expectations
+end


### PR DESCRIPTION
This adds a new set of timeline events for all the "requestables" we have in the system (further information requests, reference requests, and soon professional standing requests).

The assessors would like to see this information in the timeline, particularly for professional standing and references, but I see no harm in including further information requests too. The content of the timeline events can be improved in the future.

[Trello Card](https://trello.com/c/4Jy6n9Ek/1392-find-a-lopless-case-and-add-lops)

## Screenshots

![Screenshot 2023-01-25 at 10 25 43](https://user-images.githubusercontent.com/510498/214539349-c62bfd72-06bf-4880-b4f1-a70f2641be43.png)
