### PR TITLE
Simplify new regs for eligibility checks

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -78,8 +78,6 @@
 #  fk_rails_...  (teacher_id => teachers.id)
 #
 class ApplicationForm < ApplicationRecord
-  include Regulated
-
   belongs_to :teacher
   belongs_to :region
   belongs_to :english_language_provider, optional: true
@@ -199,6 +197,10 @@ class ApplicationForm < ApplicationRecord
     CountryCode.secondary_education_teaching_qualification_required?(
       country.code,
     )
+  end
+
+  def created_under_new_regulations?
+    created_at >= Date.parse(ENV.fetch("NEW_REGS_DATE", "2023-02-01"))
   end
 
   private

--- a/app/models/concerns/regulated.rb
+++ b/app/models/concerns/regulated.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-module Regulated
-  extend ActiveSupport::Concern
-
-  def created_under_new_regulations?
-    created_at >= Date.parse(ENV.fetch("NEW_REGS_DATE", "2023-02-01"))
-  end
-end

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -21,8 +21,6 @@
 #  fk_rails_...  (region_id => regions.id)
 #
 class EligibilityCheck < ApplicationRecord
-  include Regulated
-
   belongs_to :region, optional: true
   has_one :application
 

--- a/app/views/eligibility_interface/finish/eligible.html.erb
+++ b/app/views/eligibility_interface/finish/eligible.html.erb
@@ -3,10 +3,6 @@
 
 <%= render "shared/eligible_region_content", region: @region, eligibility_check: @eligibility_check %>
 
-<% unless @eligibility_check.created_under_new_regulations? %>
-  <%= render "shared/apply_by_february_2023" %>
-<% end %>
-
 <% if FeatureFlags::FeatureFlag.active?(:teacher_applications) && @region && @region.application_form_enabled %>
   <p class="govuk-body">Use our new application form to apply for QTS.</p>
   <%= govuk_start_button(text: "Apply for QTS", href: new_teacher_registration_path) %>

--- a/app/views/shared/_apply_by_february_2023.html.erb
+++ b/app/views/shared/_apply_by_february_2023.html.erb
@@ -1,9 +1,0 @@
-<%= govuk_inset_text do %>
-  <p class="govuk-body">
-    New criteria will apply to applications made from 1 February 2023.
-  </p>
-
-  <p class="govuk-body">
-    If you do not submit your application before this date, you'll need to submit a new application under the <a href="https://www.gov.uk/government/publications/awarding-qualified-teacher-status-to-overseas-teachers/a-fairer-approach-to-awarding-qts-to-overseas-teachers#criteria-for-awarding-qts" class="govuk-link">new criteria</a>.
-  </p>
-<% end %>

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -15,9 +15,7 @@
     <p class="govuk-body">Once you begin, we’ll sign you out if you’re inactive for 60 minutes.</p>
   <% end %>
 
-  <% if eligibility_check&.created_under_new_regulations? %>
-    <p class="govuk-body">You’ll need to complete your application within 6 months of starting it.</p>
-  <% end %>
+  <p class="govuk-body">You’ll need to complete your application within 6 months of starting it.</p>
 <% end %>
 
 <h2 class="govuk-heading-m">What we’ll ask for</h2>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -22,8 +22,6 @@
         Applications must be completed within 6 months, so you’ll need to complete it before <%= @view_object.expires_at %>.
       </p>
     <% end %>
-  <% else %>
-    <%= render "shared/apply_by_february_2023" %>
   <% end %>
 
   <ol class="app-task-list">

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -387,48 +387,6 @@ RSpec.describe EligibilityCheck, type: :model do
     end
   end
 
-  describe "#created_under_new_regulations?" do
-    subject(:created_under_new_regulations?) do
-      eligibility_check.created_under_new_regulations?
-    end
-
-    context "with default new regulations date" do
-      context "with an old eligibility check" do
-        let(:eligibility_check) do
-          create(:eligibility_check, created_at: Date.new(2020, 1, 1))
-        end
-        it { is_expected.to be false }
-      end
-
-      context "with a new eligibility check" do
-        let(:eligibility_check) do
-          create(:eligibility_check, created_at: Date.new(2024, 1, 1))
-        end
-        it { is_expected.to be true }
-      end
-    end
-
-    context "with a custom new regulations date" do
-      around do |example|
-        ClimateControl.modify(NEW_REGS_DATE: "2023-01-01") { example.run }
-      end
-
-      context "with an old eligibility check" do
-        let(:eligibility_check) do
-          create(:eligibility_check, created_at: Date.new(2021, 12, 31))
-        end
-        it { is_expected.to be false }
-      end
-
-      context "with a new eligibility check" do
-        let(:eligibility_check) do
-          create(:eligibility_check, created_at: Date.new(2023, 1, 1))
-        end
-        it { is_expected.to be true }
-      end
-    end
-  end
-
   describe "#qualified_for_subject_required?" do
     subject(:qualified_for_subject_required?) do
       eligibility_check.qualified_for_subject_required?

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -18,8 +18,6 @@ locals {
     AZURE_STORAGE_CONTAINER    = azurerm_storage_container.uploads.name
 
     DQT_API_URL = var.dqt_api_url
-
-    NEW_REGS_DATE = var.new_regs_date
   })
   logstash_endpoint = data.azurerm_key_vault_secret.secrets["LOGSTASH-ENDPOINT"].value
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -102,11 +102,6 @@ variable "dqt_api_url" {
   type = string
 }
 
-variable "new_regs_date" {
-  type    = string
-  default = "2023-02-01"
-}
-
 locals {
   apply_qts_routes = flatten([
     cloudfoundry_route.apply_qts_public,

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -6,6 +6,5 @@
   "education_hostnames": ["dev"],
   "prometheus_app": "prometheus-tra-monitoring-dev",
   "forms_storage_account_name": "s165d01afqtsformsdv",
-  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital",
-  "new_regs_date": "2023-01-04"
+  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital"
 }

--- a/terraform/workspace_variables/review.tfvars.json
+++ b/terraform/workspace_variables/review.tfvars.json
@@ -3,6 +3,5 @@
   "key_vault_name": "s165d01-afqts-dv-kv",
   "resource_group_name": "s165d01-afqts-dv-rg",
   "paas_space": "tra-dev",
-  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital",
-  "new_regs_date": "2023-01-04"
+  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital"
 }

--- a/terraform/workspace_variables/test.tfvars.json
+++ b/terraform/workspace_variables/test.tfvars.json
@@ -13,6 +13,5 @@
       "confirmations": 2
     }
   },
-  "dqt_api_url": "https://test-teacher-qualifications-api.education.gov.uk",
-  "new_regs_date": "2023-01-04"
+  "dqt_api_url": "https://test-teacher-qualifications-api.education.gov.uk"
 }


### PR DESCRIPTION
This removes the custom new regulations date in the non-production environments so it matches production, and removes the now unnecessary `created_under_new_regulations?` method for eligibility checks. This tidies up some of the views making things easier to test as the view will always look correct.