### PR TITLE
Update assessment section recorded tag

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -23,12 +23,12 @@
     <% elsif timeline_event.assessment_section_recorded? %>
       <p class="govuk-body">
         <%= description_vars[:section_name] %>:
-        <%= render(StatusTag::Component.new(
-          key: timeline_event.id,
-          status: description_vars[:section_state],
-          class_context: "timeline-event",
-          context: :assessor,
-          )) %>
+
+        <% if description_vars[:passed] %>
+          <%= govuk_tag(text: "Passed", colour: "green") %>
+        <% else %>
+          <%= govuk_tag(text: "Not passed", colour: "red") %>
+        <% end %>
       </p>
 
       <%= govuk_inset_text do %>

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -78,7 +78,7 @@ module TimelineEntry
       section = timeline_event.assessment_section
       {
         section_name: section.key.titleize,
-        section_state: timeline_event.new_state,
+        passed: section.passed,
         failure_reasons: section.selected_failure_reasons,
       }
     end

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -96,7 +96,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
 
     it "describes the event" do
       expect(component.text).to include("Personal Information:")
-      expect(component.text).to include("Completed")
+      expect(component.text).to include("Not passed")
       expect(component.text).to include(expected_failure_reason_text)
       expect(component.text).to include(failure_reason.assessor_feedback)
     end

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -162,6 +162,10 @@ FactoryBot.define do
       submitted_at { Time.zone.now }
     end
 
+    trait :old_regs do
+      created_at { Date.new(2023, 1, 31) }
+    end
+
     trait :new_regs do
       created_at { Date.new(2023, 2, 1) }
       needs_work_history { !region.application_form_skip_work_history }

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe AssessmentFactory do
   let(:application_form) do
     create(
       :application_form,
+      :old_regs,
       needs_work_history: false,
       needs_written_statement: false,
       needs_registration_number: false,
@@ -165,6 +166,7 @@ RSpec.describe AssessmentFactory do
           let(:application_form) do
             create(
               :application_form,
+              :old_regs,
               region: create(:region, :in_country, country_code: "SG"),
             )
           end

--- a/spec/services/further_information_request_expirer_spec.rb
+++ b/spec/services/further_information_request_expirer_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe FurtherInformationRequestExpirer do
       end
 
       context "when the applicant is from a country with a 4 week expiry" do
+        let(:application_form) do
+          create(:application_form, :submitted, :old_regs, region:)
+        end
+
         # Australia, Canada, Gibraltar, New Zealand, US
         %w[AU CA GI NZ US].each do |country_code|
           context "from country_code #{country_code}" do

--- a/spec/services/further_information_request_reminder_spec.rb
+++ b/spec/services/further_information_request_reminder_spec.rb
@@ -134,7 +134,9 @@ RSpec.describe FurtherInformationRequestReminder do
     end
 
     context "with a requested FI request" do
-      let(:application_form) { create(:application_form, :submitted, region:) }
+      let(:application_form) do
+        create(:application_form, :submitted, :old_regs, region:)
+      end
       let(:assessment) { create(:assessment, application_form:) }
       let(:region) { create(:region, :in_country, country_code: "FR") }
       let(:teacher) { application_form.teacher }

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
     @application_form ||=
       create(
         :application_form,
+        :old_regs,
         :with_personal_information,
         :with_completed_qualification,
         :submitted,

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -206,16 +206,6 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the(:qualification_page)
   end
 
-  it "sends legacy users to the old service" do
-    when_i_visit_the(:start_page)
-    when_i_press_start_now
-    when_i_select_a_legacy_country
-    then_i_see_the(:eligible_page)
-
-    when_i_press_apply
-    then_i_see_the_legacy_service
-  end
-
   it "can skip questions with qualification" do
     when_i_visit_the(:start_page)
     when_i_press_start_now
@@ -522,10 +512,6 @@ RSpec.describe "Eligibility check", type: :system do
 
   def when_i_press_apply
     eligible_page.apply_button.click
-  end
-
-  def then_i_see_the_legacy_service
-    expect(page).to have_current_path("/MutualRecognition/")
   end
 
   def and_i_see_the_ineligible_country_text

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -130,7 +130,13 @@ RSpec.describe "Teacher reference", type: :system do
   end
 
   def reference_request
-    @reference_request ||= create(:reference_request, :requested)
+    @reference_request ||=
+      create(
+        :reference_request,
+        :requested,
+        work_history:
+          create(:work_history, :completed, end_date: Date.new(2023, 1, 1)),
+      )
   end
 
   delegate :slug, to: :reference_request


### PR DESCRIPTION
This changes the tag that's shown on the assessment section timeline entry component as it will always show "Completed" so it's more useful to show whether the section was a pass or a fail.

See https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/998 for more background on the new status tags.

[Trello Card](https://trello.com/c/xbfT9gw0/1488-event-tags-in-case-notes-have-gone-funny)