### PR TITLE
Remove application_form_enabled (part 1 of 2)

### DIFF
--- a/app/controllers/eligibility_interface/finish_controller.rb
+++ b/app/controllers/eligibility_interface/finish_controller.rb
@@ -4,7 +4,6 @@ class EligibilityInterface::FinishController < EligibilityInterface::BaseControl
   before_action :load_eligibility_check
 
   def eligible
-    @mutual_recognition_url = MUTUAL_RECOGNITION_URL
     @region = eligibility_check.region
     session[:eligibility_check_complete] = true
   end
@@ -13,9 +12,6 @@ class EligibilityInterface::FinishController < EligibilityInterface::BaseControl
   end
 
   private
-
-  MUTUAL_RECOGNITION_URL =
-    "https://teacherservices.education.gov.uk/MutualRecognition/".freeze
 
   def ensure_eligibility_check_status
     if eligibility_check.status != :eligibility

--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -35,7 +35,6 @@ class SupportInterface::RegionsController < SupportInterface::BaseController
 
   def region_params
     params.require(:region).permit(
-      :application_form_enabled,
       :application_form_skip_work_history,
       :reduced_evidence_accepted,
       :qualifications_information,

--- a/app/views/eligibility_interface/finish/eligible.html.erb
+++ b/app/views/eligibility_interface/finish/eligible.html.erb
@@ -3,12 +3,9 @@
 
 <%= render "shared/eligible_region_content", region: @region, eligibility_check: @eligibility_check %>
 
-<% if FeatureFlags::FeatureFlag.active?(:teacher_applications) && @region && @region.application_form_enabled %>
+<% if FeatureFlags::FeatureFlag.active?(:teacher_applications) %>
   <p class="govuk-body">Use our new application form to apply for QTS.</p>
   <%= govuk_start_button(text: "Apply for QTS", href: new_teacher_registration_path) %>
-<% else %>
-  <p class="govuk-body">You’ll make your application on the Teaching Regulation Agency website.</p>
-  <%= govuk_start_button(text: "Apply for QTS", href: @mutual_recognition_url) %>
 <% end %>
 
 <%= render "shared/help_us_to_improve_this_service" %>

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -11,7 +11,7 @@
 <%= govuk_inset_text do %>
   <p class="govuk-body">You may want to spend some time gathering all the documents you need before you start your application.</p>
 
-  <% if FeatureFlags::FeatureFlag.active?(:teacher_applications) && region && region.application_form_enabled %>
+  <% if FeatureFlags::FeatureFlag.active?(:teacher_applications) %>
     <p class="govuk-body">Once you begin, we’ll sign you out if you’re inactive for 60 minutes.</p>
   <% end %>
 

--- a/app/views/support_interface/countries/index.html.erb
+++ b/app/views/support_interface/countries/index.html.erb
@@ -42,22 +42,12 @@
                 </td>
 
                 <td class="govuk-table__cell">
-                  <% if country.eligibility_skip_questions %>
-                    <%= govuk_tag(text: "Skips questions", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
+                  <% if region.application_form_skip_work_history %>
+                    <%= govuk_tag(text: "Skips work history", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
                   <% end %>
 
-                  <% if region.application_form_enabled %>
-                    <%= govuk_tag(text: "Applications enabled", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
-
-                    <% if region.application_form_skip_work_history %>
-                      <%= govuk_tag(text: "Skips work history", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
-                    <% end %>
-
-                    <% if region.reduced_evidence_accepted %>
-                      <%= govuk_tag(text: "Accepts reduced evidence", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
-                    <% end %>
-                  <% else %>
-                    <%= govuk_tag(text: "Applications disabled", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
+                  <% if region.reduced_evidence_accepted %>
+                    <%= govuk_tag(text: "Accepts reduced evidence", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
                   <% end %>
                 </td>
               </tr>

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -5,7 +5,6 @@
 <%= form_with model: [:support_interface, @region] do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_check_box :application_form_enabled, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Application form enabled" } %>
   <%= f.govuk_check_box :application_form_skip_work_history, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Skip work history" } %>
   <%= f.govuk_check_box :reduced_evidence_accepted, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Accept reduced evidence" } %>
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -262,7 +262,7 @@ COUNTRIES = {
 
 DEFAULT_COUNTRY = { eligibility_enabled: true }.freeze
 
-DEFAULT_REGION = { name: "", application_form_enabled: true }.freeze
+DEFAULT_REGION = { name: "" }.freeze
 
 COUNTRIES.each do |code, value|
   regions = value.is_a?(Hash) ? value[:regions] : value

--- a/lib/tasks/review_app.rake
+++ b/lib/tasks/review_app.rake
@@ -7,6 +7,5 @@ namespace :review_app do
 
     FeatureFlags::FeatureFlag.activate(:personas)
     FeatureFlags::FeatureFlag.activate(:teacher_applications)
-    Region.update_all(application_form_enabled: true)
   end
 end

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -44,10 +44,6 @@ FactoryBot.define do
       name { "" }
     end
 
-    trait :application_form_enabled do
-      application_form_enabled { true }
-    end
-
     trait :reduced_evidence_accepted do
       reduced_evidence_accepted { true }
     end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -17,7 +17,6 @@ module SystemHelpers
   def given_an_eligible_eligibility_check(country_check:)
     country = create(:country, :with_national_region, code: "GB-SCT")
     country.regions.first.update!(
-      application_form_enabled: true,
       qualifications_information: "Qualifications information",
       status_check: country_check,
       sanction_check: country_check,

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe "Countries support", type: :system do
     when_i_click_on_a_region
     then_i_see_a_region
 
-    when_i_check_application_form_enabled
     when_i_select_sanction_check
     when_i_select_status_check
     when_i_fill_teaching_authority_name
@@ -140,10 +139,6 @@ RSpec.describe "Countries support", type: :system do
 
   def when_i_fill_regions
     fill_in "country-all-regions-field", with: "California"
-  end
-
-  def when_i_check_application_form_enabled
-    check "region-application-form-enabled-1-field", visible: false
   end
 
   def when_i_select_sanction_check


### PR DESCRIPTION
Now that the service has launched, and the old service is disabled, we don't need this field as all regions will be enabled, unless the overall feature is disabled.