### PR TITLE
Don't sanitise nil dates

### DIFF
--- a/app/forms/concerns/teacher_interface/sanitize_dates.rb
+++ b/app/forms/concerns/teacher_interface/sanitize_dates.rb
@@ -9,7 +9,7 @@ module TeacherInterface
         today = Time.zone.now
 
         dates.each do |date|
-          next if date[1].blank? || date[2].blank?
+          next if date.nil? || date[1].blank? || date[2].blank?
 
           date[2] = 1 if date[2].to_i < 1 || date[2].to_i > 12
 


### PR DESCRIPTION
If a user chooses not to enter a date yet that's acceptable and we can ignore it when trying to sanitize it, since it'll be stored as a nil value in the database.

https://dfe-teacher-services.sentry.io/issues/3936078677/