### PR TITLE
Add missing locale string for timeline event

### DIFF
--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -32,6 +32,7 @@ en:
         further_information_request_expired: Further information expired
         email_sent: Email sent
         age_range_subjects_verified: Age range and subjects verified
+        assessment_section_recorded: Assessment section recorded
         requestable_requested:
           FurtherInformationRequest: Further information requested
           QualificationRequest: Qualification requested


### PR DESCRIPTION
This adds a missing locale string to the assessment section recorded timeline event.

![Screenshot 2023-01-26 at 13 00 03](https://user-images.githubusercontent.com/510498/214841786-e0fcfc73-68b7-48dc-ab69-6c85652a5059.png)
