### PR TITLE
Allow checking assessment sections

### DIFF
--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -15,6 +15,15 @@ module AssessorInterface
     end
 
     def update
+      unless assessment_section_view_object.render_form?
+        redirect_to assessor_interface_application_form_assessment_assessment_section_path(
+                      assessment_section_view_object.application_form,
+                      assessment_section_view_object.assessment,
+                      assessment_section_view_object.assessment_section.key,
+                    )
+        return
+      end
+
       @assessment_section_form =
         assessment_section_form.new(
           assessment_section_form_params.merge(

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -57,8 +57,6 @@ class AssessorInterface::ApplicationFormsShowViewObject
         assessment,
       )
     when :submitted_details
-      return nil unless professional_standing_request_received?
-
       url_helpers.assessor_interface_application_form_assessment_assessment_section_path(
         application_form,
         assessment,
@@ -75,8 +73,6 @@ class AssessorInterface::ApplicationFormsShowViewObject
         )
       end
     when :further_information
-      return nil unless professional_standing_request_received?
-
       further_information_request = further_information_requests[index]
 
       if further_information_request.received?
@@ -87,8 +83,6 @@ class AssessorInterface::ApplicationFormsShowViewObject
         )
       end
     when :verification_requests
-      return nil unless professional_standing_request_received?
-
       qualification_request = qualification_requests[index]
 
       url_helpers.edit_assessor_interface_application_form_assessment_qualification_request_path(

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -38,7 +38,7 @@ module AssessorInterface
     end
 
     def render_form?
-      !render_section_content?
+      professional_standing_request_received? && !render_section_content?
     end
 
     def render_section_content?
@@ -71,10 +71,17 @@ module AssessorInterface
 
     attr_reader :params
 
+    delegate :professional_standing_request, to: :assessment
+
     def build_key(failure_reason, key_section)
       key =
         "helpers.#{key_section}.assessor_interface_assessment_section_form.failure_reason_notes"
       FailureReasons.decline?(failure_reason:) ? "#{key}_decline" : key
+    end
+
+    def professional_standing_request_received?
+      professional_standing_request.nil? ||
+        professional_standing_request.received?
     end
   end
 end

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -119,7 +119,19 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
     end
   end
 
-  describe "show_english_language_moi_details?" do
+  describe "#render_form?" do
+    subject(:render_form?) { view_object.render_form? }
+
+    it { is_expected.to be true }
+
+    context "with a requested professional standing request" do
+      before { create(:professional_standing_request, :requested, assessment:) }
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#show_english_language_moi_details?" do
     let(:params) do
       {
         key:,
@@ -166,7 +178,7 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
     end
   end
 
-  describe "show_english_language_provider_details?" do
+  describe "#show_english_language_provider_details?" do
     let(:params) do
       {
         key:,


### PR DESCRIPTION
Even if the professional standing request hasn't been received yet, however we will prevent assessors from being able to submit the form.

[Trello Card](https://trello.com/c/G5Uk37cb/1493-make-lopsless-apps-viewable-before-lops-received)