### PR TITLE
Add missing button group

### DIFF
--- a/app/views/assessor_interface/assessment_recommendation_declines/preview.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_declines/preview.html.erb
@@ -11,5 +11,7 @@
   teacher: @application_form.teacher,
 )) %>
 
-<%= govuk_button_link_to "Continue", [:confirm, :assessor_interface, @application_form, @assessment, :assessment_recommendation_decline] %>
-<%= govuk_link_to t(".cancel"), assessor_interface_application_form_path(@application_form) %>
+<div class="govuk-button-group">
+  <%= govuk_button_link_to "Continue", [:confirm, :assessor_interface, @application_form, @assessment, :assessment_recommendation_decline] %>
+  <%= govuk_link_to t(".cancel"), assessor_interface_application_form_path(@application_form) %>
+</div>


### PR DESCRIPTION
This adds a missing button group to a button and a link to make sure the link renders correctly next to the button.