### PR TITLE
Show English language exemption accordion section

### DIFF
--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -51,11 +51,6 @@ module AssessorInterface
         application_form.english_language_proof_method_provider?
     end
 
-    def show_english_language_moi_details?
-      assessment_section.english_language_proficiency? &&
-        application_form.english_language_proof_method_medium_of_instruction?
-    end
-
     def show_english_language_exemption_checkbox?
       (
         application_form.english_language_citizenship_exempt == true &&

--- a/app/views/assessor_interface/assessment_sections/_english_language_exempt_accordion_section.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_english_language_exempt_accordion_section.html.erb
@@ -1,0 +1,7 @@
+<% accordion.section(heading_text: "Which countries are exempt?") do %>
+  <p class="govuk-body">
+    The following countries are exempt from additional English language proficiency requirements:
+  </p>
+
+  <%= render "shared/english_language_exempt_countries" %>
+<% end %>

--- a/app/views/assessor_interface/assessment_sections/_personal_information_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_personal_information_summary.html.erb
@@ -1,2 +1,8 @@
 <%= render "shared/application_form/personal_information_summary", application_form:, changeable: false %>
 <%= render "shared/application_form/identification_document_summary", application_form:, changeable: false %>
+
+<% if application_form.english_language_citizenship_exempt %>
+  <%= govuk_accordion do |accordion| %>
+    <% render "english_language_exempt_accordion_section", accordion: %>
+  <% end %>
+<% end %>

--- a/app/views/assessor_interface/assessment_sections/_qualifications_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_qualifications_summary.html.erb
@@ -7,4 +7,8 @@
   <% accordion.section(heading_text: "Qualification information shown to applicant") do %>
     <%= render "shared/eligible_region_content_components/proof_of_qualifications", region: %>
   <% end %>
+
+  <% if application_form.english_language_qualification_exempt %>
+    <% render "english_language_exempt_accordion_section", accordion: %>
+  <% end %>
 <% end %>

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -34,16 +34,6 @@
       ) %>
     <% end %>
 
-    <% if @assessment_section_view_object.show_english_language_moi_details? %>
-      <%= govuk_details(summary_text: "Which countries are exempt?") do %>
-        <p class="govuk-body">
-          The following countries are exempt from additional English language proficiency requirements:
-        </p>
-
-        <%= render "shared/english_language_exempt_countries" %>
-      <% end %>
-    <% end %>
-
     <% if @assessment_section_view_object.show_english_language_provider_details? %>
       <%= render "english_language_provider_details",
                  provider: @assessment_section_view_object.application_form.english_language_provider,

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -125,53 +125,6 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
     it { is_expected.to be true }
   end
 
-  describe "#show_english_language_moi_details?" do
-    let(:params) do
-      {
-        key:,
-        assessment_id: assessment.id,
-        application_form_id: application_form.id,
-      }
-    end
-
-    subject(:show_english_language_moi_details?) do
-      view_object.show_english_language_moi_details?
-    end
-
-    context "when the application EL proof method is 'medium_of_instruction'" do
-      let(:key) { "english_language_proficiency" }
-      let(:application_form) do
-        create(:application_form, :with_english_language_medium_of_instruction)
-      end
-      let(:assessment_section) do
-        create(:assessment_section, :english_language_proficiency, assessment:)
-      end
-
-      it { is_expected.to be true }
-    end
-
-    context "when the application EL proof method is not 'medium_of_instruction'" do
-      let(:key) { "english_language_proficiency" }
-      let(:application_form) do
-        create(:application_form, :with_english_language_provider)
-      end
-      let(:assessment_section) do
-        create(:assessment_section, :english_language_proficiency, assessment:)
-      end
-
-      it { is_expected.to be false }
-    end
-
-    context "when the section is not 'english_language_proficiency'" do
-      let(:key) { "personal_information" }
-      let(:assessment_section) do
-        create(:assessment_section, :personal_information, assessment:)
-      end
-
-      it { is_expected.to be false }
-    end
-  end
-
   describe "#show_english_language_provider_details?" do
     let(:params) do
       {


### PR DESCRIPTION
This adds a new accordion section to the personal information and qualification assessor task if the teacher says they are exempt from the English language requirements.

[Trello Card](https://trello.com/c/joGM3qEP/1525-add-which-countries-are-exempt-to-elp-on-exempt-countries)