### PR TITLE
Improve work history flow

### DIFF
--- a/app/controllers/teacher_interface/new_regs/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/new_regs/work_histories_controller.rb
@@ -33,6 +33,17 @@ module TeacherInterface
                         new_regs
                         work_history
                       ]
+        elsif (
+              work_history =
+                application_form.work_histories.ordered.find(&:incomplete?)
+            )
+          redirect_to [
+                        :school,
+                        :teacher_interface,
+                        :application_form,
+                        :new_regs,
+                        work_history,
+                      ]
         else
           redirect_to %i[
                         add_another

--- a/app/lib/application_form_section_status_updater.rb
+++ b/app/lib/application_form_section_status_updater.rb
@@ -130,10 +130,7 @@ class ApplicationFormSectionStatusUpdater
   end
 
   def work_history_status
-    all_work_histories_complete =
-      work_histories.all? do |work_history|
-        work_history_complete?(work_history)
-      end
+    all_work_histories_complete = work_histories.all?(&:complete?)
 
     if work_history_feature_active?
       return :not_started if work_histories.empty?
@@ -153,30 +150,6 @@ class ApplicationFormSectionStatusUpdater
         :in_progress
       end
     end
-  end
-
-  def work_history_complete?(work_history)
-    values = [
-      work_history.school_name,
-      work_history.city,
-      work_history.country_code,
-      work_history.job,
-      work_history.contact_name,
-      work_history.contact_email,
-      work_history.start_date,
-      work_history.still_employed,
-    ]
-
-    if work_history.still_employed == false
-      values.pop
-      values.append(work_history.end_date)
-    end
-
-    if work_history_feature_active?
-      values += [work_history.hours_per_week, work_history.contact_job]
-    end
-
-    values.all?(&:present?)
   end
 
   def registration_number_status

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -51,24 +51,22 @@ class WorkHistory < ApplicationRecord
   end
 
   def complete?
-    values = [
-      school_name,
-      city,
-      country_code,
-      job,
-      contact_name,
-      contact_email,
-      start_date,
-      still_employed,
-    ]
+    values = [school_name, city, country_code, job, start_date, still_employed]
 
     if still_employed == false
       values.pop
       values.append(end_date)
     end
 
+    unless application_form.reduced_evidence_accepted?
+      values += [contact_name, contact_email]
+    end
+
     if FeatureFlags::FeatureFlag.active?(:application_work_history)
-      values += [hours_per_week, contact_job]
+      values.append(hours_per_week)
+      unless application_form.reduced_evidence_accepted?
+        values.append(contact_job)
+      end
     end
 
     values.all?(&:present?)

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -49,4 +49,32 @@ class WorkHistory < ApplicationRecord
   def country_name
     CountryName.from_code(country_code)
   end
+
+  def complete?
+    values = [
+      school_name,
+      city,
+      country_code,
+      job,
+      contact_name,
+      contact_email,
+      start_date,
+      still_employed,
+    ]
+
+    if still_employed == false
+      values.pop
+      values.append(end_date)
+    end
+
+    if FeatureFlags::FeatureFlag.active?(:application_work_history)
+      values += [hours_per_week, contact_job]
+    end
+
+    values.all?(&:present?)
+  end
+
+  def incomplete?
+    !complete?
+  end
 end

--- a/spec/models/work_history_spec.rb
+++ b/spec/models/work_history_spec.rb
@@ -73,4 +73,22 @@ RSpec.describe WorkHistory, type: :model do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe "#complete?" do
+    subject(:complete?) { work_history.complete? }
+
+    it { is_expected.to be false }
+
+    context "with a partially complete qualification" do
+      before { work_history.update!(school_name: "School name") }
+
+      it { is_expected.to be false }
+    end
+
+    context "with a complete qualification" do
+      let(:work_history) { build(:work_history, :completed) }
+
+      it { is_expected.to be true }
+    end
+  end
 end

--- a/spec/models/work_history_spec.rb
+++ b/spec/models/work_history_spec.rb
@@ -90,5 +90,30 @@ RSpec.describe WorkHistory, type: :model do
 
       it { is_expected.to be true }
     end
+
+    context "without contact information" do
+      let(:application_form) { build(:application_form) }
+
+      let(:work_history) do
+        build(
+          :work_history,
+          :completed,
+          application_form:,
+          contact_name: "",
+          contact_job: "",
+          contact_email: "",
+        )
+      end
+
+      it { is_expected.to be false }
+
+      context "with a reduced evidence application form" do
+        let(:application_form) do
+          build(:application_form, reduced_evidence_accepted: true)
+        end
+
+        it { is_expected.to be true }
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes a couple of issues with the work history flow, relating to reduced evidence countries and confusing behaviour clicking on an "in progress" task list item.

See individual commits for more details.

[Trello Card](https://trello.com/c/bmHpIzVt/1453-add-your-work-history-flow) &middot; [Trello Card](https://trello.com/c/CRoqaFxZ/1452-add-another-work-history-in-progress)