### PR TITLE
[Bug] Restrict additional ELP content to relevant section

### DIFF
--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -80,6 +80,16 @@ module AssessorInterface
         application_form.english_language_exempt?
     end
 
+    def show_english_language_provider_details?
+      assessment_section.english_language_proficiency? &&
+        application_form.english_language_proof_method_provider?
+    end
+
+    def show_english_language_moi_details?
+      assessment_section.english_language_proficiency? &&
+        application_form.english_language_proof_method_medium_of_instruction?
+    end
+
     private
 
     attr_reader :params

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -117,10 +117,10 @@
 
     <% end %>
 
-    <% if @assessment_section_view_object.application_form.english_language_proof_method_medium_of_instruction? %>
+    <% if @assessment_section_view_object.show_english_language_moi_details? %>
       <%= render "english_language_moi_country_details" %>
     <% end %>
-    <% if @assessment_section_view_object.application_form.english_language_proof_method_provider? %>
+    <% if @assessment_section_view_object.show_english_language_provider_details? %>
       <%= render "english_language_provider_details", provider:  @assessment_section_view_object.application_form.english_language_provider %>
     <% end %>
 

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -218,4 +218,98 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
       it { is_expected.to be true }
     end
   end
+
+  describe "show_english_language_moi_details?" do
+    let(:params) do
+      {
+        key:,
+        assessment_id: assessment.id,
+        application_form_id: application_form.id,
+      }
+    end
+
+    subject(:show_english_language_moi_details?) do
+      view_object.show_english_language_moi_details?
+    end
+
+    context "when the application EL proof method is 'medium_of_instruction'" do
+      let(:key) { "english_language_proficiency" }
+      let(:application_form) do
+        create(:application_form, :with_english_language_medium_of_instruction)
+      end
+      let(:assessment_section) do
+        create(:assessment_section, :english_language_proficiency, assessment:)
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when the application EL proof method is not 'medium_of_instruction'" do
+      let(:key) { "english_language_proficiency" }
+      let(:application_form) do
+        create(:application_form, :with_english_language_provider)
+      end
+      let(:assessment_section) do
+        create(:assessment_section, :english_language_proficiency, assessment:)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when the section is not 'english_language_proficiency'" do
+      let(:key) { "personal_information" }
+      let(:assessment_section) do
+        create(:assessment_section, :personal_information, assessment:)
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "show_english_language_provider_details?" do
+    let(:params) do
+      {
+        key:,
+        assessment_id: assessment.id,
+        application_form_id: application_form.id,
+      }
+    end
+
+    subject(:show_english_language_provider_details?) do
+      view_object.show_english_language_provider_details?
+    end
+
+    context "when the application EL proof method is 'provider'" do
+      let(:key) { "english_language_proficiency" }
+      let(:application_form) do
+        create(:application_form, :with_english_language_provider)
+      end
+      let(:assessment_section) do
+        create(:assessment_section, :english_language_proficiency, assessment:)
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when the application EL proof method is not 'provider'" do
+      let(:key) { "english_language_proficiency" }
+      let(:application_form) do
+        create(:application_form, :with_english_language_medium_of_instruction)
+      end
+      let(:assessment_section) do
+        create(:assessment_section, :english_language_proficiency, assessment:)
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when the section is not 'english_language_proficiency'" do
+      let(:key) { "personal_information" }
+      let(:assessment_section) do
+        create(:assessment_section, :personal_information, assessment:)
+      end
+
+      it { is_expected.to be false }
+    end
+  end
 end


### PR DESCRIPTION
When an application has an EL proof method of `provider` or `medium_of_instruction` we display additional details which should only be presented in the English language proficiency section in these two cases.