### PR TITLE
Move details component above submit button

### DIFF
--- a/app/views/eligibility_interface/qualified_for_subject/new.html.erb
+++ b/app/views/eligibility_interface/qualified_for_subject/new.html.erb
@@ -41,10 +41,11 @@
     :label,
     legend: nil,
   ) %>
+
+  <%= govuk_details(
+    summary_text: "What we mean by qualified",
+    text: "Qualified means <strong>EITHER</strong> your teaching qualification specifically shows you can teach one of these subjects, <strong>OR</strong> at least 50% of your university degree was in one of them.".html_safe,
+  ) %>
+
   <%= f.govuk_submit prevent_double_click: false %>
 <% end %>
-
-<%= govuk_details(
-  summary_text: "What we mean by qualified",
-  text: "Qualified means <strong>EITHER</strong> your teaching qualification specifically shows you can teach one of these subjects, <strong>OR</strong> at least 50% of your university degree was in one of them.".html_safe,
-) %>


### PR DESCRIPTION
[Trello](https://trello.com/c/Xz3sJkfF/1487-details-component-in-wrong-place-on-eligibility-subjects-question)

Move the _What we mean by qualified_ details component above the **Continue** button

![image](https://user-images.githubusercontent.com/93511/216096209-ef5d2630-f96a-4738-b9a5-beeb8d9edc4d.png)
