### PR TITLE
Add QualificationRequest model

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -34,6 +34,7 @@ class Assessment < ApplicationRecord
   has_many :sections, class_name: "AssessmentSection", dependent: :destroy
   has_many :further_information_requests, dependent: :destroy
   has_many :reference_requests, dependent: :destroy
+  has_many :qualification_requests, dependent: :destroy
 
   enum :recommendation,
        {

--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: qualification_requests
+#
+#  id               :bigint           not null, primary key
+#  location_note    :text             default(""), not null
+#  received_at      :datetime
+#  state            :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  assessment_id    :bigint           not null
+#  qualification_id :bigint           not null
+#
+# Indexes
+#
+#  index_qualification_requests_on_assessment_id     (assessment_id)
+#  index_qualification_requests_on_qualification_id  (qualification_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#  fk_rails_...  (qualification_id => qualifications.id)
+#
+class QualificationRequest < ApplicationRecord
+  include Requestable
+
+  belongs_to :assessment
+  belongs_to :qualification
+
+  with_options if: :received? do
+    validates :location_note, presence: true
+  end
+
+  delegate :application_form, to: :assessment
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -200,6 +200,15 @@
     - created_at
     - updated_at
     - part_of_university_degree
+  :qualification_requests:
+    - id
+    - assessment_id
+    - qualification_id
+    - state
+    - received_at
+    - location_note
+    - created_at
+    - updated_at
   :reference_requests:
     - id
     - slug

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -31,6 +31,8 @@
     - complete_date
     - certificate_date
     - part_of_university_degree
+  :qualification_requests:
+    - location_note
   :reference_requests:
     - additional_information_response
   :selected_failure_reasons:

--- a/db/migrate/20230125161536_create_qualification_requests.rb
+++ b/db/migrate/20230125161536_create_qualification_requests.rb
@@ -1,0 +1,12 @@
+class CreateQualificationRequests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :qualification_requests do |t|
+      t.references :assessment, null: false, foreign_key: true
+      t.references :qualification, null: false, foreign_key: true
+      t.string :state, null: false
+      t.datetime :received_at
+      t.text :location_note, null: false, default: ""
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_23_103414) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_25_161536) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -84,9 +84,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_103414) do
     t.bigint "english_language_provider_id"
     t.text "english_language_provider_reference", default: "", null: false
     t.datetime "awarded_at"
+    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "written_statement_confirmation", default: false, null: false
-    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "english_language_provider_other", default: false, null: false
     t.datetime "declined_at"
     t.boolean "waiting_on_professional_standing", default: false, null: false
@@ -243,6 +243,18 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_103414) do
     t.index ["author_id"], name: "index_notes_on_author_id"
   end
 
+  create_table "qualification_requests", force: :cascade do |t|
+    t.bigint "assessment_id", null: false
+    t.bigint "qualification_id", null: false
+    t.string "state", null: false
+    t.datetime "received_at"
+    t.text "location_note", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessment_id"], name: "index_qualification_requests_on_assessment_id"
+    t.index ["qualification_id"], name: "index_qualification_requests_on_qualification_id"
+  end
+
   create_table "qualifications", force: :cascade do |t|
     t.bigint "application_form_id", null: false
     t.text "title", default: "", null: false
@@ -295,8 +307,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_103414) do
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
-    t.text "qualifications_information", default: "", null: false
     t.boolean "application_form_skip_work_history", default: false, null: false
+    t.text "qualifications_information", default: "", null: false
     t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_requires_submission_email", default: false, null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
@@ -454,6 +466,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_23_103414) do
   add_foreign_key "eligibility_checks", "regions"
   add_foreign_key "notes", "application_forms"
   add_foreign_key "notes", "staff", column: "author_id"
+  add_foreign_key "qualification_requests", "assessments"
+  add_foreign_key "qualification_requests", "qualifications"
   add_foreign_key "qualifications", "application_forms"
   add_foreign_key "reference_requests", "assessments"
   add_foreign_key "reference_requests", "work_histories"

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -64,5 +64,16 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :with_qualification_request do
+      after(:create) do |assessment, _evaluator|
+        create(
+          :qualification_request,
+          :requested,
+          assessment:,
+          qualification: assessment.application_form.qualifications.first,
+        )
+      end
+    end
   end
 end

--- a/spec/factories/qualification_requests.rb
+++ b/spec/factories/qualification_requests.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: qualification_requests
+#
+#  id               :bigint           not null, primary key
+#  location_note    :text             default(""), not null
+#  received_at      :datetime
+#  state            :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  assessment_id    :bigint           not null
+#  qualification_id :bigint           not null
+#
+# Indexes
+#
+#  index_qualification_requests_on_assessment_id     (assessment_id)
+#  index_qualification_requests_on_qualification_id  (qualification_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#  fk_rails_...  (qualification_id => qualifications.id)
+#
+FactoryBot.define do
+  factory :qualification_request do
+    association :assessment
+    association :qualification, :completed
+
+    trait :requested do
+      state { "requested" }
+    end
+
+    trait :received do
+      state { "received" }
+      received_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
+      receivable
+    end
+
+    trait :receivable do
+      location_note { Faker::Lorem.sentence }
+    end
+  end
+end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Assessment, type: :model do
   describe "associations" do
     it { is_expected.to have_many(:sections) }
     it { is_expected.to have_many(:further_information_requests) }
+    it { is_expected.to have_many(:qualification_requests) }
   end
 
   describe "validations" do

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: qualification_requests
+#
+#  id               :bigint           not null, primary key
+#  location_note    :text             default(""), not null
+#  received_at      :datetime
+#  state            :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  assessment_id    :bigint           not null
+#  qualification_id :bigint           not null
+#
+# Indexes
+#
+#  index_qualification_requests_on_assessment_id     (assessment_id)
+#  index_qualification_requests_on_qualification_id  (qualification_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#  fk_rails_...  (qualification_id => qualifications.id)
+#
+require "rails_helper"
+
+RSpec.describe QualificationRequest, type: :model do
+  it_behaves_like "a requestable" do
+    subject { build(:qualification_request, :receivable) }
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:assessment) }
+  end
+
+  describe "validations" do
+    context "when received" do
+      subject { build(:qualification_request, :received) }
+
+      it { is_expected.to validate_presence_of(:location_note) }
+    end
+  end
+end

--- a/spec/services/destroy_application_form_spec.rb
+++ b/spec/services/destroy_application_form_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe DestroyApplicationForm do
           :assessment,
           :with_further_information_request,
           :with_reference_request,
+          :with_qualification_request,
           application_form:,
         )
 
@@ -46,6 +47,7 @@ RSpec.describe DestroyApplicationForm do
   include_examples "deletes model", FurtherInformationRequest
   include_examples "deletes model", FurtherInformationRequestItem, 4, 2
   include_examples "deletes model", ReferenceRequest
+  include_examples "deletes model", QualificationRequest
   include_examples "deletes model", Note
   include_examples "deletes model", Qualification
   include_examples "deletes model", Teacher


### PR DESCRIPTION
This adds a new model which will be responsible for handling the verification of qualifications, following the same "Requestable" type object we've got for further information, references and professional standing.