### PR TITLE
Add working days from assessment started to further information created

### DIFF
--- a/app/jobs/update_working_days_job.rb
+++ b/app/jobs/update_working_days_job.rb
@@ -3,10 +3,13 @@
 class UpdateWorkingDaysJob < ApplicationJob
   def perform
     update_application_forms_since_submission
+
     update_assessments_since_started
     update_assessments_started_to_recommendation
     update_assessments_submission_to_recommendation
     update_assessments_submission_to_started
+
+    update_further_information_requests_assessment_started_to_creation
     update_further_information_requests_since_received
     update_further_information_requests_received_to_recommendation
   end
@@ -90,6 +93,22 @@ class UpdateWorkingDaysJob < ApplicationJob
             calendar.business_days_between(
               assessment.application_form.submitted_at,
               assessment.started_at,
+            ),
+        )
+      end
+  end
+
+  def update_further_information_requests_assessment_started_to_creation
+    FurtherInformationRequest
+      .joins(:assessment)
+      .includes(:assessment)
+      .where.not(assessment: { started_at: nil })
+      .find_each do |further_information_request|
+        further_information_request.update!(
+          working_days_assessment_started_to_creation:
+            calendar.business_days_between(
+              further_information_request.assessment.started_at,
+              further_information_request.created_at,
             ),
         )
       end

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -2,16 +2,17 @@
 #
 # Table name: further_information_requests
 #
-#  id                                      :bigint           not null, primary key
-#  failure_assessor_note                   :string           default(""), not null
-#  passed                                  :boolean
-#  received_at                             :datetime
-#  state                                   :string           not null
-#  working_days_received_to_recommendation :integer
-#  working_days_since_received             :integer
-#  created_at                              :datetime         not null
-#  updated_at                              :datetime         not null
-#  assessment_id                           :bigint           not null
+#  id                                          :bigint           not null, primary key
+#  failure_assessor_note                       :string           default(""), not null
+#  passed                                      :boolean
+#  received_at                                 :datetime
+#  state                                       :string           not null
+#  working_days_assessment_started_to_creation :integer
+#  working_days_received_to_recommendation     :integer
+#  working_days_since_received                 :integer
+#  created_at                                  :datetime         not null
+#  updated_at                                  :datetime         not null
+#  assessment_id                               :bigint           not null
 #
 # Indexes
 #

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -175,6 +175,7 @@
     - failure_assessor_note
     - working_days_since_received
     - working_days_received_to_recommendation
+    - working_days_assessment_started_to_creation
   :further_information_request_items:
     - id
     - information_type

--- a/db/migrate/20230127100824_add_working_days_assessment_started_to_creation_to_further_information_requests.rb
+++ b/db/migrate/20230127100824_add_working_days_assessment_started_to_creation_to_further_information_requests.rb
@@ -1,0 +1,9 @@
+class AddWorkingDaysAssessmentStartedToCreationToFurtherInformationRequests < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    add_column :further_information_requests,
+               :working_days_assessment_started_to_creation,
+               :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_26_214929) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_27_100824) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -233,6 +233,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_26_214929) do
     t.string "failure_assessor_note", default: "", null: false
     t.integer "working_days_received_to_recommendation"
     t.integer "working_days_since_received"
+    t.integer "working_days_assessment_started_to_creation"
     t.index ["assessment_id"], name: "index_further_information_requests_on_assessment_id"
   end
 

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -33,6 +33,7 @@ FactoryBot.define do
     association :application_form, :submitted
 
     trait :started do
+      started_at { Time.zone.now }
       after(:create) do |assessment, _evaluator|
         create(:assessment_section, :passed, assessment:)
       end

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -4,16 +4,17 @@
 #
 # Table name: further_information_requests
 #
-#  id                                      :bigint           not null, primary key
-#  failure_assessor_note                   :string           default(""), not null
-#  passed                                  :boolean
-#  received_at                             :datetime
-#  state                                   :string           not null
-#  working_days_received_to_recommendation :integer
-#  working_days_since_received             :integer
-#  created_at                              :datetime         not null
-#  updated_at                              :datetime         not null
-#  assessment_id                           :bigint           not null
+#  id                                          :bigint           not null, primary key
+#  failure_assessor_note                       :string           default(""), not null
+#  passed                                      :boolean
+#  received_at                                 :datetime
+#  state                                       :string           not null
+#  working_days_assessment_started_to_creation :integer
+#  working_days_received_to_recommendation     :integer
+#  working_days_since_received                 :integer
+#  created_at                                  :datetime         not null
+#  updated_at                                  :datetime         not null
+#  assessment_id                               :bigint           not null
 #
 # Indexes
 #

--- a/spec/jobs/update_working_days_job_spec.rb
+++ b/spec/jobs/update_working_days_job_spec.rb
@@ -8,9 +8,10 @@ RSpec.describe UpdateWorkingDaysJob, type: :job do
       travel_to(tuesday_today) { described_class.new.perform }
     end
 
+    let(:friday_previous) { Date.new(2022, 9, 30) }
     let(:tuesday_today) { Date.new(2022, 10, 4) }
     let(:friday_application_form) do
-      create(:application_form, :submitted, submitted_at: Date.new(2022, 9, 30))
+      create(:application_form, :submitted, submitted_at: friday_previous)
     end
     let(:not_recommended_assessment) { create(:assessment) }
 
@@ -132,6 +133,24 @@ RSpec.describe UpdateWorkingDaysJob, type: :job do
       it "sets the working days" do
         expect { perform }.to change {
           recommended_assessment.reload.working_days_submission_to_started
+        }.to(2)
+      end
+    end
+
+    describe "further information request assessment started to creation" do
+      let(:assessment) { create(:assessment, started_at: friday_previous) }
+      let(:further_information_request) do
+        create(
+          :further_information_request,
+          :received,
+          assessment:,
+          created_at: tuesday_today,
+        )
+      end
+
+      it "sets the working days" do
+        expect { perform }.to change {
+          further_information_request.reload.working_days_assessment_started_to_creation
         }.to(2)
       end
     end

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -4,16 +4,17 @@
 #
 # Table name: further_information_requests
 #
-#  id                                      :bigint           not null, primary key
-#  failure_assessor_note                   :string           default(""), not null
-#  passed                                  :boolean
-#  received_at                             :datetime
-#  state                                   :string           not null
-#  working_days_received_to_recommendation :integer
-#  working_days_since_received             :integer
-#  created_at                              :datetime         not null
-#  updated_at                              :datetime         not null
-#  assessment_id                           :bigint           not null
+#  id                                          :bigint           not null, primary key
+#  failure_assessor_note                       :string           default(""), not null
+#  passed                                      :boolean
+#  received_at                                 :datetime
+#  state                                       :string           not null
+#  working_days_assessment_started_to_creation :integer
+#  working_days_received_to_recommendation     :integer
+#  working_days_since_received                 :integer
+#  created_at                                  :datetime         not null
+#  updated_at                                  :datetime         not null
+#  assessment_id                               :bigint           not null
 #
 # Indexes
 #

--- a/spec/system/assessor_interface/verifying_qualifications_spec.rb
+++ b/spec/system/assessor_interface/verifying_qualifications_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Assessor verifying qualifications", type: :system do
   end
 
   def and_i_see_a_not_started_status
-    expect(assessor_application_page.overview.status.text).to eq("NOT STARTED")
+    expect(assessor_application_page.overview.status.text).to eq("RECEIVED")
   end
 
   def application_form


### PR DESCRIPTION
This adds a new `working_days_assessment_started_to_creation` column to further information requests to make it possible to add analytics related to how long it takes between an assessment starting and a further information request being created.