### PR TITLE
Enable logging on blob storage

### DIFF
--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -15,6 +15,14 @@ resource "azurerm_storage_account" "forms" {
       days = var.forms_container_delete_retention_days
     }
   }
+
+  logging {
+    delete                = true
+    read                  = true
+    version               = "2.0"
+    write                 = true
+    retention_policy_days = 7
+  }
 }
 
 


### PR DESCRIPTION
* Update the storage.tf terraform file to enable logging on all operations with a 7 day retention

We're getting timeouts on read, write and delete that we don't understand. Enabling logging to help diagnose. This will enable all environments which is likely uneccessary in the long term but it will allow us to test for now.