### PR TITLE
Allow customising English language provider check URLs

### DIFF
--- a/app/controllers/support_interface/english_language_providers_controller.rb
+++ b/app/controllers/support_interface/english_language_providers_controller.rb
@@ -31,6 +31,7 @@ class SupportInterface::EnglishLanguageProvidersController < SupportInterface::B
       :b2_level_requirement,
       :reference_name,
       :reference_hint,
+      :check_url,
     )
   end
 end

--- a/app/models/english_language_provider.rb
+++ b/app/models/english_language_provider.rb
@@ -6,6 +6,7 @@
 #
 #  id                   :bigint           not null, primary key
 #  b2_level_requirement :text             not null
+#  check_url            :string
 #  name                 :string           not null
 #  reference_hint       :text             not null
 #  reference_name       :string           not null
@@ -17,4 +18,5 @@ class EnglishLanguageProvider < ApplicationRecord
   validates :b2_level_requirement, presence: true
   validates :reference_name, presence: true
   validates :reference_hint, presence: true
+  validates :check_url, url: true, allow_blank: true
 end

--- a/app/views/assessor_interface/assessment_sections/_english_language_provider_details.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_english_language_provider_details.html.erb
@@ -4,15 +4,9 @@
       For <%= provider.name %>, B2 level requires <%= provider.b2_level_requirement %> in all 4 disciplines (reading, writing, listening and speaking).
     </p>
 
-    <% if I18n.exists?("assessor_interface.assessment_sections.show.providers.#{provider.name.parameterize}.check_url", :en) %>
+    <% if provider.check_url.present? %>
       <p class="govuk-body">Check the applicant's <%= provider.reference_name %> at:</p>
-
-      <p class="govuk-body">
-        <%= govuk_link_to(
-          t("assessor_interface.assessment_sections.show.providers.#{provider.name.parameterize}.check_url"),
-          t("assessor_interface.assessment_sections.show.providers.#{provider.name.parameterize}.check_url")
-        ) %>
-      </p>
+      <p class="govuk-body"><%= govuk_link_to provider.check_url, provider.check_url %></p>
     <% end %>
   <% else %>
     <p class="govuk-body">

--- a/app/views/support_interface/english_language_providers/edit.html.erb
+++ b/app/views/support_interface/english_language_providers/edit.html.erb
@@ -10,6 +10,7 @@
   <%= f.govuk_text_field :b2_level_requirement %>
   <%= f.govuk_text_field :reference_name %>
   <%= f.govuk_text_field :reference_hint %>
+  <%= f.govuk_url_field :check_url %>
 
   <%= f.govuk_submit "Save" %>
 <% end %>

--- a/app/views/support_interface/english_language_providers/index.html.erb
+++ b/app/views/support_interface/english_language_providers/index.html.erb
@@ -8,18 +8,23 @@
 
     <%= govuk_summary_list(actions: false) do |summary_list|
       summary_list.row do |row|
-        row.key { "B2 level requirement" }
+        row.key { t("helpers.label.english_language_provider.b2_level_requirement") }
         row.value { english_language_provider.b2_level_requirement }
       end
 
       summary_list.row do |row|
-        row.key { "Reference name" }
+        row.key { t("helpers.label.english_language_provider.reference_name") }
         row.value { english_language_provider.reference_name }
       end
 
       summary_list.row do |row|
-        row.key { "Reference hint" }
+        row.key { t("helpers.label.english_language_provider.reference_hint") }
         row.value { english_language_provider.reference_hint }
+      end
+
+      summary_list.row do |row|
+        row.key { t("helpers.label.english_language_provider.check_url") }
+        row.value { english_language_provider.check_url }
       end
     end %>
   </article>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -156,6 +156,7 @@
     - b2_level_requirement
     - reference_name
     - reference_hint
+    - check_url
     - created_at
     - updated_at
   :feature_flags_features:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -176,17 +176,6 @@ en:
             english_language_section_passed: This application has indicated English language exemption by birth/citizenship and their ID confirms this.
           qualifications:
             english_language_section_passed: This application has indicated English language exemption by qualification and their qualifications confirm this.
-        providers:
-          ielts-selt-consortium:
-            check_url: https://ielts.ucles.org.uk/ielts-trf/welcome.html
-          languagecert:
-            check_url: https://www.languagecert.org/en/results
-          pearson:
-            check_url: https://srw.pteacademic.com/
-          psi-services-uk-ltd:
-            check_url: https://results.bookmyskillsforenglish.com/
-          trinity-college-london:
-            check_url: https://trinitycollege.com/TRV
 
     further_information_requests:
       edit:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -91,6 +91,7 @@ en:
         b2_level_requirement: B2 level requirement
         reference_name: Reference name
         reference_hint: Reference hint
+        check_url: Check website
       qualification:
         add_another_options:
           true: "Yes"

--- a/db/migrate/20230131094854_add_check_url_to_english_language_providers.rb
+++ b/db/migrate/20230131094854_add_check_url_to_english_language_providers.rb
@@ -1,0 +1,5 @@
+class AddCheckUrlToEnglishLanguageProviders < ActiveRecord::Migration[7.0]
+  def change
+    add_column :english_language_providers, :check_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_27_100824) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_31_094854) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -202,6 +202,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_27_100824) do
     t.text "reference_hint", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "check_url"
   end
 
   create_table "feature_flags_features", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -295,6 +295,7 @@ ENGLISH_LANGUAGE_PROVIDERS = [
     b2_level_requirement: "a score of at least 5.5",
     reference_name: "Test Report Form Number",
     reference_hint: "Your Test Report Form Number is 15-18 digits long.",
+    check_url: "https://ielts.ucles.org.uk/ielts-trf/welcome.html",
   },
   {
     name: "LanguageCert",
@@ -303,6 +304,7 @@ ENGLISH_LANGUAGE_PROVIDERS = [
     reference_hint:
       "Your Unique Reference Number contains numbers, letters and dashes " \
         "in this format: PPC/230619/04501/09980013402512496",
+    check_url: "https://www.languagecert.org/en/results",
   },
   {
     name: "Pearson",
@@ -311,6 +313,7 @@ ENGLISH_LANGUAGE_PROVIDERS = [
     reference_hint:
       "Your Score Report Code is 10 characters long. It may contain both letters " \
         "and numbers, or just numbers.",
+    check_url: "https://srw.pteacademic.com/",
   },
   {
     name: "PSI Services (UK) Ltd",
@@ -319,6 +322,7 @@ ENGLISH_LANGUAGE_PROVIDERS = [
     reference_hint:
       "Your PSI Services (UK) Ltd Unique Reference Number contains numbers, " \
         "letters and dashes in this format: PSI/280920/YTLQVG2Z/W2N4UVNN",
+    check_url: "https://results.bookmyskillsforenglish.com/",
   },
   {
     name: "Trinity College London",
@@ -327,6 +331,7 @@ ENGLISH_LANGUAGE_PROVIDERS = [
     reference_hint:
       "Your Trinity College London Certificate Number contains numbers, letters " \
         "and special characters in this format: 1-630439614:1-123456780",
+    check_url: "https://trinitycollege.com/TRV",
   },
 ].freeze
 

--- a/spec/factories/english_language_providers.rb
+++ b/spec/factories/english_language_providers.rb
@@ -6,6 +6,7 @@
 #
 #  id                   :bigint           not null, primary key
 #  b2_level_requirement :text             not null
+#  check_url            :string
 #  name                 :string           not null
 #  reference_hint       :text             not null
 #  reference_name       :string           not null
@@ -18,5 +19,6 @@ FactoryBot.define do
     b2_level_requirement { Faker::Lorem.sentence }
     reference_name { Faker::Lorem.word }
     reference_hint { Faker::Lorem.sentence }
+    check_url { Faker::Internet.url }
   end
 end

--- a/spec/models/english_language_provider_spec.rb
+++ b/spec/models/english_language_provider_spec.rb
@@ -6,6 +6,7 @@
 #
 #  id                   :bigint           not null, primary key
 #  b2_level_requirement :text             not null
+#  check_url            :string
 #  name                 :string           not null
 #  reference_hint       :text             not null
 #  reference_name       :string           not null
@@ -23,5 +24,6 @@ RSpec.describe EnglishLanguageProvider, type: :model do
     it { is_expected.to validate_presence_of(:b2_level_requirement) }
     it { is_expected.to validate_presence_of(:reference_name) }
     it { is_expected.to validate_presence_of(:reference_hint) }
+    it { is_expected.to validate_url_of(:check_url) }
   end
 end

--- a/spec/support/autoload/page_objects/support_interface/edit_english_language_provider.rb
+++ b/spec/support/autoload/page_objects/support_interface/edit_english_language_provider.rb
@@ -13,6 +13,7 @@ module PageObjects
                 "#english-language-provider-reference-name-field"
         element :reference_hint_field,
                 "#english-language-provider-reference-hint-field"
+        element :check_url, "#english-language-provider-check-url-field"
         element :submit_button, ".govuk-button"
       end
     end


### PR DESCRIPTION
This adds the ability for the check URLs for English language providers to be customised using the support console so we don't need to hard code the values in the locale strings.