### PR TITLE
Fix name filtering

### DIFF
--- a/app/lib/filters/name.rb
+++ b/app/lib/filters/name.rb
@@ -5,9 +5,7 @@ module Filters
     def apply
       return scope if name.blank?
 
-      scope.where("given_names ilike ?", "%#{name}%").or(
-        scope.where("family_name ilike ?", "%#{name}%"),
-      )
+      scope.where("CONCAT(given_names, ' ', family_name) ilike ?", "%#{name}%")
     end
 
     private

--- a/spec/lib/filters/name_spec.rb
+++ b/spec/lib/filters/name_spec.rb
@@ -112,6 +112,23 @@ RSpec.describe Filters::Name do
         expect(subject).to eq([included])
       end
     end
+
+    context "match  that spans both fields" do
+      let(:params) { { name: "the Gangster" } }
+
+      let!(:included) do
+        create(
+          :application_form,
+          :with_personal_information,
+          given_names: "Dave the",
+          family_name: "Gangster",
+        )
+      end
+
+      it "returns a filtered scope" do
+        expect(subject).to eq([included])
+      end
+    end
   end
 
   context "the params don't include :name" do


### PR DESCRIPTION
If the query term spans the given names and family name fields then the filter is currently not returning the expected result.

Concatenate the two fields.

e.g. given_names: "Lucy", family_name: "Hong San" should match with the query "Lucy Hong"

This fixes the issue. Might be better to strip all spaces though. The edge cases might be a bit more complicated.