### PR TITLE
Remove status from further information content

### DIFF
--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -1,11 +1,10 @@
 module StatusTag
   class Component < ViewComponent::Base
-    def initialize(key:, status:, class_context: nil, context: :teacher)
+    def initialize(key:, status:, class_context: nil)
       super
       @key = key
       @status = status.to_sym
       @class_context = class_context
-      @context = context
     end
 
     def id
@@ -13,7 +12,7 @@ module StatusTag
     end
 
     def text
-      status_text(@status, context: @context)
+      I18n.t(@status, scope: %i[components status_tag])
     end
 
     def classes
@@ -40,12 +39,7 @@ module StatusTag
     }.freeze
 
     def colour
-      colours = COLOURS[@status]
-      return nil if colours.nil?
-
-      colours.is_a?(String) ? colours : colours[@context]
+      COLOURS[@status]
     end
-
-    delegate :status_text, to: :helpers
   end
 end

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -49,7 +49,6 @@ module TimelineEntry
               key: timeline_event.id,
               status: timeline_event.old_state,
               class_context: "timeline-event",
-              context: :assessor,
             ),
           ).strip,
         new_state:
@@ -58,7 +57,6 @@ module TimelineEntry
               key: timeline_event.id,
               status: timeline_event.new_state,
               class_context: "timeline-event",
-              context: :assessor,
             ),
           ).strip,
       }

--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -94,7 +94,6 @@ module ApplicationFormHelper
             key: "application-form-#{application_form.id}",
             status: application_form.status,
             class_context: "app-search-result__item",
-            context: :assessor,
           ),
         ),
       ],

--- a/app/helpers/status_helper.rb
+++ b/app/helpers/status_helper.rb
@@ -1,7 +1,0 @@
-module StatusHelper
-  def status_text(status, context: :teacher)
-    key_with_context = "components.status_tag.#{status}.#{context}"
-    key_without_context = "components.status_tag.#{status}"
-    I18n.t(key_with_context, default: I18n.t(key_without_context))
-  end
-end

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -3,7 +3,6 @@
 class AssessorInterface::ApplicationFormsIndexViewObject
   include ActionView::Helpers::FormOptionsHelper
   include Pagy::Backend
-  include StatusHelper
 
   def initialize(params:, session:)
     @params = params
@@ -47,7 +46,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
     ]
 
     statuses.map do |status|
-      text = status_text(status, context: :assessor)
+      text = I18n.t(status, scope: %i[components status_tag])
       OpenStruct.new(id: status, label: "#{text} (#{counts.fetch(status, 0)})")
     end
   end

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -30,7 +30,6 @@
               key: "#{item}-#{index}",
               status: @view_object.assessment_task_status(section, item, index),
               class_context: "app-task-list",
-              context: :assessor,
             )) %>
           </li>
         <% end %>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -144,9 +144,6 @@
   <p class="govuk-body">Your adviser can help with writing a personal statement, preparing for an interview and accessing courses to enhance your subject knowledge.</p>
 <% elsif @view_object.further_information_request&.requested? %>
   <h2 class="govuk-heading-m">We need some more information</h2>
-  <p class="govuk-body">The status of your qualified teacher status application is currently:</p>
-  <p class="govuk-body"><%= render(StatusTag::Component.new(key: "state", status: @view_object.application_form.status)) %></p>
-  <h3 class="govuk-heading-m">What you need to do</h3>
   <p class="govuk-body">The assessor needs you to provide some additional information so they can continue reviewing your application.</p>
   <div class="govuk-inset-text">
     You may need to upload 1 or more documents. Make sure any files you upload clearly show the whole document or page, and that any text is easy to read.

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -15,9 +15,7 @@ en:
       potential_duplicate_in_dqt: Potential duplication in DQT
       received: Received
       requested: Waiting on
-      submitted:
-        assessor: Not started
-        teacher: Submitted
+      submitted: Not started
       valid: Valid
       waiting_on: Waiting on
 

--- a/spec/components/status_tag_spec.rb
+++ b/spec/components/status_tag_spec.rb
@@ -4,32 +4,17 @@ require "rails_helper"
 
 RSpec.describe StatusTag::Component, type: :component do
   subject(:component) do
-    render_inline(described_class.new(key:, status:, class_context:, context:))
+    render_inline(described_class.new(key:, status:, class_context:))
   end
 
   let(:key) { "key" }
   let(:status) { :awarded }
   let(:class_context) { "app-task-list" }
-  let(:context) { :teacher }
 
   describe "text" do
     subject(:text) { component.text.strip }
 
     it { is_expected.to eq("Awarded") }
-
-    context "submitted with assessor context" do
-      let(:status) { :submitted }
-      let(:context) { :assessor }
-
-      it { is_expected.to eq("Not started") }
-    end
-
-    context "submitted with teacher context" do
-      let(:status) { :submitted }
-      let(:context) { :teacher }
-
-      it { is_expected.to eq("Submitted") }
-    end
   end
 
   describe "id" do

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
       )
     end
     let(:old_state) do
-      I18n.t("components.status_tag.#{timeline_event.old_state}.assessor")
+      I18n.t("components.status_tag.#{timeline_event.old_state}")
     end
     let(:new_state) do
       I18n.t("components.status_tag.#{timeline_event.new_state}")


### PR DESCRIPTION
There's no need to show the status tag of the application as we should have dedicated content for it.

I've also removed the status tag context as we're not rendering this status tag in any place other than for accessors now so we don't need any context to display something different for teachers and for assessors.

[Trello Card](https://trello.com/c/CVp4tdH4/1521-remove-waiting-on-label-from-fi-user)