### PR TITLE
Open English language provider links in new tabs

### DIFF
--- a/app/views/assessor_interface/assessment_sections/_english_language_provider_details.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_english_language_provider_details.html.erb
@@ -6,7 +6,7 @@
 
     <% if provider.check_url.present? %>
       <p class="govuk-body">Check the applicant's <%= provider.reference_name %> at:</p>
-      <p class="govuk-body"><%= govuk_link_to provider.check_url, provider.check_url %></p>
+      <p class="govuk-body"><%= govuk_link_to provider.check_url, provider.check_url, target: "_blank", rel: "noreferrer noopener" %></p>
     <% end %>
   <% else %>
     <p class="govuk-body">

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -81,7 +81,7 @@
     <% if (online_checker_url = @assessment_section_view_object.online_checker_url).present? %>
       <% accordion.section(heading_text: "Online checker") do %>
         <p class="govuk-body">This authority has an online checker for validating the supplied reference number:</p>
-        <p class="govuk-body"><%= govuk_link_to online_checker_url, online_checker_url, target: "_blank" %></p>
+        <p class="govuk-body"><%= govuk_link_to online_checker_url, online_checker_url, target: "_blank", rel: "noreferrer noopener" %></p>
       <% end %>
     <% end %>
 


### PR DESCRIPTION
This changes the link to the English language provider check website so it opens in a new tab, useful so assessors don't lose where they are in the assessment.

[Trello Card](https://trello.com/c/5Mzz29po/1483-elp-test-provider-web-pages-should-open-in-a-new-tab)