### PR TITLE
Sanitize months as words

### DIFF
--- a/app/forms/concerns/teacher_interface/sanitize_dates.rb
+++ b/app/forms/concerns/teacher_interface/sanitize_dates.rb
@@ -11,7 +11,7 @@ module TeacherInterface
         dates.each do |date|
           next if date[1].blank? || date[2].blank?
 
-          date[2] = 1 if date[2] > 12
+          date[2] = 1 if date[2].to_i < 1 || date[2].to_i > 12
 
           date[1] = today.year if date[1] > today.year || date[1] < 1900
         end

--- a/app/views/teacher_interface/qualifications/_form.html.erb
+++ b/app/views/teacher_interface/qualifications/_form.html.erb
@@ -22,16 +22,19 @@
 
   <%= f.govuk_date_field :start_date,
                          omit_day: true,
+                         maxlength_enabled: true,
                          legend: { text: I18n.t("application_form.qualifications.form.fields.start_date.#{qualification.locale_key}") },
                          hint: { text: "For example, 3 2020" } %>
 
   <%= f.govuk_date_field :complete_date,
                          omit_day: true,
+                         maxlength_enabled: true,
                          legend: { text: I18n.t("application_form.qualifications.form.fields.complete_date.#{qualification.locale_key}") },
                          hint: { text: "For example, 3 2020" } %>
 
   <%= f.govuk_date_field :certificate_date,
                          omit_day: true,
+                         maxlength_enabled: true,
                          legend: { text: I18n.t("application_form.qualifications.form.fields.certificate_date.#{qualification.locale_key}") },
                          hint: { text: "For example, 3 2020" } %>
 

--- a/spec/forms/teacher_interface/qualification_form_spec.rb
+++ b/spec/forms/teacher_interface/qualification_form_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe TeacherInterface::QualificationForm, type: :model do
     context "without validation, with invalid date values" do
       let(:start_date) { { 1 => 2222, 2 => 22, 3 => 1 } }
       let(:complete_date) { { 1 => 3333, 2 => 99, 3 => 1 } }
-      let(:certificate_date) { { 1 => 99, 2 => 99, 3 => 1 } }
+      let(:certificate_date) { { 1 => 99, 2 => "JUNE", 3 => 1 } }
 
       subject(:save) { form.save(validate: false) }
 


### PR DESCRIPTION
https://dfe-teacher-services.sentry.io/issues/3859958966/?project=6426061&query=is%3Aunresolved&referrer=issue-stream

- Sanitize `to_i` month values below `1` and above `12`
- Enable `maxlength` attribute on qualifications month field