### PR TITLE
Reduce app instance count

### DIFF
--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -3,7 +3,7 @@
   "key_vault_name": "s165p01-afqts-pd-kv",
   "resource_group_name": "s165p01-afqts-pd-rg",
   "paas_space": "tra-production",
-  "apply_qts_instances": 6,
+  "apply_qts_instances": 2,
   "postgres_database_service_plan": "small-ha-13",
   "education_hostnames": [""],
   "prometheus_app": "prometheus-tra-monitoring-prod",


### PR DESCRIPTION
* Reduce 6 -> 2 instances

We increased the instance count when the service launched to handle the initial peak of traffic. This has passed now and running with two instances doesn't have any obvious effect on request times. CPU ~ 6% on each instance.