### PR TITLE
Filter unique constraint exceptions

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -2,6 +2,17 @@
 
 require "active_support/parameter_filter"
 
+PG_DETAIL_REGEX = /^DETAIL:.*$/
+PG_DETAIL_FILTERED = "[PG DETAIL FILTERED]"
+
+def filter_record_not_unique_exception_messages!(event, hint)
+  if hint[:exception].is_a?(ActiveRecord::RecordNotUnique)
+    event.exception.values.each do |single_exception| # rubocop:disable Style/HashEachMethods
+      single_exception.value.gsub!(PG_DETAIL_REGEX, PG_DETAIL_FILTERED)
+    end
+  end
+end
+
 Sentry.init do |config|
   config.breadcrumbs_logger = %i[active_support_logger http_logger]
 
@@ -11,7 +22,12 @@ Sentry.init do |config|
     ActiveSupport::ParameterFilter.new(
       Rails.application.config.filter_parameters,
     )
-  config.before_send = lambda { |event, _hint| filter.filter(event.to_hash) }
+
+  config.before_send =
+    lambda do |event, hint|
+      filter_record_not_unique_exception_messages!(event, hint)
+      filter.filter(event.to_hash)
+    end
 
   config.inspect_exception_causes_for_exclusion = true
 


### PR DESCRIPTION
We have uniqueness constraints on email in the database.
We should sanitize any messages raised in `PG::UniqueViolation` exceptions as they may contain PII.

[Example of what we receive in Sentry](https://dfe-teacher-services.sentry.io/issues/3913075576/?environment=dev&project=6426061&query=is%3Aunresolved&referrer=issue-stream)