### PR TITLE
Ensure written_statement_confirmation is a boolean

### DIFF
--- a/app/forms/teacher_interface/base_form.rb
+++ b/app/forms/teacher_interface/base_form.rb
@@ -5,7 +5,7 @@ class TeacherInterface::BaseForm
   include ActiveModel::Attributes
 
   def save(validate:)
-    return false if validate && !valid?
+    return false if validate && invalid?
 
     ActiveRecord::Base.transaction do
       update_model

--- a/app/forms/teacher_interface/written_statement_confirmation_form.rb
+++ b/app/forms/teacher_interface/written_statement_confirmation_form.rb
@@ -11,7 +11,11 @@ module TeacherInterface
     private
 
     def update_model
-      application_form.update!(written_statement_confirmation:)
+      if written_statement_confirmation
+        application_form.update!(written_statement_confirmation: true)
+      else
+        application_form.update!(written_statement_confirmation: false)
+      end
     end
   end
 end


### PR DESCRIPTION
This follows up 76c9de0fe6969082d2c9174f007a82ff18f8be84 with a more explicit fix. When the user chooses to "save and continue", the validation doesn't run which means it's possible for this value to be nil or something which isn't a boolean. To prevent errors when writing to the database, we can ensure the value is a boolean.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/3909823847/?project=6426061&query=is%3Aunresolved&referrer=issue-stream)