### PR TITLE
Revert "Increase ActiveStorage timeout to 2 minutes"

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -11,4 +11,3 @@ microsoft:
   storage_account_name: <%= ENV["AZURE_STORAGE_ACCOUNT_NAME"] %>
   storage_access_key: <%= ENV["AZURE_STORAGE_ACCESS_KEY"] %>
   container: <%= ENV["AZURE_STORAGE_CONTAINER"] %>
-  timeout: 120 # 2 minutes


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-qualified-teacher-status#1111

`timeout` is not a valid parameter for Azure.

https://dfe-teacher-services.sentry.io/issues/3933646975/?referrer=slack