### PR TITLE
Add assessor comments to decline QTS

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_awards_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_awards_controller.rb
@@ -7,15 +7,15 @@ module AssessorInterface
     before_action :load_assessment_and_application_form
 
     def edit
-      @form = AssessmentDeclarationForm.new
+      @form = AssessmentDeclarationAwardForm.new
     end
 
     def update
       @form =
-        AssessmentDeclarationForm.new(
+        AssessmentDeclarationAwardForm.new(
           declaration:
             params.dig(
-              :assessor_interface_assessment_declaration_form,
+              :assessor_interface_assessment_declaration_award_form,
               :declaration,
             ),
         )

--- a/app/controllers/assessor_interface/assessment_recommendation_declines_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_declines_controller.rb
@@ -8,20 +8,27 @@ module AssessorInterface
     before_action :load_assessment_and_application_form
 
     def edit
-      @form = AssessmentDeclarationForm.new
+      @form = AssessmentDeclarationDeclineForm.new
     end
 
     def update
       @form =
-        AssessmentDeclarationForm.new(
+        AssessmentDeclarationDeclineForm.new(
           declaration:
             params.dig(
-              :assessor_interface_assessment_declaration_form,
+              :assessor_interface_assessment_declaration_decline_form,
               :declaration,
             ),
+          recommendation_assessor_note:
+            params.dig(
+              :assessor_interface_assessment_declaration_decline_form,
+              :recommendation_assessor_note,
+            ),
+          session:,
+          assessment:,
         )
 
-      if @form.valid?
+      if @form.save
         redirect_to [
                       :preview,
                       :assessor_interface,
@@ -59,6 +66,10 @@ module AssessorInterface
         if @form.confirmation
           ActiveRecord::Base.transaction do
             assessment.decline!
+            assessment.update!(
+              recommendation_assessor_note:
+                session[:recommendation_assessor_note],
+            )
             DeclineQTS.call(application_form:, user: current_staff)
           end
 

--- a/app/forms/assessor_interface/assessment_declaration_award_form.rb
+++ b/app/forms/assessor_interface/assessment_declaration_award_form.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AssessorInterface::AssessmentDeclarationForm
+class AssessorInterface::AssessmentDeclarationAwardForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 

--- a/app/forms/assessor_interface/assessment_declaration_decline_form.rb
+++ b/app/forms/assessor_interface/assessment_declaration_decline_form.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AssessorInterface::AssessmentDeclarationDeclineForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :session, :assessment
+
+  attribute :declaration, :boolean
+  attribute :recommendation_assessor_note, :string
+
+  validates :declaration, presence: true
+  validates :recommendation_assessor_note,
+            presence: true,
+            if: -> { assessment.selected_failure_reasons_empty? }
+
+  def save
+    return false unless valid?
+
+    session[:recommendation_assessor_note] = recommendation_assessor_note
+    true
+  end
+end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -8,6 +8,7 @@
 #  age_range_note                            :text             default(""), not null
 #  induction_required                        :boolean
 #  recommendation                            :string           default("unknown"), not null
+#  recommendation_assessor_note              :text             default(""), not null
 #  recommended_at                            :datetime
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
@@ -120,6 +121,10 @@ class Assessment < ApplicationRecord
       end
       recommendations << "decline" if can_decline?
     end
+  end
+
+  def selected_failure_reasons_empty?
+    sections.all? { |section| section.selected_failure_reasons.empty? }
   end
 
   private

--- a/app/views/assessor_interface/assessment_recommendation_declines/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_declines/edit.html.erb
@@ -6,38 +6,38 @@
 <p class="govuk-body-l">You’re about to decline this QTS application from <%= application_form_full_name(@application_form) %> for the following reasons:</p>
 
 <h2 class="govuk-heading-l">Your decline reasons and notes</h2>
+<% unless @assessment.further_information_requests.exists? %>
+  <% @assessment.sections.each do |section| %>
+    <% if section.selected_failure_reasons.present? %>
+      <h3 class="govuk-heading-m"><%= t(".assessment_section.#{section.key}") %></h3>
+      <ul class="govuk-list">
+        <% section.selected_failure_reasons.each do |failure_reason| %>
+          <li>
+            <h4 class="govuk-heading-s"><%= t("assessor_interface.assessment_sections.show.failure_reasons.#{failure_reason.key}") %></h4>
 
-<% @assessment.sections.each do |section| %>
-  <% if section.selected_failure_reasons.present? %>
-    <h3 class="govuk-heading-m"><%= t(".assessment_section.#{section.key}") %></h3>
-    <ul class="govuk-list">
-      <% section.selected_failure_reasons.each do |failure_reason| %>
-        <li>
-          <h4 class="govuk-heading-s"><%= t("assessor_interface.assessment_sections.show.failure_reasons.#{failure_reason.key}") %></h4>
-
-          <% if FailureReasons.decline?(failure_reason: failure_reason.key) %>
-            <p class="govuk-body govuk-!-margin-bottom-2">Your note to the applicant:</p>
-          <% else %>
-            <p class="govuk-body govuk-!-margin-bottom-2">Your note (the applicant won’t see this):</p>
-          <% end %>
-
-          <%= govuk_inset_text do %>
-            <%= simple_format failure_reason.assessor_feedback %>
-          <% end %>
-        </li>
-      <% end %>
-    </ul>
+            <% if FailureReasons.decline?(failure_reason: failure_reason.key) %>
+              <p class="govuk-body govuk-!-margin-bottom-2">Your note to the applicant:</p>
+            <% else %>
+              <p class="govuk-body govuk-!-margin-bottom-2">Your note (the applicant won’t see this):</p>
+            <% end %>
+            <%= govuk_inset_text do %>
+              <%= simple_format failure_reason.assessor_feedback %>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   <% end %>
+<% else %>
+  <p class="govuk-hint">Use this space to tell the applicant why they’ve been declined.</p>
+  <p class="govuk-hint">This is the last communication they’ll receive about this application so make sure your comments are clear.</p>
 <% end %>
 
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 
-<p class="govuk-body"><%= t(".instruction") %></p>
-<p class="govuk-body">If you need to check something, use the ‘Back’ button.</p>
-
 <%= form_with model: @form, url: [:assessor_interface, @application_form, @assessment, :assessment_recommendation_decline], method: :put do |f| %>
   <%= f.govuk_error_summary %>
-
+  <%= f.govuk_text_area :recommendation_assessor_note %>
   <%= f.govuk_check_boxes_fieldset :declaration, small: true do %>
     <%= f.govuk_check_box :declaration,
                           true,
@@ -46,6 +46,9 @@
                           link_errors: true,
                           label: { text: t(".declaration") } %>
   <% end %>
+  
+  <p class="govuk-body"><%= t(".instruction") %></p>
+  <p class="govuk-body">If you need to check something, use the ‘Back’ button.</p>
 
   <%= f.govuk_submit t(".button"), prevent_double_click: false do %>
     <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -61,7 +61,7 @@
   </div>
 <% elsif @view_object.application_form.declined? %>
   <h2 class="govuk-heading-l">Your QTS application has been declined</h2>
-
+ 
   <%- if @view_object.show_further_information_request_expired_content? -%>
     <%= govuk_inset_text(text:t(".further_information_request_expired")) %>
   <%- end -%>
@@ -86,7 +86,13 @@
       </ul>
     <% end %>
   <% end %>
-
+  <% if @view_object.assessment.recommendation_assessor_note.present? %>
+    <h3 class="govuk-heading-m">Why your application was declined</h3>
+    <p class="govuk-body">
+     <%= @view_object.assessment.recommendation_assessor_note %>
+    </p>
+  <% end %>
+  
   <h3 class="govuk-heading-m">What you can do next</h3>
 
   <% unless @view_object.declined_cannot_reapply? %>

--- a/app/views/teacher_mailer/application_declined.text.erb
+++ b/app/views/teacher_mailer/application_declined.text.erb
@@ -13,11 +13,11 @@ Unfortunately, we’re unable to award QTS status.
 <%- if @further_information_requested -%>
 # What you can do next
 
-You can sign in to explore other routes to teaching in England:
+You can sign in to find out why your application was declined:
 <%- else -%>
 # Why your QTS application was declined
 
-You can sign in to view the reason why your application was declined:
+You can sign in to find out why your application was declined:
 <%- end -%>
 
 <%= new_teacher_session_url %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -98,6 +98,7 @@
     - subjects
     - subjects_note
     - recommended_at
+    - recommendation_assessor_note
     - induction_required
     - working_days_since_started
     - working_days_submission_to_recommendation

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -218,7 +218,13 @@ en:
           attributes:
             confirmation:
               inclusion: Select ‘Yes’ to confirm, or ‘No’ to cancel.
-        assessor_interface/assessment_declaration_form:
+        assessor_interface/assessment_declaration_decline_form:
+          attributes:
+            declaration:
+              blank: You must confirm that you have reviewed this QTS application
+            recommendation_assessor_note:
+              blank: You must input notes since there are no other decline notes
+        assessor_interface/assessment_declaration_award_form:
           attributes:
             declaration:
               blank: You must confirm that you have reviewed this QTS application

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -53,6 +53,8 @@ en:
         confirmation_options:
           true: "Yes"
           false: "No"
+      assessor_interface_assessment_declaration_decline_form:
+        recommendation_assessor_note: Assessor's notes
       assessor_interface_assessment_section_form:
         age_range_min: From
         age_range_max: To

--- a/db/migrate/20230203133927_add_recommendation_note_to_assessment.rb
+++ b/db/migrate/20230203133927_add_recommendation_note_to_assessment.rb
@@ -1,0 +1,9 @@
+class AddRecommendationNoteToAssessment < ActiveRecord::Migration[7.0]
+  def change
+    add_column :assessments,
+               :recommendation_assessor_note,
+               :text,
+               null: false,
+               default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,9 +84,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_093735) do
     t.bigint "english_language_provider_id"
     t.text "english_language_provider_reference", default: "", null: false
     t.datetime "awarded_at"
-    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "written_statement_confirmation", default: false, null: false
+    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "english_language_provider_other", default: false, null: false
     t.datetime "declined_at"
     t.boolean "waiting_on_professional_standing", default: false, null: false
@@ -137,6 +137,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_093735) do
     t.integer "working_days_submission_to_started"
     t.integer "working_days_since_started"
     t.boolean "induction_required"
+    t.text "recommendation_assessor_note", default: "", null: false
     t.index ["application_form_id"], name: "index_assessments_on_application_form_id"
   end
 
@@ -321,8 +322,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_093735) do
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
-    t.boolean "application_form_skip_work_history", default: false, null: false
     t.text "qualifications_information", default: "", null: false
+    t.boolean "application_form_skip_work_history", default: false, null: false
     t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_requires_submission_email", default: false, null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -8,6 +8,7 @@
 #  age_range_note                            :text             default(""), not null
 #  induction_required                        :boolean
 #  recommendation                            :string           default("unknown"), not null
+#  recommendation_assessor_note              :text             default(""), not null
 #  recommended_at                            :datetime
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
@@ -41,6 +42,11 @@ FactoryBot.define do
 
     trait :award do
       recommendation { "award" }
+      recommended_at { Time.zone.now }
+    end
+
+    trait :decline do
+      recommendation { "decline" }
       recommended_at { Time.zone.now }
     end
 

--- a/spec/forms/assessor_interface/assessment_declaration_award_form_spec.rb
+++ b/spec/forms/assessor_interface/assessment_declaration_award_form_spec.rb
@@ -2,6 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AssessorInterface::AssessmentDeclarationForm, type: :model do
+RSpec.describe AssessorInterface::AssessmentDeclarationAwardForm,
+               type: :model do
   it { is_expected.to validate_presence_of(:declaration) }
 end

--- a/spec/forms/assessor_interface/assessment_declaration_decline_form_spec.rb
+++ b/spec/forms/assessor_interface/assessment_declaration_decline_form_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+RSpec.describe AssessorInterface::AssessmentDeclarationDeclineForm,
+               type: :model do
+  let(:session) { {} }
+  subject(:form) do
+    described_class.new(
+      session:,
+      assessment:,
+      declaration: true,
+      recommendation_assessor_note: "Note",
+    )
+  end
+
+  describe "validations" do
+    context "when recommendation is declined with no failure reasons" do
+      let(:assessment) { create(:assessment, :decline) }
+
+      it { is_expected.to validate_presence_of(:recommendation_assessor_note) }
+    end
+
+    context "when recommendation is started" do
+      let(:assessment) { create(:assessment, :started) }
+      it { is_expected.to validate_presence_of(:declaration) }
+    end
+
+    context "when recommendation is declined with failure reasons" do
+      before do
+        create(:assessment_section, :declines_with_already_qts, assessment:)
+      end
+      let(:assessment) { create(:assessment, :decline) }
+
+      it do
+        is_expected.not_to validate_presence_of(:recommendation_assessor_note)
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:assessment) { create(:assessment, :decline) }
+    context "when valid" do
+      subject(:save) { form.save }
+
+      it { is_expected.to be true }
+      it "sets the session" do
+        expect { save }.to change { session[:recommendation_assessor_note] }.to(
+          "Note",
+        )
+      end
+    end
+  end
+end

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe TeacherMailer, type: :mailer do
       it { is_expected.to include("abc") }
       it do
         is_expected.to include(
-          "You can sign in to view the reason why your application was declined:",
+          "You can sign in to find out why your application was declined:",
         )
       end
     end
@@ -81,7 +81,7 @@ RSpec.describe TeacherMailer, type: :mailer do
 
         it do
           is_expected.to include(
-            "You can sign in to explore other routes to teaching in England:",
+            "You can sign in to find out why your application was declined:",
           )
         end
       end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -10,6 +10,7 @@
 #  age_range_note                            :text             default(""), not null
 #  induction_required                        :boolean
 #  recommendation                            :string           default("unknown"), not null
+#  recommendation_assessor_note              :text             default(""), not null
 #  recommended_at                            :datetime
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
@@ -256,6 +257,23 @@ RSpec.describe Assessment, type: :model do
         ).and_return(true)
       end
       it { is_expected.to include("request_further_information") }
+    end
+  end
+
+  describe "#selected_failure_reasons_empty?" do
+    subject(:selected_failure_reasons_empty?) do
+      assessment.selected_failure_reasons_empty?
+    end
+
+    context "with no failure reasons" do
+      it { is_expected.to be true }
+    end
+
+    context "with failure reasons" do
+      before do
+        create(:assessment_section, :declines_with_already_qts, assessment:)
+      end
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/system/teacher_interface/reapply_spec.rb
+++ b/spec/system/teacher_interface/reapply_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe "Teacher reapply", type: :system do
         :declined,
         teacher:,
         region: create(:region, :national),
+        assessment: create(:assessment),
       )
   end
 end

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
 
   context "when declined" do
     let(:application_form) { create(:application_form, :declined) }
-    let(:assessment) { create(:assessment, application_form:) }
+    let!(:assessment) { create(:assessment, application_form:) }
 
     context "and an initial assessment" do
       before do


### PR DESCRIPTION
Add Assessor's notes before final decline step

Add a free text field for assessor's notes on the final decline step so that declined applicants can see more info

This is validated when there are no failure reasons, so that in the event of an empty decline (I.E. Rapid decline/FI requests) it is mandatory. Otherwise, it should be optional.