### PR TITLE
Include qualification information in assessment section

### DIFF
--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -25,26 +25,6 @@ module AssessorInterface
     delegate :checks, to: :assessment_section
     delegate :region, :country, to: :application_form
 
-    def qualifications
-      application_form.qualifications.ordered
-    end
-
-    def work_histories
-      application_form.work_histories.ordered
-    end
-
-    def work_history_months_count
-      @months_count = WorkHistoryDuration.new(application_form:).count_months
-    end
-
-    def show_registration_number_summary
-      application_form.needs_registration_number?
-    end
-
-    def show_written_statement_summary
-      application_form.needs_written_statement?
-    end
-
     def notes_label_key_for(failure_reason:)
       build_key(failure_reason, "label")
     end
@@ -55,20 +35,6 @@ module AssessorInterface
 
     def notes_placeholder_key_for(failure_reason:)
       build_key(failure_reason, "placeholder")
-    end
-
-    def online_checker_url
-      @online_checker_url ||=
-        region.teaching_authority_online_checker_url.presence ||
-          region.country.teaching_authority_online_checker_url
-    end
-
-    def work_history?
-      assessment_section.key == "work_history"
-    end
-
-    def professional_standing?
-      assessment_section.key == "professional_standing"
     end
 
     def render_form?

--- a/app/views/assessor_interface/assessment_sections/_age_range_subjects_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_age_range_subjects_summary.html.erb
@@ -1,0 +1,2 @@
+<%= render "shared/application_form/age_range_summary", application_form:, changeable: false %>
+<%= render "shared/application_form/subjects_summary", application_form:, changeable: false %>

--- a/app/views/assessor_interface/assessment_sections/_english_language_proficiency_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_english_language_proficiency_summary.html.erb
@@ -1,0 +1,1 @@
+<%= render "shared/application_form/english_language_summary", application_form:, changeable: false %>

--- a/app/views/assessor_interface/assessment_sections/_personal_information_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_personal_information_summary.html.erb
@@ -1,0 +1,2 @@
+<%= render "shared/application_form/personal_information_summary", application_form:, changeable: false %>
+<%= render "shared/application_form/identification_document_summary", application_form:, changeable: false %>

--- a/app/views/assessor_interface/assessment_sections/_professional_standing_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_professional_standing_summary.html.erb
@@ -1,0 +1,43 @@
+<% if application_form.needs_registration_number %>
+  <%= render "shared/application_form/registration_number_summary", application_form:, changeable: false %>
+<% end %>
+
+<% if application_form.needs_written_statement %>
+  <%= render "shared/application_form/written_statement_summary", application_form:, changeable: false %>
+<% end %>
+
+<% if (professional_standing_request = assessment.professional_standing_request).present? %>
+  <%= render(CheckYourAnswersSummary::Component.new(
+    id: "professional-standing-request",
+    model: professional_standing_request,
+    title: t("assessor_interface.assessment_sections.show.professional_standing_request"),
+    fields: {
+      note: {
+        title: "Written statement",
+        value: "<p class=\"govuk-body\">The competent authority has sent the letter of professional standing directly to the TRA. Follow the instructions below to locate it.</p>#{simple_format(professional_standing_request.location_note)}".html_safe,
+      },
+    },
+    )) %>
+<% end %>
+
+<%= govuk_accordion do |accordion| %>
+  <% if region.teaching_authority_online_checker_url.present? || region.country.teaching_authority_online_checker_url.present? %>
+    <% accordion.section(heading_text: "Online checker") do %>
+      <p class="govuk-body">This authority has an online checker for validating the supplied reference number:</p>
+
+      <% if (online_checker_url = region.teaching_authority_online_checker_url).present? %>
+        <p class="govuk-body"><%= govuk_link_to online_checker_url, online_checker_url, target: "_blank", rel: "noreferrer noopener" %></p>
+      <% end %>
+
+      <% if (online_checker_url = region.country.teaching_authority_online_checker_url).present? %>
+        <p class="govuk-body"><%= govuk_link_to online_checker_url, online_checker_url, target: "_blank", rel: "noreferrer noopener" %></p>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% accordion.section(heading_text: "Competent authority information shown to applicant") do %>
+    <%= render "shared/eligible_region_content_components/professional_recognition",
+               region:,
+               teaching_authority_provides_written_statement: application_form.teaching_authority_provides_written_statement %>
+  <% end %>
+<% end %>

--- a/app/views/assessor_interface/assessment_sections/_qualifications_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_qualifications_summary.html.erb
@@ -1,0 +1,4 @@
+<%= render "shared/application_form/qualifications_summary",
+           application_form:,
+           qualifications: application_form.qualifications.ordered,
+           changeable: false %>

--- a/app/views/assessor_interface/assessment_sections/_qualifications_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_qualifications_summary.html.erb
@@ -2,3 +2,9 @@
            application_form:,
            qualifications: application_form.qualifications.ordered,
            changeable: false %>
+
+<%= govuk_accordion do |accordion| %>
+  <% accordion.section(heading_text: "Qualification information shown to applicant") do %>
+    <%= render "shared/eligible_region_content_components/proof_of_qualifications", region: %>
+  <% end %>
+<% end %>

--- a/app/views/assessor_interface/assessment_sections/_work_history_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_work_history_summary.html.erb
@@ -1,0 +1,17 @@
+<% if application_form.created_under_new_regulations? %>
+  <%= render "shared/application_form/new_regs_work_history_summary",
+             work_histories: application_form.work_histories.ordered,
+             changeable: false %>
+<% else %>
+  <%= render "shared/application_form/work_history_summary",
+             application_form:,
+             show_has_work_history: true,
+             work_histories: application_form.work_histories.ordered,
+             changeable: false %>
+<% end %>
+
+<% if application_form.created_under_new_regulations? %>
+  <h2 class="govuk-heading-m">
+    This applicant has provided <%= WorkHistoryDuration.new(application_form:).count_months %> months of work experience in total.
+  </h2>
+<% end %>

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -6,92 +6,10 @@
            title: t(".title.#{section_key}"),
            application_form: @assessment_section_view_object.application_form %>
 
-<% case section_key %>
-<% when "personal_information" %>
-  <%= render "shared/application_form/personal_information_summary",
-             application_form: @assessment_section_view_object.application_form,
-             changeable: false %>
-
-  <%= render "shared/application_form/identification_document_summary",
-             application_form: @assessment_section_view_object.application_form,
-             changeable: false %>
-<% when "qualifications" %>
-  <%= render "shared/application_form/qualifications_summary",
-             application_form: @assessment_section_view_object.application_form,
-             qualifications: @assessment_section_view_object.qualifications,
-             changeable: false %>
-<% when "age_range_subjects" %>
-  <%= render "shared/application_form/age_range_summary",
-             application_form: @assessment_section_view_object.application_form,
-             changeable: false %>
-
-  <%= render "shared/application_form/subjects_summary",
-             application_form: @assessment_section_view_object.application_form,
-             changeable: false %>
-<% when "english_language_proficiency" %>
-  <%= render "shared/application_form/english_language_summary",
-             application_form: @assessment_section_view_object.application_form,
-             changeable: false %>
-<% when "work_history" %>
-  <% if FeatureFlags::FeatureFlag.active?(:application_work_history) %>
-    <%= render "shared/application_form/new_regs_work_history_summary",
-               work_histories: @assessment_section_view_object.work_histories,
-               changeable: false %>
-  <% else %>
-    <%= render "shared/application_form/work_history_summary",
-               application_form: @assessment_section_view_object.application_form,
-               show_has_work_history: true,
-               work_histories: @assessment_section_view_object.work_histories,
-               changeable: false %>
-  <% end %>
-<% when "professional_standing" %>
-  <% if @assessment_section_view_object.show_registration_number_summary %>
-    <%= render "shared/application_form/registration_number_summary",
-      application_form: @assessment_section_view_object.application_form,
-      changeable: false %>
-  <% end %>
-
-  <% if @assessment_section_view_object.show_written_statement_summary %>
-    <%= render "shared/application_form/written_statement_summary",
-               application_form: @assessment_section_view_object.application_form,
-               changeable: false %>
-  <% end %>
-
-  <% if (professional_standing_request = @assessment_section_view_object.professional_standing_request).present? %>
-    <%= render(CheckYourAnswersSummary::Component.new(
-      id: "professional-standing-request",
-      model: professional_standing_request,
-      title: t(".professional_standing_request"),
-      fields: {
-        note: {
-          title: "Written statement",
-          value: "<p class=\"govuk-body\">The competent authority has sent the letter of professional standing directly to the TRA. Follow the instructions below to locate it.</p>#{simple_format(professional_standing_request.location_note)}".html_safe,
-        },
-      },
-    )) %>
-  <% end %>
-<% end %>
-
-<% if @assessment_section_view_object.application_form.created_under_new_regulations? && @assessment_section_view_object.work_history? %>
-  <h2 class="govuk-heading-m">
-    This applicant has provided <%= @assessment_section_view_object.work_history_months_count %> months of work experience in total.
-  </h2>
-<% elsif @assessment_section_view_object.professional_standing? %>
-  <%= govuk_accordion do |accordion| %>
-    <% if (online_checker_url = @assessment_section_view_object.online_checker_url).present? %>
-      <% accordion.section(heading_text: "Online checker") do %>
-        <p class="govuk-body">This authority has an online checker for validating the supplied reference number:</p>
-        <p class="govuk-body"><%= govuk_link_to online_checker_url, online_checker_url, target: "_blank", rel: "noreferrer noopener" %></p>
-      <% end %>
-    <% end %>
-
-    <% accordion.section(heading_text: "Competent authority information shown to applicant") do %>
-      <%= render "shared/eligible_region_content_components/professional_recognition",
-                 region: @assessment_section_view_object.region,
-                 teaching_authority_provides_written_statement: @assessment_section_view_object.application_form.teaching_authority_provides_written_statement %>
-    <% end %>
-  <% end %>
-<% end %>
+<%= render "#{section_key}_summary",
+           region: @assessment_section_view_object.region,
+           application_form: @assessment_section_view_object.application_form,
+           assessment: @assessment_section_view_object.assessment %>
 
 <% if @assessment_section_view_object.render_form? %>
   <%= form_with model: @assessment_section_form,

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -369,6 +369,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
         application_form =
           create(
             :application_form,
+            :old_regs,
             :with_completed_qualification,
             :with_work_history,
             :with_registration_number,

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -47,50 +47,6 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
     end
   end
 
-  describe "qualifications" do
-    it "returns an ordered list of qualifications" do
-      expect(subject.qualifications).to match_array(
-        application_form.qualifications.ordered,
-      )
-    end
-  end
-
-  describe "work_histories" do
-    it "returns an ordered list of work histories" do
-      expect(subject.work_histories).to match_array(
-        application_form.work_histories.ordered,
-      )
-    end
-  end
-
-  describe "show_registration_number_summary" do
-    subject { super().show_registration_number_summary }
-
-    context "registration number is needed" do
-      before { application_form.update(needs_registration_number: true) }
-      it { is_expected.to eq(true) }
-    end
-
-    context "registration number is not needed" do
-      before { application_form.update(needs_registration_number: false) }
-      it { is_expected.to eq(false) }
-    end
-  end
-
-  describe "show_written_statement_summary" do
-    subject { super().show_written_statement_summary }
-
-    context "written statement is needed" do
-      before { application_form.update(needs_written_statement: true) }
-      it { is_expected.to eq(true) }
-    end
-
-    context "written statement is not needed" do
-      before { application_form.update(needs_written_statement: false) }
-      it { is_expected.to eq(false) }
-    end
-  end
-
   describe "notes_label_key_for" do
     subject { super().notes_label_key_for(failure_reason:) }
 
@@ -160,62 +116,6 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
           "helpers.placeholder.assessor_interface_assessment_section_form.failure_reason_notes",
         )
       end
-    end
-  end
-
-  describe "#online_checker_url" do
-    subject(:online_checker_url) { view_object.online_checker_url }
-
-    it { is_expected.to eq("") }
-
-    context "with a country value set" do
-      before do
-        region.country.update!(
-          teaching_authority_online_checker_url:
-            "https://www.example.com/checks",
-        )
-      end
-
-      it { is_expected.to eq("https://www.example.com/checks") }
-    end
-
-    context "with a region value set" do
-      before do
-        region.update!(
-          teaching_authority_online_checker_url:
-            "https://www.example.com/checks",
-        )
-      end
-
-      it { is_expected.to eq("https://www.example.com/checks") }
-    end
-
-    context "with a country and a region value set" do
-      before do
-        region.country.update!(
-          teaching_authority_online_checker_url:
-            "https://www.example.com/country-checks",
-        )
-        region.update!(
-          teaching_authority_online_checker_url:
-            "https://www.example.com/region-checks",
-        )
-      end
-
-      it { is_expected.to eq("https://www.example.com/region-checks") }
-    end
-  end
-
-  describe "#professional_standing?" do
-    subject(:professional_standing?) { view_object.professional_standing? }
-    it { is_expected.to be false }
-    context "with a professional standing spoke" do
-      before do
-        params[:key] = "professional_standing"
-        assessment_section.update!(key: "professional_standing")
-      end
-
-      it { is_expected.to be true }
     end
   end
 


### PR DESCRIPTION
This adds an accordion to the assessment section for qualifications which shows to the assessor what information was shown to the applicant, in a similar way to professional standing.

I've also split up the summary component of this page in to separate views which are rendered according to the assessment section. This should help to keep this page maintainable.

[Trello Card](https://trello.com/c/oioVunca/1485-qualifications-information-should-be-shown-to-assessors)