### PR TITLE
Fix mon out of range error

### DIFF
--- a/app/forms/concerns/teacher_interface/sanitize_dates.rb
+++ b/app/forms/concerns/teacher_interface/sanitize_dates.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  module SanitizeDates
+    extend ActiveSupport::Concern
+
+    included do
+      def sanitize_dates!(*dates)
+        today = Time.zone.now
+
+        dates.each do |date|
+          next if date[1].blank? || date[2].blank?
+
+          date[2] = 1 if date[2] > 12
+
+          date[1] = today.year if date[1] > today.year || date[1] < 1900
+        end
+      end
+    end
+  end
+end

--- a/app/forms/teacher_interface/qualification_form.rb
+++ b/app/forms/teacher_interface/qualification_form.rb
@@ -3,6 +3,7 @@
 module TeacherInterface
   class QualificationForm < BaseForm
     include ActiveRecord::AttributeAssignment
+    include TeacherInterface::SanitizeDates
 
     attr_accessor :qualification
     attribute :title, :string
@@ -43,6 +44,8 @@ module TeacherInterface
     end
 
     def update_model
+      sanitize_dates!(start_date, complete_date, certificate_date)
+
       qualification.update!(
         title:,
         institution_name:,

--- a/app/forms/teacher_interface/work_history_school_form.rb
+++ b/app/forms/teacher_interface/work_history_school_form.rb
@@ -3,6 +3,7 @@
 module TeacherInterface
   class WorkHistorySchoolForm < BaseForm
     include ActiveRecord::AttributeAssignment
+    include TeacherInterface::SanitizeDates
 
     attr_accessor :work_history
     attribute :meets_all_requirements, :boolean
@@ -37,6 +38,8 @@ module TeacherInterface
     end
 
     def update_model
+      sanitize_dates!(start_date, end_date)
+
       work_history.update!(
         school_name:,
         city:,

--- a/app/views/teacher_interface/new_regs/work_histories/_school_form.html.erb
+++ b/app/views/teacher_interface/new_regs/work_histories/_school_form.html.erb
@@ -43,7 +43,7 @@
 
   <%= f.govuk_text_field :hours_per_week, width: 5, label: { size: "m" } %>
 
-  <%= f.govuk_date_field :start_date, omit_day: true %>
+  <%= f.govuk_date_field :start_date, omit_day: true, maxlength_enabled: true %>
   <%= f.govuk_check_box :start_date_is_estimate, 1, 0, multiple: false, link_errors: true, label: {
     text: "This is an estimate"
   } %>
@@ -51,7 +51,7 @@
   <%= f.govuk_radio_buttons_fieldset :still_employed do %>
     <%= f.govuk_radio_button :still_employed, :true, link_errors: true %>
     <%= f.govuk_radio_button :still_employed, :false do %>
-      <%= f.govuk_date_field :end_date, omit_day: true %>
+      <%= f.govuk_date_field :end_date, omit_day: true, maxlength_enabled: true %>
       <%= f.govuk_check_box :end_date_is_estimate, 1, 0, multiple: false, link_errors: true, label: {
         text: "This is an estimate"
       } %>

--- a/spec/forms/teacher_interface/qualification_form_spec.rb
+++ b/spec/forms/teacher_interface/qualification_form_spec.rb
@@ -98,5 +98,25 @@ RSpec.describe TeacherInterface::QualificationForm, type: :model do
       expect(qualification.complete_date).to eq(Date.new(2022, 1, 1))
       expect(qualification.certificate_date).to eq(Date.new(2022, 6, 1))
     end
+
+    context "without validation, with invalid date values" do
+      let(:start_date) { { 1 => 2222, 2 => 22, 3 => 1 } }
+      let(:complete_date) { { 1 => 3333, 2 => 99, 3 => 1 } }
+      let(:certificate_date) { { 1 => 99, 2 => 99, 3 => 1 } }
+
+      subject(:save) { form.save(validate: false) }
+
+      it "applies valid date values" do
+        expect(qualification.start_date).to eq(
+          Date.new(Time.zone.now.year, 1, 1),
+        )
+        expect(qualification.complete_date).to eq(
+          Date.new(Time.zone.now.year, 1, 1),
+        )
+        expect(qualification.certificate_date).to eq(
+          Date.new(Time.zone.now.year, 1, 1),
+        )
+      end
+    end
   end
 end

--- a/spec/forms/teacher_interface/work_history_school_form_spec.rb
+++ b/spec/forms/teacher_interface/work_history_school_form_spec.rb
@@ -115,5 +115,19 @@ RSpec.describe TeacherInterface::WorkHistorySchoolForm, type: :model do
       expect(work_history.end_date).to be_nil
       expect(work_history.end_date_is_estimate).to be false
     end
+
+    context "without validation, with invalid date values" do
+      let(:start_date) { { 1 => 2222, 2 => 22, 3 => 1 } }
+      let(:end_date) { { 1 => 3333, 2 => 99, 3 => 1 } }
+
+      subject(:save) { form.save(validate: false) }
+
+      it "applies valid date values" do
+        expect(work_history.start_date).to eq(
+          Date.new(Time.zone.now.year, 1, 1),
+        )
+        expect(work_history.end_date).to eq(Date.new(Time.zone.now.year, 1, 1))
+      end
+    end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/MviSWpLB/1501-fix-sentry-errors)

We are seeing frequent `ArgumentError`s in production from the work history and qualifications forms.
These forms can be saved without validation, the errors happen when invalid date values are supplied and we save without validation, `ActiveModel` attempts to call `Time.utc` on the values and they haven't been sanitized.

This PR adds a concern to sanitize date values and apply defaults if the values are invalid/out of range.

## Sentry errors:

https://dfe-teacher-services.sentry.io/issues/3859958966/events/726ad030b8d940b78621f3db73bf6eb6/?environment=production&project=6426061&query=&referrer=previous-event&statsPeriod=14d