### PR TITLE
Prepare for award/decline flow

### DIFF
--- a/app/controllers/assessor_interface/assessments_controller.rb
+++ b/app/controllers/assessor_interface/assessments_controller.rb
@@ -45,6 +45,8 @@ module AssessorInterface
     delegate :application_form, to: :assessment
 
     def update_redirect_path(recommendation)
+      recommendation = "award" if recommendation == "award_pending_verification"
+
       if recommendation == "request_further_information"
         [
           :preview,

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -121,6 +121,8 @@ class Assessment < ApplicationRecord
         professional_standing_request&.requested? || false
     elsif request_further_information?
       any_further_information_request_failed?
+    elsif award_pending_verification?
+      true # TODO: check the state of verification requests
     else
       false
     end

--- a/app/views/assessor_interface/assessment_recommendation_declines/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_declines/edit.html.erb
@@ -6,7 +6,8 @@
 <p class="govuk-body-l">You’re about to decline this QTS application from <%= application_form_full_name(@application_form) %> for the following reasons:</p>
 
 <h2 class="govuk-heading-l">Your decline reasons and notes</h2>
-<% unless @assessment.further_information_requests.exists? %>
+
+<% if @assessment.unknown? %>
   <% @assessment.sections.each do |section| %>
     <% if section.selected_failure_reasons.present? %>
       <h3 class="govuk-heading-m"><%= t(".assessment_section.#{section.key}") %></h3>
@@ -20,6 +21,7 @@
             <% else %>
               <p class="govuk-body govuk-!-margin-bottom-2">Your note (the applicant won’t see this):</p>
             <% end %>
+
             <%= govuk_inset_text do %>
               <%= simple_format failure_reason.assessor_feedback %>
             <% end %>
@@ -37,7 +39,9 @@
 
 <%= form_with model: @form, url: [:assessor_interface, @application_form, @assessment, :assessment_recommendation_decline], method: :put do |f| %>
   <%= f.govuk_error_summary %>
+
   <%= f.govuk_text_area :recommendation_assessor_note %>
+
   <%= f.govuk_check_boxes_fieldset :declaration, small: true do %>
     <%= f.govuk_check_box :declaration,
                           true,
@@ -46,7 +50,7 @@
                           link_errors: true,
                           label: { text: t(".declaration") } %>
   <% end %>
-  
+
   <p class="govuk-body"><%= t(".instruction") %></p>
   <p class="govuk-body">If you need to check something, use the ‘Back’ button.</p>
 

--- a/app/views/assessor_interface/assessment_recommendation_declines/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_declines/edit.html.erb
@@ -1,46 +1,43 @@
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t(".heading")}" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
-<h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
-
-<p class="govuk-body-l">You’re about to decline this QTS application from <%= application_form_full_name(@application_form) %> for the following reasons:</p>
-
-<h2 class="govuk-heading-l">Your decline reasons and notes</h2>
-
-<% if @assessment.unknown? %>
-  <% @assessment.sections.each do |section| %>
-    <% if section.selected_failure_reasons.present? %>
-      <h3 class="govuk-heading-m"><%= t(".assessment_section.#{section.key}") %></h3>
-      <ul class="govuk-list">
-        <% section.selected_failure_reasons.each do |failure_reason| %>
-          <li>
-            <h4 class="govuk-heading-s"><%= t("assessor_interface.assessment_sections.show.failure_reasons.#{failure_reason.key}") %></h4>
-
-            <% if FailureReasons.decline?(failure_reason: failure_reason.key) %>
-              <p class="govuk-body govuk-!-margin-bottom-2">Your note to the applicant:</p>
-            <% else %>
-              <p class="govuk-body govuk-!-margin-bottom-2">Your note (the applicant won’t see this):</p>
-            <% end %>
-
-            <%= govuk_inset_text do %>
-              <%= simple_format failure_reason.assessor_feedback %>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    <% end %>
-  <% end %>
-<% else %>
-  <p class="govuk-hint">Use this space to tell the applicant why they’ve been declined.</p>
-  <p class="govuk-hint">This is the last communication they’ll receive about this application so make sure your comments are clear.</p>
-<% end %>
-
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
-
 <%= form_with model: @form, url: [:assessor_interface, @application_form, @assessment, :assessment_recommendation_decline], method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_text_area :recommendation_assessor_note %>
+  <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
+
+  <p class="govuk-body-l">You’re about to decline this QTS application from <%= application_form_full_name(@application_form) %> for the following reasons:</p>
+
+  <h2 class="govuk-heading-l">Your decline reasons and notes</h2>
+
+  <% if @assessment.unknown? %>
+    <% @assessment.sections.each do |section| %>
+      <% if section.selected_failure_reasons.present? %>
+        <h3 class="govuk-heading-m"><%= t(".assessment_section.#{section.key}") %></h3>
+        <ul class="govuk-list">
+          <% section.selected_failure_reasons.each do |failure_reason| %>
+            <li>
+              <h4 class="govuk-heading-s"><%= t("assessor_interface.assessment_sections.show.failure_reasons.#{failure_reason.key}") %></h4>
+
+              <% if FailureReasons.decline?(failure_reason: failure_reason.key) %>
+                <p class="govuk-body govuk-!-margin-bottom-2">Your note to the applicant:</p>
+              <% else %>
+                <p class="govuk-body govuk-!-margin-bottom-2">Your note (the applicant won’t see this):</p>
+              <% end %>
+
+              <%= govuk_inset_text do %>
+                <%= simple_format failure_reason.assessor_feedback %>
+              <% end %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_text_area :recommendation_assessor_note,
+                        label: { text: @assessment.unknown? ? "Assessor’s notes (optional)" : "Use this space to tell the applicant why they’ve been declined." },
+                        hint: { text: @assessment.unknown? ? nil : "This is the last communication they’ll receive about this application so make sure your comments are clear." } %>
 
   <%= f.govuk_check_boxes_fieldset :declaration, small: true do %>
     <%= f.govuk_check_box :declaration,

--- a/app/views/assessor_interface/assessments/edit.html.erb
+++ b/app/views/assessor_interface/assessments/edit.html.erb
@@ -4,11 +4,21 @@
 <%= form_with model: @form, url: [:assessor_interface, @application_form, @assessment], method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
+  <%
+    hint = if @assessment.can_award_pending_verification?
+             t(".hint.can_award_pending_verification")
+           elsif @assessment.can_award?
+             t(".hint.can_award")
+           else
+             t(".hint.cant_award")
+           end
+  %>
+
   <%= f.govuk_collection_radio_buttons :recommendation,
                                        @assessment.available_recommendations,
                                        :itself,
                                        legend: { size: "xl", tag: "h1" },
-                                       hint: { text: t(@assessment.can_award? ? ".hint.can_award" : ".hint.cant_award") } %>
+                                       hint: { text: hint } %>
 
   <%= f.govuk_submit prevent_double_click: false do %>
     <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -33,7 +33,8 @@ en:
     assessments:
       edit:
         hint:
-          can_award: You’ve completed your review of this QTS application and marked all sections as complete to your satisfaction.
+          can_award: You’ve completed your assessment of this QTS application and reviewed the work references.
+          can_award_pending_verification: You’ve completed your review of this QTS application and marked all sections as complete to your satisfaction.
           cant_award: You’ve completed your review of this QTS application and marked 1 or more sections as not completed to your satisfaction.
 
     assessment_recommendation_awards:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -13,14 +13,15 @@ en:
       show:
         assessment_tasks:
           sections:
-            pre_assessment_tasks: Pre-assessment tasks
-            initial_assessment: Initial assessment
             further_information_requests: Further information requests
+            initial_assessment: Initial assessment
+            pre_assessment_tasks: Pre-assessment tasks
             verification_requests: Verification requests
           items:
             age_range_subjects: Verify age range and subjects
+            assessment_recommendation: Assessment recommendation
             english_language_proficiency: Check English language proficiency
-            assessment_recommendation: Initial assessment recommendation
+            initial_assessment_recommendation: Initial assessment recommendation
             personal_information: Check personal information
             professional_standing: Check professional standing
             professional_standing_request: Awaiting third-party professional standing

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -47,8 +47,9 @@ en:
       assessor_interface_assessment_recommendation_form:
         recommendation_options:
           award: Award QTS
-          request_further_information: Request further information
+          award_pending_verification: Award QTS
           decline: Decline QTS
+          request_further_information: Request further information
       assessor_interface_assessment_confirmation_form:
         confirmation_options:
           true: "Yes"

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -54,8 +54,6 @@ en:
         confirmation_options:
           true: "Yes"
           false: "No"
-      assessor_interface_assessment_declaration_decline_form:
-        recommendation_assessor_note: Assessor's notes
       assessor_interface_assessment_section_form:
         age_range_min: From
         age_range_max: To

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -34,7 +34,9 @@
 require "rails_helper"
 
 RSpec.describe Assessment, type: :model do
-  subject(:assessment) { create(:assessment) }
+  subject(:assessment) { create(:assessment, application_form:) }
+
+  let(:application_form) { create(:application_form) }
 
   describe "associations" do
     it { is_expected.to have_many(:sections) }
@@ -50,6 +52,7 @@ RSpec.describe Assessment, type: :model do
       is_expected.to define_enum_for(:recommendation).with_values(
         unknown: "unknown",
         award: "award",
+        award_pending_verification: "award_pending_verification",
         decline: "decline",
         request_further_information: "request_further_information",
       ).backed_by_column_of_type(:string)
@@ -63,44 +66,151 @@ RSpec.describe Assessment, type: :model do
   describe "#can_award?" do
     subject(:can_award?) { assessment.can_award? }
 
-    context "with an unknown assessment" do
-      before { create(:assessment_section, :personal_information, assessment:) }
+    context "with an application under old regulations" do
+      let(:application_form) { create(:application_form, :old_regs) }
+
+      context "with an unknown assessment" do
+        before do
+          create(:assessment_section, :personal_information, assessment:)
+        end
+        it { is_expected.to be false }
+      end
+
+      context "with a passed assessment" do
+        before do
+          create(
+            :assessment_section,
+            :personal_information,
+            :passed,
+            assessment:,
+          )
+        end
+        it { is_expected.to be true }
+      end
+
+      context "with a failed assessment" do
+        before do
+          create(
+            :assessment_section,
+            :personal_information,
+            :failed,
+            assessment:,
+          )
+        end
+        it { is_expected.to be false }
+
+        context "when further information was requested" do
+          before { assessment.request_further_information! }
+
+          context "with a passed further information request" do
+            before do
+              create(:further_information_request, :passed, assessment:)
+            end
+            it { is_expected.to be true }
+          end
+
+          context "with a failed further information request" do
+            before do
+              create(:further_information_request, :failed, assessment:)
+            end
+            it { is_expected.to be false }
+          end
+        end
+      end
+
+      context "with a mixture of assessments" do
+        before do
+          create(
+            :assessment_section,
+            :personal_information,
+            :passed,
+            assessment:,
+          )
+          create(:assessment_section, :qualifications, :failed, assessment:)
+        end
+        it { is_expected.to be false }
+      end
+    end
+
+    context "with an application under old regulations" do
+      let(:application_form) { create(:application_form, :new_regs) }
       it { is_expected.to be false }
     end
+  end
 
-    context "with a passed assessment" do
-      before do
-        create(:assessment_section, :personal_information, :passed, assessment:)
-      end
-      it { is_expected.to be true }
+  describe "#can_award_pending_verification?" do
+    subject(:can_award_pending_verification?) do
+      assessment.can_award_pending_verification?
     end
 
-    context "with a failed assessment" do
-      before do
-        create(:assessment_section, :personal_information, :failed, assessment:)
+    context "with an application under new regulations" do
+      let(:application_form) { create(:application_form, :new_regs) }
+
+      context "with an unknown assessment" do
+        before do
+          create(:assessment_section, :personal_information, assessment:)
+        end
+        it { is_expected.to be false }
       end
-      it { is_expected.to be false }
 
-      context "when further information was requested" do
-        before { assessment.request_further_information! }
-
-        context "with a passed further information request" do
-          before { create(:further_information_request, :passed, assessment:) }
-          it { is_expected.to be true }
+      context "with a passed assessment" do
+        before do
+          create(
+            :assessment_section,
+            :personal_information,
+            :passed,
+            assessment:,
+          )
         end
+        it { is_expected.to be true }
+      end
 
-        context "with a failed further information request" do
-          before { create(:further_information_request, :failed, assessment:) }
-          it { is_expected.to be false }
+      context "with a failed assessment" do
+        before do
+          create(
+            :assessment_section,
+            :personal_information,
+            :failed,
+            assessment:,
+          )
         end
+        it { is_expected.to be false }
+
+        context "when further information was requested" do
+          before { assessment.request_further_information! }
+
+          context "with a passed further information request" do
+            before do
+              create(:further_information_request, :passed, assessment:)
+            end
+            it { is_expected.to be true }
+          end
+
+          context "with a failed further information request" do
+            before do
+              create(:further_information_request, :failed, assessment:)
+            end
+            it { is_expected.to be false }
+          end
+        end
+      end
+
+      context "with a mixture of assessments" do
+        before do
+          create(
+            :assessment_section,
+            :personal_information,
+            :passed,
+            assessment:,
+          )
+          create(:assessment_section, :qualifications, :failed, assessment:)
+        end
+        it { is_expected.to be false }
       end
     end
 
-    context "with a mixture of assessments" do
-      before do
-        create(:assessment_section, :personal_information, :passed, assessment:)
-        create(:assessment_section, :qualifications, :failed, assessment:)
-      end
+    context "with an application under old regulations" do
+      let(:application_form) { create(:application_form, :old_regs) }
       it { is_expected.to be false }
     end
   end
@@ -243,6 +353,15 @@ RSpec.describe Assessment, type: :model do
     context "with an award-able assessment" do
       before { allow(assessment).to receive(:can_award?).and_return(true) }
       it { is_expected.to include("award") }
+    end
+
+    context "with an award-able pending verification assessment" do
+      before do
+        allow(assessment).to receive(
+          :can_award_pending_verification?,
+        ).and_return(true)
+      end
+      it { is_expected.to include("award_pending_verification") }
     end
 
     context "with a decline-able assessment" do

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -302,6 +302,11 @@ RSpec.describe Assessment, type: :model do
         it { is_expected.to be true }
       end
     end
+
+    context "when awarded pending verification" do
+      before { assessment.award_pending_verification! }
+      it { is_expected.to be true }
+    end
   end
 
   describe "#can_request_further_information?" do

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -51,6 +51,10 @@ module PageObjects
       def requested_qualifications_task
         task_list.find_item("Qualifications – requested")
       end
+
+      def assessment_recommendation_task
+        task_list.find_item("Assessment recommendation")
+      end
     end
   end
 end

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
               personal_information
               qualifications
               work_history
-              assessment_recommendation
+              initial_assessment_recommendation
             ],
           )
         end
@@ -78,7 +78,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
               personal_information
               qualifications
               professional_standing
-              assessment_recommendation
+              initial_assessment_recommendation
             ],
           )
         end
@@ -109,13 +109,19 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       context "with a qualification request" do
         before { create(:qualification_request, assessment:) }
 
-        it { is_expected.to eq(%i[qualification_requests]) }
+        it do
+          is_expected.to eq(
+            %i[qualification_requests assessment_recommendation],
+          )
+        end
       end
 
       context "with a reference request" do
         before { create(:reference_request, assessment:) }
 
-        it { is_expected.to eq(%i[reference_requests]) }
+        it do
+          is_expected.to eq(%i[reference_requests assessment_recommendation])
+        end
       end
     end
   end
@@ -158,7 +164,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       end
 
       context "and assessment recommendation" do
-        let(:item) { :assessment_recommendation }
+        let(:item) { :initial_assessment_recommendation }
 
         it do
           is_expected.to eq(
@@ -232,7 +238,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
 
     let(:index) { 0 }
 
-    context "with submitted details section" do
+    context "with initial assessment section" do
       let(:section) { :initial_assessment }
 
       context "personal information" do
@@ -242,7 +248,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       end
 
       context "assessment recommendation" do
-        let(:item) { :assessment_recommendation }
+        let(:item) { :initial_assessment_recommendation }
 
         context "with unfinished assessment sections" do
           it { is_expected.to eq(:cannot_start) }
@@ -327,6 +333,32 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           assessment.decline!
           create(:further_information_request, :received, :failed, assessment:)
         end
+        it { is_expected.to eq(:completed) }
+      end
+    end
+
+    context "with verification requests section" do
+      let(:section) { :verification_requests }
+      let(:item) { :assessment_recommendation }
+
+      it { is_expected.to eq(:cannot_start) }
+
+      context "when decline-able" do
+        before do
+          assessment.request_further_information!
+          create(:further_information_request, :received, :failed, assessment:)
+        end
+
+        it { is_expected.to eq(:not_started) }
+      end
+
+      context "with an award recommendation" do
+        before { assessment.award! }
+        it { is_expected.to eq(:completed) }
+      end
+
+      context "with a decline recommendation" do
+        before { assessment.award! }
         it { is_expected.to eq(:completed) }
       end
     end


### PR DESCRIPTION
This adds a new recommendation `award_pending_verification` to represent the two different award steps we've got under the new regulations, and then blocks awarding if the application is under the new regulations and allows declining. See individual commits for more details.

[Trello Card](https://trello.com/c/Q083XNwJ/1408-build-decline-after-verification)

## Screenshots

<img width="404" alt="Screenshot 2023-02-09 at 17 02 04" src="https://user-images.githubusercontent.com/510498/217890112-bb9e218d-2266-4d5b-a7f6-29d6448c0b91.png">
<img width="703" alt="Screenshot 2023-02-09 at 17 22 13" src="https://user-images.githubusercontent.com/510498/217890116-34f7b671-5c3a-4b21-81c5-77fb4e066c1f.png">
<img width="760" alt="Screenshot 2023-02-09 at 17 22 30" src="https://user-images.githubusercontent.com/510498/217890118-b1b5f5ff-1f80-441e-8ed8-db2e98c70851.png">
