### PR TITLE
Add missing qualification for subject error message

### DIFF
--- a/config/locales/eligibility_interface.en.yml
+++ b/config/locales/eligibility_interface.en.yml
@@ -30,6 +30,10 @@ en:
           attributes:
             teach_children:
               inclusion: Tell us whether you’re qualified to teach children aged between 5 and 16
+        eligibility_interface/qualified_for_subject_form:
+          attributes:
+            qualified_for_subject:
+              inclusion: Tell us whether you’re qualified to teach one of these subjects
         eligibility_interface/work_experience_form:
           attributes:
             work_experience:


### PR DESCRIPTION
## Trello

https://trello.com/c/Uc3Jm8TE/1471-eligibility-checker-qualification-subjects-form-missing-validation-error-message

## Changes

![image](https://user-images.githubusercontent.com/93511/215750768-803cb58c-27e7-45e2-8439-8b80f6dfdb7d.png)

Adds form error message for missing qualfication for subject answer.