### PR TITLE
Fix validation error when clearing location note

### DIFF
--- a/app/forms/assessor_interface/requestable_location_form.rb
+++ b/app/forms/assessor_interface/requestable_location_form.rb
@@ -16,12 +16,14 @@ class AssessorInterface::RequestableLocationForm
     return false unless valid?
 
     ActiveRecord::Base.transaction do
-      requestable.update!(location_note:)
+      requestable.location_note = location_note
 
       if received.present? && !requestable.received?
         receive_professional_standing
       elsif received.blank? && requestable.received?
         request_professional_standing
+      else
+        requestable.save!
       end
 
       ApplicationFormStatusUpdater.call(application_form:, user:)

--- a/spec/forms/assessor_interface/requestable_location_form_spec.rb
+++ b/spec/forms/assessor_interface/requestable_location_form_spec.rb
@@ -36,6 +36,7 @@ RSpec.describe AssessorInterface::RequestableLocationForm, type: :model do
 
     context "when not received" do
       let(:received) { "" }
+      let(:location_note) { "" }
 
       it { is_expected.to be true }
 
@@ -47,6 +48,20 @@ RSpec.describe AssessorInterface::RequestableLocationForm, type: :model do
         expect { save }.to_not have_recorded_timeline_event(
           :requestable_received,
         )
+      end
+
+      context "when already received" do
+        let(:requestable) { create(:professional_standing_request, :received) }
+
+        it { is_expected.to be true }
+
+        it "changes the state" do
+          expect { save }.to change(requestable, :state).to("requested")
+        end
+
+        it "changes the note" do
+          expect { save }.to change(requestable, :location_note).to("")
+        end
       end
     end
 


### PR DESCRIPTION
This fixes an issue when remove the location note at the same time as marking a requestable as requested by not trying to change the location note until we save the model.

[Trello Card](https://trello.com/c/SLKQu3w5/1519-lopsless-professional-standing-request)