### PR TITLE
Minor snags

### DIFF
--- a/app/helpers/proof_of_recognition_helper.rb
+++ b/app/helpers/proof_of_recognition_helper.rb
@@ -16,7 +16,8 @@ module ProofOfRecognitionHelper
   def proof_of_recognition_description_for(region:)
     if region.teaching_authority_provides_written_statement?
       "The document must confirm:"
-    elsif !region.status_check_written? && region.sanction_check_written?
+    elsif !region.status_check_written? && region.sanction_check_written? &&
+          !region.application_form_skip_work_history?
       "In the #{region_certificate_name(region)} the #{region_teaching_authority_name(region)} must confirm " \
         "that your authorisation to teach has never been:"
     else

--- a/app/views/shared/eligible_region_content_components/_english_language.html.erb
+++ b/app/views/shared/eligible_region_content_components/_english_language.html.erb
@@ -37,7 +37,7 @@
 <% else %>
   <p class="govuk-body">Find an <a href="https://www.gov.uk/guidance/prove-your-english-language-abilities-with-a-secure-english-language-test-selt" class="govuk-link">approved provider</a> if you need to get an English language certificate.</p>
 <% end %>
-<p class="govuk-body">Learn more about <a href="https://www.coe.int/en/web/common-european-framework-reference-languages/table-1-cefr-3.3-common-reference-levels-global-scale" class="govuk-link">level B2 English language</a></p>
+<p class="govuk-body">Learn more about <a href="https://www.coe.int/en/web/common-european-framework-reference-languages/table-1-cefr-3.3-common-reference-levels-global-scale" class="govuk-link">level B2 English language</a>.</p>
 
 <%= govuk_details(summary_text: "What if you have more than one nationality?") do %>
   <p class="govuk-body">

--- a/app/views/teacher_interface/new_regs/work_histories/add_another.html.erb
+++ b/app/views/teacher_interface/new_regs/work_histories/add_another.html.erb
@@ -1,35 +1,35 @@
 <% content_for :page_title, t(".title") %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_new_regs_work_histories_path) %>
 
-<h1 class="govuk-heading-l">You’ve told us about <%= pluralize(@months_count, "month") %> of work experience so far</h1>
-
-<h2 class="govuk-heading-s">How we calculate your work experience</h2>
-
-<p class="govuk-body">We use a 30-hour working week to calculate your experience.</p>
-
-<p class="govuk-body">If you add a role where you worked <span class="govuk-!-font-weight-bold">under</span> 30 hours per week, we’ll convert the hours you enter into 30-hour weeks. That means the number of months you’ve added so far may be smaller than you expected.</p>
-
-<div class="govuk-inset-text">
-  For example, if you tell us about a role where you worked 15 hours per week for 18 months, we’ll convert this to 9 months of 30-hour weeks. We’ll then add this role to your total as 9 months.
-</div>
-
-<h3 class="govuk-heading-s">Adding more roles</h3>
-
-<p class="govuk-body">You can add as many roles as you want, but you must show at least 9 months of active teaching experience.</p>
-
-<ul class="govuk-list govuk-list--bullet">
-  <li>If you have more than 9 months but under 20, you may be awarded QTS, but you’ll need to do a 2-year period of statutory induction.</li>
-  <li>If you have more than 20 months, there’s no need to do an induction period.</li>
-</ul>
-
-<%= govuk_details(summary_text: "I do not have more than 9 months of teaching experience") do %>
-  <p class="govuk-body">QTS requires a minimum of 9 months of active teaching experience. We can keep your application open for 6 months, so you can continue later, if you gain enough experience in that time.</p>
-
-  <p class="govuk-body">Alternatively, you can <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas" class="govuk-link" rel="noreferrer noopener" target="_blank">explore other ways to teach in England (opens in new tab)</a>.</p>
-<% end %>
-
 <%= form_with model: @form, url: %i[add_another teacher_interface application_form new_regs work_histories], method: :post do |f| %>
   <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-l">You’ve told us about <%= pluralize(@months_count, "month") %> of work experience so far</h1>
+
+  <h2 class="govuk-heading-s">How we calculate your work experience</h2>
+
+  <p class="govuk-body">We use a 30-hour working week to calculate your experience.</p>
+
+  <p class="govuk-body">If you add a role where you worked <span class="govuk-!-font-weight-bold">under</span> 30 hours per week, we’ll convert the hours you enter into 30-hour weeks. That means the number of months you’ve added so far may be smaller than you expected.</p>
+
+  <div class="govuk-inset-text">
+    For example, if you tell us about a role where you worked 15 hours per week for 18 months, we’ll convert this to 9 months of 30-hour weeks. We’ll then add this role to your total as 9 months.
+  </div>
+
+  <h3 class="govuk-heading-s">Adding more roles</h3>
+
+  <p class="govuk-body">You can add as many roles as you want, but you must show at least 9 months of active teaching experience.</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>If you have more than 9 months but under 20, you may be awarded QTS, but you’ll need to do a 2-year period of statutory induction.</li>
+    <li>If you have more than 20 months, there’s no need to do an induction period.</li>
+  </ul>
+
+  <%= govuk_details(summary_text: "I do not have more than 9 months of teaching experience") do %>
+    <p class="govuk-body">QTS requires a minimum of 9 months of active teaching experience. We can keep your application open for 6 months, so you can continue later, if you gain enough experience in that time.</p>
+
+    <p class="govuk-body">Alternatively, you can <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas" class="govuk-link" rel="noreferrer noopener" target="_blank">explore other ways to teach in England (opens in new tab)</a>.</p>
+  <% end %>
 
   <%= f.govuk_collection_radio_buttons :add_another,
                                        [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -174,7 +174,7 @@ en:
         teacher_interface/add_another_work_history_form:
           attributes:
             add_another:
-              inclusion: Select whether you need to add another work history
+              inclusion: Select whether you need to add another role
         teacher_interface/delete_qualification_form:
           attributes:
             confirm:
@@ -186,7 +186,7 @@ en:
         teacher_interface/delete_work_history_form:
           attributes:
             confirm:
-              inclusion: Select whether you want to delete this work history
+              inclusion: Select whether you want to delete this role
         teacher_interface/english_language_exemption_form:
           attributes:
             exempt:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -320,11 +320,11 @@ en:
         teacher_interface/work_history_contact_form:
           attributes:
             contact_name:
-              blank: Enter the full name
+              blank: Enter this person’s full name
             contact_job:
               blank: Enter this person’s job title
             contact_email:
-              blank: Enter the email address
+              blank: Enter this person’s email address
         teacher_interface/work_history_school_form:
           attributes:
             meets_all_requirements:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -143,7 +143,7 @@ en:
         teachers/otp_form:
           attributes:
             otp:
-              blank: Enter your code
+              blank: Enter your confirmation code
               wrong_length: Enter a valid code
         teacher_interface/age_range_form:
           attributes:


### PR DESCRIPTION
Change 'the full name' to 'this person's full name' in reference information

Add 'confirmation' to OTP code message

Fix northern ireland and other 'skip work history' countries showing the wrong eligibility content

Fix add another role error message being incorrect & showing halfway down the page