### PR TITLE
Add missing failure reason description

### DIFF
--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -37,6 +37,7 @@ en:
           registration_number: Tell us your registration number
           satisfactory_evidence_work_history: Tell us more about your work history
           school_details_cannot_be_verified: Tell us more about this school
+          unrecognised_references: Tell us more about your work history
           work_history_break: Tell us more about your work history
     new_regs:
       work_histories:


### PR DESCRIPTION
This is shown to teachers when further information is requested so we need to make sure there's a locale string available.

[Trello Card](https://trello.com/c/K1CA2Yfa/1520-unrecognised-references-has-no-label)