### PR TITLE
Remove legacy regions (part 2 of 2)

### DIFF
--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -5,7 +5,6 @@
 #  id                                            :bigint           not null, primary key
 #  application_form_enabled                      :boolean          default(FALSE)
 #  application_form_skip_work_history            :boolean          default(FALSE), not null
-#  legacy                                        :boolean          default(TRUE), not null
 #  name                                          :string           default(""), not null
 #  qualifications_information                    :text             default(""), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -246,7 +246,6 @@
     - updated_at
     - status_check
     - sanction_check
-    - legacy
     - application_form_enabled
     - application_form_skip_work_history
     - reduced_evidence_accepted

--- a/db/migrate/20230206170918_remove_legacy_from_regions.rb
+++ b/db/migrate/20230206170918_remove_legacy_from_regions.rb
@@ -1,0 +1,5 @@
+class RemoveLegacyFromRegions < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :regions, :legacy, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_01_152147) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_06_170918) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -312,7 +312,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_01_152147) do
     t.string "status_check", default: "none", null: false
     t.string "sanction_check", default: "none", null: false
     t.text "teaching_authority_address", default: "", null: false
-    t.boolean "legacy", default: true, null: false
     t.text "teaching_authority_emails", default: [], null: false, array: true
     t.text "teaching_authority_websites", default: [], null: false, array: true
     t.text "teaching_authority_name", default: "", null: false

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -5,7 +5,6 @@
 #  id                                            :bigint           not null, primary key
 #  application_form_enabled                      :boolean          default(FALSE)
 #  application_form_skip_work_history            :boolean          default(FALSE), not null
-#  legacy                                        :boolean          default(TRUE), not null
 #  name                                          :string           default(""), not null
 #  qualifications_information                    :text             default(""), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -5,7 +5,6 @@
 #  id                                            :bigint           not null, primary key
 #  application_form_enabled                      :boolean          default(FALSE)
 #  application_form_skip_work_history            :boolean          default(FALSE), not null
-#  legacy                                        :boolean          default(TRUE), not null
 #  name                                          :string           default(""), not null
 #  qualifications_information                    :text             default(""), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null


### PR DESCRIPTION
We've removed all references to the column and since the new regulations have launched we no longer need the functionality.

Depends on #1088 