### PR TITLE
Add ability to assess subject criteria

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -63,6 +63,16 @@ class AssessmentFactory
       "qualifications_meet_level_6_or_equivalent",
       "teaching_qualifications_completed_in_eligible_country",
       "qualified_in_mainstream_education",
+      (
+        if application_form.secondary_education_teaching_qualification_required?
+          "qualified_to_teach_children_11_to_16"
+        end
+      ),
+      (
+        if application_form.secondary_education_teaching_qualification_required?
+          "teaching_qualification_subjects_criteria"
+        end
+      ),
       "has_teacher_qualification_certificate",
       "has_teacher_qualification_transcript",
       "has_university_degree_certificate",
@@ -99,6 +109,16 @@ class AssessmentFactory
       FailureReasons::NOT_QUALIFIED_TO_TEACH_MAINSTREAM,
       FailureReasons::QUALIFICATIONS_DONT_MATCH_SUBJECTS,
       FailureReasons::QUALIFICATIONS_DONT_MATCH_OTHER_DETAILS,
+      (
+        if application_form.secondary_education_teaching_qualification_required?
+          FailureReasons::QUALIFIED_TO_TEACH_CHILDREN_11_TO_16
+        end
+      ),
+      (
+        if application_form.secondary_education_teaching_qualification_required?
+          FailureReasons::TEACHING_QUALIFICATION_SUBJECTS_CRITERIA
+        end
+      ),
       FailureReasons::TEACHING_CERTIFICATE_ILLEGIBLE,
       FailureReasons::TEACHING_TRANSCRIPT_ILLEGIBLE,
       FailureReasons::DEGREE_CERTIFICATE_ILLEGIBLE,
@@ -111,7 +131,20 @@ class AssessmentFactory
   end
 
   def age_range_subjects_section
-    checks = %i[qualified_in_mainstream_education age_range_subjects_matches]
+    checks = [
+      "qualified_in_mainstream_education",
+      (
+        if application_form.secondary_education_teaching_qualification_required?
+          "qualified_to_teach_children_11_to_16"
+        end
+      ),
+      (
+        if application_form.secondary_education_teaching_qualification_required?
+          "teaching_qualification_subjects_criteria"
+        end
+      ),
+      "age_range_subjects_matches",
+    ].compact
 
     failure_reasons = [
       FailureReasons::NOT_QUALIFIED_TO_TEACH_MAINSTREAM,

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -9,10 +9,14 @@ class FailureReasons
     DUPLICATE_APPLICATION = "duplicate_application",
     FULL_PROFESSIONAL_STATUS = "full_professional_status",
     NOT_QUALIFIED_TO_TEACH_MAINSTREAM = "not_qualified_to_teach_mainstream",
+    QUALIFIED_TO_TEACH_CHILDREN_11_TO_16 =
+      "qualified_to_teach_children_11_to_16",
     TEACHING_HOURS_NOT_FULFILLED = "teaching_hours_not_fulfilled",
     TEACHING_QUALIFICATION = "teaching_qualification",
     TEACHING_QUALIFICATION_1_YEAR = "teaching_qualification_1_year",
     TEACHING_QUALIFICATION_PEDAGOGY = "teaching_qualification_pedagogy",
+    TEACHING_QUALIFICATION_SUBJECTS_CRITERIA =
+      "teaching_qualification_subjects_criteria",
     TEACHING_QUALIFICATIONS_FROM_INELIGIBLE_COUNTRY =
       "teaching_qualifications_from_ineligible_country",
     TEACHING_QUALIFICATIONS_NOT_AT_REQUIRED_LEVEL =

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -193,6 +193,12 @@ class ApplicationForm < ApplicationRecord
     english_language_citizenship_exempt || english_language_qualification_exempt
   end
 
+  def secondary_education_teaching_qualification_required?
+    CountryCode.secondary_education_teaching_qualification_required?(
+      country.code,
+    )
+  end
+
   private
 
   def build_documents

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -92,11 +92,13 @@ en:
           qualifications_meet_level_6_or_equivalent: applicant holds qualifications that meet the required academic level (level 6 qualification or higher)
           qualified_in_mainstream_education: they’re qualified to teach in mainstream education (not vocationally only/SEN only/early years/pre-school only)
           qualified_to_teach: the applicant is qualified to teach at state or government schools
+          qualified_to_teach_children_11_to_16: the applicant is qualified to teach children aged 11-16
           registration_number: registration number provided and verified (where applicable)
           satisfactory_evidence_work_history: the applicant has provided satisfactory evidence of their work history
           teaching_qualification: confirmation of the applicant’s teaching qualification
           teaching_qualification_1_year: the teaching qualification lasted at least 1 academic year
           teaching_qualification_pedagogy: the teaching qualification had at least 75% of the course focused on pedagogy
+          teaching_qualification_subjects_criteria: the teaching qualification specifically qualifies them to teach either Maths, Science, Biology, Chemistry, Physics, French, German, Italian, Japanese, Latin, Mandarin, Russian or Spanish (OR they have a teaching qualification for children aged 11-16 AND at least 50% of their degree was in one of those subjects)
           teaching_qualifications_completed_in_eligible_country: teaching qualifications were completed in an eligible country (for example, we cannot award QTS where they applied through Spain, but their teaching was completed in South Africa)
           verify_school_details: the school details to verify what the applicant has entered
           work_history_references: that the applicant has provided a reference for each role with an acceptable email address
@@ -123,6 +125,7 @@ en:
           qualifications_dont_match_other_details: Uploaded qualifications do not match other details entered, for example, name of qualification, name of institution or dates.
           qualifications_dont_match_subjects: Subjects entered are acceptable for QTS, but the uploaded qualifications do not match them.
           qualified_to_teach: We were not provided with sufficient evidence to confirm qualification to teach at state or government schools.
+          qualified_to_teach_children_11_to_16: The applicant is not qualified to teach children aged 11-16.
           registration_number: We could not verify the registration number using the online checker.
           satisfactory_evidence_work_history: The information provided on work history is not sufficient to award QTS.
           school_details_cannot_be_verified: We cannot verify the details of one of the schools that the applicant has entered.
@@ -131,6 +134,7 @@ en:
           teaching_qualification: We were not provided with sufficient evidence to confirm the teaching qualification entered on the online application form.
           teaching_qualification_1_year: The teacher training course qualification did not last at least 1 academic year.
           teaching_qualification_pedagogy: The teaching qualification did not have enough focus on pedagogy (at least 75% of modules focus on pedagogy).
+          teaching_qualification_subjects_criteria: The applicant is not qualified to teach one of the subjects that we can currently accept.
           teaching_qualifications_from_ineligible_country: Teaching qualifications were completed in an ineligible country.
           teaching_qualifications_not_at_required_level: Teaching qualifications do not meet the required academic level (level 6).
           teaching_transcript_illegible: The teaching qualification transcript (or translation) is illegible or in a format that we cannot accept.

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -160,6 +160,55 @@ RSpec.describe AssessmentFactory do
             )
           end
         end
+
+        context "with an application form with subject criteria" do
+          let(:application_form) do
+            create(
+              :application_form,
+              region: create(:region, :in_country, country_code: "SG"),
+            )
+          end
+
+          it "has the right checks and failure reasons" do
+            section = sections.qualifications.first
+
+            expect(section.checks).to eq(
+              %w[
+                qualifications_meet_level_6_or_equivalent
+                teaching_qualifications_completed_in_eligible_country
+                qualified_in_mainstream_education
+                qualified_to_teach_children_11_to_16
+                teaching_qualification_subjects_criteria
+                has_teacher_qualification_certificate
+                has_teacher_qualification_transcript
+                has_university_degree_certificate
+                has_university_degree_transcript
+                has_additional_qualification_certificate
+                has_additional_degree_transcript
+              ],
+            )
+
+            expect(section.failure_reasons).to eq(
+              %w[
+                application_and_qualification_names_do_not_match
+                teaching_qualifications_from_ineligible_country
+                teaching_qualifications_not_at_required_level
+                teaching_hours_not_fulfilled
+                not_qualified_to_teach_mainstream
+                qualifications_dont_match_subjects
+                qualifications_dont_match_other_details
+                qualified_to_teach_children_11_to_16
+                teaching_qualification_subjects_criteria
+                teaching_certificate_illegible
+                teaching_transcript_illegible
+                degree_certificate_illegible
+                degree_transcript_illegible
+                additional_degree_certificate_illegible
+                additional_degree_transcript_illegible
+              ],
+            )
+          end
+        end
       end
 
       describe "age range and subjects section" do
@@ -175,6 +224,32 @@ RSpec.describe AssessmentFactory do
           expect(section.failure_reasons).to eq(
             %w[not_qualified_to_teach_mainstream age_range],
           )
+        end
+
+        context "with an application form with subject criteria" do
+          let(:application_form) do
+            create(
+              :application_form,
+              region: create(:region, :in_country, country_code: "SG"),
+            )
+          end
+
+          it "has the right checks and failure reasons" do
+            section = sections.age_range_subjects.first
+
+            expect(section.checks).to eq(
+              %w[
+                qualified_in_mainstream_education
+                qualified_to_teach_children_11_to_16
+                teaching_qualification_subjects_criteria
+                age_range_subjects_matches
+              ],
+            )
+
+            expect(section.failure_reasons).to eq(
+              %w[not_qualified_to_teach_mainstream age_range],
+            )
+          end
         end
       end
 


### PR DESCRIPTION
This adds the ability to assess the new subject criteria for relevant application forms.

Depends on #1011 

[Trello Card](https://trello.com/c/A5x2KBQc/1388-initial-assess-new-subject-criteria)