### PR TITLE
Protect against ELP section not being present

### DIFF
--- a/app/forms/concerns/assessor_interface/updates_english_language_status.rb
+++ b/app/forms/concerns/assessor_interface/updates_english_language_status.rb
@@ -18,7 +18,7 @@ module AssessorInterface::UpdatesEnglishLanguageStatus
         super.merge(
           english_language_section_passed:
             (
-              english_language_section(assessment).passed &&
+              english_language_section(assessment)&.passed &&
                 application_form.send(self::EXEMPTION_ATTR)
             ),
         )
@@ -52,7 +52,10 @@ module AssessorInterface::UpdatesEnglishLanguageStatus
     end
 
     def update_english_language_status?
-      english_language_section_passed &&
+      self
+        .class
+        .english_language_section(assessment_section.assessment)
+        .present? && english_language_section_passed &&
         application_form.send(self.class::EXEMPTION_ATTR)
     end
 


### PR DESCRIPTION
## Context

We saw Sentry errors earlier related to an application which had no associated `english_language_proficiency` assessment section.

https://sentry.io/organizations/dfe-teacher-services/issues/3905818985/?project=6426061

## Changes

Protect against the case where no ELP assessment section is present, we shouldn't attempt to make updates.