### PR TITLE
Remove eligibility features flags

### DIFF
--- a/app/controllers/eligibility_interface/work_experience_controller.rb
+++ b/app/controllers/eligibility_interface/work_experience_controller.rb
@@ -5,10 +5,6 @@ module EligibilityInterface
     include EnforceEligibilityQuestionOrder
 
     def new
-      unless FeatureFlags::FeatureFlag.active?(:eligibility_work_experience)
-        redirect_to paths[:misconduct]
-      end
-
       @work_experience_form =
         WorkExperienceForm.new(
           work_experience: eligibility_check.work_experience,

--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -89,9 +89,7 @@ class EligibilityCheck < ApplicationRecord
   end
 
   def ineligible_reasons
-    work_experience_ineligible =
-      FeatureFlags::FeatureFlag.active?(:eligibility_work_experience) &&
-        work_experience_under_9_months?
+    work_experience_ineligible = work_experience_under_9_months?
 
     qualified_for_subject_ineligible =
       qualified_for_subject_required? && qualified_for_subject == false
@@ -120,14 +118,7 @@ class EligibilityCheck < ApplicationRecord
     end
 
     region.present? && qualification && degree && teach_children? &&
-      free_of_sanctions &&
-      (
-        if FeatureFlags::FeatureFlag.active?(:eligibility_work_experience)
-          !work_experience_under_9_months?
-        else
-          true
-        end
-      )
+      free_of_sanctions && !work_experience_under_9_months?
   end
 
   def teach_children?
@@ -175,13 +166,8 @@ class EligibilityCheck < ApplicationRecord
       return :eligibility
     end
 
-    if FeatureFlags::FeatureFlag.active?(:eligibility_work_experience)
-      return :misconduct unless work_experience.nil?
-      return :work_experience unless teach_children.nil?
-    else
-      return :misconduct unless teach_children.nil?
-    end
-
+    return :misconduct unless work_experience.nil?
+    return :work_experience unless teach_children.nil?
     return :teach_children unless degree.nil?
     return :degree unless qualification.nil?
     return :qualification if region.present?

--- a/app/views/eligibility_interface/misconduct/new.html.erb
+++ b/app/views/eligibility_interface/misconduct/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{'Error: ' if @misconduct_form.errors.any?}Do you have any sanctions or restrictions on your employment record?" %>
-<% content_for :back_link_url, back_link_url(FeatureFlags::FeatureFlag.active?(:eligibility_work_experience) ? eligibility_interface_work_experience_path : eligibility_interface_teach_children_path) %>
+<% content_for :back_link_url, back_link_url(eligibility_interface_work_experience_path) %>
 
 <%= form_with model: @misconduct_form, url: eligibility_interface_misconduct_path, method: :post do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/shared/_eligible_region_content.html.erb
+++ b/app/views/shared/_eligible_region_content.html.erb
@@ -32,10 +32,8 @@
     <%= render "shared/eligible_region_content_components/proof_of_qualifications", region: %>
   <% end %>
 
-  <% if FeatureFlags::FeatureFlag.active?(:eligibility_english_language) %>
-    <% accordion.section(heading_text: "Proof of English language ability") do %>
-      <%= render "shared/eligible_region_content_components/english_language", region: %>
-    <% end %>
+  <% accordion.section(heading_text: "Proof of English language ability") do %>
+    <%= render "shared/eligible_region_content_components/english_language", region: %>
   <% end %>
 
   <% unless FeatureFlags::FeatureFlag.active?(:application_work_history) && region.status_check_none? && region.sanction_check_none? %>

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -9,11 +9,6 @@ feature_flags:
     description: >
       Add new work history question to the application form.
 
-  eligibility_work_experience:
-    author: Thomas Leese
-    description: >
-      Add a question to the eligibility checker asking about work experience.
-
   personas:
     author: Thomas Leese
     description: >

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -9,11 +9,6 @@ feature_flags:
     description: >
       Add new work history question to the application form.
 
-  eligibility_english_language:
-    author: Thomas Leese
-    description: >
-      Add English language proficiency content to the eligible page.
-
   eligibility_work_experience:
     author: Thomas Leese
     description: >

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -363,6 +363,20 @@ RSpec.describe EligibilityCheck, type: :model do
         }
       end
 
+      it { is_expected.to eq(:work_experience) }
+    end
+
+    context "when free of sanctions is present" do
+      let(:attributes) do
+        {
+          work_experience: "under_9_months",
+          teach_children: true,
+          qualification: true,
+          degree: true,
+          region: create(:region),
+        }
+      end
+
       it { is_expected.to eq(:misconduct) }
     end
 

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -43,6 +43,8 @@ module SystemHelpers
     click_button "Continue", visible: false
     choose "Yes", visible: false
     click_button "Continue", visible: false
+    choose "More than 20 months", visible: false
+    click_button "Continue", visible: false
     choose "No", visible: false
     click_button "Continue", visible: false
   end

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -6,40 +6,9 @@ RSpec.describe "Eligibility check", type: :system do
   before do
     given_countries_exist
     given_the_service_is_open
-    given_work_experience_is_inactive
   end
 
   it "happy path" do
-    when_i_visit_the(:start_page)
-    then_i_see_the(:start_page)
-
-    when_i_press_start_now
-    then_i_see_the(:country_page)
-
-    when_i_select_an_eligible_country
-    then_i_see_the(:qualification_page)
-
-    when_i_have_a_qualification
-    then_i_see_the(:degree_page)
-
-    when_i_have_a_degree
-    then_i_see_the(:teach_children_page)
-
-    when_i_can_teach_children
-    then_i_see_the(:misconduct_page)
-
-    when_i_dont_have_a_misconduct_record
-    then_i_see_the(:eligible_page)
-
-    when_i_visit_the(:start_page)
-    then_i_see_the(:start_page)
-    when_i_press_start_now
-    then_i_have_two_eligibility_checks
-  end
-
-  it "happy path with work experience" do
-    given_work_experience_is_active
-
     when_i_visit_the(:start_page)
     then_i_see_the(:start_page)
 
@@ -71,37 +40,6 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   it "ineligible paths" do
-    when_i_visit_the(:start_page)
-
-    when_i_press_start_now
-    when_i_select_an_ineligible_country
-    then_i_see_the(:ineligible_page)
-    and_i_see_the_ineligible_country_text
-
-    when_i_press_back
-    when_i_select_an_eligible_country
-    then_i_see_the(:qualification_page)
-
-    when_i_dont_have_a_qualification
-    then_i_see_the(:degree_page)
-
-    when_i_dont_have_a_degree
-    then_i_see_the(:teach_children_page)
-
-    when_i_cant_teach_children
-    then_i_see_the(:misconduct_page)
-
-    when_i_have_a_misconduct_record
-    then_i_see_the(:ineligible_page)
-    and_i_see_the_ineligible_degree_text
-    and_i_see_the_ineligible_qualification_text_with_eligible_country
-    and_i_see_the_ineligible_teach_children_text
-    and_i_see_the_ineligible_misconduct_text
-  end
-
-  it "ineligible paths with work experience" do
-    given_work_experience_is_active
-
     when_i_visit_the(:start_page)
 
     when_i_press_start_now
@@ -189,10 +127,16 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_have_a_degree
     then_i_see_the(:teach_children_page)
 
-    when_i_visit_the(:misconduct_page)
+    when_i_visit_the(:work_experience_page)
     then_i_see_the(:teach_children_page)
 
     when_i_can_teach_children
+    then_i_see_the(:work_experience_page)
+
+    when_i_visit_the(:misconduct_page)
+    then_i_see_the(:work_experience_page)
+
+    when_i_have_more_than_20_months_work_experience
     then_i_see_the(:misconduct_page)
   end
 
@@ -229,6 +173,9 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the(:teach_children_page)
 
     when_i_cant_teach_children
+    then_i_see_the(:work_experience_page)
+
+    when_i_have_under_9_months_work_experience
     then_i_see_the(:misconduct_page)
 
     when_i_have_a_misconduct_record
@@ -237,6 +184,7 @@ RSpec.describe "Eligibility check", type: :system do
     and_i_see_the_ineligible_qualification_text_with_skip_questions_country
     and_i_see_the_ineligible_degree_text
     and_i_see_the_ineligible_teach_children_text
+    and_i_see_the_ineligible_work_experience_text
     and_i_see_the_ineligible_misconduct_text
   end
 
@@ -302,6 +250,9 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the(:qualified_for_subject_page)
 
     when_i_am_qualified_to_teach_a_relevant_subject
+    then_i_see_the(:work_experience_page)
+
+    when_i_have_more_than_20_months_work_experience
     then_i_see_the(:misconduct_page)
 
     when_i_dont_have_a_misconduct_record
@@ -328,6 +279,9 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the(:qualified_for_subject_page)
 
     when_i_am_qualified_to_teach_a_relevant_subject
+    then_i_see_the(:work_experience_page)
+
+    when_i_have_more_than_20_months_work_experience
     then_i_see_the(:misconduct_page)
 
     when_i_dont_have_a_misconduct_record
@@ -354,6 +308,9 @@ RSpec.describe "Eligibility check", type: :system do
     then_i_see_the(:qualified_for_subject_page)
 
     when_i_am_not_qualified_to_teach_a_relevant_subject
+    then_i_see_the(:work_experience_page)
+
+    when_i_have_more_than_20_months_work_experience
     then_i_see_the(:misconduct_page)
 
     when_i_dont_have_a_misconduct_record
@@ -364,14 +321,6 @@ RSpec.describe "Eligibility check", type: :system do
 
   def then_access_is_denied
     expect(page).to have_content("HTTP Basic: Access denied")
-  end
-
-  def given_work_experience_is_inactive
-    FeatureFlags::FeatureFlag.deactivate(:eligibility_work_experience)
-  end
-
-  def given_work_experience_is_active
-    FeatureFlags::FeatureFlag.activate(:eligibility_work_experience)
   end
 
   def given_countries_exist

--- a/spec/views/shared/eligible_region_content_spec.rb
+++ b/spec/views/shared/eligible_region_content_spec.rb
@@ -89,24 +89,13 @@ RSpec.describe "Eligible region content", type: :view do
 
   describe "English language proficiency" do
     let(:region) { create(:region, reduced_evidence_accepted: false) }
-    context "when feature is inactive" do
-      it do
-        is_expected.to_not match(
-          /We need to understand your level of English language proficiency/,
-        )
-      end
-    end
 
-    context "when feature is active" do
-      before do
-        FeatureFlags::FeatureFlag.activate(:eligibility_english_language)
-      end
+    it { is_expected.to match(/Proof of English language ability/) }
 
-      it do
-        is_expected.to match(
-          /You’ll need to provide your passport or official identification documents for that country as proof/,
-        )
-      end
+    it do
+      is_expected.to match(
+        /You’ll need to provide your passport or official identification documents for that country as proof/,
+      )
     end
   end
 


### PR DESCRIPTION
This removes two feature flags related to new questions we added to the eligibility checker which now that we've launched we're unlikely to need to remove these questions, and this simplifies the code and manual testing.