### PR TITLE
Configure Pagy overflow behaviour

### DIFF
--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -167,8 +167,8 @@ Pagy::DEFAULT[:size] = [1, 1, 1, 1]
 
 # Overflow extra: Allow for easy handling of overflowing pages
 # See https://ddnexus.github.io/pagy/extras/overflow
-# require 'pagy/extras/overflow'
-# Pagy::DEFAULT[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+require "pagy/extras/overflow"
+Pagy::DEFAULT[:overflow] = :empty_page # default  (other options: :last_page and :exception)
 
 # Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
 # See https://ddnexus.github.io/pagy/extras/support


### PR DESCRIPTION
This handles the `Pagy::OverflowError` exception for us and automatically removes the page parameter so the user sees the first page.

This should resolve: https://dfe-teacher-services.sentry.io/issues/3693260260/