### PR TITLE
Ensure recommendation_assessor_note is not null

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_declines_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_declines_controller.rb
@@ -66,10 +66,14 @@ module AssessorInterface
         if @form.confirmation
           ActiveRecord::Base.transaction do
             assessment.decline!
-            assessment.update!(
-              recommendation_assessor_note:
-                session[:recommendation_assessor_note],
-            )
+
+            if (
+                 recommendation_assessor_note =
+                   session[:recommendation_assessor_note]
+               ).present?
+              assessment.update!(recommendation_assessor_note:)
+            end
+
             DeclineQTS.call(application_form:, user: current_staff)
           end
 


### PR DESCRIPTION
The column isn't nullable so when writing it to the database we should only do so if it's present.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/3929467726/?referrer=slack)