### PR TITLE
Assess references that have been received

### DIFF
--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -20,6 +20,7 @@ module StatusTag
     end
 
     COLOURS = {
+      accepted: "green",
       awarded: "green",
       awarded_pending_checks: "turquoise",
       cannot_start: "grey",
@@ -33,6 +34,7 @@ module StatusTag
       potential_duplicate_in_dqt: "pink",
       received: "purple",
       requested: "yellow",
+      rejected: "red",
       submitted: "grey",
       valid: "green",
       waiting_on: "yellow",

--- a/app/controllers/assessor_interface/reference_requests_controller.rb
+++ b/app/controllers/assessor_interface/reference_requests_controller.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module AssessorInterface
+  class ReferenceRequestsController < BaseController
+    before_action :authorize_note
+
+    def edit
+      @form = RequestableForm.new(requestable: reference_request)
+    end
+
+    def update
+      @form =
+        RequestableForm.new(
+          requestable: reference_request,
+          **reference_request_form_params,
+        )
+
+      if @form.save
+        redirect_to [
+                      :assessor_interface,
+                      assessment.application_form,
+                      assessment,
+                      :verify_references,
+                    ]
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def reference_request_form_params
+      params.fetch(:assessor_interface_requestable_form, {}).permit(:passed)
+    end
+
+    def reference_request
+      @reference_request ||=
+        ReferenceRequest
+          .includes(:work_history, assessment: :application_form)
+          .where(
+            assessment_id: params[:assessment_id],
+            assessment: {
+              application_form_id: params[:application_form_id],
+            },
+          )
+          .find(params[:id])
+    end
+
+    delegate :assessment, to: :reference_request
+  end
+end

--- a/app/controllers/assessor_interface/verify_references_controller.rb
+++ b/app/controllers/assessor_interface/verify_references_controller.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module AssessorInterface
+  class VerifyReferencesController < BaseController
+    before_action :authorize_note
+
+    def index
+      @view_object = VerifyReferencesViewObject.new(assessment:)
+      @form = VerifyReferencesForm.new(assessment:)
+    end
+
+    def update
+      @view_object = VerifyReferencesViewObject.new(assessment:)
+      @form = VerifyReferencesForm.new(assessment:, **verify_references_params)
+
+      if @form.save
+        redirect_to [:assessor_interface, assessment.application_form]
+      else
+        render :index, status: :unprocessable_entity
+      end
+    end
+
+    def assessment
+      @assessment ||= Assessment.find(params[:assessment_id])
+    end
+
+    def verify_references_params
+      params.fetch(:assessor_interface_verify_references_form, {}).permit(
+        :references_verified,
+      )
+    end
+  end
+end

--- a/app/forms/assessor_interface/requestable_form.rb
+++ b/app/forms/assessor_interface/requestable_form.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AssessorInterface::RequestableForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :requestable
+  attribute :passed, :boolean
+  validates :passed, inclusion: [true, false]
+
+  def save
+    return false if invalid?
+
+    requestable.reviewed!(passed)
+    true
+  end
+
+  delegate :assessment, to: :requestable
+  delegate :application_form, to: :assessment
+end

--- a/app/forms/assessor_interface/verify_references_form.rb
+++ b/app/forms/assessor_interface/verify_references_form.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AssessorInterface::VerifyReferencesForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :assessment
+  attribute :references_verified, :boolean
+  validates :references_verified, inclusion: [true, false]
+
+  delegate :application_form, to: :assessment
+
+  def save
+    return false if invalid?
+
+    assessment.update!(references_verified:)
+
+    true
+  end
+end

--- a/app/lib/work_history_duration.rb
+++ b/app/lib/work_history_duration.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 class WorkHistoryDuration
-  def initialize(application_form: nil, work_history_relation: nil)
+  def initialize(
+    application_form: nil,
+    work_history_relation: nil,
+    work_history_record: nil
+  )
     if !application_form.nil? && work_history_relation.nil?
       @work_history_relation =
         application_form
@@ -10,6 +14,8 @@ class WorkHistoryDuration
           .where.not(hours_per_week: nil)
     elsif !work_history_relation.nil? && application_form.nil?
       @work_history_relation = work_history_relation
+    elsif !work_history_record.nil?
+      @work_histories = [work_history_record]
     else
       raise "Pass only an application_form or a work_history_relation."
     end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -10,6 +10,7 @@
 #  recommendation                            :string           default("unknown"), not null
 #  recommendation_assessor_note              :text             default(""), not null
 #  recommended_at                            :datetime
+#  references_verified                       :boolean          default(FALSE), not null
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null

--- a/app/models/concerns/reviewable.rb
+++ b/app/models/concerns/reviewable.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Reviewable
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :assessment
+
+    validates :reviewed_at, presence: true, unless: -> { passed.nil? }
+
+    def reviewed!(passed)
+      update!(passed:, reviewed_at: Time.zone.now)
+    end
+
+    def status
+      return state if passed.nil?
+
+      passed ? "accepted" : "rejected"
+    end
+  end
+end

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -34,6 +34,7 @@
 #
 class ReferenceRequest < ApplicationRecord
   include Requestable
+  include Reviewable
 
   has_secure_token :slug
 

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -10,8 +10,10 @@
 #  dates_response                  :boolean
 #  hours_response                  :boolean
 #  lessons_response                :boolean
+#  passed                          :boolean
 #  received_at                     :datetime
 #  reports_response                :boolean
+#  reviewed_at                     :datetime
 #  slug                            :string           not null
 #  state                           :string           not null
 #  created_at                      :datetime         not null

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -102,8 +102,6 @@ class AssessorInterface::ApplicationFormsShowViewObject
           assessment,
           qualification_request,
         )
-      end
-
       when :reference_requests
         if application_form.received_reference
           url_helpers.assessor_interface_application_form_assessment_verify_references_path(
@@ -111,6 +109,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
             assessment,
           )
         end
+      end
     end
   end
 
@@ -138,6 +137,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
     when :verification_requests
       case item
       when :reference_requests
+        return :completed if assessment.references_verified
         application_form.received_reference ? :received : :waiting_on
       when :qualification_requests
         application_form.received_qualification ? :received : :waiting_on

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -103,6 +103,14 @@ class AssessorInterface::ApplicationFormsShowViewObject
           qualification_request,
         )
       end
+
+      when :reference_requests
+        if application_form.received_reference
+          url_helpers.assessor_interface_application_form_assessment_verify_references_path(
+            application_form,
+            assessment,
+          )
+        end
     end
   end
 

--- a/app/view_objects/assessor_interface/verify_references_view_object.rb
+++ b/app/view_objects/assessor_interface/verify_references_view_object.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class AssessorInterface::VerifyReferencesViewObject
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::DateHelper
+
+  attr_reader :assessment
+
+  def initialize(assessment:)
+    @assessment = assessment
+  end
+
+  def reference_requests
+    @reference_requests ||=
+      assessment
+        .reference_requests
+        .includes(:work_history)
+        .order("work_histories.start_date")
+        .to_a
+  end
+
+  def name_and_duration(work_history, most_recent: false)
+    months =
+      WorkHistoryDuration.new(work_history_record: work_history).count_months
+
+    result = "#{work_history.school_name} (#{months} months)"
+    result.concat(" ", most_recent_tag) if most_recent
+    result.html_safe
+  end
+
+  delegate :application_form, to: :assessment
+
+  def most_recent_tag
+    tag.span("MOST RECENT", class: "govuk-!-font-weight-bold")
+  end
+end

--- a/app/views/assessor_interface/notes/new.html.erb
+++ b/app/views/assessor_interface/notes/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "#{"Error: " if @create_note_form.errors.any?}Add a note" %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, params[:next].presence || assessor_interface_application_form_path(@application_form) %>
 
 <%= form_with model: @create_note_form, url: assessor_interface_application_form_notes_path(@application_form) do |f| %>
   <%= hidden_field_tag :next, params[:next] %>

--- a/app/views/assessor_interface/reference_requests/edit.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit.html.erb
@@ -1,0 +1,87 @@
+<% work_history = @reference_request.work_history %>
+<h1 class="govuk-heading-xl"><%= t("assessor_interface.reference_requests.edit.title") %></h1>
+
+<%= form_with(
+  model: @form,
+  url: [:assessor_interface, @form.application_form, @form.assessment, @reference_request],
+  method: :put
+) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--m">Reference details</caption>
+    <tbody class="govuk-table__body">
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Name of institution</th>
+        <td class="govuk-table__cell"><%= work_history.school_name %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Number of months</th>
+        <td class="govuk-table__cell"><%= WorkHistoryDuration.new(work_history_record: work_history).count_months %></td>
+      </tr>
+      <tr class="govuk-table__row">
+        <th scope="row" class="govuk-table__header">Name of reference</th>
+        <td class="govuk-table__cell"><%= work_history.contact_name %></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <%= render CheckYourAnswersSummary::Component.new(
+    id: @reference_request.id,
+    model: @reference_request,
+    title: t("assessor_interface.reference_requests.edit.summary_card_title"),
+    fields: {
+      dates_response: {
+        title: t("assessor_interface.reference_requests.edit.dates_response",
+                 school_name: work_history.school_name,
+                 start_date: work_history.start_date.to_fs(:long_ordinal_uk),
+                 end_date: work_history.end_date.blank? ? "present" : work_history.end_date.to_fs(:long_ordinal_uk)),
+        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.dates_response}"),
+      },
+      hours_response: {
+        title: t("assessor_interface.reference_requests.edit.hours_response"),
+        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.hours_response}"),
+      },
+      children_response: {
+        title: t("assessor_interface.reference_requests.edit.children_response"),
+        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.children_response}"),
+      },
+      lessons_response: {
+        title: t("assessor_interface.reference_requests.edit.lessons_response"),
+        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.lessons_response}"),
+      },
+      reports_response: {
+        title: t("assessor_interface.reference_requests.edit.reports_response"),
+        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.reports_response}"),
+      },
+      additional_information_response: {
+        title: t("assessor_interface.reference_requests.edit.additional_information_response"),
+        value: @reference_request.additional_information_response,
+      },
+    },
+    changeable: false
+  ) %>
+
+  <%= f.govuk_radio_buttons_fieldset(
+    :passed,
+    legend: {
+      text: "Are you satisfied that this reference should count towards the applicant’s work experience?",
+      size: "s"
+    }) do %>
+    <%= f.govuk_radio_button(
+        :passed,
+        :true,
+        link_errors: true,
+        label: { text: "Yes" },
+      ) %>
+    <%= f.govuk_radio_button(
+      :passed,
+      :false,
+      label: { text: "No" },
+    ) %>
+  <% end %>
+
+  <%= f.govuk_submit prevent_double_click: false do %>
+    <%= govuk_link_to "Cancel", [:assessor_interface, @form.application_form] %>
+  <% end %>
+<% end %>

--- a/app/views/assessor_interface/verify_references/index.html.erb
+++ b/app/views/assessor_interface/verify_references/index.html.erb
@@ -1,0 +1,64 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}Work references" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@form.application_form) %>
+
+<%= render "shared/assessor_header", title: "Work references", application_form: @view_object.application_form %>
+
+<%= form_with(
+  model: @form,
+  url: [:assessor_interface, @form.application_form, @form.assessment, :update_verify_references],
+  method: :put
+) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <p>This page shows all the work references requested for this application and the number of months of work experience that each one represents.</p>
+  <p>You can select and review any reference that has the status <span>RECEIVED</span>.</p>
+
+  <ol class="app-task-list">
+    <li>
+      <h2 class="app-task-list__section">
+        Work references
+      </h2>
+      <ul class="app-task-list__items govuk-!-padding-left-0">
+        <% @view_object.reference_requests.each_with_index do |reference_request, idx| %>
+          <li class="app-task-list__item">
+            <span class="app-task-list__task-name">
+              <%= govuk_link_to(
+                @view_object.name_and_duration(reference_request.work_history, most_recent: idx.zero?),
+                [:edit, :assessor_interface, @form.application_form, @form.assessment, reference_request]
+              ) %>
+            </span>
+            <strong class="govuk-tag app-task-list__tag govuk-tag--green" id="reference-status"><%= reference_request.status %></strong>
+          </li>
+        <% end %>
+      </ul>
+    </li>
+  </ol>
+  <h2 class="govuk-heading-s">Check:</h2>
+  <ul class="govuk-list govuk-list--bullet govuk-list--spaced">
+    <li>the reference from the current or most recent role has been received and is valid (if required)</li>
+    <li>the references that you’ve checked and marked as valid add up to the required number of months for this application to progress</li>
+  </ul>
+
+  <%= f.govuk_radio_buttons_fieldset(
+    :references_verified,
+    legend: {
+      text: "Have enough valid work references been received for this application to progress to either an award or decline?",
+      size: "s"
+    }) do %>
+    <%= f.govuk_radio_button(
+      :references_verified,
+      :true,
+      link_errors: true,
+      label: { text: "Yes, I can progress this application to award or decline" },
+    ) %>
+  <%= f.govuk_radio_button(
+    :references_verified,
+    :false,
+    label: { text: "No, I cannot progress this application yet" },
+  ) %>
+  <% end %>
+
+  <%= f.govuk_submit prevent_double_click: false do %>
+    <%= govuk_link_to "Cancel", [:assessor_interface, @view_object.application_form] %>
+  <% end %>
+<% end %>

--- a/app/views/assessor_interface/verify_references/index.html.erb
+++ b/app/views/assessor_interface/verify_references/index.html.erb
@@ -27,7 +27,12 @@
                 [:edit, :assessor_interface, @form.application_form, @form.assessment, reference_request]
               ) %>
             </span>
-            <strong class="govuk-tag app-task-list__tag govuk-tag--green" id="reference-status"><%= reference_request.status %></strong>
+
+            <%= render StatusTag::Component.new(
+                key: "reference-request-#{reference_request.id}",
+                status: reference_request.status,
+                class_context: "app-task-list",
+            ) %>
           </li>
         <% end %>
       </ul>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -239,6 +239,8 @@
     - additional_information_response
     - created_at
     - updated_at
+    - passed
+    - reviewed_at
   :regions:
     - id
     - country_id

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -104,6 +104,7 @@
     - working_days_submission_to_recommendation
     - working_days_submission_to_started
     - working_days_started_to_recommendation
+    - references_verified
   :countries:
     - id
     - code

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -206,6 +206,19 @@ en:
     qualification_requests:
       edit:
         title: Qualification verification – response received
+    reference_requests:
+      edit:
+        title: Review work reference
+        summary_card_title: Responses
+        dates_response: Did the applicant work at %{school_name} from %{start_date} to %{end_date}
+        hours_response: Did the applicant normally work more than 30 hours per week in this role?
+        children_response: Did the applicant work unsupervised with children aged between 5 and 16 years?
+        lessons_response: Was the applicant solely responsible for planning, preparing and delivering lessons to at least 4 students at a time?
+        reports_response: Was the applicant solely responsible for assessing and reporting on the progress of the students?
+        additional_information_response: Is there anything else you’d like to tell us about this applicant?
+        response_value:
+          "true": "Yes"
+          "false": "No"
 
   activemodel:
     errors:
@@ -331,3 +344,11 @@ en:
           attributes:
             work_history_ids:
               blank: References account for less than 9 months
+        assessor_interface/verify_references_form:
+          attributes:
+            references_verified:
+              inclusion: Select whether enough valid work references been received for this application to progress to either an award or decline
+        assessor_interface/reference_request_form:
+          attributes:
+            passed:
+              inclusion: Select whether this reference should count towards the applicant’s work experience

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -210,7 +210,7 @@ en:
       edit:
         title: Review work reference
         summary_card_title: Responses
-        dates_response: Did the applicant work at %{school_name} from %{start_date} to %{end_date}
+        dates_response: Did the applicant work at %{school_name} from %{start_date} to %{end_date}?
         hours_response: Did the applicant normally work more than 30 hours per week in this role?
         children_response: Did the applicant work unsupervised with children aged between 5 and 16 years?
         lessons_response: Was the applicant solely responsible for planning, preparing and delivering lessons to at least 4 students at a time?

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -1,6 +1,7 @@
 en:
   components:
     status_tag:
+      accepted: Accepted
       awarded: Awarded
       awarded_pending_checks: Award pending
       cannot_start: Cannot start
@@ -14,6 +15,7 @@ en:
       not_started: Not started
       potential_duplicate_in_dqt: Potential duplication in DQT
       received: Received
+      rejected: Rejected
       requested: Waiting on
       submitted: Not started
       valid: Valid

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -83,6 +83,17 @@ Rails.application.routes.draw do
         resources :qualification_requests,
                   path: "/qualification-requests",
                   only: %i[edit update]
+
+        get "/verify-references",
+            to: "verify_references#index",
+            as: :verify_references
+        put "/verify-references",
+            to: "verify_references#update",
+            as: :update_verify_references
+
+        resources :reference_requests,
+                  path: "/work-references",
+                  only: %i[edit update]
       end
     end
   end

--- a/db/migrate/20230207170321_add_references_verified_to_assessments.rb
+++ b/db/migrate/20230207170321_add_references_verified_to_assessments.rb
@@ -1,0 +1,9 @@
+class AddReferencesVerifiedToAssessments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :assessments,
+               :references_verified,
+               :boolean,
+               default: false,
+               null: false
+  end
+end

--- a/db/migrate/20230214112253_add_passed_to_reference_requests.rb
+++ b/db/migrate/20230214112253_add_passed_to_reference_requests.rb
@@ -1,0 +1,8 @@
+class AddPassedToReferenceRequests < ActiveRecord::Migration[7.0]
+  def change
+    change_table :reference_requests, bulk: true do |t|
+      t.boolean :passed
+      t.datetime :reviewed_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_08_093735) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_14_112253) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -300,6 +300,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_093735) do
     t.text "additional_information_response", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "passed"
+    t.datetime "reviewed_at", precision: nil
     t.index ["assessment_id"], name: "index_reference_requests_on_assessment_id"
     t.index ["slug"], name: "index_reference_requests_on_slug", unique: true
     t.index ["work_history_id"], name: "index_reference_requests_on_work_history_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -138,6 +138,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_093735) do
     t.integer "working_days_since_started"
     t.boolean "induction_required"
     t.text "recommendation_assessor_note", default: "", null: false
+    t.boolean "references_verified", default: false, null: false
     t.index ["application_form_id"], name: "index_assessments_on_application_form_id"
   end
 
@@ -156,8 +157,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_093735) do
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "eligibility_enabled", default: true, null: false
-    t.boolean "eligibility_skip_questions", default: false, null: false
     t.text "qualifications_information", default: "", null: false
+    t.boolean "eligibility_skip_questions", default: false, null: false
     t.index ["code"], name: "index_countries_on_code", unique: true
   end
 
@@ -320,8 +321,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_08_093735) do
     t.string "teaching_authority_online_checker_url", default: "", null: false
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
-    t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.text "qualifications_information", default: "", null: false
+    t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "application_form_skip_work_history", default: false, null: false
     t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_requires_submission_email", default: false, null: false

--- a/spec/components/status_tag_spec.rb
+++ b/spec/components/status_tag_spec.rb
@@ -79,5 +79,11 @@ RSpec.describe StatusTag::Component, type: :component do
 
       it { is_expected.to eq("govuk-tag app-task-list__tag") }
     end
+
+    context "with a 'rejected' status" do
+      let(:status) { :rejected }
+
+      it { is_expected.to eq("govuk-tag govuk-tag--red app-task-list__tag") }
+    end
   end
 end

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -68,11 +68,28 @@ FactoryBot.define do
       end
     end
 
+    trait :with_received_professional_standing_request do
+      after(:create) do |assessment, _evaluator|
+        create(:professional_standing_request, :received, assessment:)
+      end
+    end
+
     trait :with_reference_request do
       after(:create) do |assessment, _evaluator|
         create(
           :reference_request,
           :requested,
+          assessment:,
+          work_history: assessment.application_form.work_histories.first,
+        )
+      end
+    end
+
+    trait :with_received_reference_request do
+      after(:create) do |assessment, _evaluator|
+        create(
+          :reference_request,
+          :received,
           assessment:,
           work_history: assessment.application_form.work_histories.first,
         )

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -10,6 +10,7 @@
 #  recommendation                            :string           default("unknown"), not null
 #  recommendation_assessor_note              :text             default(""), not null
 #  recommended_at                            :datetime
+#  references_verified                       :boolean          default(FALSE), not null
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null

--- a/spec/factories/reference_requests.rb
+++ b/spec/factories/reference_requests.rb
@@ -10,8 +10,10 @@
 #  dates_response                  :boolean
 #  hours_response                  :boolean
 #  lessons_response                :boolean
+#  passed                          :boolean
 #  received_at                     :datetime
 #  reports_response                :boolean
+#  reviewed_at                     :datetime
 #  slug                            :string           not null
 #  state                           :string           not null
 #  created_at                      :datetime         not null

--- a/spec/forms/assessor_interface/requestable_form_spec.rb
+++ b/spec/forms/assessor_interface/requestable_form_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::RequestableForm, type: :model do
+  let(:requestable) { create(:reference_request, :received) }
+  let(:passed) { nil }
+
+  subject(:form) { described_class.new(requestable:, passed:) }
+
+  describe "save" do
+    context "when passed is nil" do
+      it "fails validation" do
+        expect(form.save).to be false
+
+        expect(form.errors).to have_key(:passed)
+      end
+    end
+
+    context "when passed is true" do
+      let(:passed) { true }
+
+      it "updates passed field" do
+        expect { form.save }.to change(requestable, :passed).from(nil).to(true)
+      end
+
+      it "sets reviewed at" do
+        freeze_time do
+          expect { form.save }.to change(requestable, :reviewed_at).from(
+            nil,
+          ).to(Time.zone.now)
+        end
+      end
+    end
+
+    context "when passed is false" do
+      let(:passed) { false }
+
+      it "updates passed field" do
+        expect { form.save }.to change(requestable, :passed).from(nil).to(false)
+      end
+
+      it "sets reviewed at" do
+        freeze_time do
+          expect { form.save }.to change(requestable, :reviewed_at).from(
+            nil,
+          ).to(Time.zone.now)
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/assessor_interface/verify_references_form_spec.rb
+++ b/spec/forms/assessor_interface/verify_references_form_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::VerifyReferencesForm, type: :model do
+  let(:assessment) { create(:assessment) }
+  let(:references_verified) { nil }
+
+  subject(:form) { described_class.new(assessment:, references_verified:) }
+
+  describe "save" do
+    context "when verify_references is nil" do
+      it "fails validation" do
+        expect(form.save).to be false
+
+        expect(form.errors).to have_key(:references_verified)
+      end
+    end
+
+    context "when verify_references is passed" do
+      let(:references_verified) { true }
+
+      it "updates ApplicationForm#verify_references_status" do
+        expect { form.save }.to change(assessment, :references_verified).from(
+          false,
+        ).to(true)
+      end
+    end
+  end
+end

--- a/spec/lib/work_history_duration_spec.rb
+++ b/spec/lib/work_history_duration_spec.rb
@@ -120,6 +120,26 @@ RSpec.describe WorkHistoryDuration do
       it_behaves_like "month counter"
     end
 
+    context "passing a work history record" do
+      let(:work_history) do
+        create(
+          :work_history,
+          application_form:,
+          start_date: Date.new(2022, 1, 1),
+          end_date: Date.new(2022, 12, 22),
+          hours_per_week: 30,
+        )
+      end
+
+      let(:work_history_duration) do
+        described_class.new(work_history_record: work_history)
+      end
+
+      subject(:count) { work_history_duration.count_months }
+
+      it { is_expected.to eq(12) }
+    end
+
     context "passing nothing" do
       subject(:work_history_duration) { described_class.new }
 

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -12,6 +12,7 @@
 #  recommendation                            :string           default("unknown"), not null
 #  recommendation_assessor_note              :text             default(""), not null
 #  recommended_at                            :datetime
+#  references_verified                       :boolean          default(FALSE), not null
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null

--- a/spec/models/reference_request_spec.rb
+++ b/spec/models/reference_request_spec.rb
@@ -10,8 +10,10 @@
 #  dates_response                  :boolean
 #  hours_response                  :boolean
 #  lessons_response                :boolean
+#  passed                          :boolean
 #  received_at                     :datetime
 #  reports_response                :boolean
+#  reviewed_at                     :datetime
 #  slug                            :string           not null
 #  state                           :string           not null
 #  created_at                      :datetime         not null

--- a/spec/models/reference_request_spec.rb
+++ b/spec/models/reference_request_spec.rb
@@ -39,6 +39,10 @@ RSpec.describe ReferenceRequest do
     subject { build(:reference_request, :receivable) }
   end
 
+  it_behaves_like "a reviewable" do
+    subject { build(:reference_request) }
+  end
+
   it { is_expected.to have_secure_token(:slug) }
 
   describe "associations" do

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -55,6 +55,10 @@ module PageObjects
       def assessment_recommendation_task
         task_list.find_item("Assessment recommendation")
       end
+
+      def verify_references_task
+        task_list.find_item("Verify reference requests")
+      end
     end
   end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/reference_request_page.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/reference_request_page.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class ReferenceRequestPage < SitePrism::Page
+      # rubocop:disable Layout/LineLength
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/work-references/{reference_request_id}/edit"
+      # rubocop:enable Layout/LineLength
+
+      section :table, ".govuk-table" do
+        elements :headers, ".govuk-table__header"
+        elements :cells, ".govuk-table__cell"
+      end
+
+      section :responses, ".govuk-summary-card" do
+        element :heading, ".govuk-summary-card__title"
+        elements :keys, ".govuk-summary-list__key"
+        elements :values, ".govuk-summary-list__value"
+      end
+
+      section :form, "form" do
+        element :yes_radio_item,
+                "#assessor-interface-requestable-form-passed-true-field",
+                visible: false
+        element :continue_button, ".govuk-button"
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/verify_references_page.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/verify_references_page.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class VerifyReferencesPage < SitePrism::Page
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/verify-references"
+
+      section :task_list, ".app-task-list__item" do
+        elements :reference_requests, ".app-task-list__task-name a"
+        elements :status_tags, ".app-task-list__tag"
+      end
+
+      section :form, "form" do
+        element :yes_radio_item,
+                "#assessor-interface-verify-references-form-references-verified-true-field",
+                visible: false
+        element :continue_button, ".govuk-button"
+      end
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -485,4 +485,14 @@ module PageHelpers
     @work_experience_page ||=
       PageObjects::EligibilityInterface::WorkExperience.new
   end
+
+  def verify_references_page
+    @verify_references_page ||=
+      PageObjects::AssessorInterface::VerifyReferencesPage.new
+  end
+
+  def reference_request_page
+    @reference_request_page ||=
+      PageObjects::AssessorInterface::ReferenceRequestPage.new
+  end
 end

--- a/spec/support/shared_examples/reviewable.rb
+++ b/spec/support/shared_examples/reviewable.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "a reviewable" do
+  describe "validations" do
+    context "when reviewed" do
+      before { subject.passed = [true, false].sample }
+
+      it { is_expected.to validate_presence_of(:reviewed_at) }
+    end
+  end
+
+  [true, false].each do |passed|
+    describe "#reviewed!(#{passed})" do
+      let(:call) { subject.reviewed!(passed) }
+
+      it "changes passed field" do
+        expect { call }.to change(subject, :passed).from(nil).to(passed)
+      end
+
+      it "sets the reviewed at date" do
+        freeze_time do
+          expect { call }.to change(subject, :reviewed_at).from(nil).to(
+            Time.zone.now,
+          )
+        end
+      end
+    end
+  end
+
+  describe "#status" do
+    it "is the same as state when passed is nil and state is defined" do
+      subject.passed = nil
+      subject.state = "received"
+      expect(subject.status).to eq("received")
+    end
+
+    it "is accepted when passed is true" do
+      subject.passed = true
+      expect(subject.status).to eq("accepted")
+    end
+
+    it "is rejected when passed is false" do
+      subject.passed = false
+      expect(subject.status).to eq("rejected")
+    end
+  end
+end

--- a/spec/system/assessor_interface/verifying_references_spec.rb
+++ b/spec/system/assessor_interface/verifying_references_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assessor verifying references", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_an_assessor_user
+    given_there_is_an_application_form_with_reference_request
+  end
+
+  it "Verify accepted references" do
+    when_i_visit_the(:assessor_application_page, application_id:)
+    and_i_see_a_waiting_on_status
+    and_i_click_verify_references
+    then_i_see_the(:verify_references_page, application_id:)
+
+    when_i_click_on_a_reference_request
+    then_i_see_the(
+      :reference_request_page,
+      application_id:,
+      assessment_id:,
+      reference_request_id:,
+    )
+    and_i_see_the_reference_summary
+
+    when_i_verify_the_reference_request
+    then_i_see_the_reference_request_status_is_accepted
+
+    when_i_verify_that_all_references_are_accepted
+    then_i_see_the_verify_references_task_is_completed
+  end
+
+  private
+
+  def given_there_is_an_application_form_with_reference_request
+    application_form
+  end
+
+  def and_i_see_a_waiting_on_status
+    expect(assessor_application_page.overview.status.text).to eq("WAITING ON")
+  end
+
+  def and_i_click_verify_references
+    assessor_application_page.verify_references_task.link.click
+  end
+
+  def when_i_click_on_a_reference_request
+    verify_references_page.task_list.reference_requests.first.click
+  end
+
+  def and_i_see_the_reference_summary
+    expect(reference_request_page.table.headers[0].text).to eq(
+      "Name of institution",
+    )
+    expect(reference_request_page.table.cells[0].text).to eq("School")
+    expect(reference_request_page.table.headers[1].text).to eq(
+      "Number of months",
+    )
+    expect(reference_request_page.table.cells[1].text).to eq("38")
+    expect(reference_request_page.table.headers[2].text).to eq(
+      "Name of reference",
+    )
+    expect(reference_request_page.table.cells[2].text).to eq(
+      reference_request.work_history.contact_name,
+    )
+    expect(reference_request_page.responses.heading.text).to eq("Responses")
+
+    expect(reference_request_page.responses.values[0].text).to eq(
+      I18n.t(
+        "assessor_interface.reference_requests.edit.response_value.#{reference_request.dates_response}",
+      ),
+    )
+    expect(reference_request_page.responses.values[1].text).to eq(
+      I18n.t(
+        "assessor_interface.reference_requests.edit.response_value.#{reference_request.hours_response}",
+      ),
+    )
+    expect(reference_request_page.responses.values[2].text).to eq(
+      I18n.t(
+        "assessor_interface.reference_requests.edit.response_value.#{reference_request.children_response}",
+      ),
+    )
+    expect(reference_request_page.responses.values[3].text).to eq(
+      I18n.t(
+        "assessor_interface.reference_requests.edit.response_value.#{reference_request.lessons_response}",
+      ),
+    )
+    expect(reference_request_page.responses.values[4].text).to eq(
+      I18n.t(
+        "assessor_interface.reference_requests.edit.response_value.#{reference_request.reports_response}",
+      ),
+    )
+    expect(reference_request_page.responses.values[5].text).to eq(
+      reference_request.additional_information_response,
+    )
+  end
+
+  def when_i_verify_the_reference_request
+    reference_request_page.form.yes_radio_item.choose
+    reference_request_page.form.continue_button.click
+  end
+
+  def then_i_see_the_reference_request_status_is_accepted
+    expect(verify_references_page.task_list.status_tags.first.text).to eq(
+      "ACCEPTED",
+    )
+  end
+
+  def when_i_verify_that_all_references_are_accepted
+    verify_references_page.form.yes_radio_item.choose
+    verify_references_page.form.continue_button.click
+  end
+
+  def then_i_see_the_verify_references_task_is_completed
+    expect(
+      assessor_application_page.verify_references_task.status_tag.text,
+    ).to eq("COMPLETED")
+  end
+
+  def application_form
+    @application_form ||=
+      begin
+        application_form =
+          create(:application_form, :waiting_on, received_reference: true)
+        create(:work_history, :completed, application_form:)
+        assessment =
+          create(
+            :assessment,
+            :with_received_professional_standing_request,
+            :with_received_reference_request,
+            application_form:,
+          )
+        create(:assessment_section, :passed, assessment:)
+        application_form
+      end
+  end
+
+  def application_id
+    application_form.id
+  end
+
+  def assessment_id
+    application_form.assessment.id
+  end
+
+  def reference_request
+    application_form.assessment.reference_requests.first
+  end
+
+  def reference_request_id
+    reference_request.id
+  end
+end

--- a/spec/view_objects/assessor_interface/verify_references_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/verify_references_view_object_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::VerifyReferencesViewObject do
+  let(:assessment) { create(:assessment) }
+  subject(:view_object) { described_class.new(assessment:) }
+
+  describe "#name_and_duration" do
+    let(:work_history) do
+      create(
+        :work_history,
+        application_form: assessment.application_form,
+        school_name: "School of Rock",
+        start_date: Date.new(2022, 1, 1),
+        end_date: Date.new(2022, 12, 22),
+        hours_per_week: 30,
+      )
+    end
+
+    subject(:name_and_duration) { view_object.name_and_duration(work_history) }
+
+    it { is_expected.to eq("School of Rock (12 months)") }
+
+    context "when work history is most recent" do
+      subject(:name_and_duration) do
+        view_object.name_and_duration(work_history, most_recent: true)
+      end
+
+      it do
+        is_expected.to eq(
+          %(School of Rock (12 months) <span class="govuk-!-font-weight-bold">MOST RECENT</span>),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/FA4eVtHf/1499-assess-references-that-have-been-received)

## Context and changes

_As an assessor that is looking at the reference that have been received about an applicants work history
I need to be able to view the information that a referee has submitted
so that I can  decide whether to award or decline an application_

Adds a _verify reference requests_ and _review reference request_ pages.

I'm not 100% sure what the happy path from verifying all references should be so for the moment this PR takes the user to the application overview. This probably isn't right.

## Verifying reference requests

![image](https://user-images.githubusercontent.com/93511/218812246-5833acd8-db57-41d4-8108-1bcb96de38d9.png)

## Reviewing a reference request

![image](https://user-images.githubusercontent.com/93511/218812487-58cc727c-ea56-4fe8-9c12-e96666573cdd.png)
