### PR TITLE
Add reference request business rules

### DIFF
--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -56,4 +56,8 @@ class Region < ApplicationRecord
   validates :status_check, inclusion: { in: status_checks.values }
 
   validates :teaching_authority_online_checker_url, url: { allow_blank: true }
+
+  def checks_available?
+    !sanction_check_none? && !status_check_none?
+  end
 end

--- a/spec/services/submit_reference_request_spec.rb
+++ b/spec/services/submit_reference_request_spec.rb
@@ -30,8 +30,10 @@ RSpec.describe SubmitReferenceRequest do
     )
   end
 
-  it "changes the application form state to received" do
-    expect { call }.to change(application_form, :received?).from(false).to(true)
+  it "changes the application form reference received" do
+    expect { call }.to change(application_form, :received_reference).from(
+      false,
+    ).to(true)
   end
 
   it "changes the reference request received at" do
@@ -46,15 +48,6 @@ RSpec.describe SubmitReferenceRequest do
     expect { call }.to have_recorded_timeline_event(
       :requestable_received,
       requestable: reference_request,
-    )
-  end
-
-  it "records a state changed timeline event" do
-    expect { call }.to have_recorded_timeline_event(
-      :state_changed,
-      creator_name: user,
-      old_state: "submitted",
-      new_state: "received",
     )
   end
 end


### PR DESCRIPTION
This adds the logic related to when an application form is considered to be ready for an assessor to review after receiving a response to a reference request. Specifically, we allow the assessor to start reviewing if we've received more than 20 months, or if there are no more references to request.

[Trello Card](https://trello.com/c/K7NgGBN0/1405-returned-references-trigger-received-status)