### PR TITLE
Add CONFIRM_PRODUCTION to ci make recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ ci:	## Run in automation environment
 	$(eval DISABLE_PASSCODE=true)
 	$(eval AUTO_APPROVE=-auto-approve)
 	$(eval SP_AUTH=true)
+	$(eval CONFIRM_PRODUCTION=true)
 
 tags: ##Tags that will be added to resource group on it's creation in ARM template
 	$(eval RG_TAGS=$(shell echo '{"Portfolio": "Early years and Schools Group", "Parent Business":"Teaching Regulation Agency", "Product" : "Apply for QTS in England", "Service Line": "Teaching Workforce", "Service": "Teacher Services", "Service Offering": "Apply for QTS in England", "Environment" : "$(ENV_TAG)"}' | jq . ))


### PR DESCRIPTION
A check added to the production recipe in a previous commit has broken production deployments, this change should fix that.