### PR TITLE
Awaiting third-party professional standing requests

### DIFF
--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -117,6 +117,7 @@ module TimelineEntry
       {
         requested_at:
           timeline_event.requestable.created_at.to_fs(:date_and_time),
+        location_note: timeline_event.requestable.try(:location_note),
       }
     end
 

--- a/app/controllers/assessor_interface/base_controller.rb
+++ b/app/controllers/assessor_interface/base_controller.rb
@@ -12,5 +12,9 @@ class AssessorInterface::BaseController < ApplicationController
     authorize :assessor
   end
 
+  def authorize_note
+    authorize :note
+  end
+
   alias_method :pundit_user, :current_staff
 end

--- a/app/controllers/assessor_interface/notes_controller.rb
+++ b/app/controllers/assessor_interface/notes_controller.rb
@@ -26,10 +26,6 @@ module AssessorInterface
 
     private
 
-    def authorize_note
-      authorize :note
-    end
-
     def application_form
       @application_form ||= ApplicationForm.find(params[:application_form_id])
     end

--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module AssessorInterface
+  class ProfessionalStandingRequestsController < BaseController
+    before_action :authorize_note
+
+    def edit
+      @professional_standing_request_form =
+        ProfessionalStandingRequestForm.new(
+          professional_standing_request:,
+          user: current_staff,
+          received: professional_standing_request.received?,
+          location_note: professional_standing_request.location_note,
+        )
+    end
+
+    def update
+      @professional_standing_request_form =
+        ProfessionalStandingRequestForm.new(
+          professional_standing_request_form.merge(
+            professional_standing_request:,
+            user: current_staff,
+          ),
+        )
+
+      if @professional_standing_request_form.save
+        redirect_to [:assessor_interface, application_form]
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def professional_standing_request_form
+      params.require(
+        :assessor_interface_professional_standing_request_form,
+      ).permit(:received, :location_note)
+    end
+
+    def application_form
+      @application_form ||=
+        ApplicationForm.includes(
+          assessment: :professional_standing_request,
+        ).find(params[:application_form_id])
+    end
+
+    delegate :professional_standing_request, to: :assessment
+    delegate :assessment, to: :application_form
+  end
+end

--- a/app/forms/assessor_interface/professional_standing_request_form.rb
+++ b/app/forms/assessor_interface/professional_standing_request_form.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class AssessorInterface::ProfessionalStandingRequestForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :professional_standing_request, :user
+  validates :professional_standing_request, :user, presence: true
+
+  attribute :received, :boolean
+
+  attribute :location_note, :string
+  validates :location_note, presence: true, if: -> { received.present? }
+
+  def save
+    return false unless valid?
+
+    ActiveRecord::Base.transaction do
+      professional_standing_request.update!(location_note:)
+
+      if received.present? && !professional_standing_request.received?
+        receive_professional_standing
+      elsif received.blank? && professional_standing_request.received?
+        request_professional_standing
+      end
+
+      ApplicationFormStatusUpdater.call(application_form:, user:)
+    end
+
+    true
+  end
+
+  delegate :application_form, to: :professional_standing_request
+
+  private
+
+  def receive_professional_standing
+    professional_standing_request.received!
+
+    TimelineEvent.create!(
+      event_type: "requestable_received",
+      application_form:,
+      creator: user,
+      requestable: professional_standing_request,
+    )
+  end
+
+  def request_professional_standing
+    professional_standing_request.requested!
+
+    TimelineEvent
+      .requestable_received
+      .where(requestable: professional_standing_request)
+      .destroy_all
+  end
+end

--- a/app/forms/assessor_interface/professional_standing_request_form.rb
+++ b/app/forms/assessor_interface/professional_standing_request_form.rb
@@ -30,7 +30,7 @@ class AssessorInterface::ProfessionalStandingRequestForm
     true
   end
 
-  delegate :application_form, to: :professional_standing_request
+  delegate :application_form, :assessment, to: :professional_standing_request
 
   private
 

--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -69,12 +69,12 @@ class ApplicationFormStatusUpdater
       elsif waiting_on_professional_standing ||
             waiting_on_further_information || waiting_on_reference
         "waiting_on"
-      elsif received_professional_standing || received_further_information ||
-            received_reference
+      elsif received_further_information || received_reference
         "received"
       elsif assessment&.started?
         "initial_assessment"
-      elsif application_form.submitted_at.present?
+      elsif application_form.submitted_at.present? ||
+            received_professional_standing
         "submitted"
       else
         "draft"
@@ -84,7 +84,9 @@ class ApplicationFormStatusUpdater
   delegate :assessment, :dqt_trn_request, :teacher, to: :application_form
 
   def professional_standing_requests
-    @professional_standing_requests ||= []
+    @professional_standing_requests ||= [
+      assessment&.professional_standing_request,
+    ].compact
   end
 
   def further_information_requests

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -33,6 +33,7 @@ class Assessment < ApplicationRecord
 
   has_many :sections, class_name: "AssessmentSection", dependent: :destroy
   has_many :further_information_requests, dependent: :destroy
+  has_one :professional_standing_request, dependent: :destroy, required: false
   has_many :reference_requests, dependent: :destroy
   has_many :qualification_requests, dependent: :destroy
 

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -4,6 +4,8 @@ module Requestable
   extend ActiveSupport::Concern
 
   included do
+    belongs_to :assessment
+
     enum :state,
          { requested: "requested", received: "received", expired: "expired" },
          default: "requested"

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -20,7 +20,6 @@
 class FurtherInformationRequest < ApplicationRecord
   include Requestable
 
-  belongs_to :assessment
   has_many :items,
            class_name: "FurtherInformationRequestItem",
            inverse_of: :further_information_request,

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: professional_standing_requests
+#
+#  id            :bigint           not null, primary key
+#  location_note :text             default(""), not null
+#  received_at   :datetime
+#  state         :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  assessment_id :bigint           not null
+#
+# Indexes
+#
+#  index_professional_standing_requests_on_assessment_id  (assessment_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#
+class ProfessionalStandingRequest < ApplicationRecord
+  include Requestable
+
+  with_options if: :received? do
+    validates :location_note, presence: true
+  end
+end

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -26,4 +26,6 @@ class ProfessionalStandingRequest < ApplicationRecord
   with_options if: :received? do
     validates :location_note, presence: true
   end
+
+  delegate :application_form, to: :assessment
 end

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -35,7 +35,6 @@ class ReferenceRequest < ApplicationRecord
 
   has_secure_token :slug
 
-  belongs_to :assessment
   belongs_to :work_history
 
   with_options if: :received? do

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -113,6 +113,7 @@ class TimelineEvent < ApplicationRecord
             presence: true,
             inclusion: %w[
               FurtherInformationRequest
+              ProfessionalStandingRequest
               QualificationRequest
               ReferenceRequest
             ],

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -47,7 +47,10 @@ class AssessorInterface::ApplicationFormsShowViewObject
   def assessment_task_path(section, item, index)
     case section
     when :pre_assessment_tasks
-      nil
+      url_helpers.edit_assessor_interface_application_form_assessment_professional_standing_request_path(
+        application_form,
+        assessment,
+      )
     when :submitted_details
       return nil unless professional_standing_request_received?
 

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -20,7 +20,7 @@ module AssessorInterface
     end
 
     delegate :assessment, to: :assessment_section
-    delegate :application_form, to: :assessment
+    delegate :application_form, :professional_standing_request, to: :assessment
     delegate :registration_number, to: :application_form
     delegate :checks, to: :assessment_section
     delegate :region, :country, to: :application_form

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -51,6 +51,20 @@
                application_form: @assessment_section_view_object.application_form,
                changeable: false %>
   <% end %>
+
+  <% if (professional_standing_request = @assessment_section_view_object.professional_standing_request).present? %>
+    <%= render(CheckYourAnswersSummary::Component.new(
+      id: "professional-standing-request",
+      model: professional_standing_request,
+      title: t(".professional_standing_request"),
+      fields: {
+        note: {
+          title: "Written statement",
+          value: "<p class=\"govuk-body\">The competent authority has sent the letter of professional standing directly to the TRA. Follow the instructions below to locate it.</p>#{simple_format(professional_standing_request.note)}".html_safe,
+        },
+      },
+    )) %>
+  <% end %>
 <% end %>
 
 <% if @assessment_section_view_object.application_form.created_under_new_regulations? && @assessment_section_view_object.work_history? %>

--- a/app/views/assessor_interface/professional_standing_requests/edit.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title, "#{"Error: " if @professional_standing_request_form.errors.any?}#{t(".title")}" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@professional_standing_request_form.application_form) %>
+
+<%= form_with model: @professional_standing_request_form, url: [:assessor_interface, @professional_standing_request_form.application_form, @professional_standing_request_form.assessment, :professional_standing_request], method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
+
+  <p class="govuk-body">Only use this screen when the letter of professional standing has been received.</p>
+
+  <p class="govuk-body">This screen is not an assessment of professional standing, it just confirms that it has been received.</p>
+
+  <%= f.govuk_check_boxes_fieldset :received, multiple: false, legend: nil do %>
+    <%= f.govuk_check_box :received, true, false, multiple: false, link_errors: true,
+                          label: { text: t("helpers.label.assessor_interface_professional_standing_request_form.received") } %>
+  <% end %>
+
+  <%= f.govuk_text_area :location_note %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -189,6 +189,14 @@
     - text
     - created_at
     - updated_at
+  :professional_standing_requests:
+    - id
+    - assessment_id
+    - state
+    - received_at
+    - location_note
+    - created_at
+    - updated_at
   :qualifications:
     - id
     - application_form_id

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -23,6 +23,8 @@
     - response
   :notes:
     - text
+  :professional_standing_requests:
+    - location_note
   :qualifications:
     - title
     - institution_name

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -149,6 +149,7 @@ en:
           true:
             GB-SCT: Provisional registration
             GB-NIR: "No"
+        professional_standing_request: Third-party professional standing
 
     further_information_requests:
       edit:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -155,6 +155,10 @@ en:
         title: Review further information from applicant
         check_your_answers: Further information requested
 
+    professional_standing_requests:
+      edit:
+        title: Third-party professional standing – response received
+
   activemodel:
     errors:
       models:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -13,9 +13,11 @@ en:
       show:
         assessment_tasks:
           sections:
+            pre_assessment_tasks: Pre-assessment tasks
             submitted_details: Check submitted details
             recommendation: Your recommendation
           items:
+            professional_standing_request: Awaiting third-party professional standing
             personal_information: Check personal information
             qualifications: Check qualifications
             age_range_subjects: Verify age range and subjects

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -259,3 +259,7 @@ en:
           attributes:
             induction_required:
               inclusion: Select whether the teacher requires induction
+        assessor_interface/professional_standing_request_form:
+          attributes:
+            location_note:
+              blank: Enter where the assessor can find it

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -33,18 +33,22 @@ en:
         assessment_section_recorded: Assessment section recorded
         requestable_requested:
           FurtherInformationRequest: Further information requested
+          ProfessionalStandingRequest: Professional standing requested
           QualificationRequest: Qualification requested
           ReferenceRequest: Reference requested
         requestable_received:
           FurtherInformationRequest: Further information received
+          ProfessionalStandingRequest: Professional standing received
           QualificationRequest: Qualification received
           ReferenceRequest: Reference received
         requestable_expired:
           FurtherInformationRequest: Further information expired
+          ProfessionalStandingRequest: Professional standing expired
           QualificationRequest: Qualification expired
           ReferenceRequest: Reference expired
         requestable_assessed:
           FurtherInformationRequest: Further information assessed
+          ProfessionalStandingRequest: Professional standing assessed
           QualificationRequest: Qualification assessed
           ReferenceRequest: Reference assessed
       description:
@@ -55,17 +59,21 @@ en:
         email_sent: "%{subject}"
         requestable_requested:
           FurtherInformationRequest: Further information has been requested.
+          ProfessionalStandingRequest: The professional standing has been requested.
           QualificationRequest: A qualification has been requested.
           ReferenceRequest: A reference has been requested.
         requestable_received:
           FurtherInformationRequest: Further information requested on %{requested_at} has been received.
+          ProfessionalStandingRequest: "The professional standing has been received: %{location_note}"
           QualificationRequest: A qualification has been received.
           ReferenceRequest: A reference has been received.
         requestable_expired:
           FurtherInformationRequest: Further information requested on %{requested_at} has expired. Application has been declined.
+          ProfessionalStandingRequest: The professional standing request has expired.
           QualificationRequest: A qualification request has expired.
           ReferenceRequest: A reference has expired.
         requestable_assessed:
           FurtherInformationRequest: Further information request has been assessed.
+          ProfessionalStandingRequest: The professional standing request has been assessed.
           QualificationRequest: A qualification has been assessed.
           ReferenceRequest: A reference has been assessed.

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -73,6 +73,9 @@ en:
           true: "Yes"
           false: "No"
         failure_assessor_note: Explain why this section is not completed to your satisfaction
+      assessor_interface_professional_standing_request_form:
+        received: The letter of professional standing has been received.
+        location_note: Where can the assessor find it?
       eligibility_interface_country_form:
         location: In which country are you currently recognised as a teacher?
       eligibility_interface_work_experience_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
                   path: "/sections",
                   param: :key,
                   only: %i[show update]
+
         resources :further_information_requests,
                   path: "/further-information-requests",
                   only: %i[new create show edit update] do
@@ -48,6 +49,10 @@ Rails.application.routes.draw do
               to: "further_information_requests#preview",
               on: :collection
         end
+
+        resource :professional_standing_request,
+                 path: "/professional-standing-request",
+                 only: %i[edit update]
       end
     end
   end

--- a/db/migrate/20230123123703_create_professional_standing_request.rb
+++ b/db/migrate/20230123123703_create_professional_standing_request.rb
@@ -1,0 +1,11 @@
+class CreateProfessionalStandingRequest < ActiveRecord::Migration[7.0]
+  def change
+    create_table :professional_standing_requests do |t|
+      t.references :assessment, null: false, foreign_key: true
+      t.string :state, null: false
+      t.datetime :received_at
+      t.text :location_note, null: false, default: ""
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -244,6 +244,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_191242) do
     t.index ["author_id"], name: "index_notes_on_author_id"
   end
 
+  create_table "professional_standing_requests", force: :cascade do |t|
+    t.bigint "assessment_id", null: false
+    t.string "state", null: false
+    t.datetime "received_at"
+    t.text "location_note", default: "", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["assessment_id"], name: "index_professional_standing_requests_on_assessment_id"
+  end
+
   create_table "qualification_requests", force: :cascade do |t|
     t.bigint "assessment_id", null: false
     t.bigint "qualification_id", null: false
@@ -468,6 +478,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_191242) do
   add_foreign_key "eligibility_checks", "regions"
   add_foreign_key "notes", "application_forms"
   add_foreign_key "notes", "staff", column: "author_id"
+  add_foreign_key "professional_standing_requests", "assessments"
   add_foreign_key "qualification_requests", "assessments"
   add_foreign_key "qualification_requests", "qualifications"
   add_foreign_key "qualifications", "application_forms"

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -33,6 +33,7 @@ namespace :example_data do
     TimelineEvent.delete_all
     DQTTRNRequest.delete_all
     ReminderEmail.delete_all
+    ProfessionalStandingRequest.delete_all
     ReferenceRequest.delete_all
     FurtherInformationRequest.delete_all
     SelectedFailureReason.delete_all
@@ -148,13 +149,21 @@ def create_application_forms(new_regs:)
       assessment = AssessmentFactory.call(application_form:)
 
       if application_form.waiting_on?
-        FactoryBot.create(
-          :further_information_request,
-          :requested,
-          :with_items,
-          assessment:,
-        )
-      elsif (work_history = assessment.application_form.work_histories.first) &&
+        if application_form.needs_written_statement && rand(2).zero?
+          FactoryBot.create(
+            :professional_standing_request,
+            :requested,
+            assessment:,
+          )
+        else
+          FactoryBot.create(
+            :further_information_request,
+            :requested,
+            :with_items,
+            assessment:,
+          )
+        end
+      elsif (work_history = application_form.work_histories.first) &&
             rand(2).zero?
         reference_request_trait = ReferenceRequest.states.keys.sample
         FactoryBot.create(

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -186,6 +186,26 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
   end
 
+  context "professional standing request requested" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_requested,
+        requestable: create(:professional_standing_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "The professional standing has been requested.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
   context "qualification request requested" do
     let(:timeline_event) do
       create(
@@ -236,6 +256,31 @@ RSpec.describe TimelineEntry::Component, type: :component do
         "Further information requested on " \
           "#{timeline_event.requestable.created_at.strftime("%e %B %Y at %l:%M %P")} has been received.",
       )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "professional standing request received" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_received,
+        requestable:
+          create(
+            :professional_standing_request,
+            location_note: "This is a note.",
+          ),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "The professional standing has been received:",
+      )
+      expect(component.text).to include("This is a note.")
     end
 
     it "attributes to the creator" do
@@ -301,6 +346,26 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
   end
 
+  context "professional standing request expired" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_expired,
+        requestable: create(:professional_standing_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "The professional standing request has expired.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
   context "qualification request expired" do
     let(:timeline_event) do
       create(
@@ -358,6 +423,26 @@ RSpec.describe TimelineEntry::Component, type: :component do
         "Further information request has been assessed.",
       )
       expect(component.text).to include("For this reason.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "professional standing request assessed" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_assessed,
+        requestable: create(:professional_standing_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "The professional standing request has been assessed.",
+      )
     end
 
     it "attributes to the creator" do

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -54,6 +54,12 @@ FactoryBot.define do
       end
     end
 
+    trait :with_professional_standing_request do
+      after(:create) do |assessment, _evaluator|
+        create(:professional_standing_request, :requested, assessment:)
+      end
+    end
+
     trait :with_reference_request do
       after(:create) do |assessment, _evaluator|
         create(

--- a/spec/factories/professional_standing_requests.rb
+++ b/spec/factories/professional_standing_requests.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: professional_standing_requests
+#
+#  id            :bigint           not null, primary key
+#  location_note :text             default(""), not null
+#  received_at   :datetime
+#  state         :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  assessment_id :bigint           not null
+#
+# Indexes
+#
+#  index_professional_standing_requests_on_assessment_id  (assessment_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#
+FactoryBot.define do
+  factory :professional_standing_request do
+    association :assessment
+
+    trait :requested do
+      state { "requested" }
+    end
+
+    trait :received do
+      state { "received" }
+      received_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
+      receivable
+    end
+
+    trait :receivable do
+      location_note { Faker::Lorem.sentence }
+    end
+  end
+end

--- a/spec/forms/assessor_interface/professional_standing_form_spec.rb
+++ b/spec/forms/assessor_interface/professional_standing_form_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::ProfessionalStandingRequestForm,
+               type: :model do
+  let(:professional_standing_request) { create(:professional_standing_request) }
+  let(:user) { create(:staff) }
+
+  let(:received) { "" }
+  let(:location_note) { "" }
+
+  subject(:form) do
+    described_class.new(
+      professional_standing_request:,
+      user:,
+      received:,
+      location_note:,
+    )
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:professional_standing_request) }
+    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to allow_values(true, false).for(:received) }
+
+    context "when received" do
+      let(:received) { "true" }
+
+      it { is_expected.to validate_presence_of(:location_note) }
+    end
+
+    context "when not received" do
+      let(:received) { "" }
+
+      it { is_expected.to_not validate_presence_of(:location_note) }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    context "when not received" do
+      let(:received) { "" }
+
+      it { is_expected.to be true }
+
+      it "doesn't change the state" do
+        expect { save }.to_not change(professional_standing_request, :state)
+      end
+
+      it "doesn't record a timeline event" do
+        expect { save }.to_not have_recorded_timeline_event(
+          :requestable_received,
+        )
+      end
+    end
+
+    context "when received" do
+      let(:received) { "true" }
+      let(:location_note) { "Note." }
+
+      it { is_expected.to be true }
+
+      it "changes the state" do
+        expect { save }.to change(professional_standing_request, :state).to(
+          "received",
+        )
+      end
+
+      it "changes the note" do
+        expect { save }.to change(
+          professional_standing_request,
+          :location_note,
+        ).to("Note.")
+      end
+
+      it "records a timeline event" do
+        expect { save }.to have_recorded_timeline_event(
+          :requestable_received,
+          creator: user,
+          requestable: professional_standing_request,
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -65,6 +65,42 @@ RSpec.describe ApplicationFormStatusUpdater do
       include_examples "changes status", "awarded_pending_checks"
     end
 
+    context "with a requested profession standing request" do
+      let(:assessment) { create(:assessment, application_form:) }
+
+      before do
+        application_form.update!(submitted_at: Time.zone.now)
+        create(:professional_standing_request, :requested, assessment:)
+      end
+
+      include_examples "changes status", "waiting_on"
+
+      it "changes waiting_on_professional_standing" do
+        expect { call }.to change(
+          application_form,
+          :waiting_on_professional_standing,
+        ).from(false).to(true)
+      end
+    end
+
+    context "with a received profession standing request" do
+      let(:assessment) { create(:assessment, application_form:) }
+
+      before do
+        application_form.update!(submitted_at: Time.zone.now)
+        create(:professional_standing_request, :received, assessment:)
+      end
+
+      include_examples "changes status", "submitted"
+
+      it "changes waiting_on_professional_standing" do
+        expect { call }.to change(
+          application_form,
+          :received_professional_standing,
+        ).from(false).to(true)
+      end
+    end
+
     context "with a received FI request" do
       let(:assessment) { create(:assessment, application_form:) }
 

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe Assessment, type: :model do
 
   describe "associations" do
     it { is_expected.to have_many(:sections) }
+    it { is_expected.to have_one(:professional_standing_request).optional }
     it { is_expected.to have_many(:further_information_requests) }
     it { is_expected.to have_many(:qualification_requests) }
   end

--- a/spec/models/professional_standing_request_spec.rb
+++ b/spec/models/professional_standing_request_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: professional_standing_requests
+#
+#  id            :bigint           not null, primary key
+#  location_note :text             default(""), not null
+#  received_at   :datetime
+#  state         :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  assessment_id :bigint           not null
+#
+# Indexes
+#
+#  index_professional_standing_requests_on_assessment_id  (assessment_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (assessment_id => assessments.id)
+#
+require "rails_helper"
+
+RSpec.describe ProfessionalStandingRequest, type: :model do
+  it_behaves_like "a requestable" do
+    subject { build(:professional_standing_request, :receivable) }
+  end
+
+  describe "associations" do
+    it { is_expected.to belong_to(:assessment) }
+  end
+
+  describe "validations" do
+    context "when received" do
+      subject { build(:professional_standing_request, :received) }
+
+      it { is_expected.to validate_presence_of(:location_note) }
+    end
+  end
+end

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -211,7 +211,12 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:requestable_type) }
       it do
         is_expected.to validate_inclusion_of(:requestable_type).in_array(
-          %w[FurtherInformationRequest ReferenceRequest],
+          %w[
+            FurtherInformationRequest
+            ProfessionalStandingRequest
+            QualificationRequest
+            ReferenceRequest
+          ],
         )
       end
     end
@@ -232,7 +237,12 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:requestable_type) }
       it do
         is_expected.to validate_inclusion_of(:requestable_type).in_array(
-          %w[FurtherInformationRequest QualificationRequest ReferenceRequest],
+          %w[
+            FurtherInformationRequest
+            ProfessionalStandingRequest
+            QualificationRequest
+            ReferenceRequest
+          ],
         )
       end
     end
@@ -253,7 +263,12 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:requestable_type) }
       it do
         is_expected.to validate_inclusion_of(:requestable_type).in_array(
-          %w[FurtherInformationRequest QualificationRequest ReferenceRequest],
+          %w[
+            FurtherInformationRequest
+            ProfessionalStandingRequest
+            QualificationRequest
+            ReferenceRequest
+          ],
         )
       end
     end
@@ -274,7 +289,12 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:requestable_type) }
       it do
         is_expected.to validate_inclusion_of(:requestable_type).in_array(
-          %w[FurtherInformationRequest QualificationRequest ReferenceRequest],
+          %w[
+            FurtherInformationRequest
+            ProfessionalStandingRequest
+            QualificationRequest
+            ReferenceRequest
+          ],
         )
       end
     end

--- a/spec/services/destroy_application_form_spec.rb
+++ b/spec/services/destroy_application_form_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe DestroyApplicationForm do
         create(
           :assessment,
           :with_further_information_request,
+          :with_professional_standing_request,
           :with_reference_request,
           :with_qualification_request,
           application_form:,
@@ -46,10 +47,11 @@ RSpec.describe DestroyApplicationForm do
   include_examples "deletes model", Document, 16, 8
   include_examples "deletes model", FurtherInformationRequest
   include_examples "deletes model", FurtherInformationRequestItem, 4, 2
-  include_examples "deletes model", ReferenceRequest
-  include_examples "deletes model", QualificationRequest
   include_examples "deletes model", Note
+  include_examples "deletes model", ProfessionalStandingRequest
   include_examples "deletes model", Qualification
+  include_examples "deletes model", QualificationRequest
+  include_examples "deletes model", ReferenceRequest
   include_examples "deletes model", Teacher
   include_examples "deletes model", TimelineEvent
   include_examples "deletes model", Upload

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -81,6 +81,50 @@ RSpec.describe SubmitApplicationForm do
     end
   end
 
+  describe "creating professional standing request" do
+    let(:assessment) { Assessment.find_by(application_form:) }
+
+    subject(:professional_standing_request) do
+      ProfessionalStandingRequest.find_by(assessment:)
+    end
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when teaching authority provides the written statement" do
+      before do
+        region.update!(teaching_authority_provides_written_statement: true)
+        call
+      end
+
+      it { is_expected.to_not be_nil }
+      it { is_expected.to be_requested }
+    end
+  end
+
+  describe "professional standing request timeline event" do
+    it "doesn't record a timeline event" do
+      expect { call }.to_not have_recorded_timeline_event(
+        :requestable_requested,
+      )
+    end
+
+    context "when teaching authority provides the written statement" do
+      before do
+        region.update!(teaching_authority_provides_written_statement: true)
+      end
+
+      it "records a timeline event" do
+        expect { call }.to have_recorded_timeline_event(:requestable_requested)
+      end
+    end
+  end
+
   describe "sending application received email" do
     it "queues an email job" do
       expect { call }.to have_enqueued_mail(

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -16,6 +16,10 @@ module PageObjects
 
       section :task_list, TaskList, ".app-task-list"
 
+      def awaiting_professional_standing_task
+        task_list.find_item("Awaiting third-party professional standing")
+      end
+
       def personal_information_task
         task_list.find_item("Check personal information")
       end

--- a/spec/support/autoload/page_objects/assessor_interface/edit_professional_standing_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/edit_professional_standing_request.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class EditProfessionalStandingRequest < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/professional-standing-request/edit"
+
+      section :form, "form" do
+        element :received_checkbox, ".govuk-checkboxes__input", visible: false
+        element :note_textarea, ".govuk-textarea"
+        element :continue_button, ".govuk-button"
+      end
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -22,6 +22,11 @@ module PageHelpers
       PageObjects::AssessorInterface::ApplicationStatus.new
   end
 
+  def assessor_edit_professional_standing_request_page
+    @assessor_edit_professional_standing_request_page ||=
+      PageObjects::AssessorInterface::EditProfessionalStandingRequest.new
+  end
+
   def applications_page
     @applications_page ||= PageObjects::AssessorInterface::Applications.new
   end

--- a/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assessor awaiting professional standing", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_an_assessor_user
+    given_there_is_an_application_form_with_professional_standing_request
+  end
+
+  it "review complete" do
+    when_i_visit_the(:assessor_application_page, application_id:)
+    and_i_see_a_waiting_on_status
+    and_i_click_awaiting_professional_standing
+    then_i_see_the(
+      :assessor_edit_professional_standing_request_page,
+      application_id:,
+    )
+
+    when_i_fill_in_the_form
+    then_i_see_the(:assessor_application_page, application_id:)
+    and_i_see_a_not_started_status
+  end
+
+  private
+
+  def given_there_is_an_application_form_with_professional_standing_request
+    application_form
+  end
+
+  def and_i_see_a_waiting_on_status
+    expect(assessor_application_page.overview.status.text).to eq("WAITING ON")
+  end
+
+  def and_i_click_awaiting_professional_standing
+    assessor_application_page.awaiting_professional_standing_task.link.click
+  end
+
+  def when_i_fill_in_the_form
+    assessor_edit_professional_standing_request_page
+      .form
+      .received_checkbox
+      .click
+    assessor_edit_professional_standing_request_page.form.note_textarea.fill_in with:
+      "Note."
+    assessor_edit_professional_standing_request_page.form.continue_button.click
+  end
+
+  def and_i_see_a_not_started_status
+    expect(assessor_application_page.overview.status.text).to eq("NOT STARTED")
+  end
+
+  def application_form
+    @application_form ||=
+      create(
+        :application_form,
+        :waiting_on,
+        assessment: create(:assessment, :with_professional_standing_request),
+      )
+  end
+
+  def application_id
+    application_form.id
+  end
+end

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -35,6 +35,18 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
 
     let(:params) { { id: application_form.id } }
 
+    describe "pre-assessment tasks" do
+      subject(:pre_assessment_tasks) { assessment_tasks[:pre_assessment_tasks] }
+
+      it { is_expected.to be_nil }
+
+      context "with a professional standing request" do
+        before { create(:professional_standing_request, assessment:) }
+
+        it { is_expected.to eq(%i[professional_standing_request]) }
+      end
+    end
+
     describe "submitted details" do
       subject(:submitted_details) { assessment_tasks.fetch(:submitted_details) }
 
@@ -91,6 +103,13 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
     let(:params) { { id: application_form.id } }
 
     let(:index) { 0 }
+
+    context "with pre-assessment tasks section" do
+      let(:section) { :pre_assessment_tasks }
+      let(:item) { :professional_standing }
+
+      it { is_expected.to be_nil }
+    end
 
     context "with submitted details section" do
       let(:section) { :submitted_details }

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -108,7 +108,12 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       let(:section) { :pre_assessment_tasks }
       let(:item) { :professional_standing }
 
-      it { is_expected.to be_nil }
+      it do
+        is_expected.to eq(
+          "/assessor/applications/#{application_form.id}" \
+            "/assessments/#{assessment.id}/professional-standing-request/edit",
+        )
+      end
     end
 
     context "with submitted details section" do


### PR DESCRIPTION
This adds a new pre-assessment task allowing assessors to review professional standing when the teaching authority provides the written statement to the TRA directly.

Depends on #1009 and #998 

[Trello Card](https://trello.com/c/4Jy6n9Ek/1392-find-a-lopless-case-and-add-lops)

## Screenshots

<img width="714" alt="Screenshot 2023-01-23 at 22 10 15" src="https://user-images.githubusercontent.com/510498/214242746-be199034-e43f-47bb-8182-edab22bd175b.png">
<img width="714" alt="Screenshot 2023-01-23 at 22 16 04" src="https://user-images.githubusercontent.com/510498/214242753-4bbe848e-c54b-4c52-9ff6-d02dea3dba57.png">

![Screenshot 2023-01-24 at 11 51 57](https://user-images.githubusercontent.com/510498/214289729-738862ba-5f06-418e-be94-684feba7775a.png)

![Screenshot 2023-01-24 at 12 08 59](https://user-images.githubusercontent.com/510498/214289733-1397c002-10e7-4d5e-98ef-5949d6385193.png)
