### PR TITLE
Sanitise date of birth

### DIFF
--- a/app/forms/teacher_interface/name_and_date_of_birth_form.rb
+++ b/app/forms/teacher_interface/name_and_date_of_birth_form.rb
@@ -3,6 +3,7 @@
 module TeacherInterface
   class NameAndDateOfBirthForm < BaseForm
     include ActiveRecord::AttributeAssignment
+    include TeacherInterface::SanitizeDates
 
     attr_accessor :application_form
     attribute :given_names, :string
@@ -16,6 +17,7 @@ module TeacherInterface
     validate :date_of_birth_valid
 
     def update_model
+      sanitize_dates!(date_of_birth)
       application_form.update!(given_names:, family_name:, date_of_birth:)
     end
 


### PR DESCRIPTION
This applies the date sanitisation code to reduce and a fix a number of Sentry errors to the date of birth of the applicant.

See
https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/1083 for more information on this fix.