### PR TITLE
Allow early declines

### DIFF
--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -15,15 +15,6 @@ module AssessorInterface
     end
 
     def update
-      unless assessment_section_view_object.render_form?
-        redirect_to assessor_interface_application_form_assessment_assessment_section_path(
-                      assessment_section_view_object.application_form,
-                      assessment_section_view_object.assessment,
-                      assessment_section_view_object.assessment_section.key,
-                    )
-        return
-      end
-
       @assessment_section_form =
         assessment_section_form.new(
           assessment_section_form_params.merge(

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -109,6 +109,10 @@ class Assessment < ApplicationRecord
     end
   end
 
+  def recommendable?
+    can_award? || can_decline? || can_request_further_information?
+  end
+
   def available_recommendations
     [].tap do |recommendations|
       recommendations << "award" if can_award?

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -90,8 +90,7 @@ class Assessment < ApplicationRecord
           all_sections_finished?
         end
 
-      (sections_ready && any_section_failed? && any_section_declines?) ||
-        professional_standing_request&.requested? || false
+      sections_ready && any_section_failed? && any_section_declines?
     elsif request_further_information?
       any_further_information_request_failed?
     else

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -61,4 +61,8 @@ class AssessmentSection < ApplicationRecord
   def declines_assessment?
     selected_failure_reasons.declinable.any?
   end
+
+  def failed
+    passed == false
+  end
 end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -59,7 +59,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
     when :initial_assessment
       if item == :assessment_recommendation
         return nil unless professional_standing_request_received?
-        return nil unless assessment.sections_finished?
+        return nil unless assessment.send(:all_sections_finished?)
         return nil unless assessment_editable?
 
         url_helpers.edit_assessor_interface_application_form_assessment_path(
@@ -105,7 +105,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
       return :cannot_start unless professional_standing_request_received?
 
       if item == :assessment_recommendation
-        return :cannot_start unless assessment.sections_finished?
+        return :cannot_start unless assessment.send(:all_sections_finished?)
         return :not_started if assessment.unknown?
         return :in_progress if assessment_editable?
         :completed

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -38,7 +38,7 @@ module AssessorInterface
     end
 
     def render_form?
-      professional_standing_request_received? && !render_section_content?
+      !render_section_content?
     end
 
     def render_section_content?
@@ -71,17 +71,10 @@ module AssessorInterface
 
     attr_reader :params
 
-    delegate :professional_standing_request, to: :assessment
-
     def build_key(failure_reason, key_section)
       key =
         "helpers.#{key_section}.assessor_interface_assessment_section_form.failure_reason_notes"
       FailureReasons.decline?(failure_reason:) ? "#{key}_decline" : key
-    end
-
-    def professional_standing_request_received?
-      professional_standing_request.nil? ||
-        professional_standing_request.received?
     end
   end
 end

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -263,7 +263,16 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           end
 
           context "and request further information" do
-            before { assessment.request_further_information! }
+            before do
+              assessment.request_further_information!
+              create(
+                :selected_failure_reason,
+                :fi_requestable,
+                assessment_section:,
+              )
+              assessment_section.reload.update!(passed: false)
+            end
+
             it { is_expected.to eq(:in_progress) }
 
             context "and further information requested" do

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -123,12 +123,6 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
     subject(:render_form?) { view_object.render_form? }
 
     it { is_expected.to be true }
-
-    context "with a requested professional standing request" do
-      before { create(:professional_standing_request, :requested, assessment:) }
-
-      it { is_expected.to be false }
-    end
   end
 
   describe "#show_english_language_moi_details?" do


### PR DESCRIPTION
This changes the logic around when the "Initial assessment recommendation" task item is available to assessors to allow assessors to decline an assessment before assessing all the sections and before waiting for the professional standing request to be received. I've also refactored the code to push more of the logic on the recommendation methods of the assessment instead of being in the view object, hopefully this makes the code easier to understand.

[Trello Card](https://trello.com/c/k1QCG8w4/1496-contingency-make-it-quicker-to-decline-an-application)