### PR TITLE
Allow filtering on "not assigned"

### DIFF
--- a/app/lib/filters/assessor.rb
+++ b/app/lib/filters/assessor.rb
@@ -6,14 +6,20 @@ module Filters
       return scope if assessor_ids.empty?
 
       scope.where(assessor_id: assessor_ids).or(
-        scope.where(reviewer_id: assessor_ids),
+        scope.where(reviewer_id: reviewer_ids),
       )
     end
 
     private
 
     def assessor_ids
-      Array(params[:assessor_ids]).reject(&:blank?)
+      Array(params[:assessor_ids])
+        .reject(&:blank?)
+        .map { |id| id == "null" ? nil : id.to_i }
+    end
+
+    def reviewer_ids
+      Array(params[:assessor_ids]).reject(&:blank?).reject { |id| id == "null" }
     end
   end
 end

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -22,7 +22,8 @@ class AssessorInterface::ApplicationFormsIndexViewObject
   end
 
   def assessor_filter_options
-    Staff.assessors.order(:name)
+    Staff.assessors.order(:name) +
+      [OpenStruct.new(id: "null", name: "Not assigned")]
   end
 
   def country_filter_options

--- a/spec/lib/filters/assessor_spec.rb
+++ b/spec/lib/filters/assessor_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Filters::Assessor do
   subject { described_class.apply(scope:, params:) }
 
   context "the params include assessor_id" do
-    describe "filtering 'assigned to'" do
+    describe "filtering 'assessor'" do
       let(:params) { { assessor_ids: assessor_one.id } }
       let(:scope) { ApplicationForm.all }
 
@@ -51,6 +51,19 @@ RSpec.describe Filters::Assessor do
       create(:application_form)
       create(:application_form, assessor: create(:staff))
     end
+
+    it "returns a filtered scope" do
+      expect(subject).to match_array(included)
+    end
+  end
+
+  context "the params include an unassigned null value" do
+    let(:params) { { assessor_ids: ["null"] } }
+    let(:scope) { ApplicationForm.all }
+
+    let!(:included) { [create(:application_form)] }
+
+    let!(:filtered) { create(:application_form, assessor: create(:staff)) }
 
     it "returns a filtered scope" do
       expect(subject).to match_array(included)

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Assessor filtering application forms", type: :system do
   end
 
   def and_i_apply_the_assessor_filter
-    expect(applications_page.assessor_filter.assessors.count).to eq(3)
+    expect(applications_page.assessor_filter.assessors.count).to eq(4)
     applications_page.assessor_filter.assessors.second.checkbox.click
     applications_page.apply_filters.click
   end

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -113,16 +113,18 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
   describe "#assessor_filter_options" do
     subject(:assessor_filter_options) { view_object.assessor_filter_options }
 
-    it { is_expected.to be_empty }
+    it do
+      is_expected.to include(OpenStruct.new(id: "null", name: "Not assigned"))
+    end
 
     context "with an assessor user" do
-      let(:staff) { create(:staff, :with_award_decline_permission) }
+      let!(:staff) { create(:staff, :with_award_decline_permission) }
 
       it { is_expected.to include(staff) }
     end
 
     context "with an non-assessor user" do
-      let(:staff) { create(:staff) }
+      let!(:staff) { create(:staff) }
 
       it { is_expected.not_to include(staff) }
     end


### PR DESCRIPTION
This adds an additional option when filtering the applications in the assessor interface to search for applications which have not been assigned to anybody.