### PR TITLE
Remove legacy regions (part 1 of 2)

### DIFF
--- a/app/controllers/eligibility_interface/countries_controller.rb
+++ b/app/controllers/eligibility_interface/countries_controller.rb
@@ -22,7 +22,6 @@ module EligibilityInterface
       {
         eligible: eligibility_interface_qualifications_path,
         ineligible: eligibility_interface_ineligible_path,
-        legacy: eligibility_interface_eligible_path,
         region: eligibility_interface_region_path,
       }.fetch(eligibility_check.country_eligibility_status)
     end

--- a/app/controllers/eligibility_interface/region_controller.rb
+++ b/app/controllers/eligibility_interface/region_controller.rb
@@ -12,20 +12,13 @@ module EligibilityInterface
       @region_form =
         RegionForm.new(region_form_params.merge(eligibility_check:))
       if @region_form.save
-        redirect_to next_url
+        redirect_to eligibility_interface_qualifications_path
       else
         render :new, status: :unprocessable_entity
       end
     end
 
     private
-
-    def next_url
-      {
-        eligible: eligibility_interface_qualifications_path,
-        legacy: eligibility_interface_eligible_path,
-      }.fetch(eligibility_check.region_eligibility_status)
-    end
 
     def region_form_params
       params.require(:eligibility_interface_region_form).permit(:region_id)

--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -29,16 +29,12 @@ class SupportInterface::RegionsController < SupportInterface::BaseController
     authorize :support, :show?
 
     @region = Region.find(params[:id])
-
-    # Non-legacy previews are more useful to the team.
-    @region.legacy = false
   end
 
   private
 
   def region_params
     params.require(:region).permit(
-      :legacy,
       :application_form_enabled,
       :application_form_skip_work_history,
       :reduced_evidence_accepted,

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -139,12 +139,13 @@ class EligibilityCheck < ApplicationRecord
   end
 
   def country_eligibility_status
-    return region_eligibility_status if region
-    country_exists? ? :region : :ineligible
-  end
-
-  def region_eligibility_status
-    region.legacy ? :legacy : :eligible
+    if region
+      :eligible
+    elsif country_exists?
+      :region
+    else
+      :ineligible
+    end
   end
 
   def country_regions
@@ -159,8 +160,7 @@ class EligibilityCheck < ApplicationRecord
   end
 
   def status
-    if country_code.present? &&
-         %i[ineligible legacy].include?(country_eligibility_status)
+    if country_code.present? && country_eligibility_status == :ineligible
       return :eligibility
     end
 

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -20,41 +20,39 @@
   <% end %>
 <% end %>
 
-<% if region && !region.legacy %>
-  <h2 class="govuk-heading-m">What we’ll ask for</h2>
-  <p class="govuk-body">You’ll need to provide the following evidence when you apply.</p>
+<h2 class="govuk-heading-m">What we’ll ask for</h2>
+<p class="govuk-body">You’ll need to provide the following evidence when you apply.</p>
 
-  <%= govuk_accordion do |accordion| %>
-    <% accordion.section(heading_text: "Proof of identity") do %>
-      <%= render "shared/eligible_region_content_components/proof_of_identity" %>
-    <% end %>
+<%= govuk_accordion do |accordion| %>
+  <% accordion.section(heading_text: "Proof of identity") do %>
+    <%= render "shared/eligible_region_content_components/proof_of_identity" %>
+  <% end %>
 
-    <% accordion.section(heading_text: "Proof of qualifications") do %>
-      <%= render "shared/eligible_region_content_components/proof_of_qualifications", region: %>
-    <% end %>
+  <% accordion.section(heading_text: "Proof of qualifications") do %>
+    <%= render "shared/eligible_region_content_components/proof_of_qualifications", region: %>
+  <% end %>
 
-    <% if FeatureFlags::FeatureFlag.active?(:eligibility_english_language) %>
-      <% accordion.section(heading_text: "Proof of English language ability") do %>
-        <%= render "shared/eligible_region_content_components/english_language", region: %>
-      <% end %>
+  <% if FeatureFlags::FeatureFlag.active?(:eligibility_english_language) %>
+    <% accordion.section(heading_text: "Proof of English language ability") do %>
+      <%= render "shared/eligible_region_content_components/english_language", region: %>
     <% end %>
+  <% end %>
 
-    <% unless FeatureFlags::FeatureFlag.active?(:application_work_history) && region.status_check_none? && region.sanction_check_none? %>
-      <% accordion.section(heading_text: "Proof that you’re recognised as a teacher") do %>
-        <%= render "shared/eligible_region_content_components/professional_recognition",
-                   region:,
-                   teaching_authority_provides_written_statement: region.teaching_authority_provides_written_statement %>
-      <% end %>
+  <% unless FeatureFlags::FeatureFlag.active?(:application_work_history) && region.status_check_none? && region.sanction_check_none? %>
+    <% accordion.section(heading_text: "Proof that you’re recognised as a teacher") do %>
+      <%= render "shared/eligible_region_content_components/professional_recognition",
+                 region:,
+                 teaching_authority_provides_written_statement: region.teaching_authority_provides_written_statement %>
     <% end %>
+  <% end %>
 
-    <% if FeatureFlags::FeatureFlag.active?(:application_work_history) && !region.application_form_skip_work_history %>
-      <% accordion.section(heading_text: "Proof of work history") do %>
-        <%= render "shared/eligible_region_content_components/proof_of_work_history", region:, eligibility_check: %>
-      <% end %>
+  <% if FeatureFlags::FeatureFlag.active?(:application_work_history) && !region.application_form_skip_work_history %>
+    <% accordion.section(heading_text: "Proof of work history") do %>
+      <%= render "shared/eligible_region_content_components/proof_of_work_history", region:, eligibility_check: %>
     <% end %>
+  <% end %>
 
-    <% accordion.section(heading_text: "Certified translations") do %>
-      <% render "shared/eligible_region_content_components/certified_translation", region: %>
-    <% end %>
+  <% accordion.section(heading_text: "Certified translations") do %>
+    <% render "shared/eligible_region_content_components/certified_translation", region: %>
   <% end %>
 <% end %>

--- a/app/views/support_interface/countries/index.html.erb
+++ b/app/views/support_interface/countries/index.html.erb
@@ -42,7 +42,7 @@
                 </td>
 
                 <td class="govuk-table__cell">
-                  <% if region.legacy && !country.eligibility_skip_questions %>
+                  <% if country.eligibility_skip_questions %>
                     <%= govuk_tag(text: "Skips questions", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
                   <% end %>
 

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -5,8 +5,6 @@
 <%= form_with model: [:support_interface, @region] do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_check_box :legacy, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Skip eligibility checker (legacy)" } %>
-
   <%= f.govuk_check_box :application_form_enabled, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Application form enabled" } %>
   <%= f.govuk_check_box :application_form_skip_work_history, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Skip work history" } %>
   <%= f.govuk_check_box :reduced_evidence_accepted, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Accept reduced evidence" } %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -262,11 +262,7 @@ COUNTRIES = {
 
 DEFAULT_COUNTRY = { eligibility_enabled: true }.freeze
 
-DEFAULT_REGION = {
-  name: "",
-  legacy: false,
-  application_form_enabled: true,
-}.freeze
+DEFAULT_REGION = { name: "", application_form_enabled: true }.freeze
 
 COUNTRIES.each do |code, value|
   regions = value.is_a?(Hash) ? value[:regions] : value

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -36,12 +36,6 @@ FactoryBot.define do
       end
     end
 
-    trait :with_legacy_region do
-      after(:create) do |country, _evaluator|
-        create(:region, :legacy, country:)
-      end
-    end
-
     trait :with_teaching_authority do
       teaching_authority_address { Faker::Address.street_address }
       teaching_authority_emails { [Faker::Internet.email] }

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -40,14 +40,9 @@ FactoryBot.define do
     association :country
 
     sequence(:name) { |n| "Region #{n}" }
-    legacy { false }
 
     trait :national do
       name { "" }
-    end
-
-    trait :legacy do
-      legacy { true }
     end
 
     trait :application_form_enabled do

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -197,12 +197,6 @@ RSpec.describe EligibilityCheck, type: :model do
       it { is_expected.to eq(:eligible) }
     end
 
-    context "when the region exists and is legacy" do
-      before { eligibility_check.region = create(:region, :legacy) }
-
-      it { is_expected.to eq(:legacy) }
-    end
-
     context "when the region exists and country skips questions" do
       let(:country) do
         create(
@@ -221,36 +215,6 @@ RSpec.describe EligibilityCheck, type: :model do
       before { eligibility_check.country_code = "ABC" }
 
       it { is_expected.to be(:ineligible) }
-    end
-  end
-
-  describe "#region_eligibility_status" do
-    subject(:region_eligibility_status) do
-      eligibility_check.region_eligibility_status
-    end
-
-    context "when the region exists and is not legacy" do
-      before { eligibility_check.region = create(:region) }
-
-      it { is_expected.to eq(:eligible) }
-    end
-
-    context "when the region exists and is legacy" do
-      before { eligibility_check.region = create(:region, :legacy) }
-
-      it { is_expected.to eq(:legacy) }
-    end
-
-    context "when the region exists and country skips questions" do
-      before do
-        eligibility_check.region =
-          create(
-            :region,
-            country: create(:country, eligibility_skip_questions: true),
-          )
-      end
-
-      it { is_expected.to eq(:eligible) }
     end
   end
 
@@ -411,14 +375,6 @@ RSpec.describe EligibilityCheck, type: :model do
           degree: true,
           region: create(:region),
         }
-      end
-
-      it { is_expected.to eq(:eligibility) }
-    end
-
-    context "with a legacy region" do
-      let(:attributes) do
-        { country_code: country.code, region: create(:region, :legacy) }
       end
 
       it { is_expected.to eq(:eligibility) }

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -376,7 +376,6 @@ RSpec.describe "Eligibility check", type: :system do
 
   def given_countries_exist
     create(:country, :with_national_region, code: "GB-SCT")
-    create(:country, :with_legacy_region, code: "FR")
     create(
       :country,
       :with_national_region,
@@ -404,10 +403,6 @@ RSpec.describe "Eligibility check", type: :system do
 
   def when_i_select_an_ineligible_country
     country_page.submit(country: "Spain")
-  end
-
-  def when_i_select_a_legacy_country
-    country_page.submit(country: "France")
   end
 
   def when_i_select_a_skip_questions_country

--- a/spec/views/shared/eligible_region_content_spec.rb
+++ b/spec/views/shared/eligible_region_content_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Eligible region content", type: :view do
-  let(:region) { nil }
+  let(:region) { create(:region) }
   let(:eligibility_check) { nil }
 
   subject do
@@ -9,7 +9,7 @@ RSpec.describe "Eligible region content", type: :view do
   end
 
   it { is_expected.to match(/You’re eligible/) }
-  it { is_expected.to_not match(/What we’ll ask for/) }
+  it { is_expected.to match(/What we’ll ask for/) }
 
   context "with a fully online region" do
     let(:region) do


### PR DESCRIPTION
Now that we've launched the new regulations, we can remove this column as all of the countries are live. Before removing the column we need to remove all references to it.