### PR TITLE
Ensure region exists for eligible check

### DIFF
--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -152,11 +152,11 @@ class EligibilityCheck < ApplicationRecord
       return :eligibility
     end
 
-    if skip_additional_questions? && region.present? && qualification
-      return :eligibility
-    end
+    if region.present?
+      return :eligibility if skip_additional_questions? && qualification
 
-    return :eligibility unless free_of_sanctions.nil?
+      return :eligibility unless free_of_sanctions.nil?
+    end
 
     if qualified_for_subject_required? &&
          (teach_children == false || qualified_for_subject == false)

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -170,6 +170,7 @@ RSpec.describe EligibilityCheck, type: :model do
         eligibility_check.qualification = true
         eligibility_check.degree = true
         eligibility_check.country_code = country.code
+        eligibility_check.region = country.regions.first
       end
 
       it { is_expected.to be true }


### PR DESCRIPTION
If an eligibility check is marked as eligible, we should make sure the region exists before rendering the eligible page.

There have been a small number of Sentry issues reported about this so fixing it should get that number down.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/3946951765/)