### PR TITLE
Add and amend content around changing application after submission

### DIFF
--- a/app/views/teacher_interface/application_forms/edit.html.erb
+++ b/app/views/teacher_interface/application_forms/edit.html.erb
@@ -59,7 +59,7 @@
 
       <h2 class="govuk-heading-m">Submitting your application</h2>
       <p class="govuk-body">By selecting the ‘Submit application button’ you confirm that, to the best of your knowledge, the details you’ve provided are correct.</p>
-
+      <p class="govuk-body">You will not be able to change your application, add new documents or delete anything once you submit it.</p>
       <%= f.govuk_submit "Submit your application" %>
     <%- end -%>
   </section>

--- a/app/views/teacher_interface/further_information_requests/edit.html.erb
+++ b/app/views/teacher_interface/further_information_requests/edit.html.erb
@@ -14,6 +14,7 @@
 
 <% if @view_object.can_submit? %>
   <h3 class="govuk-heading-m">Submitting your further information</h3>
-  <p class="govuk-body">By selecting the ‘Submit application button’ you confirm that, to the best of your knowledge, the details you’ve provided are correct.</p>
-  <%= govuk_button_to "Submit your application", teacher_interface_application_form_further_information_request_path(@view_object.further_information_request), method: :patch %>
+  <p class="govuk-body">By selecting the ‘Submit your response’ button you confirm that, to the best of your knowledge, the details you’ve provided are correct.</p>
+  <p class="govuk-body">You will not be able to change your response, add new documents or delete anything once you submit it.</p>
+  <%= govuk_button_to "Submit your response", teacher_interface_application_form_further_information_request_path(@view_object.further_information_request), method: :patch %>
 <% end %>

--- a/app/views/teacher_interface/reference_requests/edit.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit.html.erb
@@ -38,5 +38,6 @@
 <% if @reference_request.responses_given? %>
   <h3 class="govuk-heading-m">Submitting your response</h3>
   <p class="govuk-body">By selecting the ‘Submit your response’ button, you confirm that, to the best of your knowledge, the details you’ve provided are correct.</p>
+  <p class="govuk-body">You will not be able to change your response or delete anything once you submit it.</p>
   <%= govuk_button_to "Submit your response", teacher_interface_reference_request_path, method: :patch %>
 <% end %>


### PR DESCRIPTION
[Trello](https://trello.com/c/lpV1ASAT/1556-strengthen-you-cannot-update-your-application-post-submission)

Amend content shown above application, further information and reference request submit button to make teacher aware they cannot make further changes.