### PR TITLE
Increase ActiveStorage timeout to 2 minutes

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -11,3 +11,4 @@ microsoft:
   storage_account_name: <%= ENV["AZURE_STORAGE_ACCOUNT_NAME"] %>
   storage_access_key: <%= ENV["AZURE_STORAGE_ACCESS_KEY"] %>
   container: <%= ENV["AZURE_STORAGE_CONTAINER"] %>
+  timeout: 120 # 2 minutes


### PR DESCRIPTION
This increases the timeout on uploading a file from 1 minute to 2 minutes, hopefully reducing the number of users seeing an error message while trying to upload a file.