### PR TITLE
Add English language proficiency test document failure reason

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -191,7 +191,13 @@ class AssessmentFactory
         else
           [
             FailureReasons::EL_QUALIFICATION_INVALID,
-            FailureReasons::EL_UNVERIFIABLE_REFERENCE_NUMBER,
+            (
+              if application_form.english_language_provider_other
+                FailureReasons::EL_PROFICIENCY_DOCUMENT_ILLEGIBLE
+              else
+                FailureReasons::EL_UNVERIFIABLE_REFERENCE_NUMBER
+              end
+            ),
             FailureReasons::EL_GRADE_BELOW_B2,
             FailureReasons::EL_SELT_EXPIRED,
           ]

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -44,6 +44,8 @@ class FailureReasons
     EL_MOI_INVALID_FORMAT = "english_language_moi_invalid_format",
     EL_UNVERIFIABLE_REFERENCE_NUMBER =
       "english_language_unverifiable_reference_number",
+    EL_PROFICIENCY_DOCUMENT_ILLEGIBLE =
+      "english_language_proficiency_document_illegible",
     IDENTIFICATION_DOCUMENT_EXPIRED = "identification_document_expired",
     IDENTIFICATION_DOCUMENT_ILLEGIBLE = "identification_document_illegible",
     IDENTIFICATION_DOCUMENT_MISMATCH = "identification_document_mismatch",
@@ -72,6 +74,7 @@ class FailureReasons
     DEGREE_CERTIFICATE_ILLEGIBLE => :qualification_certificate,
     DEGREE_TRANSCRIPT_ILLEGIBLE => :qualification_transcript,
     EL_MOI_INVALID_FORMAT => :medium_of_instruction,
+    EL_PROFICIENCY_DOCUMENT_ILLEGIBLE => :english_language_proficiency,
     IDENTIFICATION_DOCUMENT_EXPIRED => :identification,
     IDENTIFICATION_DOCUMENT_ILLEGIBLE => :identification,
     IDENTIFICATION_DOCUMENT_MISMATCH => :name_change,

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -142,6 +142,7 @@ en:
           english_language_exemption_by_qualification_not_confirmed: The applicant’s qualification documents do not confirm English language exemption by country of study.
           english_language_moi_not_taught_in_english: The applicant’s MOI does not show that they were taught exclusively in English.
           english_language_moi_invalid_format: The applicant’s Medium of instruction (MOI) document is illegible or in a format that we cannot accept.
+          english_language_proficiency_document_illegible: The applicant’s English language proficiency test document is illegible or in a format that we cannot accept.
           english_language_qualification_invalid: The applicant’s English language qualification is not from one of the approved providers.
           english_language_not_achieved_b2: The applicant provided evidence of a SELT but has not achieved B2 level.
           english_language_selt_expired: The applicant provided evidence of a SELT but the test was not completed within the last 2 years.


### PR DESCRIPTION
This adds a new failure reason for teachers who are using the reduced evidence journey and are able to upload their English language proficiency test results in the form of a document. We need to allow them to upload an alternative document if it's not legible or in a format we can't open.

[Trello Card](https://trello.com/c/KRAPsCjW/1523-new-fi-reason-for-reduced-evidence-countries-elp)