### PR TITLE
Change initial assessment work history failure reasons content

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -224,6 +224,7 @@ class AssessmentFactory
         [
           FailureReasons::WORK_HISTORY_BREAK,
           FailureReasons::SCHOOL_DETAILS_CANNOT_BE_VERIFIED,
+          FailureReasons::UNRECOGNISED_REFERENCES,
         ]
       else
         [FailureReasons::SATISFACTORY_EVIDENCE_WORK_HISTORY]

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -29,6 +29,7 @@ class FailureReasons
       "teaching_qualifications_from_ineligible_country",
     TEACHING_QUALIFICATIONS_NOT_AT_REQUIRED_LEVEL =
       "teaching_qualifications_not_at_required_level",
+    UNRECOGNISED_REFERENCES = "unrecognised_references",
   ].freeze
 
   FURTHER_INFORMATIONABLE = [

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -157,6 +157,7 @@ en:
           teaching_qualifications_from_ineligible_country: Teaching qualifications were completed in an ineligible country.
           teaching_qualifications_not_at_required_level: Teaching qualifications do not meet the required academic level (level 6).
           teaching_transcript_illegible: The teaching qualification transcript (or translation) is illegible or in a format that we cannot accept.
+          unrecognised_references: Application contained 1 or more references that cannot be considered.
           work_history_break: There is an unexplained break in the applicant’s work history.
           written_statement_illegible: The letter from the country or state’s authority is illegible or in a format that we cannot accept.
           written_statement_recent: The letter from the country or state’s authority was not issued within the last 3 months.

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -147,7 +147,7 @@ en:
           qualified_to_teach_children_11_to_16: The applicant is not qualified to teach children aged 11-16.
           registration_number: We could not verify the registration number using the online checker.
           satisfactory_evidence_work_history: The information provided on work history is not sufficient to award QTS.
-          school_details_cannot_be_verified: We cannot verify the details of one of the schools that the applicant has entered.
+          school_details_cannot_be_verified: We could not verify the details of one of the schools that the applicant has entered.
           teaching_certificate_illegible: The teaching qualification certificate (or translation) is illegible or in a format that we cannot accept.
           teaching_hours_not_fulfilled: The required teaching hours have not been fulfilled.
           teaching_qualification: We were not provided with sufficient evidence to confirm the teaching qualification entered on the online application form.

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -157,7 +157,7 @@ en:
           teaching_qualifications_from_ineligible_country: Teaching qualifications were completed in an ineligible country.
           teaching_qualifications_not_at_required_level: Teaching qualifications do not meet the required academic level (level 6).
           teaching_transcript_illegible: The teaching qualification transcript (or translation) is illegible or in a format that we cannot accept.
-          work_history_break: We need more information about a break in the applicant’s work history.
+          work_history_break: There is an unexplained break in the applicant’s work history.
           written_statement_illegible: The letter from the country or state’s authority is illegible or in a format that we cannot accept.
           written_statement_recent: The letter from the country or state’s authority was not issued within the last 3 months.
         induction_required:

--- a/lib/tasks/assessment_sections.rake
+++ b/lib/tasks/assessment_sections.rake
@@ -1,0 +1,29 @@
+namespace :assessment_sections do
+  desc "Edit failure reasons on an assessment section. \
+  eg. edit_failure_reasons['work_history', 'new_reason', 'existing_reason1 existing_reason2']"
+  task :edit_failure_reasons,
+       %i[key new_failure_reason failure_reasons] =>
+         :environment do |_task, args|
+    key = args[:key]
+    new_failure_reason = args[:new_failure_reason]
+    failure_reasons = args[:failure_reasons].split(" ")
+
+    scope = AssessmentSection.where(key:, failure_reasons:)
+
+    if scope.count.zero?
+      raise "No assessment sections found for key: #{key}, failure_reasons: #{failure_reasons}"
+    end
+
+    puts "#{scope.count} assessment sections match"
+
+    if failure_reasons.include?(new_failure_reason)
+      failure_reasons.delete(new_failure_reason)
+    else
+      failure_reasons << new_failure_reason
+    end
+
+    scope.update_all(failure_reasons:)
+
+    puts "Assessment sections with key #{key} updated with failure reasons: #{failure_reasons}"
+  end
+end

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -307,7 +307,11 @@ RSpec.describe AssessmentFactory do
             )
 
             expect(section.failure_reasons).to eq(
-              %w[work_history_break school_details_cannot_be_verified],
+              %w[
+                work_history_break
+                school_details_cannot_be_verified
+                unrecognised_references
+              ],
             )
           end
         end


### PR DESCRIPTION
## Trello

https://trello.com/c/Wz2zPfAg/1469-change-initial-assessment-failure-reasons-content

## Changes

- Amend the content of 2 existing failure reasons in work history spoke
- Add a new failure reason for references that can't be considered
- Add a rake task to update existing work history assessment sections: 
  `rake assessment_sections:edit_failure_reasons["work_history","unrecognised_references","work_history_break school_details_cannot_be_verified"]`

![image](https://user-images.githubusercontent.com/93511/216077469-570983f1-580d-45d5-bbfc-01f8bd56b91a.png)


