### PR TITLE
Remove application_form_enabled (part 2 of 2)

### DIFF
--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -3,7 +3,6 @@
 # Table name: regions
 #
 #  id                                            :bigint           not null, primary key
-#  application_form_enabled                      :boolean          default(FALSE)
 #  application_form_skip_work_history            :boolean          default(FALSE), not null
 #  name                                          :string           default(""), not null
 #  qualifications_information                    :text             default(""), not null

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -245,7 +245,6 @@
     - updated_at
     - status_check
     - sanction_check
-    - application_form_enabled
     - application_form_skip_work_history
     - reduced_evidence_accepted
     - teaching_authority_address

--- a/db/migrate/20230207121321_remove_application_form_enabled_from_regions.rb
+++ b/db/migrate/20230207121321_remove_application_form_enabled_from_regions.rb
@@ -1,0 +1,5 @@
+class RemoveApplicationFormEnabledFromRegions < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :regions, :application_form_enabled, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -315,7 +315,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_093735) do
     t.text "teaching_authority_websites", default: [], null: false, array: true
     t.text "teaching_authority_name", default: "", null: false
     t.text "teaching_authority_other", default: "", null: false
-    t.boolean "application_form_enabled", default: false
     t.text "teaching_authority_certificate", default: "", null: false
     t.string "teaching_authority_online_checker_url", default: "", null: false
     t.string "teaching_authority_status_information", default: "", null: false

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -3,7 +3,6 @@
 # Table name: regions
 #
 #  id                                            :bigint           not null, primary key
-#  application_form_enabled                      :boolean          default(FALSE)
 #  application_form_skip_work_history            :boolean          default(FALSE), not null
 #  name                                          :string           default(""), not null
 #  qualifications_information                    :text             default(""), not null

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -3,7 +3,6 @@
 # Table name: regions
 #
 #  id                                            :bigint           not null, primary key
-#  application_form_enabled                      :boolean          default(FALSE)
 #  application_form_skip_work_history            :boolean          default(FALSE), not null
 #  name                                          :string           default(""), not null
 #  qualifications_information                    :text             default(""), not null


### PR DESCRIPTION
We've removed all references to the column and since the new regulations have launched we no longer need the functionality.

Depends on #1095 