### PR TITLE
Ensure we send a boolean value as written statement confirmation

### DIFF
--- a/app/controllers/teacher_interface/written_statements_controller.rb
+++ b/app/controllers/teacher_interface/written_statements_controller.rb
@@ -20,19 +20,15 @@ module TeacherInterface
     def update
       @form =
         WrittenStatementConfirmationForm.new(
-          written_statement_confirmation_form_params.merge(application_form:),
+          application_form:,
+          written_statement_confirmation:
+            params.dig(
+              :teacher_interface_written_statement_confirmation_form,
+              :written_statement_confirmation,
+            ),
         )
 
       handle_application_form_section(form: @form)
-    end
-
-    private
-
-    def written_statement_confirmation_form_params
-      params.fetch(
-        :teacher_interface_written_statement_confirmation_form,
-        {},
-      ).permit(:written_statement_confirmation)
     end
   end
 end

--- a/app/forms/teacher_interface/written_statement_confirmation_form.rb
+++ b/app/forms/teacher_interface/written_statement_confirmation_form.rb
@@ -3,7 +3,7 @@
 module TeacherInterface
   class WrittenStatementConfirmationForm < BaseForm
     attr_accessor :application_form
-    attribute :written_statement_confirmation
+    attribute :written_statement_confirmation, :boolean
 
     validates :application_form, presence: true
     validates :written_statement_confirmation, presence: true

--- a/app/views/teacher_interface/written_statements/edit.html.erb
+++ b/app/views/teacher_interface/written_statements/edit.html.erb
@@ -15,11 +15,10 @@
     Check the box below to confirm you understand that it’s your responsibility to request this document.
   </p>
 
-  <%= f.govuk_check_boxes_fieldset :written_statement_confirmation, legend: nil, small: true do %>
+  <%= f.govuk_check_boxes_fieldset :written_statement_confirmation, multiple: false, legend: nil, small: true do %>
     <%= f.govuk_check_box :written_statement_confirmation,
                           true,
                           false,
-                          multiple: false,
                           link_errors: true,
                           label: {
                             text: "I understand that it’s my responsibility to request written evidence from #{region_teaching_authority_name_phrase(@application_form.region)} to be sent directly to #{govuk_link_to t("service.email.verification"), "mailto:#{t("service.email.verification")}"}.".html_safe,

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -162,6 +162,10 @@ FactoryBot.define do
       submitted_at { Time.zone.now }
     end
 
+    trait :old_regs do
+      created_at { Date.new(2023, 1, 31) }
+    end
+
     trait :new_regs do
       created_at { Date.new(2023, 2, 1) }
       needs_work_history { !region.application_form_skip_work_history }

--- a/spec/forms/teacher_interface/written_statement_confirmation_form_spec.rb
+++ b/spec/forms/teacher_interface/written_statement_confirmation_form_spec.rb
@@ -18,12 +18,22 @@ RSpec.describe TeacherInterface::WrittenStatementConfirmationForm,
   end
 
   describe "#save" do
-    let(:written_statement_confirmation) { "true" }
-
     before { form.save(validate: true) }
 
-    it "updates the application form" do
-      expect(application_form).to be_written_statement_confirmation
+    context "with a written statement confirmation" do
+      let(:written_statement_confirmation) { "true" }
+
+      it "updates the application form" do
+        expect(application_form).to be_written_statement_confirmation
+      end
+    end
+
+    context "without a written statement confirmation" do
+      let(:written_statement_confirmation) { "" }
+
+      it "updates the application form" do
+        expect(application_form).to_not be_written_statement_confirmation
+      end
     end
   end
 end

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe AssessmentFactory do
   let(:application_form) do
     create(
       :application_form,
+      :old_regs,
       needs_work_history: false,
       needs_written_statement: false,
       needs_registration_number: false,
@@ -165,6 +166,7 @@ RSpec.describe AssessmentFactory do
           let(:application_form) do
             create(
               :application_form,
+              :old_regs,
               region: create(:region, :in_country, country_code: "SG"),
             )
           end

--- a/spec/services/further_information_request_expirer_spec.rb
+++ b/spec/services/further_information_request_expirer_spec.rb
@@ -51,6 +51,10 @@ RSpec.describe FurtherInformationRequestExpirer do
       end
 
       context "when the applicant is from a country with a 4 week expiry" do
+        let(:application_form) do
+          create(:application_form, :submitted, :old_regs, region:)
+        end
+
         # Australia, Canada, Gibraltar, New Zealand, US
         %w[AU CA GI NZ US].each do |country_code|
           context "from country_code #{country_code}" do

--- a/spec/services/further_information_request_reminder_spec.rb
+++ b/spec/services/further_information_request_reminder_spec.rb
@@ -134,7 +134,9 @@ RSpec.describe FurtherInformationRequestReminder do
     end
 
     context "with a requested FI request" do
-      let(:application_form) { create(:application_form, :submitted, region:) }
+      let(:application_form) do
+        create(:application_form, :submitted, :old_regs, region:)
+      end
       let(:assessment) { create(:assessment, application_form:) }
       let(:region) { create(:region, :in_country, country_code: "FR") }
       let(:teacher) { application_form.teacher }

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
     @application_form ||=
       create(
         :application_form,
+        :old_regs,
         :with_personal_information,
         :with_completed_qualification,
         :submitted,

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -206,16 +206,6 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the(:qualification_page)
   end
 
-  it "sends legacy users to the old service" do
-    when_i_visit_the(:start_page)
-    when_i_press_start_now
-    when_i_select_a_legacy_country
-    then_i_see_the(:eligible_page)
-
-    when_i_press_apply
-    then_i_see_the_legacy_service
-  end
-
   it "can skip questions with qualification" do
     when_i_visit_the(:start_page)
     when_i_press_start_now
@@ -522,10 +512,6 @@ RSpec.describe "Eligibility check", type: :system do
 
   def when_i_press_apply
     eligible_page.apply_button.click
-  end
-
-  def then_i_see_the_legacy_service
-    expect(page).to have_current_path("/MutualRecognition/")
   end
 
   def and_i_see_the_ineligible_country_text

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -130,7 +130,13 @@ RSpec.describe "Teacher reference", type: :system do
   end
 
   def reference_request
-    @reference_request ||= create(:reference_request, :requested)
+    @reference_request ||=
+      create(
+        :reference_request,
+        :requested,
+        work_history:
+          create(:work_history, :completed, end_date: Date.new(2023, 1, 1)),
+      )
   end
 
   delegate :slug, to: :reference_request


### PR DESCRIPTION
This field is not nullable, so we should make sure that we send false instead of nil. With a form that's got a single checkbox, if the box isn't checked then we get no form params back, so instead of using permit we can try and fetch for the single value. If it's not checked it'll come in as nil, which will now be stored as false.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/3909823847/?environment=production&project=6426061&query=is%3Aunresolved&referrer=issue-stream)