### PR TITLE
Be consistent about "English language proficiency"

### DIFF
--- a/app/views/shared/_english_language_approved_providers.html.erb
+++ b/app/views/shared/_english_language_approved_providers.html.erb
@@ -1,7 +1,7 @@
 <%= govuk_details(summary_text: "About approved providers") do %>
   <p class="govuk-body">
     <% if reduced_evidence_accepted %>
-      To apply for QTS you must use an approved provider. We cannot accept English language tests from a provider that does not appear on the list.
+      To apply for QTS you must use an approved provider. We cannot accept English language proficiency tests from a provider that does not appear on the list.
     <% else %>
       To apply for QTS you need to show that you’ve passed a Secure English Language Test (SELT) at B2 level, from one of the approved providers on the list, within the last 2 years. We cannot accept English language tests from a provider that does not appear on the list.
     <% end %>

--- a/app/views/shared/application_form/_english_language_summary.html.erb
+++ b/app/views/shared/application_form/_english_language_summary.html.erb
@@ -30,7 +30,7 @@
       href: %i[provider_reference teacher_interface application_form english_language]
     } : nil,
     english_language_proficiency_document: !application_form.english_language_exempt? && application_form.english_language_proof_method_provider? && application_form.english_language_provider_other ? {
-      title: "English language proficiency test",
+      title: "English language proficiency test document",
       href: [:teacher_interface, :application_form, application_form.english_language_proficiency_document]
     } : nil,
   },

--- a/app/views/support_interface/english_language_providers/index.html.erb
+++ b/app/views/support_interface/english_language_providers/index.html.erb
@@ -1,6 +1,6 @@
-<% content_for :page_title, "English language test providers" %>
+<% content_for :page_title, "English language proficiency test providers" %>
 
-<h1 class="govuk-heading-l">English language test providers</h1>
+<h1 class="govuk-heading-l">English language proficiency test providers</h1>
 
 <% @english_language_providers.each do |english_language_provider| %>
   <article>

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -30,9 +30,9 @@
     <h1 class="govuk-heading-l">Upload the Medium of instruction (MOI) from your university degree</h1>
     <p class="govuk-body">This document must confirm that the primary language used to teach this degree course was English.</p>
   <% elsif @document.english_language_proficiency? %>
-    <h1 class="govuk-heading-l">Upload evidence of English Proficiency test</h1>
-    <p class="govuk-body">This document must confirm that you have an English Language Proficiency Test from an approved provider at level B2 of the Common European Framework of Reference for Languages (CEFR) scale.</p>
-    <p class="govuk-body">The test must be on the list of approved English language tests and awarded within the last 2 years before the date of your application.</p>
+    <h1 class="govuk-heading-l">Upload your English language proficiency test</h1>
+    <p class="govuk-body">This document must confirm that you have an English language proficiency test from an approved provider at level B2 of the Common European Framework of Reference for Languages (CEFR) scale.</p>
+    <p class="govuk-body">The test must be on the list of approved English language proficiency tests and awarded within the last 2 years before the date of your application.</p>
     <%= render "shared/english_language_approved_providers", reduced_evidence_accepted: @application_form.reduced_evidence_accepted %>
   <% elsif @document.written_statement? %>
     <span class="govuk-caption-l">Proof that you’re recognised as a teacher</span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,7 +27,7 @@ en:
       identification: identity
       name_change: name change
       medium_of_instruction: medium of instruction
-      english_language_proficiency: english proficiency test
+      english_language_proficiency: English language proficiency test
       qualification_certificate: certificate
       qualification_transcript: transcript
       qualification_document: qualification

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -26,7 +26,7 @@ en:
         proof_method: There are 2 ways you can do this.
         proof_method_options:
           medium_of_instruction: This type of official document is sometimes called a ‘Medium of instruction’ (MOI). You can get it by contacting the institution where you studied and it will need to be provided by a senior member of that institution.
-          provider: The test must have been taken within the last 2 years. We cannot accept English language tests from a provider that does not appear on the list.
+          provider: The test must have been taken within the last 2 years. We cannot accept English language proficiency tests from a provider that does not appear on the list.
       teacher_interface_further_information_request_item_text_form:
         response: Use the text box below to respond to the assessor’s question.
       teacher_interface_has_work_history_form:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -22,7 +22,7 @@ en:
           description: If your teaching qualification or university degree was taught in any of the following countries, you’re exempt from English language requirements.
           evidence: You’ll need to provide the transcript from the qualification as evidence. You can do this in the ‘Your qualifications’ section of the application form.
       edit_provider:
-        heading: Tell us about your approved English language test provider
+        heading: Tell us about your approved English language proficiency test provider
         description: We need to know which of the approved providers you used for your English language proficiency test.
       edit_provider_reference:
         heading: English language proficiency
@@ -199,8 +199,8 @@ en:
         teacher_interface/english_language_provider_form:
           attributes:
             provider_id:
-              blank: Select your approved English language test provider
-              inclusion: Select your approved English language test provider
+              blank: Select your approved English language proficiency test provider
+              inclusion: Select your approved English language proficiency test provider
         teacher_interface/english_language_provider_reference_form:
           attributes:
             reference:

--- a/spec/system/teacher_interface/english_language_spec.rb
+++ b/spec/system/teacher_interface/english_language_spec.rb
@@ -379,7 +379,7 @@ RSpec.describe "Teacher English language", type: :system do
     reference_summary_list_row =
       teacher_check_english_language_page.summary_list.rows.fifth
     expect(reference_summary_list_row.key.text).to eq(
-      "English language proficiency test",
+      "English language proficiency test document",
     )
     expect(reference_summary_list_row.value.text).to eq(
       "upload.pdf (opens in a new tab)",


### PR DESCRIPTION
This fixes various usages of the phrase "English language" to be consistent about referencing proficiency.

[Trello Card](https://trello.com/c/SYf1XEzF/436-english-language-we-should-be-consistent)