### PR TITLE
Fix bug with English language exemption checkbox

### DIFF
--- a/app/forms/concerns/assessor_interface/updates_english_language_status.rb
+++ b/app/forms/concerns/assessor_interface/updates_english_language_status.rb
@@ -26,7 +26,8 @@ module AssessorInterface::UpdatesEnglishLanguageStatus
 
       def permittable_parameters
         args, kwargs = super
-        [args, kwargs.merge(english_language_section_passed: [])]
+        args += %i[english_language_section_passed]
+        [args, kwargs]
       end
 
       def english_language_section(assessment)
@@ -52,11 +53,13 @@ module AssessorInterface::UpdatesEnglishLanguageStatus
     end
 
     def update_english_language_status?
-      self
-        .class
-        .english_language_section(assessment_section.assessment)
-        .present? && english_language_section_passed &&
-        application_form.send(self.class::EXEMPTION_ATTR)
+      elp_assessment_section =
+        self.class.english_language_section(assessment_section.assessment)
+
+      return false if elp_assessment_section.nil?
+      return false unless application_form.send(self.class::EXEMPTION_ATTR)
+
+      english_language_section_passed != elp_assessment_section.passed
     end
 
     def application_form

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -24,7 +24,7 @@
         :english_language_section_passed,
         true,
         false,
-        mutliple: false,
+        multiple: false,
         link_errors: true,
         small: true,
         label: {


### PR DESCRIPTION
It wasn't possible to uncheck the checkbox after being submitted as checked, which has been fixed in this commit.

[Trello Card](https://trello.com/c/URewoaoc/1522-tickbox-for-exempt-country-applicants)