### PR TITLE
Remove content about age 11-16

### DIFF
--- a/app/views/shared/eligible_region_content_components/_proof_of_work_history.html.erb
+++ b/app/views/shared/eligible_region_content_components/_proof_of_work_history.html.erb
@@ -7,12 +7,7 @@
 <% end %>
 
 <ul class="govuk-list govuk-list--bullet">
-  <% if eligibility_check&.qualified_for_subject_required? %>
-    <li>worked unsupervised with children aged between 11 and 16 years</li>
-  <% else %>
-    <li>worked unsupervised with children aged between 5 and 16 years</li>
-  <% end %>
-
+  <li>worked unsupervised with children aged between 5 and 16 years</li>
   <li>were solely responsible for planning, preparing and delivering lessons to at least 4 students at a time</li>
   <li>were solely responsible for assessing and reporting on the progress of those students</li>
 </ul>


### PR DESCRIPTION
The applicant must be qualified to teach between ages 11 to 16 but in their work history they may have taught anyone between the ages of 5 and 16.

[Trello Card](https://trello.com/c/QdZ1bUyh/1470-checker-eligible-page-7-restricted-countries-work-history-bullet)