### PR TITLE
Eligibility Check - Filter by subject

### DIFF
--- a/app/controllers/concerns/enforce_eligibility_question_order.rb
+++ b/app/controllers/concerns/enforce_eligibility_question_order.rb
@@ -26,6 +26,7 @@ module EnforceEligibilityQuestionOrder
       qualification: eligibility_interface_qualifications_path,
       degree: eligibility_interface_degree_path,
       teach_children: eligibility_interface_teach_children_path,
+      qualified_for_subject: eligibility_interface_qualified_for_subject_path,
       work_experience: eligibility_interface_work_experience_path,
       misconduct: eligibility_interface_misconduct_path,
     }

--- a/app/controllers/eligibility_interface/qualified_for_subject_controller.rb
+++ b/app/controllers/eligibility_interface/qualified_for_subject_controller.rb
@@ -1,0 +1,32 @@
+module EligibilityInterface
+  class QualifiedForSubjectController < BaseController
+    include EnforceEligibilityQuestionOrder
+
+    def new
+      @qualified_for_subject_form =
+        QualifiedForSubjectForm.new(
+          qualified_for_subject: eligibility_check.qualified_for_subject,
+        )
+    end
+
+    def create
+      @qualified_for_subject_form =
+        QualifiedForSubjectForm.new(
+          qualified_for_subject_form_params.merge(eligibility_check:),
+        )
+      if @qualified_for_subject_form.save
+        redirect_to paths[:work_experience]
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def qualified_for_subject_form_params
+      params.require(:eligibility_interface_qualified_for_subject_form).permit(
+        :qualified_for_subject,
+      )
+    end
+  end
+end

--- a/app/controllers/eligibility_interface/teach_children_controller.rb
+++ b/app/controllers/eligibility_interface/teach_children_controller.rb
@@ -4,7 +4,10 @@ module EligibilityInterface
 
     def new
       @teach_children_form =
-        TeachChildrenForm.new(teach_children: eligibility_check.teach_children)
+        TeachChildrenForm.new(
+          eligibility_check:,
+          teach_children: eligibility_check.teach_children,
+        )
     end
 
     def create
@@ -13,13 +16,21 @@ module EligibilityInterface
           teach_children_form_params.merge(eligibility_check:),
         )
       if @teach_children_form.save
-        redirect_to paths[:work_experience]
+        redirect_to next_path
       else
         render :new, status: :unprocessable_entity
       end
     end
 
     private
+
+    def next_path
+      if eligibility_check.qualified_for_subject_required?
+        paths[:qualified_for_subject]
+      else
+        paths[:work_experience]
+      end
+    end
 
     def teach_children_form_params
       params.require(:eligibility_interface_teach_children_form).permit(

--- a/app/forms/eligibility_interface/qualified_for_subject_form.rb
+++ b/app/forms/eligibility_interface/qualified_for_subject_form.rb
@@ -1,0 +1,16 @@
+class EligibilityInterface::QualifiedForSubjectForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :eligibility_check
+  attribute :qualified_for_subject, :boolean
+
+  validates :eligibility_check, presence: true
+  validates :qualified_for_subject, inclusion: { in: [true, false] }
+
+  def save
+    return false unless valid?
+
+    eligibility_check.update!(qualified_for_subject:)
+  end
+end

--- a/app/lib/country_code.rb
+++ b/app/lib/country_code.rb
@@ -32,6 +32,12 @@ class CountryCode
       Country::CODES_ELIGIBLE_IN_FEBRUARY_2023.include?(code)
     end
 
+    def secondary_education_teaching_qualification_required?(code)
+      Country::CODES_REQUIRING_SECONDARY_EDUCATION_TEACHING_QUALIFICATION.include?(
+        code,
+      )
+    end
+
     LOCATIONS_BY_COUNTRY_CODE =
       Country::LOCATION_AUTOCOMPLETE_CANONICAL_LIST
         .map { |row| [CountryCode.from_location(row.last), row.last] }

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -43,6 +43,9 @@ class Country < ApplicationRecord
   CODES_ELIGIBLE_IN_FEBRUARY_2023 =
     YAML.load(File.read("lib/countries-eligible-in-february-2023.yaml"))
 
+  CODES_REQUIRING_SECONDARY_EDUCATION_TEACHING_QUALIFICATION =
+    CODES_ELIGIBLE_IN_FEBRUARY_2023 - %w[HK UA]
+
   validates :code, inclusion: { in: CODES }
 
   validates :teaching_authority_online_checker_url, url: { allow_blank: true }

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -9,6 +9,7 @@
 #  degree                 :boolean
 #  free_of_sanctions      :boolean
 #  qualification          :boolean
+#  qualified_for_subject  :boolean
 #  teach_children         :boolean
 #  work_experience        :string
 #  created_at             :datetime         not null

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -93,11 +93,22 @@ class EligibilityCheck < ApplicationRecord
       FeatureFlags::FeatureFlag.active?(:eligibility_work_experience) &&
         work_experience_under_9_months?
 
+    qualified_for_subject_ineligible =
+      qualified_for_subject_required? && qualified_for_subject == false
+
+    teach_children_ineligible =
+      !qualified_for_subject_required? && teach_children == false
+
+    teach_children_secondary_ineligible =
+      qualified_for_subject_required? && teach_children == false
+
     [
       (:country if region.nil?),
       (:qualification if qualification == false),
       (:degree if degree == false),
-      (:teach_children if teach_children == false),
+      (:teach_children if teach_children_ineligible),
+      (:teach_children_secondary if teach_children_secondary_ineligible),
+      (:qualified_for_subject if qualified_for_subject_ineligible),
       (:misconduct if free_of_sanctions == false),
       (:work_experience if work_experience_ineligible),
     ].compact
@@ -108,7 +119,7 @@ class EligibilityCheck < ApplicationRecord
       return true
     end
 
-    region.present? && qualification && degree && teach_children &&
+    region.present? && qualification && degree && teach_children? &&
       free_of_sanctions &&
       (
         if FeatureFlags::FeatureFlag.active?(:eligibility_work_experience)
@@ -117,6 +128,14 @@ class EligibilityCheck < ApplicationRecord
           true
         end
       )
+  end
+
+  def teach_children?
+    if qualified_for_subject_required?
+      teach_children && qualified_for_subject
+    else
+      teach_children
+    end
   end
 
   def country_eligibility_status
@@ -151,6 +170,11 @@ class EligibilityCheck < ApplicationRecord
 
     return :eligibility unless free_of_sanctions.nil?
 
+    if qualified_for_subject_required? &&
+         (teach_children == false || qualified_for_subject == false)
+      return :eligibility
+    end
+
     if FeatureFlags::FeatureFlag.active?(:eligibility_work_experience)
       return :misconduct unless work_experience.nil?
       return :work_experience unless teach_children.nil?
@@ -164,6 +188,14 @@ class EligibilityCheck < ApplicationRecord
     return :region if country_code.present?
 
     :country
+  end
+
+  def qualified_for_subject_required?
+    return false if region.blank?
+
+    CountryCode.secondary_education_teaching_qualification_required?(
+      region.country.code,
+    )
   end
 
   private

--- a/app/views/eligibility_interface/finish/ineligible.html.erb
+++ b/app/views/eligibility_interface/finish/ineligible.html.erb
@@ -41,6 +41,7 @@
   <ul class="govuk-list govuk-list--bullet">
     <li><%= govuk_link_to "apply for QTS using alternative routes", "https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#qts-exemption-for-teachers-from-outside-the-uk" %></li>
     <li><%= govuk_link_to "learn more about teaching in England", "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas" %></li>
+    <li><%= govuk_link_to "learn more about the new QTS regulations", "https://www.gov.uk/government/publications/awarding-qualified-teacher-status-to-overseas-teachers/a-fairer-approach-to-awarding-qts-to-overseas-teachers--2" %></li>
   </ul>
 <% end %>
 

--- a/app/views/eligibility_interface/qualified_for_subject/new.html.erb
+++ b/app/views/eligibility_interface/qualified_for_subject/new.html.erb
@@ -1,0 +1,50 @@
+<% content_for :page_title, "#{'Error: ' if @qualified_for_subject_form.errors.any?}Does your teaching qualification or university degree qualify you to teach one of the following subjects?" %>
+<% content_for :back_link_url, back_link_url(eligibility_interface_teach_children_path) %>
+
+<%= form_with model: @qualified_for_subject_form, url: eligibility_interface_qualified_for_subject_url, method: :post do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-l">Does your teaching qualification or university degree qualify you to teach one of the following subjects?</h1>
+  <p class="govuk-hint">
+    You'll need to upload your certificate, along with a transcript that shows all the modules you studied and the scores you achieved.
+  </p>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Maths</li>
+        <li>Science</li>
+        <li>Biology</li>
+        <li>Chemistry</li>
+        <li>Physics</li>
+        <li>French</li>
+        <li>German</li>
+      </ul>
+    </div>
+
+    <div class="govuk-grid-column-one-half">
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Italian</li>
+        <li>Japanese</li>
+        <li>Latin</li>
+        <li>Mandarin</li>
+        <li>Russian</li>
+        <li>Spanish</li>
+      </ul>
+    </div>
+  </div>
+
+  <%= f.govuk_collection_radio_buttons(
+    :qualified_for_subject,
+    [OpenStruct.new(label: 'Yes', value: true), OpenStruct.new(label: 'No', value: false)],
+    :value,
+    :label,
+    legend: nil,
+  ) %>
+  <%= f.govuk_submit prevent_double_click: false %>
+<% end %>
+
+<%= govuk_details(
+  summary_text: "What we mean by qualified",
+  text: "Qualified means <strong>EITHER</strong> your teaching qualification specifically shows you can teach one of these subjects, <strong>OR</strong> at least 50% of your university degree was in one of them.".html_safe,
+) %>

--- a/app/views/eligibility_interface/teach_children/new.html.erb
+++ b/app/views/eligibility_interface/teach_children/new.html.erb
@@ -1,4 +1,16 @@
-<% content_for :page_title, "#{'Error: ' if @teach_children_form.errors.any?}Are you qualified to teach children who are aged somewhere between 5 and 16 years?" %>
+<%
+  legend = "Are you qualified to teach children who are aged somewhere between 5 and 16 years?"
+  hint = "You do not need to be qualified to teach this full age range. \
+          For example, you might be qualified to teach children aged 5 to 11, or 14 to 16."
+
+  if @teach_children_form.eligibility_check.qualified_for_subject_required?
+    legend = "Are you qualified to teach children aged 11-16 years?"
+    hint = "In England, 11-16 is the age for secondary education. \
+            You must be qualified to teach children in this age range to apply for QTS."
+  end
+%>
+
+<% content_for :page_title, "#{'Error: ' if @teach_children_form.errors.any?}#{legend}" %>
 <% content_for :back_link_url, back_link_url(eligibility_interface_degree_path) %>
 
 <%= form_with model: @teach_children_form, url: eligibility_interface_teach_children_url, method: :post do |f| %>
@@ -8,8 +20,8 @@
     [OpenStruct.new(label: 'Yes', value: true), OpenStruct.new(label: 'No', value: false)],
     :value,
     :label,
-    legend: { size: 'l', tag: 'h1', text: 'Are you qualified to teach children who are aged somewhere between 5 and 16 years?' },
-    hint: { text: 'You do not need to be qualified to teach this full age range. For example, you might be qualified to teach children aged 5 to 11, or 14 to 16.' }
+    legend: { size: 'l', tag: 'h1', text: legend },
+    hint: { text: hint }
   ) %>
   <%= f.govuk_submit prevent_double_click: false %>
 <% end %>

--- a/app/views/shared/eligible_region_content_components/_proof_of_work_history.html.erb
+++ b/app/views/shared/eligible_region_content_components/_proof_of_work_history.html.erb
@@ -5,7 +5,11 @@
 <% else %>
   <p class="govuk-body">You’ll need to provide the name and email address of a contact who can confirm that during your professional work experience you:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>worked unsupervised with children aged between 5 and 16 years</li>
+    <% if eligibility_check&.qualified_for_subject_required? %>
+      <li>worked unsupervised with children aged between 11 and 16 years</li>
+    <% else %>
+      <li>worked unsupervised with children aged between 5 and 16 years</li>
+    <% end %>
     <li>were solely responsible for planning, preparing and delivering lessons to at least 4 students at a time</li>
     <li>were solely responsible for assessing and reporting on the progress of those students</li>   
   </ul>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -147,6 +147,7 @@
     - completed_at
     - completed_requirements
     - work_experience
+    - qualified_for_subject
   :english_language_providers:
     - id
     - name

--- a/config/locales/eligibility_interface.en.yml
+++ b/config/locales/eligibility_interface.en.yml
@@ -44,6 +44,8 @@ en:
           misconduct: To teach in England, you must not have any findings of misconduct or restrictions on your employment record.
           qualification: You have not completed a formal teaching qualification in %{country_name}, for example, an undergraduate teaching degree or postgraduate teaching qualification.
           teach_children: You are not qualified to teach children who are aged somewhere between 5 and 16 years.
+          teach_children_secondary: You’re not qualified to teach children aged 11-16 years.
+          qualified_for_subject: You’re not qualified to teach one of the subjects for which we currently accept applications.
           work_experience: You do not have sufficient work experience as a teacher.
   eligibility_interface:
     three_months_before_applying: This must be dated within 3 months of you applying for QTS.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,8 @@ Rails.application.routes.draw do
     post "region", to: "region#create"
     get "teach-children", to: "teach_children#new"
     post "teach-children", to: "teach_children#create"
+    get "qualified-for-subject", to: "qualified_for_subject#new"
+    post "qualified-for-subject", to: "qualified_for_subject#create"
     get "work-experience", to: "work_experience#new"
     post "work-experience", to: "work_experience#create"
   end

--- a/db/migrate/20230124175130_add_qualified_for_subject_to_eligibility_checks.rb
+++ b/db/migrate/20230124175130_add_qualified_for_subject_to_eligibility_checks.rb
@@ -1,0 +1,5 @@
+class AddQualifiedForSubjectToEligibilityChecks < ActiveRecord::Migration[7.0]
+  def change
+    add_column :eligibility_checks, :qualified_for_subject, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -190,6 +190,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_161536) do
     t.datetime "completed_at"
     t.boolean "completed_requirements"
     t.string "work_experience"
+    t.boolean "qualified_for_subject"
   end
 
   create_table "english_language_providers", force: :cascade do |t|

--- a/spec/factories/eligibility_checks.rb
+++ b/spec/factories/eligibility_checks.rb
@@ -9,6 +9,7 @@
 #  degree                 :boolean
 #  free_of_sanctions      :boolean
 #  qualification          :boolean
+#  qualified_for_subject  :boolean
 #  teach_children         :boolean
 #  work_experience        :string
 #  created_at             :datetime         not null

--- a/spec/lib/country_code_spec.rb
+++ b/spec/lib/country_code_spec.rb
@@ -92,4 +92,13 @@ RSpec.describe CountryCode do
 
     include_examples "true with codes", Country::CODES_ELIGIBLE_IN_FEBRUARY_2023
   end
+
+  describe "#secondary_education_teaching_qualification_required?" do
+    subject(:secondary_education_teaching_qualification_required?) do
+      described_class.secondary_education_teaching_qualification_required?(code)
+    end
+
+    include_examples "true with codes",
+                     Country::CODES_REQUIRING_SECONDARY_EDUCATION_TEACHING_QUALIFICATION
+  end
 end

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -9,6 +9,7 @@
 #  degree                 :boolean
 #  free_of_sanctions      :boolean
 #  qualification          :boolean
+#  qualified_for_subject  :boolean
 #  teach_children         :boolean
 #  work_experience        :string
 #  created_at             :datetime         not null

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -95,6 +95,27 @@ RSpec.describe EligibilityCheck, type: :model do
       it { is_expected.to include(:teach_children) }
     end
 
+    context "when filtering by subject" do
+      let(:region) do
+        country = create(:country, :with_national_region, code: "IN")
+        country.regions.first
+      end
+
+      before { eligibility_check.region = region }
+
+      context "when teach_children is false" do
+        before { eligibility_check.teach_children = false }
+
+        it { is_expected.to include(:teach_children_secondary) }
+      end
+
+      context "when qualified_for_subject is false" do
+        before { eligibility_check.qualified_for_subject = false }
+
+        it { is_expected.to include(:qualified_for_subject) }
+      end
+    end
+
     context "when qualification is true" do
       before { eligibility_check.qualification = true }
 
@@ -449,6 +470,31 @@ RSpec.describe EligibilityCheck, type: :model do
         end
         it { is_expected.to be true }
       end
+    end
+  end
+
+  describe "#qualified_for_subject_required?" do
+    subject(:qualified_for_subject_required?) do
+      eligibility_check.qualified_for_subject_required?
+    end
+
+    let(:region) do
+      country = create(:country, :with_national_region, code:)
+      country.regions.first
+    end
+
+    before { eligibility_check.region = region }
+
+    context "with a relevant country" do
+      let(:code) { "JM" }
+
+      it { is_expected.to be true }
+    end
+
+    context "with an unaffected country" do
+      let(:code) { "UA" }
+
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/support/autoload/page_objects/eligibility_interface/qualified_for_subject.rb
+++ b/spec/support/autoload/page_objects/eligibility_interface/qualified_for_subject.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module EligibilityInterface
+    class QualifiedForSubject < Question
+      set_url "/eligibility/qualified-for-subject"
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -167,6 +167,11 @@ module PageHelpers
       PageObjects::EligibilityInterface::TeachChildren.new
   end
 
+  def qualified_for_subject_page
+    @qualified_for_subject_page ||=
+      PageObjects::EligibilityInterface::QualifiedForSubject.new
+  end
+
   def teacher_add_another_work_history_page
     @teacher_add_another_work_history_page ||=
       PageObjects::TeacherInterface::AddAnotherWorkHistory.new

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -292,6 +292,84 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the(:start_page)
   end
 
+  it "happy path when filtering by country requiring qualification for subject" do
+    when_i_visit_the(:start_page)
+    then_i_see_the(:start_page)
+
+    when_i_press_start_now
+    then_i_see_the(:country_page)
+
+    when_i_select_a_qualified_for_subject_country
+    then_i_see_the(:qualification_page)
+
+    when_i_have_a_qualification
+    then_i_see_the(:degree_page)
+
+    when_i_have_a_degree
+    then_i_see_the(:teach_children_page)
+
+    when_i_can_teach_children
+    then_i_see_the(:qualified_for_subject_page)
+
+    when_i_am_qualified_to_teach_a_relevant_subject
+    then_i_see_the(:misconduct_page)
+
+    when_i_dont_have_a_misconduct_record
+    then_i_see_the(:eligible_page)
+  end
+
+  it "ineligible path when filtering by country, not qualified for UK secondary" do
+    when_i_visit_the(:start_page)
+    then_i_see_the(:start_page)
+
+    when_i_press_start_now
+    then_i_see_the(:country_page)
+
+    when_i_select_a_qualified_for_subject_country
+    then_i_see_the(:qualification_page)
+
+    when_i_have_a_qualification
+    then_i_see_the(:degree_page)
+
+    when_i_have_a_degree
+    then_i_see_the(:teach_children_page)
+
+    when_i_cant_teach_children
+    then_i_see_the(:qualified_for_subject_page)
+
+    when_i_am_qualified_to_teach_a_relevant_subject
+    then_i_see_the(:misconduct_page)
+
+    when_i_dont_have_a_misconduct_record
+    then_i_see_the(:ineligible_page)
+  end
+
+  it "ineligible path when filtering by country, not qualified in relevant subject" do
+    when_i_visit_the(:start_page)
+    then_i_see_the(:start_page)
+
+    when_i_press_start_now
+    then_i_see_the(:country_page)
+
+    when_i_select_a_qualified_for_subject_country
+    then_i_see_the(:qualification_page)
+
+    when_i_have_a_qualification
+    then_i_see_the(:degree_page)
+
+    when_i_have_a_degree
+    then_i_see_the(:teach_children_page)
+
+    when_i_can_teach_children
+    then_i_see_the(:qualified_for_subject_page)
+
+    when_i_am_not_qualified_to_teach_a_relevant_subject
+    then_i_see_the(:misconduct_page)
+
+    when_i_dont_have_a_misconduct_record
+    then_i_see_the(:ineligible_page)
+  end
+
   private
 
   def then_access_is_denied
@@ -319,6 +397,7 @@ RSpec.describe "Eligibility check", type: :system do
     it = create(:country, code: "IT")
     create(:region, country: it, name: "Region")
     create(:region, country: it, name: "Other Region")
+    create(:country, :with_national_region, code: "JM")
   end
 
   def then_i_do_not_see_the_start_page
@@ -369,6 +448,10 @@ RSpec.describe "Eligibility check", type: :system do
     country_page.form.continue_button.click
   end
 
+  def when_i_select_a_qualified_for_subject_country
+    country_page.submit(country: "Jamaica")
+  end
+
   def then_i_see_the_country_error_message
     expect(country_page).to have_error_summary
     expect(country_page.error_summary.body).to have_content(
@@ -411,6 +494,14 @@ RSpec.describe "Eligibility check", type: :system do
 
   def when_i_cant_teach_children
     teach_children_page.submit_no
+  end
+
+  def when_i_am_qualified_to_teach_a_relevant_subject
+    qualified_for_subject_page.submit_yes
+  end
+
+  def when_i_am_not_qualified_to_teach_a_relevant_subject
+    qualified_for_subject_page.submit_no
   end
 
   def when_i_have_more_than_20_months_work_experience


### PR DESCRIPTION
## Trello

https://trello.com/c/p5UVMi59/1432-build-new-subject-criteria-in-eligibility-checker

## Context

From 1 Feb, applicants from the some countries will only be able to apply/be awarded QTS if they are qualified to teach Maths, Languages ( French, German, Italian, Japanese, Latin, Mandarin, Russian, Spanish) and Sciences (physics, chemistry, Biology, general science)

## Changes

- Teach children question presents a different age range (slightly different content) if the teacher has selected a relevant country.
![image](https://user-images.githubusercontent.com/93511/214617402-24902e18-b1f8-41b3-820a-15f08795f9f5.png)

- A "Yes" answer takes them to a question about which subject they are qualified in.
![image](https://user-images.githubusercontent.com/93511/214617546-cef7237a-da58-4aa8-b947-7d0109532cca.png)

- Answering "No" in either case takes them through the rest of the eligibility questions ending with the _Ineligible_ outcome and presents relevant reasons: 
![image](https://user-images.githubusercontent.com/93511/214617876-e0816d61-423a-487a-93e6-23ea3f9cf94e.png)


