### PR TITLE
Use explicit matchers in filter tests

### DIFF
--- a/spec/lib/filters/assessor_spec.rb
+++ b/spec/lib/filters/assessor_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Filters::Assessor do
       let!(:filtered) { create(:application_form, assessor: assessor_two) }
 
       it "returns a filtered scope" do
-        expect(subject).to eq([included])
+        expect(subject).to contain_exactly(included)
       end
     end
 
@@ -31,7 +31,7 @@ RSpec.describe Filters::Assessor do
       let!(:filtered) { create(:application_form, reviewer: assessor_two) }
 
       it "returns a filtered scope" do
-        expect(subject).to eq([included])
+        expect(subject).to contain_exactly(included)
       end
     end
   end

--- a/spec/lib/filters/country_spec.rb
+++ b/spec/lib/filters/country_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Filters::Country do
     end
 
     it "returns a filtered scope" do
-      expect(subject).to eq([included])
+      expect(subject).to contain_exactly(included)
     end
   end
 

--- a/spec/lib/filters/name_spec.rb
+++ b/spec/lib/filters/name_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Filters::Name do
       end
 
       it "returns a filtered scope" do
-        expect(subject).to eq([included])
+        expect(subject).to contain_exactly(included)
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe Filters::Name do
       end
 
       it "returns a filtered scope" do
-        expect(subject).to eq([included])
+        expect(subject).to contain_exactly(included)
       end
     end
 
@@ -71,7 +71,7 @@ RSpec.describe Filters::Name do
       end
 
       it "returns a filtered scope" do
-        expect(subject).to eq([included])
+        expect(subject).to contain_exactly(included)
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe Filters::Name do
       end
 
       it "returns a filtered scope" do
-        expect(subject).to eq([included])
+        expect(subject).to contain_exactly(included)
       end
     end
 
@@ -109,7 +109,7 @@ RSpec.describe Filters::Name do
       end
 
       it "returns a filtered scope" do
-        expect(subject).to eq([included])
+        expect(subject).to contain_exactly(included)
       end
     end
 
@@ -126,7 +126,7 @@ RSpec.describe Filters::Name do
       end
 
       it "returns a filtered scope" do
-        expect(subject).to eq([included])
+        expect(subject).to contain_exactly(included)
       end
     end
   end

--- a/spec/lib/filters/status_spec.rb
+++ b/spec/lib/filters/status_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Filters::Status do
     let!(:filtered) { create(:application_form, :submitted) }
 
     it "returns a filtered scope" do
-      expect(subject).to eq([included])
+      expect(subject).to contain_exactly(included)
     end
   end
 
@@ -32,7 +32,7 @@ RSpec.describe Filters::Status do
     end
 
     it "returns a filtered scope" do
-      expect(subject).to eq(included)
+      expect(subject).to match_array(included)
     end
   end
 

--- a/spec/lib/filters/submitted_at_spec.rb
+++ b/spec/lib/filters/submitted_at_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Filters::SubmittedAt do
       create(:application_form, :submitted, submitted_at: Date.new(2021, 1, 1))
     end
 
-    it { is_expected.to eq([included]) }
+    it { is_expected.to contain_exactly(included) }
   end
 
   context "with submitted_at before param" do
@@ -48,7 +48,7 @@ RSpec.describe Filters::SubmittedAt do
       create(:application_form, :submitted, submitted_at: Date.new(2020, 1, 2))
     end
 
-    it { is_expected.to eq([included]) }
+    it { is_expected.to contain_exactly(included) }
   end
 
   context "with submitted_at after param" do
@@ -69,7 +69,7 @@ RSpec.describe Filters::SubmittedAt do
       create(:application_form, :submitted, submitted_at: Date.new(2020, 1, 1))
     end
 
-    it { is_expected.to eq([included]) }
+    it { is_expected.to contain_exactly(included) }
   end
 
   context "without submitted_at params" do


### PR DESCRIPTION
This should fix a flaky test where we're expecting the order of the array to be consistent when it won't necessarily be and is not the responsibility of the filters to do so.