### PR TITLE
Allow marking qualification requests as received

### DIFF
--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -5,25 +5,22 @@ module AssessorInterface
     before_action :authorize_note
 
     def edit
-      @professional_standing_request_form =
-        ProfessionalStandingRequestForm.new(
-          professional_standing_request:,
+      @form =
+        RequestableLocationForm.new(
+          requestable:,
           user: current_staff,
-          received: professional_standing_request.received?,
-          location_note: professional_standing_request.location_note,
+          received: requestable.received?,
+          location_note: requestable.location_note,
         )
     end
 
     def update
-      @professional_standing_request_form =
-        ProfessionalStandingRequestForm.new(
-          professional_standing_request_form.merge(
-            professional_standing_request:,
-            user: current_staff,
-          ),
+      @form =
+        RequestableLocationForm.new(
+          requestable_location_form.merge(requestable:, user: current_staff),
         )
 
-      if @professional_standing_request_form.save
+      if @form.save
         redirect_to [:assessor_interface, application_form]
       else
         render :edit, status: :unprocessable_entity
@@ -32,10 +29,11 @@ module AssessorInterface
 
     private
 
-    def professional_standing_request_form
-      params.require(
-        :assessor_interface_professional_standing_request_form,
-      ).permit(:received, :location_note)
+    def requestable_location_form
+      params.require(:assessor_interface_requestable_location_form).permit(
+        :received,
+        :location_note,
+      )
     end
 
     def application_form
@@ -47,5 +45,7 @@ module AssessorInterface
 
     delegate :professional_standing_request, to: :assessment
     delegate :assessment, to: :application_form
+
+    alias_method :requestable, :professional_standing_request
   end
 end

--- a/app/controllers/assessor_interface/qualification_requests_controller.rb
+++ b/app/controllers/assessor_interface/qualification_requests_controller.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module AssessorInterface
+  class QualificationRequestsController < BaseController
+    before_action :authorize_note
+
+    def edit
+      @form =
+        RequestableLocationForm.new(
+          requestable:,
+          user: current_staff,
+          received: requestable.received?,
+          location_note: requestable.location_note,
+        )
+    end
+
+    def update
+      @form =
+        RequestableLocationForm.new(
+          requestable_location_form.merge(requestable:, user: current_staff),
+        )
+
+      if @form.save
+        redirect_to [:assessor_interface, application_form]
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def requestable_location_form
+      params.require(:assessor_interface_requestable_location_form).permit(
+        :received,
+        :location_note,
+      )
+    end
+
+    def qualification_request
+      @qualification_request ||=
+        QualificationRequest
+          .includes(assessment: :application_form)
+          .where(
+            assessment_id: params[:assessment_id],
+            assessment: {
+              application_form_id: params[:application_form_id],
+            },
+          )
+          .find(params[:id])
+    end
+
+    delegate :application_form, :assessment, to: :qualification_request
+
+    alias_method :requestable, :qualification_request
+  end
+end

--- a/app/forms/assessor_interface/requestable_location_form.rb
+++ b/app/forms/assessor_interface/requestable_location_form.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-class AssessorInterface::ProfessionalStandingRequestForm
+class AssessorInterface::RequestableLocationForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attr_accessor :professional_standing_request, :user
-  validates :professional_standing_request, :user, presence: true
+  attr_accessor :requestable, :user
+  validates :requestable, :user, presence: true
 
   attribute :received, :boolean
 
@@ -16,11 +16,11 @@ class AssessorInterface::ProfessionalStandingRequestForm
     return false unless valid?
 
     ActiveRecord::Base.transaction do
-      professional_standing_request.update!(location_note:)
+      requestable.update!(location_note:)
 
-      if received.present? && !professional_standing_request.received?
+      if received.present? && !requestable.received?
         receive_professional_standing
-      elsif received.blank? && professional_standing_request.received?
+      elsif received.blank? && requestable.received?
         request_professional_standing
       end
 
@@ -30,27 +30,24 @@ class AssessorInterface::ProfessionalStandingRequestForm
     true
   end
 
-  delegate :application_form, :assessment, to: :professional_standing_request
+  delegate :application_form, :assessment, to: :requestable
 
   private
 
   def receive_professional_standing
-    professional_standing_request.received!
+    requestable.received!
 
     TimelineEvent.create!(
       event_type: "requestable_received",
       application_form:,
       creator: user,
-      requestable: professional_standing_request,
+      requestable:,
     )
   end
 
   def request_professional_standing
-    professional_standing_request.requested!
+    requestable.requested!
 
-    TimelineEvent
-      .requestable_received
-      .where(requestable: professional_standing_request)
-      .destroy_all
+    TimelineEvent.requestable_received.where(requestable:).destroy_all
   end
 end

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -17,6 +17,8 @@ module Requestable
     define_method :received! do
       update!(state: "received", received_at: Time.zone.now)
     end
+
+    delegate :application_form, to: :assessment
   end
 
   def expired_at

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -27,8 +27,6 @@ class FurtherInformationRequest < ApplicationRecord
 
   has_many :reminder_emails
 
-  delegate :application_form, to: :assessment
-
   FOUR_WEEK_COUNTRY_CODES = %w[AU CA GI NZ US].freeze
 
   def failed

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -26,6 +26,4 @@ class ProfessionalStandingRequest < ApplicationRecord
   with_options if: :received? do
     validates :location_note, presence: true
   end
-
-  delegate :application_form, to: :assessment
 end

--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -32,6 +32,4 @@ class QualificationRequest < ApplicationRecord
   with_options if: :received? do
     validates :location_note, presence: true
   end
-
-  delegate :application_form, to: :assessment
 end

--- a/app/views/assessor_interface/professional_standing_requests/edit.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit.html.erb
@@ -1,7 +1,7 @@
-<% content_for :page_title, "#{"Error: " if @professional_standing_request_form.errors.any?}#{t(".title")}" %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@professional_standing_request_form.application_form) %>
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t(".title")}" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@form.application_form) %>
 
-<%= form_with model: @professional_standing_request_form, url: [:assessor_interface, @professional_standing_request_form.application_form, @professional_standing_request_form.assessment, :professional_standing_request], method: :put do |f| %>
+<%= form_with model: @form, url: [:assessor_interface, @form.application_form, @form.assessment, :professional_standing_request], method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
@@ -12,7 +12,7 @@
 
   <%= f.govuk_check_boxes_fieldset :received, multiple: false, legend: nil do %>
     <%= f.govuk_check_box :received, true, false, multiple: false, link_errors: true,
-                          label: { text: t("helpers.label.assessor_interface_professional_standing_request_form.received") } %>
+                          label: { text: t("helpers.label.assessor_interface_requestable_location_form.received.professional_standing_request") } %>
   <% end %>
 
   <%= f.govuk_text_area :location_note %>

--- a/app/views/assessor_interface/qualification_requests/edit.html.erb
+++ b/app/views/assessor_interface/qualification_requests/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t(".title")}" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@form.application_form) %>
+
+<%= form_with model: @form, url: [:assessor_interface, @form.application_form, @form.assessment, @form.requestable], method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
+
+  <p class="govuk-body">Only use this screen when the qualification has been received.</p>
+
+  <p class="govuk-body">This screen is not an assessment of the qualification, it just confirms that it has been received.</p>
+
+  <%= f.govuk_check_boxes_fieldset :received, multiple: false, legend: nil do %>
+    <%= f.govuk_check_box :received, true, false, multiple: false, link_errors: true,
+                          label: { text: t("helpers.label.assessor_interface_requestable_location_form.received.qualification_request") } %>
+  <% end %>
+
+  <%= f.govuk_text_area :location_note %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -162,6 +162,10 @@ en:
       edit:
         title: Third-party professional standing – response received
 
+    qualification_requests:
+      edit:
+        title: Qualification verification – response received
+
   activemodel:
     errors:
       models:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -264,7 +264,7 @@ en:
           attributes:
             induction_required:
               inclusion: Select whether the teacher requires induction
-        assessor_interface/professional_standing_request_form:
+        assessor_interface/requestable_location_form:
           attributes:
             location_note:
               blank: Enter where the assessor can find it

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -14,17 +14,19 @@ en:
         assessment_tasks:
           sections:
             pre_assessment_tasks: Pre-assessment tasks
-            submitted_details: Check submitted details
             recommendation: Your recommendation
+            submitted_details: Check submitted details
+            verification_requests: Verification requests
           items:
-            professional_standing_request: Awaiting third-party professional standing
-            personal_information: Check personal information
-            qualifications: Check qualifications
             age_range_subjects: Verify age range and subjects
-            work_history: Check work history
-            professional_standing: Check professional standing
             initial_assessment: Initial assessment recommendation
+            personal_information: Check personal information
+            professional_standing: Check professional standing
+            professional_standing_request: Awaiting third-party professional standing
+            qualification_request: Qualifications – requested
+            qualifications: Check qualifications
             review_requested_information: Review requested information from applicant
+            work_history: Check work history
 
     assessments:
       edit:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -76,6 +76,7 @@ en:
       assessor_interface_requestable_location_form:
         received:
           professional_standing_request: The letter of professional standing has been received.
+          qualification_request: The qualification has been received.
         location_note: Where can the assessor find it?
       eligibility_interface_country_form:
         location: In which country are you currently recognised as a teacher?

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -73,8 +73,9 @@ en:
           true: "Yes"
           false: "No"
         failure_assessor_note: Explain why this section is not completed to your satisfaction
-      assessor_interface_professional_standing_request_form:
-        received: The letter of professional standing has been received.
+      assessor_interface_requestable_location_form:
+        received:
+          professional_standing_request: The letter of professional standing has been received.
         location_note: Where can the assessor find it?
       eligibility_interface_country_form:
         location: In which country are you currently recognised as a teacher?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,10 @@ Rails.application.routes.draw do
         resource :professional_standing_request,
                  path: "/professional-standing-request",
                  only: %i[edit update]
+
+        resources :qualification_requests,
+                  path: "/qualification-requests",
+                  only: %i[edit update]
       end
     end
   end

--- a/spec/forms/assessor_interface/requestable_location_form_spec.rb
+++ b/spec/forms/assessor_interface/requestable_location_form_spec.rb
@@ -2,25 +2,19 @@
 
 require "rails_helper"
 
-RSpec.describe AssessorInterface::ProfessionalStandingRequestForm,
-               type: :model do
-  let(:professional_standing_request) { create(:professional_standing_request) }
+RSpec.describe AssessorInterface::RequestableLocationForm, type: :model do
+  let(:requestable) { create(:professional_standing_request) }
   let(:user) { create(:staff) }
 
   let(:received) { "" }
   let(:location_note) { "" }
 
   subject(:form) do
-    described_class.new(
-      professional_standing_request:,
-      user:,
-      received:,
-      location_note:,
-    )
+    described_class.new(requestable:, user:, received:, location_note:)
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:professional_standing_request) }
+    it { is_expected.to validate_presence_of(:requestable) }
     it { is_expected.to validate_presence_of(:user) }
     it { is_expected.to allow_values(true, false).for(:received) }
 
@@ -46,7 +40,7 @@ RSpec.describe AssessorInterface::ProfessionalStandingRequestForm,
       it { is_expected.to be true }
 
       it "doesn't change the state" do
-        expect { save }.to_not change(professional_standing_request, :state)
+        expect { save }.to_not change(requestable, :state)
       end
 
       it "doesn't record a timeline event" do
@@ -63,23 +57,18 @@ RSpec.describe AssessorInterface::ProfessionalStandingRequestForm,
       it { is_expected.to be true }
 
       it "changes the state" do
-        expect { save }.to change(professional_standing_request, :state).to(
-          "received",
-        )
+        expect { save }.to change(requestable, :state).to("received")
       end
 
       it "changes the note" do
-        expect { save }.to change(
-          professional_standing_request,
-          :location_note,
-        ).to("Note.")
+        expect { save }.to change(requestable, :location_note).to("Note.")
       end
 
       it "records a timeline event" do
         expect { save }.to have_recorded_timeline_event(
           :requestable_received,
           creator: user,
-          requestable: professional_standing_request,
+          requestable:,
         )
       end
     end

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -43,6 +43,10 @@ module PageObjects
       def review_requested_information_task
         task_list.find_item("Review requested information from applicant")
       end
+
+      def requested_qualifications_task
+        task_list.find_item("Qualifications – requested")
+      end
     end
   end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/edit_qualification_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/edit_qualification_request.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class EditQualificationRequest < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/qualification-requests/{id}/edit"
+
+      section :form, "form" do
+        element :received_checkbox, ".govuk-checkboxes__input", visible: false
+        element :note_textarea, ".govuk-textarea"
+        element :continue_button, ".govuk-button"
+      end
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -27,6 +27,11 @@ module PageHelpers
       PageObjects::AssessorInterface::EditProfessionalStandingRequest.new
   end
 
+  def assessor_edit_qualification_request_page
+    @assessor_edit_qualification_request_page ||=
+      PageObjects::AssessorInterface::EditQualificationRequest.new
+  end
+
   def applications_page
     @applications_page ||= PageObjects::AssessorInterface::Applications.new
   end

--- a/spec/system/assessor_interface/verifying_qualifications_spec.rb
+++ b/spec/system/assessor_interface/verifying_qualifications_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assessor verifying qualifications", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_an_assessor_user
+    given_there_is_an_application_form_with_qualification_request
+  end
+
+  it "review complete" do
+    when_i_visit_the(:assessor_application_page, application_id:)
+    and_i_see_a_waiting_on_status
+    and_i_click_qualification_requested
+    then_i_see_the(:assessor_edit_qualification_request_page, application_id:)
+
+    when_i_fill_in_the_form
+    then_i_see_the(:assessor_application_page, application_id:)
+    and_i_see_a_not_started_status
+  end
+
+  private
+
+  def given_there_is_an_application_form_with_qualification_request
+    application_form
+  end
+
+  def and_i_see_a_waiting_on_status
+    expect(assessor_application_page.overview.status.text).to eq("WAITING ON")
+  end
+
+  def and_i_click_qualification_requested
+    assessor_application_page.requested_qualifications_task.link.click
+  end
+
+  def when_i_fill_in_the_form
+    assessor_edit_qualification_request_page.form.received_checkbox.click
+    assessor_edit_qualification_request_page.form.note_textarea.fill_in with:
+      "Note."
+    assessor_edit_qualification_request_page.form.continue_button.click
+  end
+
+  def and_i_see_a_not_started_status
+    expect(assessor_application_page.overview.status.text).to eq("NOT STARTED")
+  end
+
+  def application_form
+    @application_form ||=
+      begin
+        application_form =
+          create(:application_form, :waiting_on, :with_completed_qualification)
+        create(:assessment, :with_qualification_request, application_form:)
+        application_form
+      end
+  end
+
+  def application_id
+    application_form.id
+  end
+end

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -90,6 +90,20 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
         it { is_expected.to eq([:review_requested_information]) }
       end
     end
+
+    describe "verification requests" do
+      subject(:verification_requests) do
+        assessment_tasks[:verification_requests]
+      end
+
+      it { is_expected.to be_nil }
+
+      context "with a qualification request" do
+        before { create(:qualification_request, assessment:) }
+
+        it { is_expected.to eq(%i[qualification_request]) }
+      end
+    end
   end
 
   describe "#assessment_task_path" do
@@ -160,6 +174,24 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           is_expected.to eq(
             "/assessor/applications/#{application_form.id}/assessments/#{assessment.id}" \
               "/further-information-requests/#{further_information_request.id}/edit",
+          )
+        end
+      end
+    end
+
+    context "with verification_requests section" do
+      let(:section) { :verification_requests }
+      let(:item) { :qualification_request }
+
+      context "and a qualification request" do
+        let!(:qualification_request) do
+          create(:qualification_request, :requested, assessment:)
+        end
+
+        it do
+          is_expected.to eq(
+            "/assessor/applications/#{application_form.id}/assessments/#{assessment.id}" \
+              "/qualification-requests/#{qualification_request.id}/edit",
           )
         end
       end


### PR DESCRIPTION
This implements the ability to mark a qualification request as received in a very similar way to #999. It doesn't full implement the qualification request feature as it's not been designed yet, but we know this page will be required.