### PR TITLE
Validate written in English question

### DIFF
--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -5,11 +5,17 @@ module TeacherInterface
     attr_accessor :document
     attribute :original_attachment
     attribute :translated_attachment
-    attribute :written_in_english, type: :boolean
+    attribute :written_in_english, :boolean
 
     validates :document, presence: true
     validates :original_attachment, file_upload: true
     validates :translated_attachment, file_upload: true
+    validates :written_in_english,
+              inclusion: [true, false],
+              if: -> { document&.translatable? }
+    validates :written_in_english,
+              absence: true,
+              unless: -> { document&.translatable? }
     validate :attachments_present
 
     def update_model
@@ -33,15 +39,14 @@ module TeacherInterface
     def attachments_present
       has_errors =
         original_attachment.blank? ||
-          (written_in_english == "false" && translated_attachment.blank?)
+          (written_in_english == false && translated_attachment.blank?)
 
       # We lose any uploaded documents if the form isn't valid - the user has to upload both again,
       # so we should show both errors even if there was only one.
 
       if has_errors
         errors.add(:original_attachment, :blank)
-
-        if written_in_english == "false"
+        if written_in_english == false
           errors.add(:translated_attachment, :blank)
         end
       end

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -282,6 +282,8 @@ en:
               blank: Enter your first subject
         teacher_interface/upload_form:
           attributes:
+            written_in_english:
+              inclusion: Select whether your document is written in English
             original_attachment:
               blank: Select a file to upload
               invalid_content_type: Files must be in PDF, JPG, PNG, DOCX or DOC format

--- a/spec/forms/teacher_interface/upload_form_spec.rb
+++ b/spec/forms/teacher_interface/upload_form_spec.rb
@@ -17,6 +17,16 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
 
   it { is_expected.to validate_presence_of(:document) }
 
+  describe "validations" do
+    it { is_expected.to validate_absence_of(:written_in_english) }
+
+    context "with a translatable document" do
+      let(:document) { create(:document, :translatable) }
+
+      it { is_expected.to allow_values(true, false).for(:written_in_english) }
+    end
+  end
+
   describe "#valid?" do
     subject(:valid?) { upload_form.valid? }
 

--- a/spec/system/teacher_interface/application_spec.rb
+++ b/spec/system/teacher_interface/application_spec.rb
@@ -590,12 +590,14 @@ RSpec.describe "Teacher application", type: :system do
     teacher_upload_document_page.form.original_attachment.attach_file Rails.root.join(
       file_fixture("upload.pdf"),
     )
+    teacher_upload_document_page.form.written_in_english_items.first.choose
   end
 
   def when_i_fill_in_the_upload_transcript_form
     teacher_upload_document_page.form.original_attachment.attach_file Rails.root.join(
       file_fixture("upload.pdf"),
     )
+    teacher_upload_document_page.form.written_in_english_items.first.choose
   end
 
   def when_i_click_age_range
@@ -666,6 +668,7 @@ RSpec.describe "Teacher application", type: :system do
   def when_i_fill_in_the_upload_written_statement_form
     attach_file "teacher-interface-upload-form-original-attachment-field",
                 Rails.root.join(file_fixture("upload.pdf"))
+    teacher_upload_document_page.form.written_in_english_items.first.choose
   end
 
   def then_i_see_the_teacher_application_page

--- a/spec/system/teacher_interface/written_statement_spec.rb
+++ b/spec/system/teacher_interface/written_statement_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe "Teacher written statement", type: :system do
     teacher_upload_document_page.form.original_attachment.attach_file Rails.root.join(
       file_fixture("upload.pdf"),
     )
+    teacher_upload_document_page.form.written_in_english_items.first.choose
     teacher_upload_document_page.form.continue_button.click
   end
 


### PR DESCRIPTION
This adds validation to the document upload form to ensure that the user answers the "Is your document written in English?" question on the document form.

I've also fixed an issue where the field wasn't being converted to a boolean correctly.

[Trello Card](https://trello.com/c/2MqxcR33/1515-is-your-document-written-in-english-no-error-when-neither-are-selected)