### PR TITLE
Ensure we associate example applications with providers from seed data

### DIFF
--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -256,7 +256,9 @@ FactoryBot.define do
 
     trait :with_english_language_provider do
       english_language_proof_method { "provider" }
-      association :english_language_provider
+      english_language_provider do
+        EnglishLanguageProvider.all.sample || create(:english_language_provider)
+      end
       english_language_provider_reference { "reference" }
     end
 


### PR DESCRIPTION
This will make sure we only use the providers from seed data when generating example data instead of creating dummy providers.