### PR TITLE
Small fixes to English language failure reasons

### DIFF
--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -14,10 +14,8 @@ class FailureReasons
     EL_GRADE_BELOW_B2 = "english_language_not_achieved_b2",
     EL_MOI_NOT_TAUGHT_IN_ENGLISH = "english_language_moi_not_taught_in_english",
     EL_QUALIFICATION_INVALID = "english_language_qualification_invalid",
-    "english_language_unverifiable_reference_number",
     EL_SELT_EXPIRED = "english_language_selt_expired",
-    EL_UNVERIFIABLE_REFERENCE_NUMBER =
-      FULL_PROFESSIONAL_STATUS = "full_professional_status",
+    FULL_PROFESSIONAL_STATUS = "full_professional_status",
     NOT_QUALIFIED_TO_TEACH_MAINSTREAM = "not_qualified_to_teach_mainstream",
     QUALIFIED_TO_TEACH_CHILDREN_11_TO_16 =
       "qualified_to_teach_children_11_to_16",
@@ -44,6 +42,8 @@ class FailureReasons
     DEGREE_CERTIFICATE_ILLEGIBLE = "degree_certificate_illegible",
     DEGREE_TRANSCRIPT_ILLEGIBLE = "degree_transcript_illegible",
     EL_MOI_INVALID_FORMAT = "english_language_moi_invalid_format",
+    EL_UNVERIFIABLE_REFERENCE_NUMBER =
+      "english_language_unverifiable_reference_number",
     IDENTIFICATION_DOCUMENT_EXPIRED = "identification_document_expired",
     IDENTIFICATION_DOCUMENT_ILLEGIBLE = "identification_document_illegible",
     IDENTIFICATION_DOCUMENT_MISMATCH = "identification_document_mismatch",
@@ -70,6 +70,7 @@ class FailureReasons
     APPLICATION_AND_QUALIFICATION_NAMES_DO_NOT_MATCH => :name_change,
     DEGREE_CERTIFICATE_ILLEGIBLE => :qualification_certificate,
     DEGREE_TRANSCRIPT_ILLEGIBLE => :qualification_transcript,
+    EL_MOI_INVALID_FORMAT => :medium_of_instruction,
     IDENTIFICATION_DOCUMENT_EXPIRED => :identification,
     IDENTIFICATION_DOCUMENT_ILLEGIBLE => :identification,
     IDENTIFICATION_DOCUMENT_MISMATCH => :name_change,

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -31,6 +31,7 @@ en:
         failure_reason:
           age_range: Tell us more about the age range you can teach
           applicant_already_dqt: Additional personal information
+          english_language_unverifiable_reference_number: Tell us more about your English language proficiency
           qualifications_dont_match_other_details: Tell us more about your qualifications
           qualifications_dont_match_subjects: Tell us more about the subjects you can teach
           registration_number: Tell us your registration number


### PR DESCRIPTION
This makes a couple of small fixes to the English language failure reasons. It fixes a bug where the full status failure reason was showing instead of an unverifiable reference, and adds some content to the teacher interface.