### PR TITLE
Inline countries lists without grid CSS

### DIFF
--- a/app/views/shared/_english_language_exempt_countries.erb
+++ b/app/views/shared/_english_language_exempt_countries.erb
@@ -1,9 +1,7 @@
 <% english_language_exempt_countries.in_groups(2, false) do |exempt_countries| %>
-  <div class="govuk-grid-column-one-half">
-    <ul class="govuk-list govuk-list--bullet">
-      <% exempt_countries.each do |exempt_country| %>
-        <li><%= exempt_country %></li>
-      <% end %>
-    </ul>
-  </div>
+  <ul class="govuk-list govuk-list--bullet govuk-!-display-inline-block govuk-!-margin-4">
+    <% exempt_countries.each do |exempt_country| %>
+      <li><%= exempt_country %></li>
+    <% end %>
+  </ul>
 <% end %>


### PR DESCRIPTION
## Trello

https://trello.com/c/Xz3sJkfF/1487-details-component-in-wrong-place-on-eligibility-subjects-question

## Context & changes

The govuk-grid CSS rules don't play nicely with details components and display the contents outside the inset block.
Use inline and margin modifiers to place the countries lists side by side instead.

![image](https://user-images.githubusercontent.com/93511/216017797-ad5a43f1-6abf-4954-82bd-8bbf32706fc0.png)
