### PR TITLE
Render relevant exemption checkbox in the correct section

### DIFF
--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -90,6 +90,17 @@ module AssessorInterface
         application_form.english_language_proof_method_medium_of_instruction?
     end
 
+    def show_english_language_exemption_checkbox?
+      (
+        application_form.english_language_citizenship_exempt == true &&
+          assessment_section.personal_information?
+      ) ||
+        (
+          application_form.english_language_qualification_exempt == true &&
+            assessment_section.qualifications?
+        )
+    end
+
     private
 
     attr_reader :params

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -101,7 +101,7 @@
 
     <%= f.govuk_error_summary %>
 
-    <% if @assessment_section_form.class.include?(AssessorInterface::UpdatesEnglishLanguageStatus) %>
+    <% if @assessment_section_view_object.show_english_language_exemption_checkbox? %>
       <%= f.govuk_check_box(
         :english_language_section_passed,
         true,
@@ -114,7 +114,6 @@
           size: "s",
         }
       ) %>
-
     <% end %>
 
     <% if @assessment_section_view_object.show_english_language_moi_details? %>

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -312,4 +312,72 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
       it { is_expected.to be false }
     end
   end
+
+  describe "#show_english_language_exemption_checkbox?" do
+    let(:params) do
+      {
+        key:,
+        assessment_id: assessment.id,
+        application_form_id: application_form.id,
+      }
+    end
+
+    subject(:show_english_language_exemption_checkbox?) do
+      view_object.show_english_language_exemption_checkbox?
+    end
+
+    before { create(:assessment_section, :qualifications, assessment:) }
+
+    context "when the section is personal information" do
+      let(:key) { "personal_information" }
+
+      context "with exemption by citizenship" do
+        let(:application_form) do
+          create(
+            :application_form,
+            :with_english_language_exemption_by_citizenship,
+          )
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context "with exemption by country of study" do
+        let(:application_form) do
+          create(
+            :application_form,
+            :with_english_language_exemption_by_qualification,
+          )
+        end
+
+        it { is_expected.to be false }
+      end
+    end
+
+    context "when the section is qualifications" do
+      let(:key) { "qualifications" }
+
+      context "with exemption by citizenship" do
+        let(:application_form) do
+          create(
+            :application_form,
+            :with_english_language_exemption_by_citizenship,
+          )
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context "with exemption by country of study" do
+        let(:application_form) do
+          create(
+            :application_form,
+            :with_english_language_exemption_by_qualification,
+          )
+        end
+
+        it { is_expected.to be true }
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Trello

https://trello.com/c/dGyjVbq9/1473-case-management-elp-showing-both-exemption-checkboxes-in-single-application

## Context

We should only show the English language proficiency confirmation checkbox in the personal information section when the applicant has indicated exemption by citizenship.

Likewise we should only show the checkbox in the qualifications section when they have indicated exemption by country of study.

Previously showing on both sections regardless of the exemption reason.

## Changes

Restrict rendering the checkbox depending on section and exemption reason.