### PR TITLE
Track qualification request statuses

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -30,6 +30,7 @@
 #  qualifications_status                         :string           default("not_started"), not null
 #  received_further_information                  :boolean          default(FALSE), not null
 #  received_professional_standing                :boolean          default(FALSE), not null
+#  received_qualification                        :boolean          default(FALSE), not null
 #  received_reference                            :boolean          default(FALSE), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  reference                                     :string(31)       not null
@@ -42,6 +43,7 @@
 #  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
 #  waiting_on_further_information                :boolean          default(FALSE), not null
 #  waiting_on_professional_standing              :boolean          default(FALSE), not null
+#  waiting_on_qualification                      :boolean          default(FALSE), not null
 #  waiting_on_reference                          :boolean          default(FALSE), not null
 #  work_history_status                           :string           default("not_started"), not null
 #  working_days_since_submission                 :integer

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -31,6 +31,8 @@
     - received_further_information
     - waiting_on_reference
     - received_reference
+    - waiting_on_qualification
+    - received_qualification
     - personal_information_status
     - identification_document_status
     - qualifications_status

--- a/db/migrate/20230126214929_add_waiting_on_and_received_qualification_to_application_forms.rb
+++ b/db/migrate/20230126214929_add_waiting_on_and_received_qualification_to_application_forms.rb
@@ -1,0 +1,10 @@
+class AddWaitingOnAndReceivedQualificationToApplicationForms < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    change_table :application_forms, bulk: true do |t|
+      t.boolean :waiting_on_qualification, null: false, default: false
+      t.boolean :received_qualification, null: false, default: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_25_191242) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_26_214929) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -95,6 +95,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_25_191242) do
     t.boolean "received_further_information", default: false, null: false
     t.boolean "waiting_on_reference", default: false, null: false
     t.boolean "received_reference", default: false, null: false
+    t.boolean "waiting_on_qualification", default: false, null: false
+    t.boolean "received_qualification", default: false, null: false
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["english_language_provider_id"], name: "index_application_forms_on_english_language_provider_id"
     t.index ["family_name"], name: "index_application_forms_on_family_name"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -30,6 +30,7 @@
 #  qualifications_status                         :string           default("not_started"), not null
 #  received_further_information                  :boolean          default(FALSE), not null
 #  received_professional_standing                :boolean          default(FALSE), not null
+#  received_qualification                        :boolean          default(FALSE), not null
 #  received_reference                            :boolean          default(FALSE), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  reference                                     :string(31)       not null
@@ -42,6 +43,7 @@
 #  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
 #  waiting_on_further_information                :boolean          default(FALSE), not null
 #  waiting_on_professional_standing              :boolean          default(FALSE), not null
+#  waiting_on_qualification                      :boolean          default(FALSE), not null
 #  waiting_on_reference                          :boolean          default(FALSE), not null
 #  work_history_status                           :string           default("not_started"), not null
 #  working_days_since_submission                 :integer

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -65,6 +65,42 @@ RSpec.describe ApplicationFormStatusUpdater do
       include_examples "changes status", "awarded_pending_checks"
     end
 
+    context "with a received information request" do
+      let(:assessment) { create(:assessment, application_form:) }
+
+      before do
+        application_form.update!(submitted_at: Time.zone.now)
+        create(:further_information_request, :received, assessment:)
+      end
+
+      include_examples "changes status", "received"
+
+      it "changes received_further_information" do
+        expect { call }.to change(
+          application_form,
+          :received_further_information,
+        ).from(false).to(true)
+      end
+    end
+
+    context "with a requested further information request" do
+      let(:assessment) { create(:assessment, application_form:) }
+
+      before do
+        application_form.update!(submitted_at: Time.zone.now)
+        create(:further_information_request, :requested, assessment:)
+      end
+
+      include_examples "changes status", "waiting_on"
+
+      it "changes waiting_on_further_information" do
+        expect { call }.to change(
+          application_form,
+          :waiting_on_further_information,
+        ).from(false).to(true)
+      end
+    end
+
     context "with a requested profession standing request" do
       let(:assessment) { create(:assessment, application_form:) }
 
@@ -101,12 +137,12 @@ RSpec.describe ApplicationFormStatusUpdater do
       end
     end
 
-    context "with a received FI request" do
+    context "with a received information request" do
       let(:assessment) { create(:assessment, application_form:) }
 
       before do
         application_form.update!(submitted_at: Time.zone.now)
-        create(:further_information_request, :received, assessment:)
+        create(:qualification_request, :received, assessment:)
       end
 
       include_examples "changes status", "received"
@@ -114,25 +150,25 @@ RSpec.describe ApplicationFormStatusUpdater do
       it "changes received_further_information" do
         expect { call }.to change(
           application_form,
-          :received_further_information,
+          :received_qualification,
         ).from(false).to(true)
       end
     end
 
-    context "with a requested FI request" do
+    context "with a requested qualification request" do
       let(:assessment) { create(:assessment, application_form:) }
 
       before do
         application_form.update!(submitted_at: Time.zone.now)
-        create(:further_information_request, :requested, assessment:)
+        create(:qualification_request, :requested, assessment:)
       end
 
       include_examples "changes status", "waiting_on"
 
-      it "changes waiting_on_further_information" do
+      it "changes waiting_on_qualification" do
         expect { call }.to change(
           application_form,
-          :waiting_on_further_information,
+          :waiting_on_qualification,
         ).from(false).to(true)
       end
     end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -30,6 +30,7 @@
 #  qualifications_status                         :string           default("not_started"), not null
 #  received_further_information                  :boolean          default(FALSE), not null
 #  received_professional_standing                :boolean          default(FALSE), not null
+#  received_qualification                        :boolean          default(FALSE), not null
 #  received_reference                            :boolean          default(FALSE), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  reference                                     :string(31)       not null
@@ -42,6 +43,7 @@
 #  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
 #  waiting_on_further_information                :boolean          default(FALSE), not null
 #  waiting_on_professional_standing              :boolean          default(FALSE), not null
+#  waiting_on_qualification                      :boolean          default(FALSE), not null
 #  waiting_on_reference                          :boolean          default(FALSE), not null
 #  work_history_status                           :string           default("not_started"), not null
 #  working_days_since_submission                 :integer


### PR DESCRIPTION
This adds new `waiting_on_qualification` and `received_qualification` fields which corresponds to when an application form is waiting on or received a qualification request, to allow for filtering and analytics.