### PR TITLE
Improve reference request flow

### DIFF
--- a/app/components/check_your_answers_summary/component.html.erb
+++ b/app/components/check_your_answers_summary/component.html.erb
@@ -20,10 +20,12 @@
           <dt class="govuk-summary-list__key"><%= row.fetch(:title) %></dt>
           <dd class="govuk-summary-list__value"><%= row.fetch(:value) %></dd>
 
-          <% if (href = row[:href]).present? %>
+          <% if changeable %>
             <dd class="govuk-summary-list__actions">
-              <%= govuk_link_to(href) do %>
-                Change <span class="govuk-visually-hidden"><%= row.fetch(:title).downcase %></span>
+              <% if (href = row[:href]).present? %>
+                <%= govuk_link_to(href) do %>
+                  Change <span class="govuk-visually-hidden"><%= row.fetch(:title).downcase %></span>
+                <% end %>
               <% end %>
             </dd>
           <% end %>

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -32,6 +32,37 @@ module TeacherInterface
       redirect_to teacher_interface_reference_request_path
     end
 
+    def edit_contact
+      @application_form = reference_request.application_form
+      @work_history = reference_request.work_history
+
+      @form =
+        ReferenceRequestContactResponseForm.new(
+          reference_request:,
+          contact_response: reference_request.contact_response,
+          contact_name: reference_request.contact_name,
+          contact_job: reference_request.contact_job,
+          contact_comment: reference_request.contact_comment,
+        )
+    end
+
+    def update_contact
+      @application_form = reference_request.application_form
+      @work_history = reference_request.work_history
+
+      @form =
+        ReferenceRequestContactResponseForm.new(
+          contact_response_form_params.merge(reference_request:),
+        )
+
+      handle_application_form_section(
+        form: @form,
+        if_success_then_redirect:
+          dates_teacher_interface_reference_request_path,
+        if_failure_then_render: :edit_contact,
+      )
+    end
+
     def edit_dates
       @work_history = reference_request.work_history
 
@@ -225,6 +256,12 @@ module TeacherInterface
         ReferenceRequest.where(state: %i[requested expired]).find_by!(
           slug: params[:slug],
         )
+    end
+
+    def contact_response_form_params
+      params.require(
+        :teacher_interface_reference_request_contact_response_form,
+      ).permit(:contact_response, :contact_name, :contact_job, :contact_comment)
     end
 
     def dates_response_form_params

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -230,43 +230,43 @@ module TeacherInterface
     def dates_response_form_params
       params.require(
         :teacher_interface_reference_request_dates_response_form,
-      ).permit(:dates_response)
+      ).permit(:dates_response, :dates_comment)
     end
 
     def hours_response_form_params
       params.require(
         :teacher_interface_reference_request_hours_response_form,
-      ).permit(:hours_response)
+      ).permit(:hours_response, :hours_comment)
     end
 
     def children_response_form_params
       params.require(
         :teacher_interface_reference_request_children_response_form,
-      ).permit(:children_response)
+      ).permit(:children_response, :children_comment)
     end
 
     def lessons_response_form_params
       params.require(
         :teacher_interface_reference_request_lessons_response_form,
-      ).permit(:lessons_response)
+      ).permit(:lessons_response, :lessons_comment)
     end
 
     def reports_response_form_params
       params.require(
         :teacher_interface_reference_request_reports_response_form,
-      ).permit(:reports_response)
+      ).permit(:reports_response, :reports_comment)
     end
 
     def misconduct_response_form_params
       params.require(
         :teacher_interface_reference_request_misconduct_response_form,
-      ).permit(:misconduct_response)
+      ).permit(:misconduct_response, :misconduct_comment)
     end
 
     def satisfied_response_form_params
       params.require(
         :teacher_interface_reference_request_satisfied_response_form,
-      ).permit(:satisfied_response)
+      ).permit(:satisfied_response, :satisfied_comment)
     end
 
     def additional_information_response_form_params

--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -33,6 +33,8 @@ module TeacherInterface
     end
 
     def edit_dates
+      @work_history = reference_request.work_history
+
       @form =
         ReferenceRequestDatesResponseForm.new(
           reference_request:,
@@ -41,6 +43,8 @@ module TeacherInterface
     end
 
     def update_dates
+      @work_history = reference_request.work_history
+
       @form =
         ReferenceRequestDatesResponseForm.new(
           dates_response_form_params.merge(reference_request:),
@@ -141,8 +145,52 @@ module TeacherInterface
       handle_application_form_section(
         form: @form,
         if_success_then_redirect:
-          additional_information_teacher_interface_reference_request_path,
+          misconduct_teacher_interface_reference_request_path,
         if_failure_then_render: :edit_reports,
+      )
+    end
+
+    def edit_misconduct
+      @form =
+        ReferenceRequestMisconductResponseForm.new(
+          reference_request:,
+          misconduct_response: reference_request.misconduct_response,
+        )
+    end
+
+    def update_misconduct
+      @form =
+        ReferenceRequestMisconductResponseForm.new(
+          misconduct_response_form_params.merge(reference_request:),
+        )
+
+      handle_application_form_section(
+        form: @form,
+        if_success_then_redirect:
+          satisfied_teacher_interface_reference_request_path,
+        if_failure_then_render: :edit_misconduct,
+      )
+    end
+
+    def edit_satisfied
+      @form =
+        ReferenceRequestSatisfiedResponseForm.new(
+          reference_request:,
+          satisfied_response: reference_request.satisfied_response,
+        )
+    end
+
+    def update_satisfied
+      @form =
+        ReferenceRequestSatisfiedResponseForm.new(
+          satisfied_response_form_params.merge(reference_request:),
+        )
+
+      handle_application_form_section(
+        form: @form,
+        if_success_then_redirect:
+          additional_information_teacher_interface_reference_request_path,
+        if_failure_then_render: :edit_satisfied,
       )
     end
 
@@ -207,6 +255,18 @@ module TeacherInterface
       params.require(
         :teacher_interface_reference_request_reports_response_form,
       ).permit(:reports_response)
+    end
+
+    def misconduct_response_form_params
+      params.require(
+        :teacher_interface_reference_request_misconduct_response_form,
+      ).permit(:misconduct_response)
+    end
+
+    def satisfied_response_form_params
+      params.require(
+        :teacher_interface_reference_request_satisfied_response_form,
+      ).permit(:satisfied_response)
     end
 
     def additional_information_response_form_params

--- a/app/forms/teacher_interface/reference_request_children_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_children_response_form.rb
@@ -4,12 +4,16 @@ module TeacherInterface
   class ReferenceRequestChildrenResponseForm < BaseForm
     attr_accessor :reference_request
     attribute :children_response, :boolean
+    attribute :children_comment, :string
 
     validates :reference_request, presence: true
     validates :children_response, inclusion: [true, false]
+    validates :children_comment,
+              presence: true,
+              if: -> { children_response == false }
 
     def update_model
-      reference_request.update!(children_response:)
+      reference_request.update!(children_response:, children_comment:)
     end
   end
 end

--- a/app/forms/teacher_interface/reference_request_contact_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_contact_response_form.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class ReferenceRequestContactResponseForm < BaseForm
+    attr_accessor :reference_request
+    attribute :contact_response, :boolean
+    attribute :contact_name, :string
+    attribute :contact_job, :string
+    attribute :contact_comment, :string
+
+    validates :reference_request, presence: true
+    validates :contact_response, inclusion: [true, false]
+    validates :contact_name,
+              presence: true,
+              if: -> { contact_response == false }
+    validates :contact_job, presence: true, if: -> { contact_response == false }
+
+    def update_model
+      reference_request.update!(
+        contact_response:,
+        contact_name:,
+        contact_job:,
+        contact_comment:,
+      )
+    end
+  end
+end

--- a/app/forms/teacher_interface/reference_request_dates_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_dates_response_form.rb
@@ -4,12 +4,14 @@ module TeacherInterface
   class ReferenceRequestDatesResponseForm < BaseForm
     attr_accessor :reference_request
     attribute :dates_response, :boolean
+    attribute :dates_comment, :string
 
     validates :reference_request, presence: true
     validates :dates_response, inclusion: [true, false]
+    validates :dates_comment, presence: true, if: -> { dates_response == false }
 
     def update_model
-      reference_request.update!(dates_response:)
+      reference_request.update!(dates_response:, dates_comment:)
     end
   end
 end

--- a/app/forms/teacher_interface/reference_request_hours_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_hours_response_form.rb
@@ -4,12 +4,14 @@ module TeacherInterface
   class ReferenceRequestHoursResponseForm < BaseForm
     attr_accessor :reference_request
     attribute :hours_response, :boolean
+    attribute :hours_comment, :string
 
     validates :reference_request, presence: true
     validates :hours_response, inclusion: [true, false]
+    validates :hours_comment, presence: true, if: -> { hours_response == false }
 
     def update_model
-      reference_request.update!(hours_response:)
+      reference_request.update!(hours_response:, hours_comment:)
     end
   end
 end

--- a/app/forms/teacher_interface/reference_request_lessons_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_lessons_response_form.rb
@@ -4,12 +4,16 @@ module TeacherInterface
   class ReferenceRequestLessonsResponseForm < BaseForm
     attr_accessor :reference_request
     attribute :lessons_response, :boolean
+    attribute :lessons_comment, :string
 
     validates :reference_request, presence: true
     validates :lessons_response, inclusion: [true, false]
+    validates :lessons_comment,
+              presence: true,
+              if: -> { lessons_response == false }
 
     def update_model
-      reference_request.update!(lessons_response:)
+      reference_request.update!(lessons_response:, lessons_comment:)
     end
   end
 end

--- a/app/forms/teacher_interface/reference_request_misconduct_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_misconduct_response_form.rb
@@ -4,12 +4,16 @@ module TeacherInterface
   class ReferenceRequestMisconductResponseForm < BaseForm
     attr_accessor :reference_request
     attribute :misconduct_response, :boolean
+    attribute :misconduct_comment, :string
 
     validates :reference_request, presence: true
     validates :misconduct_response, inclusion: [true, false]
+    validates :misconduct_comment,
+              presence: true,
+              if: -> { misconduct_response == true }
 
     def update_model
-      reference_request.update!(misconduct_response:)
+      reference_request.update!(misconduct_response:, misconduct_comment:)
     end
   end
 end

--- a/app/forms/teacher_interface/reference_request_misconduct_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_misconduct_response_form.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class ReferenceRequestMisconductResponseForm < BaseForm
+    attr_accessor :reference_request
+    attribute :misconduct_response, :boolean
+
+    validates :reference_request, presence: true
+    validates :misconduct_response, inclusion: [true, false]
+
+    def update_model
+      reference_request.update!(misconduct_response:)
+    end
+  end
+end

--- a/app/forms/teacher_interface/reference_request_reports_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_reports_response_form.rb
@@ -4,12 +4,16 @@ module TeacherInterface
   class ReferenceRequestReportsResponseForm < BaseForm
     attr_accessor :reference_request
     attribute :reports_response, :boolean
+    attribute :reports_comment, :string
 
     validates :reference_request, presence: true
     validates :reports_response, inclusion: [true, false]
+    validates :reports_comment,
+              presence: true,
+              if: -> { reports_response == false }
 
     def update_model
-      reference_request.update!(reports_response:)
+      reference_request.update!(reports_response:, reports_comment:)
     end
   end
 end

--- a/app/forms/teacher_interface/reference_request_satisfied_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_satisfied_response_form.rb
@@ -4,12 +4,16 @@ module TeacherInterface
   class ReferenceRequestSatisfiedResponseForm < BaseForm
     attr_accessor :reference_request
     attribute :satisfied_response, :boolean
+    attribute :satisfied_comment, :string
 
     validates :reference_request, presence: true
     validates :satisfied_response, inclusion: [true, false]
+    validates :satisfied_comment,
+              presence: true,
+              if: -> { satisfied_response == false }
 
     def update_model
-      reference_request.update!(satisfied_response:)
+      reference_request.update!(satisfied_response:, satisfied_comment:)
     end
   end
 end

--- a/app/forms/teacher_interface/reference_request_satisfied_response_form.rb
+++ b/app/forms/teacher_interface/reference_request_satisfied_response_form.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class ReferenceRequestSatisfiedResponseForm < BaseForm
+    attr_accessor :reference_request
+    attribute :satisfied_response, :boolean
+
+    validates :reference_request, presence: true
+    validates :satisfied_response, inclusion: [true, false]
+
+    def update_model
+      reference_request.update!(satisfied_response:)
+    end
+  end
+end

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -66,11 +66,16 @@ class ReferenceRequest < ApplicationRecord
   delegate :application_form, to: :assessment
 
   def responses_given?
-    responses.none?(&:nil?)
-  end
-
-  def responses_valid?
-    responses.all?(&:present?)
+    [
+      contact_response,
+      dates_response,
+      hours_response,
+      children_response,
+      lessons_response,
+      reports_response,
+      misconduct_response,
+      satisfied_response,
+    ].none?(&:nil?)
   end
 
   def expires_after
@@ -79,20 +84,5 @@ class ReferenceRequest < ApplicationRecord
 
   def after_reviewed(*)
     UpdateAssessmentInductionRequired.call(assessment:)
-  end
-
-  private
-
-  def responses
-    [
-      contact_response,
-      dates_response,
-      hours_response,
-      children_response,
-      lessons_response,
-      reports_response,
-      misconduct_response.nil? ? nil : !misconduct_response, # true means there is a report of misconduct
-      satisfied_response,
-    ]
   end
 end

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -91,7 +91,7 @@ class ReferenceRequest < ApplicationRecord
       children_response,
       lessons_response,
       reports_response,
-      misconduct_response,
+      misconduct_response.nil? ? nil : !misconduct_response, # true means there is a report of misconduct
       satisfied_response,
     ]
   end

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -6,14 +6,27 @@
 #
 #  id                              :bigint           not null, primary key
 #  additional_information_response :text             default(""), not null
+#  children_comment                :text             default(""), not null
 #  children_response               :boolean
+#  contact_comment                 :text             default(""), not null
+#  contact_job                     :string           default(""), not null
+#  contact_name                    :string           default(""), not null
+#  contact_response                :boolean
+#  dates_comment                   :text             default(""), not null
 #  dates_response                  :boolean
+#  hours_comment                   :text             default(""), not null
 #  hours_response                  :boolean
+#  lessons_comment                 :text             default(""), not null
 #  lessons_response                :boolean
+#  misconduct_comment              :text             default(""), not null
+#  misconduct_response             :boolean
 #  passed                          :boolean
 #  received_at                     :datetime
+#  reports_comment                 :text             default(""), not null
 #  reports_response                :boolean
 #  reviewed_at                     :datetime
+#  satisfied_comment               :text             default(""), not null
+#  satisfied_response              :boolean
 #  slug                            :string           not null
 #  state                           :string           not null
 #  created_at                      :datetime         not null
@@ -40,11 +53,14 @@ class ReferenceRequest < ApplicationRecord
   belongs_to :work_history
 
   with_options if: :received? do
+    validates :contact_response, inclusion: [true, false]
     validates :dates_response, inclusion: [true, false]
     validates :hours_response, inclusion: [true, false]
     validates :children_response, inclusion: [true, false]
     validates :lessons_response, inclusion: [true, false]
     validates :reports_response, inclusion: [true, false]
+    validates :misconduct_response, inclusion: [true, false]
+    validates :satisfied_response, inclusion: [true, false]
   end
 
   delegate :application_form, to: :assessment
@@ -69,11 +85,14 @@ class ReferenceRequest < ApplicationRecord
 
   def responses
     [
+      contact_response,
       dates_response,
       hours_response,
       children_response,
       lessons_response,
       reports_response,
+      misconduct_response,
+      satisfied_response,
     ]
   end
 end

--- a/app/views/assessor_interface/reference_requests/edit.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit.html.erb
@@ -33,35 +33,35 @@
     title: t("assessor_interface.reference_requests.edit.summary_card_title"),
     fields: {
       dates_response: {
-        title: t("assessor_interface.reference_requests.edit.dates_response",
+        title: t(".dates_response",
                  school_name: work_history.school_name,
                  start_date: work_history.start_date.to_fs(:long_ordinal_uk),
                  end_date: work_history.end_date.blank? ? "present" : work_history.end_date.to_fs(:long_ordinal_uk)),
-        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.dates_response}"),
+        value: @reference_request.dates_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.dates_comment}",
       },
       hours_response: {
         title: t("assessor_interface.reference_requests.edit.hours_response", count: work_history.hours_per_week),
-        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.hours_response}"),
+        value: @reference_request.hours_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.hours_comment}",
       },
       children_response: {
         title: t("assessor_interface.reference_requests.edit.children_response"),
-        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.children_response}"),
+        value: @reference_request.children_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.children_comment}",
       },
       lessons_response: {
         title: t("assessor_interface.reference_requests.edit.lessons_response"),
-        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.lessons_response}"),
+        value: @reference_request.lessons_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.lessons_comment}",
       },
       reports_response: {
         title: t("assessor_interface.reference_requests.edit.reports_response"),
-        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.reports_response}"),
+        value: @reference_request.reports_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.reports_comment}",
       },
       misconduct_response: {
         title: t("assessor_interface.reference_requests.edit.misconduct_response"),
-        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.misconduct_response}"),
+        value: @reference_request.misconduct_response ? "#{t(".response_value.true")} — #{@reference_request.misconduct_comment}" : t(".response_value.false"),
       },
       satisfied_response: {
         title: t("assessor_interface.reference_requests.edit.satisfied_response"),
-        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.satisfied_response}"),
+        value: @reference_request.satisfied_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.satisfied_comment}",
       },
       additional_information_response: {
         title: t("assessor_interface.reference_requests.edit.additional_information_response"),

--- a/app/views/assessor_interface/reference_requests/edit.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit.html.erb
@@ -32,6 +32,17 @@
     model: @reference_request,
     title: t("assessor_interface.reference_requests.edit.summary_card_title"),
     fields: {
+      contact_name: {
+        title: t("assessor_interface.reference_requests.edit.contact_name"),
+        value: @reference_request.contact_name.presence || work_history.contact_name,
+      },
+      contact_job: {
+        title: t("assessor_interface.reference_requests.edit.contact_job"),
+        value: @reference_request.contact_job.presence || work_history.contact_job,
+      },
+      contact_comment: {
+        title: t("assessor_interface.reference_requests.edit.contact_comment"),
+      },
       dates_response: {
         title: t(".dates_response",
                  school_name: work_history.school_name,

--- a/app/views/assessor_interface/reference_requests/edit.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit.html.erb
@@ -1,4 +1,5 @@
 <% work_history = @reference_request.work_history %>
+
 <h1 class="govuk-heading-xl"><%= t("assessor_interface.reference_requests.edit.title") %></h1>
 
 <%= form_with(
@@ -39,7 +40,7 @@
         value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.dates_response}"),
       },
       hours_response: {
-        title: t("assessor_interface.reference_requests.edit.hours_response"),
+        title: t("assessor_interface.reference_requests.edit.hours_response", count: work_history.hours_per_week),
         value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.hours_response}"),
       },
       children_response: {
@@ -53,6 +54,14 @@
       reports_response: {
         title: t("assessor_interface.reference_requests.edit.reports_response"),
         value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.reports_response}"),
+      },
+      misconduct_response: {
+        title: t("assessor_interface.reference_requests.edit.misconduct_response"),
+        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.misconduct_response}"),
+      },
+      satisfied_response: {
+        title: t("assessor_interface.reference_requests.edit.satisfied_response"),
+        value: t("assessor_interface.reference_requests.edit.response_value.#{@reference_request.satisfied_response}"),
       },
       additional_information_response: {
         title: t("assessor_interface.reference_requests.edit.additional_information_response"),

--- a/app/views/assessor_interface/reference_requests/edit.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit.html.erb
@@ -27,60 +27,7 @@
     </tbody>
   </table>
 
-  <%= render CheckYourAnswersSummary::Component.new(
-    id: @reference_request.id,
-    model: @reference_request,
-    title: t("assessor_interface.reference_requests.edit.summary_card_title"),
-    fields: {
-      contact_name: {
-        title: t("assessor_interface.reference_requests.edit.contact_name"),
-        value: @reference_request.contact_name.presence || work_history.contact_name,
-      },
-      contact_job: {
-        title: t("assessor_interface.reference_requests.edit.contact_job"),
-        value: @reference_request.contact_job.presence || work_history.contact_job,
-      },
-      contact_comment: {
-        title: t("assessor_interface.reference_requests.edit.contact_comment"),
-      },
-      dates_response: {
-        title: t(".dates_response",
-                 school_name: work_history.school_name,
-                 start_date: work_history.start_date.to_fs(:long_ordinal_uk),
-                 end_date: work_history.end_date.blank? ? "present" : work_history.end_date.to_fs(:long_ordinal_uk)),
-        value: @reference_request.dates_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.dates_comment}",
-      },
-      hours_response: {
-        title: t("assessor_interface.reference_requests.edit.hours_response", count: work_history.hours_per_week),
-        value: @reference_request.hours_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.hours_comment}",
-      },
-      children_response: {
-        title: t("assessor_interface.reference_requests.edit.children_response"),
-        value: @reference_request.children_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.children_comment}",
-      },
-      lessons_response: {
-        title: t("assessor_interface.reference_requests.edit.lessons_response"),
-        value: @reference_request.lessons_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.lessons_comment}",
-      },
-      reports_response: {
-        title: t("assessor_interface.reference_requests.edit.reports_response"),
-        value: @reference_request.reports_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.reports_comment}",
-      },
-      misconduct_response: {
-        title: t("assessor_interface.reference_requests.edit.misconduct_response"),
-        value: @reference_request.misconduct_response ? "#{t(".response_value.true")} — #{@reference_request.misconduct_comment}" : t(".response_value.false"),
-      },
-      satisfied_response: {
-        title: t("assessor_interface.reference_requests.edit.satisfied_response"),
-        value: @reference_request.satisfied_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.satisfied_comment}",
-      },
-      additional_information_response: {
-        title: t("assessor_interface.reference_requests.edit.additional_information_response"),
-        value: @reference_request.additional_information_response,
-      },
-    },
-    changeable: false
-  ) %>
+  <%= render "shared/reference_request_summary", reference_request: @reference_request, changeable: false %>
 
   <%= f.govuk_radio_buttons_fieldset(
     :passed,

--- a/app/views/referee_mailer/reference_reminder.text.erb
+++ b/app/views/referee_mailer/reference_reminder.text.erb
@@ -4,7 +4,7 @@ We still need you to confirm some information about <%= application_form_full_na
 
 We recently contacted you to ask you to help us confirm that the information [Applicant name] has provided about their work history and experience is accurate.
 
-Please follow the link below and answer the questions by <%= @reference_request.expired_at.strftime("%e %B %Y") %>. If we do not receive your response by this date, it could affect the outcome for the applicant.
+Please follow the link below and answer the questions by <%= @reference_request.expired_at.to_date.to_fs(:long_ordinal_uk) %>. If we do not receive your response by this date, it could affect the outcome for the applicant.
 
 <%= teacher_interface_reference_request_url(@reference_request.slug) %>
 

--- a/app/views/referee_mailer/reference_requested.text.erb
+++ b/app/views/referee_mailer/reference_requested.text.erb
@@ -6,11 +6,18 @@ As part of the QTS application process, our assessors need to understand each ap
 
 <%= application_form_full_name(@application_form) %> has given us your name and email address to help us confirm that the information they’ve provided about their work history and experience is accurate.
 
-Please follow the link below and answer the questions by <%= @reference_request.expired_at.strftime("%e %B %Y") %>.
+# About QTS
+
+<%= application_form_full_name(@application_form) %> is NOT applying for a job – their QTS application just allows us to assess their qualifications and teaching experience to understand whether they can teach in England.
+
+# What we need you to do
+
+Please follow the link below and answer the questions by <%= @reference_request.expired_at.to_date.to_fs(:long_ordinal_uk) %>.
 
 <%= teacher_interface_reference_request_url(@reference_request.slug) %>
 
 It should take no longer than 5 minutes.
 
 Kind regards,
-The Teacher Qualifications Team (part of the Teaching Regulation Agency)
+The Teacher Qualifications Team
+(an executive agency sponsored by the Department for Education, England)

--- a/app/views/shared/_reference_request_summary.html.erb
+++ b/app/views/shared/_reference_request_summary.html.erb
@@ -1,0 +1,78 @@
+<% work_history = reference_request.work_history %>
+
+<%= render(CheckYourAnswersSummary::Component.new(
+  id: "reference-request-#{reference_request.id}",
+  model: reference_request,
+  title: "Reference requested",
+  fields: {
+    original_contact_name: {
+      title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_name"),
+      value: work_history.contact_name,
+    },
+    original_contact_job: {
+      title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_job"),
+      value: work_history.contact_job,
+    },
+    contact_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_contact_response_form.contact_response"),
+      href: contact_teacher_interface_reference_request_path(reference_request.slug),
+    },
+    contact_name: reference_request.contact_response ? nil : {
+      title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_name"),
+      value: reference_request.contact_name.presence,
+      href: contact_teacher_interface_reference_request_path(reference_request.slug),
+    },
+    contact_job: reference_request.contact_response ? nil : {
+      title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_job"),
+      value: reference_request.contact_job.presence,
+      href: contact_teacher_interface_reference_request_path(reference_request.slug),
+    },
+    contact_comment: reference_request.contact_response ? nil : {
+      title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_comment"),
+      href: contact_teacher_interface_reference_request_path(reference_request.slug),
+    },
+    dates_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response",
+               school_name: work_history.school_name,
+               start_date: work_history.start_date.to_fs(:long_ordinal_uk),
+               end_date: work_history.end_date.blank? ? "present" : work_history.end_date.to_fs(:long_ordinal_uk)),
+      value: reference_request.dates_response ? "Yes" : "No — #{reference_request.dates_comment}",
+      href: dates_teacher_interface_reference_request_path(reference_request.slug),
+    },
+    hours_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_hours_response_form.hours_response", count: work_history.hours_per_week),
+      value: reference_request.hours_response ? "Yes" : "No — #{reference_request.hours_comment}",
+      href: hours_teacher_interface_reference_request_path(reference_request.slug),
+    },
+    children_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_children_response_form.children_response"),
+      value: reference_request.children_response ? "Yes" : "No — #{reference_request.children_comment}",
+      href: children_teacher_interface_reference_request_path(reference_request.slug),
+    },
+    lessons_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_lessons_response_form.lessons_response"),
+      value: reference_request.lessons_response ? "Yes" : "No — #{reference_request.lessons_comment}",
+      href: lessons_teacher_interface_reference_request_path(reference_request.slug),
+    },
+    reports_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_reports_response_form.reports_response"),
+      value: reference_request.reports_response ? "Yes" : "No — #{reference_request.reports_comment}",
+      href: reports_teacher_interface_reference_request_path(reference_request.slug),
+    },
+    misconduct_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_misconduct_response_form.misconduct_response"),
+      value: reference_request.misconduct_response ? "Yes — #{reference_request.misconduct_comment}" : "No",
+      href: misconduct_teacher_interface_reference_request_path(reference_request.slug),
+    },
+    satisfied_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_satisfied_response_form.satisfied_response"),
+      value: reference_request.satisfied_response ? "Yes" : "No — #{reference_request.satisfied_comment}",
+      href: satisfied_teacher_interface_reference_request_path(reference_request.slug),
+    },
+    additional_information_response: {
+      title: t("helpers.label.teacher_interface_reference_request_additional_information_response_form.additional_information_response"),
+      href: additional_information_teacher_interface_reference_request_path(reference_request.slug),
+    },
+  },
+  changeable:
+)) %>

--- a/app/views/shared/_reference_request_summary.html.erb
+++ b/app/views/shared/_reference_request_summary.html.erb
@@ -32,10 +32,18 @@
       href: contact_teacher_interface_reference_request_path(reference_request.slug),
     },
     dates_response: {
-      title: t("helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response",
-               school_name: work_history.school_name,
-               start_date: work_history.start_date.to_fs(:long_ordinal_uk),
-               end_date: work_history.end_date.blank? ? "present" : work_history.end_date.to_fs(:long_ordinal_uk)),
+      title: work_history.end_date.blank? ?
+               t(
+                 "helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response.current",
+                 school_name: work_history.school_name,
+                 start_date: work_history.start_date.to_fs(:long_ordinal_uk)
+               ) :
+               t(
+                 "helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response.previous",
+                 school_name: work_history.school_name,
+                 start_date: work_history.start_date.to_fs(:long_ordinal_uk),
+                 end_date: work_history.end_date.to_fs(:long_ordinal_uk),
+               ),
       value: reference_request.dates_response ? "Yes" : "No — #{reference_request.dates_comment}",
       href: dates_teacher_interface_reference_request_path(reference_request.slug),
     },

--- a/app/views/teacher_interface/reference_requests/edit.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit.html.erb
@@ -8,7 +8,10 @@
   title: t(".reference_requested"),
   fields: {
     dates_response: {
-      title: t("helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response"),
+      title: t("helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response",
+               school_name: @work_history.school_name,
+               start_date: @work_history.start_date.to_fs(:long_ordinal_uk),
+               end_date: @work_history.end_date.blank? ? "present" : @work_history.end_date.to_fs(:long_ordinal_uk)),
       href: dates_teacher_interface_reference_request_path,
     },
     hours_response: {
@@ -26,6 +29,14 @@
     reports_response: {
       title: t("helpers.legend.teacher_interface_reference_request_reports_response_form.reports_response"),
       href: reports_teacher_interface_reference_request_path,
+    },
+    misconduct_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_misconduct_response_form.misconduct_response"),
+      href: misconduct_teacher_interface_reference_request_path,
+    },
+    satisfied_response: {
+      title: t("helpers.legend.teacher_interface_reference_request_satisfied_response_form.satisfied_response"),
+      href: satisfied_teacher_interface_reference_request_path,
     },
     additional_information_response: {
       title: t("helpers.label.teacher_interface_reference_request_additional_information_response_form.additional_information_response"),

--- a/app/views/teacher_interface/reference_requests/edit.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit.html.erb
@@ -2,66 +2,7 @@
 
 <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
 
-<%= render(CheckYourAnswersSummary::Component.new(
-  id: "reference-request-#{@reference_request.id}",
-  model: @reference_request,
-  title: t(".reference_requested"),
-  fields: {
-    contact_name: {
-      title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_name"),
-      value: @reference_request.contact_name.presence || @work_history.contact_name,
-      href: contact_teacher_interface_reference_request_path,
-    },
-    contact_job: {
-      title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_job"),
-      value: @reference_request.contact_job.presence || @work_history.contact_job,
-      href: contact_teacher_interface_reference_request_path,
-    },
-    dates_response: {
-      title: t("helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response",
-               school_name: @work_history.school_name,
-               start_date: @work_history.start_date.to_fs(:long_ordinal_uk),
-               end_date: @work_history.end_date.blank? ? "present" : @work_history.end_date.to_fs(:long_ordinal_uk)),
-      value: @reference_request.dates_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.dates_comment}",
-      href: dates_teacher_interface_reference_request_path,
-    },
-    hours_response: {
-      title: t("helpers.legend.teacher_interface_reference_request_hours_response_form.hours_response", count: @work_history.hours_per_week),
-      value: @reference_request.hours_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.hours_comment}",
-      href: hours_teacher_interface_reference_request_path,
-    },
-    children_response: {
-      title: t("helpers.legend.teacher_interface_reference_request_children_response_form.children_response"),
-      value: @reference_request.children_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.children_comment}",
-      href: children_teacher_interface_reference_request_path,
-    },
-    lessons_response: {
-      title: t("helpers.legend.teacher_interface_reference_request_lessons_response_form.lessons_response"),
-      value: @reference_request.lessons_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.lessons_comment}",
-      href: lessons_teacher_interface_reference_request_path,
-    },
-    reports_response: {
-      title: t("helpers.legend.teacher_interface_reference_request_reports_response_form.reports_response"),
-      value: @reference_request.reports_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.reports_comment}",
-      href: reports_teacher_interface_reference_request_path,
-    },
-    misconduct_response: {
-      title: t("helpers.legend.teacher_interface_reference_request_misconduct_response_form.misconduct_response"),
-      value: @reference_request.misconduct_response ? "#{t(".response_value.true")} — #{@reference_request.misconduct_comment}" : t(".response_value.false"),
-      href: misconduct_teacher_interface_reference_request_path,
-    },
-    satisfied_response: {
-      title: t("helpers.legend.teacher_interface_reference_request_satisfied_response_form.satisfied_response"),
-      value: @reference_request.satisfied_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.satisfied_comment}",
-      href: satisfied_teacher_interface_reference_request_path,
-    },
-    additional_information_response: {
-      title: t("helpers.label.teacher_interface_reference_request_additional_information_response_form.additional_information_response"),
-      href: additional_information_teacher_interface_reference_request_path,
-    },
-  },
-  changeable: true
-)) %>
+<%= render "shared/reference_request_summary", reference_request: @reference_request, changeable: true %>
 
 <% if @reference_request.responses_given? %>
   <h3 class="govuk-heading-m">Submitting your response</h3>

--- a/app/views/teacher_interface/reference_requests/edit.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit.html.erb
@@ -7,35 +7,52 @@
   model: @reference_request,
   title: t(".reference_requested"),
   fields: {
+    contact_name: {
+      title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_name"),
+      value: @reference_request.contact_name.presence || @work_history.contact_name,
+      href: contact_teacher_interface_reference_request_path,
+    },
+    contact_job: {
+      title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_job"),
+      value: @reference_request.contact_job.presence || @work_history.contact_job,
+      href: contact_teacher_interface_reference_request_path,
+    },
     dates_response: {
       title: t("helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response",
                school_name: @work_history.school_name,
                start_date: @work_history.start_date.to_fs(:long_ordinal_uk),
                end_date: @work_history.end_date.blank? ? "present" : @work_history.end_date.to_fs(:long_ordinal_uk)),
+      value: @reference_request.dates_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.dates_comment}",
       href: dates_teacher_interface_reference_request_path,
     },
     hours_response: {
       title: t("helpers.legend.teacher_interface_reference_request_hours_response_form.hours_response", count: @work_history.hours_per_week),
+      value: @reference_request.hours_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.hours_comment}",
       href: hours_teacher_interface_reference_request_path,
     },
     children_response: {
       title: t("helpers.legend.teacher_interface_reference_request_children_response_form.children_response"),
+      value: @reference_request.children_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.children_comment}",
       href: children_teacher_interface_reference_request_path,
     },
     lessons_response: {
       title: t("helpers.legend.teacher_interface_reference_request_lessons_response_form.lessons_response"),
+      value: @reference_request.lessons_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.lessons_comment}",
       href: lessons_teacher_interface_reference_request_path,
     },
     reports_response: {
       title: t("helpers.legend.teacher_interface_reference_request_reports_response_form.reports_response"),
+      value: @reference_request.reports_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.reports_comment}",
       href: reports_teacher_interface_reference_request_path,
     },
     misconduct_response: {
       title: t("helpers.legend.teacher_interface_reference_request_misconduct_response_form.misconduct_response"),
+      value: @reference_request.misconduct_response ? "#{t(".response_value.true")} — #{@reference_request.misconduct_comment}" : t(".response_value.false"),
       href: misconduct_teacher_interface_reference_request_path,
     },
     satisfied_response: {
       title: t("helpers.legend.teacher_interface_reference_request_satisfied_response_form.satisfied_response"),
+      value: @reference_request.satisfied_response ? t(".response_value.true") : "#{t(".response_value.false")} — #{@reference_request.satisfied_comment}",
       href: satisfied_teacher_interface_reference_request_path,
     },
     additional_information_response: {

--- a/app/views/teacher_interface/reference_requests/edit_additional_information.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_additional_information.html.erb
@@ -4,7 +4,7 @@
 <%= form_with model: @form, url: additional_information_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>
 
-  <span class="govuk-caption-l">Any other comments (optional)</span>
+  <span class="govuk-caption-l">Any other comments</span>
 
   <%= f.govuk_text_area :additional_information_response, label: { tag: "h1", size: "l" } %>
 

--- a/app/views/teacher_interface/reference_requests/edit_children.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_children.html.erb
@@ -6,10 +6,12 @@
 
   <span class="govuk-caption-l">Question 3 of 7</span>
 
-  <%= f.govuk_collection_radio_buttons :children_response,
-                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
-                                       :value,
-                                       legend: { tag: "h1", size: "l" } %>
+  <%= f.govuk_radio_buttons_fieldset :children_response, legend: { tag: "h1", size: "l" } do %>
+    <%= f.govuk_radio_button :children_response, :true, link_errors: true %>
+    <%= f.govuk_radio_button :children_response, :false do %>
+      <%= f.govuk_text_area :children_comment %>
+    <% end %>
+  <% end %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teacher_interface/reference_requests/edit_children.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_children.html.erb
@@ -4,7 +4,7 @@
 <%= form_with model: @form, url: children_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>
 
-  <span class="govuk-caption-l">Question 3 of 5</span>
+  <span class="govuk-caption-l">Question 3 of 7</span>
 
   <%= f.govuk_collection_radio_buttons :children_response,
                                        [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],

--- a/app/views/teacher_interface/reference_requests/edit_contact.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_contact.html.erb
@@ -1,0 +1,39 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t(".title")}" %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+
+<%= form_with model: @form, url: contact_teacher_interface_reference_request_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h2 class="govuk-heading-l">About you</h2>
+
+  <p class="body-text">
+    This screen shows the details that <%= application_form_full_name(@application_form) %> has provided about you.
+    Take a moment to check that they’re correct.
+  </p>
+
+  <%= render(CheckYourAnswersSummary::Component.new(
+    id: "work-history",
+    model: @work_history,
+    title: t(".title"),
+    fields: {
+      contact_name: {
+        title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_name")
+      },
+      contact_job: {
+        title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_job")
+      },
+    },
+    changeable: false
+  )) %>
+
+  <%= f.govuk_radio_buttons_fieldset :contact_response do %>
+    <%= f.govuk_radio_button :contact_response, :true, link_errors: true %>
+    <%= f.govuk_radio_button :contact_response, :false do %>
+      <%= f.govuk_text_field :contact_name %>
+      <%= f.govuk_text_field :contact_job %>
+      <%= f.govuk_text_area :contact_comment %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/teacher_interface/reference_requests/edit_dates.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_dates.html.erb
@@ -1,15 +1,22 @@
-<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response")}" %>
+<% title = t(
+  "assessor_interface.reference_requests.edit.dates_response",
+  school_name: @work_history.school_name,
+  start_date: @work_history.start_date.to_fs(:long_ordinal_uk),
+  end_date: @work_history.end_date.blank? ? "present" : @work_history.end_date.to_fs(:long_ordinal_uk),
+) %>
+
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{title}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
 
 <%= form_with model: @form, url: dates_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>
 
-  <span class="govuk-caption-l">Question 1 of 5</span>
+  <span class="govuk-caption-l">Question 1 of 7</span>
 
   <%= f.govuk_collection_radio_buttons :dates_response,
                                        [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
                                        :value,
-                                       legend: { tag: "h1", size: "l" } %>
+                                       legend: { tag: "h1", size: "l", text: title } %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teacher_interface/reference_requests/edit_dates.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_dates.html.erb
@@ -1,5 +1,5 @@
 <% title = t(
-  "assessor_interface.reference_requests.edit.dates_response",
+  "helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response",
   school_name: @work_history.school_name,
   start_date: @work_history.start_date.to_fs(:long_ordinal_uk),
   end_date: @work_history.end_date.blank? ? "present" : @work_history.end_date.to_fs(:long_ordinal_uk),
@@ -13,10 +13,12 @@
 
   <span class="govuk-caption-l">Question 1 of 7</span>
 
-  <%= f.govuk_collection_radio_buttons :dates_response,
-                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
-                                       :value,
-                                       legend: { tag: "h1", size: "l", text: title } %>
+  <%= f.govuk_radio_buttons_fieldset :dates_response, legend: { tag: "h1", size: "l", text: title } do %>
+    <%= f.govuk_radio_button :dates_response, :true, link_errors: true %>
+    <%= f.govuk_radio_button :dates_response, :false do %>
+      <%= f.govuk_text_area :dates_comment %>
+    <% end %>
+  <% end %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teacher_interface/reference_requests/edit_dates.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_dates.html.erb
@@ -1,9 +1,15 @@
-<% title = t(
-  "helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response",
-  school_name: @work_history.school_name,
-  start_date: @work_history.start_date.to_fs(:long_ordinal_uk),
-  end_date: @work_history.end_date.blank? ? "present" : @work_history.end_date.to_fs(:long_ordinal_uk),
-) %>
+<% title = @work_history.end_date.blank? ?
+             t(
+               "helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response.current",
+               school_name: @work_history.school_name,
+               start_date: @work_history.start_date.to_fs(:long_ordinal_uk)
+             ) :
+             t(
+               "helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response.previous",
+               school_name: @work_history.school_name,
+               start_date: @work_history.start_date.to_fs(:long_ordinal_uk),
+               end_date: @work_history.end_date.to_fs(:long_ordinal_uk),
+             ) %>
 
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{title}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>

--- a/app/views/teacher_interface/reference_requests/edit_hours.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_hours.html.erb
@@ -8,10 +8,12 @@
 
   <span class="govuk-caption-l">Question 2 of 7</span>
 
-  <%= f.govuk_collection_radio_buttons :hours_response,
-                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
-                                       :value,
-                                       legend: { tag: "h1", size: "l", text: title } %>
+  <%= f.govuk_radio_buttons_fieldset :hours_response, legend: { tag: "h1", size: "l", text: title } do %>
+    <%= f.govuk_radio_button :hours_response, :true, link_errors: true %>
+    <%= f.govuk_radio_button :hours_response, :false do %>
+      <%= f.govuk_text_area :hours_comment %>
+    <% end %>
+  <% end %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teacher_interface/reference_requests/edit_hours.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_hours.html.erb
@@ -1,15 +1,17 @@
-<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_hours_response_form.hours_response", count: @work_history.hours_per_week)}" %>
+<% title = t("helpers.legend.teacher_interface_reference_request_hours_response_form.hours_response", count: @work_history.hours_per_week) %>
+
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{title}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
 
 <%= form_with model: @form, url: hours_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>
 
-  <span class="govuk-caption-l">Question 2 of 5</span>
+  <span class="govuk-caption-l">Question 2 of 7</span>
 
   <%= f.govuk_collection_radio_buttons :hours_response,
                                        [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
                                        :value,
-                                       legend: { tag: "h1", size: "l", text: t("helpers.legend.teacher_interface_reference_request_hours_response_form.hours_response", count: @work_history.hours_per_week) } %>
+                                       legend: { tag: "h1", size: "l", text: title } %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teacher_interface/reference_requests/edit_lessons.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_lessons.html.erb
@@ -6,10 +6,12 @@
 
   <span class="govuk-caption-l">Question 4 of 7</span>
 
-  <%= f.govuk_collection_radio_buttons :lessons_response,
-                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
-                                       :value,
-                                       legend: { tag: "h1", size: "l" } %>
+  <%= f.govuk_radio_buttons_fieldset :lessons_response, legend: { tag: "h1", size: "l" } do %>
+    <%= f.govuk_radio_button :lessons_response, :true, link_errors: true %>
+    <%= f.govuk_radio_button :lessons_response, :false do %>
+      <%= f.govuk_text_area :lessons_comment %>
+    <% end %>
+  <% end %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teacher_interface/reference_requests/edit_lessons.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_lessons.html.erb
@@ -4,7 +4,7 @@
 <%= form_with model: @form, url: lessons_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>
 
-  <span class="govuk-caption-l">Question 4 of 5</span>
+  <span class="govuk-caption-l">Question 4 of 7</span>
 
   <%= f.govuk_collection_radio_buttons :lessons_response,
                                        [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],

--- a/app/views/teacher_interface/reference_requests/edit_misconduct.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_misconduct.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_reports_response_form.misconduct_response")}" %>
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_misconduct_response_form.misconduct_response")}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
 
 <%= form_with model: @form, url: misconduct_teacher_interface_reference_request_path do |f| %>

--- a/app/views/teacher_interface/reference_requests/edit_misconduct.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_misconduct.html.erb
@@ -6,10 +6,12 @@
 
   <span class="govuk-caption-l">Question 6 of 7</span>
 
-  <%= f.govuk_collection_radio_buttons :misconduct_response,
-                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
-                                       :value,
-                                       legend: { tag: "h1", size: "l" } %>
+  <%= f.govuk_radio_buttons_fieldset :misconduct_response, legend: { tag: "h1", size: "l" } do %>
+    <%= f.govuk_radio_button :misconduct_response, :true, link_errors: true do %>
+      <%= f.govuk_text_area :misconduct_comment %>
+    <% end %>
+    <%= f.govuk_radio_button :misconduct_response, :false %>
+  <% end %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teacher_interface/reference_requests/edit_misconduct.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_misconduct.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_reports_response_form.misconduct_response")}" %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+
+<%= form_with model: @form, url: misconduct_teacher_interface_reference_request_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l">Question 6 of 7</span>
+
+  <%= f.govuk_collection_radio_buttons :misconduct_response,
+                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
+                                       :value,
+                                       legend: { tag: "h1", size: "l" } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/teacher_interface/reference_requests/edit_reports.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_reports.html.erb
@@ -4,7 +4,7 @@
 <%= form_with model: @form, url: reports_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>
 
-  <span class="govuk-caption-l">Question 5 of 5</span>
+  <span class="govuk-caption-l">Question 5 of 7</span>
 
   <%= f.govuk_collection_radio_buttons :reports_response,
                                        [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],

--- a/app/views/teacher_interface/reference_requests/edit_reports.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_reports.html.erb
@@ -6,10 +6,12 @@
 
   <span class="govuk-caption-l">Question 5 of 7</span>
 
-  <%= f.govuk_collection_radio_buttons :reports_response,
-                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
-                                       :value,
-                                       legend: { tag: "h1", size: "l" } %>
+  <%= f.govuk_radio_buttons_fieldset :reports_response, legend: { tag: "h1", size: "l" } do %>
+    <%= f.govuk_radio_button :reports_response, :true, link_errors: true %>
+    <%= f.govuk_radio_button :reports_response, :false do %>
+      <%= f.govuk_text_area :reports_comment %>
+    <% end %>
+  <% end %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teacher_interface/reference_requests/edit_satisfied.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_satisfied.html.erb
@@ -6,10 +6,12 @@
 
   <span class="govuk-caption-l">Question 7 of 7</span>
 
-  <%= f.govuk_collection_radio_buttons :satisfied_response,
-                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
-                                       :value,
-                                       legend: { tag: "h1", size: "l" } %>
+  <%= f.govuk_radio_buttons_fieldset :satisfied_response, legend: { tag: "h1", size: "l" } do %>
+    <%= f.govuk_radio_button :satisfied_response, :true, link_errors: true %>
+    <%= f.govuk_radio_button :satisfied_response, :false do %>
+      <%= f.govuk_text_area :satisfied_comment %>
+    <% end %>
+  <% end %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teacher_interface/reference_requests/edit_satisfied.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_satisfied.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_reports_response_form.satisfied_response")}" %>
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_satisfied_response_form.satisfied_response")}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
 
 <%= form_with model: @form, url: satisfied_teacher_interface_reference_request_path do |f| %>

--- a/app/views/teacher_interface/reference_requests/edit_satisfied.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_satisfied.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_reports_response_form.satisfied_response")}" %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+
+<%= form_with model: @form, url: satisfied_teacher_interface_reference_request_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l">Question 7 of 7</span>
+
+  <%= f.govuk_collection_radio_buttons :satisfied_response,
+                                       [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
+                                       :value,
+                                       legend: { tag: "h1", size: "l" } %>
+
+  <%= f.govuk_submit %>
+<% end %>

--- a/app/views/teacher_interface/reference_requests/show.html.erb
+++ b/app/views/teacher_interface/reference_requests/show.html.erb
@@ -1,13 +1,23 @@
 <% content_for :page_title, t(".title") %>
 
-<% if @reference_request.requested? %>
+<% if @reference_request.received? %>
+  <%= govuk_panel(title_text: "You’ve successfully submitted your response") %>
+
+  <h3 class="govuk-heading-m">Thank you for submitting your response.</h3>
+
+  <p class="govuk-body">The QTS assessor will now review your response and continue their review of the applicant.</p>
+
+  <p class="govuk-body">You do not need to do anything else. You can now close this page.</p>
+<% else %>
   <h1 class="govuk-heading-xl"><%= t("service.name.teacher") %></h1>
 
   <h2 class="govuk-heading-m"><%= t(".title") %></h2>
 
   <p class="govuk-body"><%= application_form_full_name(@application_form) %> is applying for qualified teacher status (QTS) in England.</p>
 
-  <p class="govuk-body">As part of our assessment, we need to understand their work history and experience. They’ve provided your details to help us verify that they worked at:</p>
+  <p class="govuk-body">Their application for QTS means we’ll assess their qualifications and teaching experience. It is <strong class="govuk-!-font-weight-bold">NOT</strong> an application for a teaching job – we just need to assess whether they can teach in English schools.</p>
+
+  <p class="govuk-body">They’ve provided your details to help us verify that they worked at:</p>
 
   <%= govuk_inset_text do %>
     <p class="govuk-body">
@@ -18,12 +28,4 @@
   <p class="govuk-body">We need to to ask you a few questions about the applicant’s role. It should take no longer than 5 minutes.</p>
 
   <%= govuk_start_button(text: "Start now", href: dates_teacher_interface_reference_request_path) %>
-<% else %>
-  <%= govuk_panel(title_text: "You’ve successfully submitted your response") %>
-
-  <h3 class="govuk-heading-m">Thank you for submitting your response.</h3>
-
-  <p class="govuk-body">The QTS assessor will now review your response and continue their review of the applicant.</p>
-
-  <p class="govuk-body">You do not need to do anything else. You can now close this page.</p>
 <% end %>

--- a/app/views/teacher_interface/reference_requests/show.html.erb
+++ b/app/views/teacher_interface/reference_requests/show.html.erb
@@ -27,5 +27,5 @@
 
   <p class="govuk-body">We need to to ask you a few questions about the applicant’s role. It should take no longer than 5 minutes.</p>
 
-  <%= govuk_start_button(text: "Start now", href: dates_teacher_interface_reference_request_path) %>
+  <%= govuk_start_button(text: "Start now", href: contact_teacher_interface_reference_request_path) %>
 <% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -236,11 +236,24 @@
     - work_history_id
     - state
     - received_at
+    - contact_response
+    - contact_name
+    - contact_job
+    - contact_comment
     - dates_response
+    - dates_comment
     - hours_response
+    - hours_comment
     - children_response
+    - children_comment
     - lessons_response
+    - lessons_comment
     - reports_response
+    - reports_comment
+    - misconduct_response
+    - misconduct_comment
+    - satisfied_response
+    - satisfied_comment
     - additional_information_response
     - created_at
     - updated_at

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -219,6 +219,8 @@ en:
         lessons_response: Was the applicant solely responsible for planning, preparing and delivering lessons to at least 4 students at a time?
         reports_response: Was the applicant solely responsible for assessing and reporting on the progress of the students?
         additional_information_response: Is there anything else you’d like to tell us about this applicant?
+        misconduct_response: Do you know of any professional misconduct by the applicant, or any disciplinary action taken against them?
+        satisfied_response: Are you satisfied that the applicant is suitable to work with children?
         response_value:
           "true": "Yes"
           "false": "No"

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -213,14 +213,17 @@ en:
       edit:
         title: Review work reference
         summary_card_title: Responses
+        contact_name: Referee full name
+        contact_job: Referee job title
+        contact_comment: Any other comments (optional)
         dates_response: Did the applicant work at %{school_name} from %{start_date} to %{end_date}?
         hours_response: Did the applicant normally work more than 30 hours per week in this role?
         children_response: Did the applicant work unsupervised with children aged between 5 and 16 years?
         lessons_response: Was the applicant solely responsible for planning, preparing and delivering lessons to at least 4 students at a time?
         reports_response: Was the applicant solely responsible for assessing and reporting on the progress of the students?
-        additional_information_response: Is there anything else you’d like to tell us about this applicant?
         misconduct_response: Do you know of any professional misconduct by the applicant, or any disciplinary action taken against them?
         satisfied_response: Are you satisfied that the applicant is suitable to work with children?
+        additional_information_response: Is there anything else you’d like to tell us about this applicant?
         response_value:
           "true": "Yes"
           "false": "No"

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -212,21 +212,6 @@ en:
     reference_requests:
       edit:
         title: Review work reference
-        summary_card_title: Responses
-        contact_name: Referee full name
-        contact_job: Referee job title
-        contact_comment: Any other comments (optional)
-        dates_response: Did the applicant work at %{school_name} from %{start_date} to %{end_date}?
-        hours_response: Did the applicant normally work more than 30 hours per week in this role?
-        children_response: Did the applicant work unsupervised with children aged between 5 and 16 years?
-        lessons_response: Was the applicant solely responsible for planning, preparing and delivering lessons to at least 4 students at a time?
-        reports_response: Was the applicant solely responsible for assessing and reporting on the progress of the students?
-        misconduct_response: Do you know of any professional misconduct by the applicant, or any disciplinary action taken against them?
-        satisfied_response: Are you satisfied that the applicant is suitable to work with children?
-        additional_information_response: Is there anything else you’d like to tell us about this applicant?
-        response_value:
-          "true": "Yes"
-          "false": "No"
 
   activemodel:
     errors:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -160,6 +160,14 @@ en:
         reports_response_options:
           true: "Yes"
           false: "No"
+      teacher_interface_reference_request_misconduct_response_form:
+        reports_response_options:
+          true: "Yes"
+          false: "No"
+      teacher_interface_reference_request_satisfied_response_form:
+        reports_response_options:
+          true: "Yes"
+          false: "No"
       teacher_interface_registration_number_form:
         registration_number: What is your registration number?
       teacher_interface_subjects_form:
@@ -225,7 +233,7 @@ en:
       teacher_interface_reference_request_children_response_form:
         children_response: Did the applicant work unsupervised with children aged somewhere between 5 and 16 years?
       teacher_interface_reference_request_dates_response_form:
-        dates_response: Did the applicant work at the school for the dates they provided?
+        dates_response: Did the applicant work at %{school_name} from %{start_date} to %{end_date}?
       teacher_interface_reference_request_hours_response_form:
         hours_response:
           one: Did the applicant normally work more than 1 hour per week in this role?
@@ -234,6 +242,10 @@ en:
         lessons_response: Was the applicant solely responsible for planning, preparing and delivering lessons to at least 4 students at a time?
       teacher_interface_reference_request_reports_response_form:
         reports_response: Was the applicant solely responsible for assessing and reporting on the progress of the students?
+      teacher_interface_reference_request_misconduct_response_form:
+        misconduct_response: Do you know of any professional misconduct by the applicant, or any disciplinary action taken against them?
+      teacher_interface_reference_request_satisfied_response_form:
+        satisfied_response: Are you satisfied that the applicant is suitable to work with children?
       teacher_interface_work_history_school_form:
         start_date: When did you start this role?
         still_employed: Are you still employed at this school?

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -35,8 +35,12 @@ en:
         email: We need to send you a code so that you can sign into the Apply for QTS in England service. Please enter the email address you used to register.
       teacher_interface_qualification_form:
         institution_country_location: This must be the country in which you’re recognised as a teacher.
+      teacher_interface_reference_request_additional_information_response_form:
+        additional_information_response: If you have any other concerns about this applicant’s suitability to teach, use this space to briefly describe them. The applicant will NOT see your comments.
+      teacher_interface_reference_request_children_response_form:
+        children_response: They do not need to have taught this full age range. For example, they may have taught children aged 5 to 11, or 14 to 16.
       teacher_interface_reference_request_hours_response_form:
-        hours_response: This means all the hours they spent working per week for this role (not just the hours they spent teaching students).
+        hours_response: This means all the hours they spent working per week, including time spent teaching as well as other non-teaching activities (such as planning lessons, after-school meetings, running extra-curricular clubs and marking work).
       teacher_interface_registration_number_form:
         registration_number: Your country has an online register of teachers. If you have a registration number, enter it on this screen. If you do not have one, just select ‘Continue’.
       teacher_interface_work_history_school_form:
@@ -144,30 +148,37 @@ en:
         children_response_options:
           true: "Yes"
           false: "No"
+        children_comment: Tell us why you answered ‘No’ to this question.
       teacher_interface_reference_request_dates_response_form:
         dates_response_options:
           true: "Yes"
           false: "No"
+        dates_comment: Tell us why you answered ‘No’ to this question.
       teacher_interface_reference_request_hours_response_form:
         hours_response_options:
           true: "Yes"
           false: "No"
+        hours_comment: Tell us why you answered ‘No’ to this question.
       teacher_interface_reference_request_lessons_response_form:
         lessons_response_options:
           true: "Yes"
           false: "No"
+        lessons_comment: Tell us why you answered ‘No’ to this question.
       teacher_interface_reference_request_reports_response_form:
         reports_response_options:
           true: "Yes"
           false: "No"
+        reports_comment: Tell us why you answered ‘No’ to this question.
       teacher_interface_reference_request_misconduct_response_form:
-        reports_response_options:
+        misconduct_response_options:
           true: "Yes"
           false: "No"
+        misconduct_comment: Tell us why you answered ‘Yes’ to this question.
       teacher_interface_reference_request_satisfied_response_form:
-        reports_response_options:
+        satisfied_response_options:
           true: "Yes"
           false: "No"
+        satisfied_comment: Tell us why you answered ‘No’ to this question.
       teacher_interface_registration_number_form:
         registration_number: What is your registration number?
       teacher_interface_subjects_form:
@@ -231,7 +242,9 @@ en:
       teacher_interface_has_work_history_form:
         has_work_history: Have you worked professionally as a teacher?
       teacher_interface_reference_request_children_response_form:
-        children_response: Did the applicant work unsupervised with children aged somewhere between 5 and 16 years?
+        children_response: Did the applicant teach children aged somewhere between 5 and 16 years?
+      teacher_interface_reference_request_contact_response_form:
+        contact_response: Are these details correct?
       teacher_interface_reference_request_dates_response_form:
         dates_response: Did the applicant work at %{school_name} from %{start_date} to %{end_date}?
       teacher_interface_reference_request_hours_response_form:
@@ -239,9 +252,9 @@ en:
           one: Did the applicant normally work more than 1 hour per week in this role?
           other: Did the applicant normally work more than %{count} hours per week in this role?
       teacher_interface_reference_request_lessons_response_form:
-        lessons_response: Was the applicant solely responsible for planning, preparing and delivering lessons to at least 4 students at a time?
+        lessons_response: Did the applicant plan, prepare and deliver lessons to a class of at least 4 students?
       teacher_interface_reference_request_reports_response_form:
-        reports_response: Was the applicant solely responsible for assessing and reporting on the progress of the students?
+        reports_response: Was the applicant responsible for assessing and reporting on the progress of the students?
       teacher_interface_reference_request_misconduct_response_form:
         misconduct_response: Do you know of any professional misconduct by the applicant, or any disciplinary action taken against them?
       teacher_interface_reference_request_satisfied_response_form:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -143,7 +143,7 @@ en:
       teacher_interface_qualification_form:
         institution_country_location: Country of institution
       teacher_interface_reference_request_additional_information_response_form:
-        additional_information_response: Is there anything else you’d like to tell us about this applicant?
+        additional_information_response: Do you have any other concerns about this applicant? (optional)
       teacher_interface_reference_request_children_response_form:
         children_response_options:
           true: "Yes"

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -253,7 +253,9 @@ en:
       teacher_interface_reference_request_contact_response_form:
         contact_response: Are these details correct?
       teacher_interface_reference_request_dates_response_form:
-        dates_response: Did the applicant work at %{school_name} from %{start_date} to %{end_date}?
+        dates_response:
+          current: Has the applicant worked at %{school_name} since %{start_date}?
+          previous: Did the applicant work at %{school_name} from %{start_date} to %{end_date}?
       teacher_interface_reference_request_hours_response_form:
         hours_response:
           one: Did the applicant normally work more than 1 hour per week in this role?

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -149,6 +149,13 @@ en:
           true: "Yes"
           false: "No"
         children_comment: Tell us why you answered ‘No’ to this question.
+      teacher_interface_reference_request_contact_response_form:
+        contact_response_options:
+          true: "Yes"
+          false: "No"
+        contact_name: Your full name
+        contact_job: Your job title
+        contact_comment: Any other comments (optional)
       teacher_interface_reference_request_dates_response_form:
         dates_response_options:
           true: "Yes"

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -255,22 +255,44 @@ en:
           attributes:
             children_response:
               inclusion: Tell us whether the applicant worked unsupervised with children aged somewhere between 5 and 16 years
+            children_comment:
+              blank: Tell us why you answered ‘No’ to this question.
         teacher_interface/reference_request_dates_response_form:
           attributes:
             dates_response:
               inclusion: Tell us whether the applicant worked at the school for the dates they provided
+            dates_comment:
+              blank: Tell us why you answered ‘No’ to this question.
         teacher_interface/reference_request_hours_response_form:
           attributes:
             hours_response:
               inclusion: Tell us whether the applicant worked at the school for approximately the number of hours per week they provided
+            hours_comment:
+              blank: Tell us why you answered ‘No’ to this question.
         teacher_interface/reference_request_lessons_response_form:
           attributes:
             lessons_response:
               inclusion: Tell us whether the applicant was solely responsible for planning, preparing and delivering lessons to at least 4 students at a time
+            lessons_comment:
+              blank: Tell us why you answered ‘No’ to this question.
+        teacher_interface/reference_request_misconduct_response_form:
+          attributes:
+            misconduct_response:
+              inclusion: Tell us whether you know of any professional misconduct by the applicant, or any disciplinary action taken against them
+            misconduct_comment:
+              blank: Tell us why you answered ‘Yes’ to this question.
         teacher_interface/reference_request_reports_response_form:
           attributes:
             reports_response:
               inclusion: Tell us whether the applicant was solely responsible for assessing and reporting on the progress of the students
+            reports_comment:
+              blank: Tell us why you answered ‘No’ to this question.
+        teacher_interface/reference_request_satisfied_response_form:
+          attributes:
+            satisfied_response:
+              inclusion: Tell us whether you are satisfied that the applicant is suitable to work with children
+            satisfied_comment:
+              blank: Tell us why you answered ‘No’ to this question.
         teacher_interface/sanction_confirmation_form:
           attributes:
             confirmed_no_sanctions:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -44,10 +44,6 @@ en:
         title: You’ve been asked to act as a reference
       edit:
         title: Check your answers
-        reference_requested: Reference requested
-        response_value:
-          "true": "Yes"
-          "false": "No"
       edit_contact:
         title: About you
     work_histories:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -45,6 +45,11 @@ en:
       edit:
         title: Check your answers
         reference_requested: Reference requested
+        response_value:
+          "true": "Yes"
+          "false": "No"
+      edit_contact:
+        title: About you
     work_histories:
       add_another:
         title: Add another role
@@ -257,6 +262,14 @@ en:
               inclusion: Tell us whether the applicant worked unsupervised with children aged somewhere between 5 and 16 years
             children_comment:
               blank: Tell us why you answered ‘No’ to this question.
+        teacher_interface/reference_request_contact_response_form:
+          attributes:
+            contact_response:
+              inclusion: Tell us whether these details are correct
+            contact_name:
+              blank: Tell us your full name
+            contact_job:
+              blank: Tell us your job title
         teacher_interface/reference_request_dates_response_form:
           attributes:
             dates_response:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -280,6 +280,9 @@ Rails.application.routes.draw do
               param: :slug,
               only: %i[show edit update] do
       member do
+        get "contact", to: "reference_requests#edit_contact"
+        post "contact", to: "reference_requests#update_contact"
+
         get "dates", to: "reference_requests#edit_dates"
         post "dates", to: "reference_requests#update_dates"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -295,6 +295,12 @@ Rails.application.routes.draw do
         get "reports", to: "reference_requests#edit_reports"
         post "reports", to: "reference_requests#update_reports"
 
+        get "misconduct", to: "reference_requests#edit_misconduct"
+        post "misconduct", to: "reference_requests#update_misconduct"
+
+        get "satisfied", to: "reference_requests#edit_satisfied"
+        post "satisfied", to: "reference_requests#update_satisfied"
+
         get "additional-information",
             to: "reference_requests#edit_additional_information"
         post "additional-information",

--- a/db/migrate/20230221111216_add_responses_to_reference_requests.rb
+++ b/db/migrate/20230221111216_add_responses_to_reference_requests.rb
@@ -1,0 +1,22 @@
+class AddResponsesToReferenceRequests < ActiveRecord::Migration[7.0]
+  def change
+    change_table :reference_requests, bulk: true do |t|
+      t.boolean :contact_response
+      t.string :contact_name, default: "", null: false
+      t.string :contact_job, default: "", null: false
+      t.text :contact_comment, default: "", null: false
+
+      t.text :dates_comment, default: "", null: false
+      t.text :hours_comment, default: "", null: false
+      t.text :children_comment, default: "", null: false
+      t.text :lessons_comment, default: "", null: false
+      t.text :reports_comment, default: "", null: false
+
+      t.boolean :misconduct_response
+      t.text :misconduct_comment, default: "", null: false
+
+      t.boolean :satisfied_response
+      t.text :satisfied_comment, default: "", null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_20_130858) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_21_111216) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -307,6 +307,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_20_130858) do
     t.datetime "updated_at", null: false
     t.boolean "passed"
     t.datetime "reviewed_at", precision: nil
+    t.boolean "contact_response"
+    t.string "contact_name", default: "", null: false
+    t.string "contact_job", default: "", null: false
+    t.text "contact_comment", default: "", null: false
+    t.text "dates_comment", default: "", null: false
+    t.text "hours_comment", default: "", null: false
+    t.text "children_comment", default: "", null: false
+    t.text "lessons_comment", default: "", null: false
+    t.text "reports_comment", default: "", null: false
+    t.boolean "misconduct_response"
+    t.text "misconduct_comment", default: "", null: false
+    t.boolean "satisfied_response"
+    t.text "satisfied_comment", default: "", null: false
     t.index ["assessment_id"], name: "index_reference_requests_on_assessment_id"
     t.index ["slug"], name: "index_reference_requests_on_slug", unique: true
     t.index ["work_history_id"], name: "index_reference_requests_on_work_history_id"

--- a/spec/factories/reference_requests.rb
+++ b/spec/factories/reference_requests.rb
@@ -74,25 +74,53 @@ FactoryBot.define do
 
     trait :receivable do
       contact_response { Faker::Boolean.boolean }
+      contact_name { contact_response ? "" : Faker::Name.name }
+      contact_job { contact_response ? "" : Faker::Job.title }
+      contact_comment { contact_response ? "" : Faker::Lorem.sentence }
+
       dates_response { Faker::Boolean.boolean }
+      dates_comment { dates_response ? "" : Faker::Lorem.sentence }
+
       hours_response { Faker::Boolean.boolean }
+      hours_comment { hours_response ? "" : Faker::Lorem.sentence }
+
       children_response { Faker::Boolean.boolean }
+      children_comment { children_response ? "" : Faker::Lorem.sentence }
+
       lessons_response { Faker::Boolean.boolean }
+      lessons_comment { lessons_response ? "" : Faker::Lorem.sentence }
+
       reports_response { Faker::Boolean.boolean }
+      reports_comment { reports_response ? "" : Faker::Lorem.sentence }
+
       misconduct_response { Faker::Boolean.boolean }
+      misconduct_comment { misconduct_response ? Faker::Lorem.sentence : "" }
+
       satisfied_response { Faker::Boolean.boolean }
+      satisfied_comment { satisfied_response ? "" : Faker::Lorem.sentence }
+
       additional_information_response { Faker::Lorem.sentence }
     end
 
     trait :responses_invalid do
       contact_response { false }
+      contact_name { Faker::Name.name }
+      contact_job { Faker::Job.title }
+      contact_comment { Faker::Lorem.sentence }
       dates_response { false }
+      dates_comment { Faker::Lorem.sentence }
       hours_response { false }
+      hours_comment { Faker::Lorem.sentence }
       children_response { false }
+      children_comment { Faker::Lorem.sentence }
       lessons_response { false }
+      lessons_comment { Faker::Lorem.sentence }
       reports_response { false }
+      reports_comment { Faker::Lorem.sentence }
       misconduct_response { true }
+      misconduct_comment { Faker::Lorem.sentence }
       satisfied_response { false }
+      satisfied_comment { Faker::Lorem.sentence }
     end
 
     trait :responses_valid do

--- a/spec/factories/reference_requests.rb
+++ b/spec/factories/reference_requests.rb
@@ -91,7 +91,7 @@ FactoryBot.define do
       children_response { false }
       lessons_response { false }
       reports_response { false }
-      misconduct_response { false }
+      misconduct_response { true }
       satisfied_response { false }
     end
 
@@ -102,7 +102,7 @@ FactoryBot.define do
       children_response { true }
       lessons_response { true }
       reports_response { true }
-      misconduct_response { true }
+      misconduct_response { false }
       satisfied_response { true }
     end
   end

--- a/spec/factories/reference_requests.rb
+++ b/spec/factories/reference_requests.rb
@@ -6,14 +6,27 @@
 #
 #  id                              :bigint           not null, primary key
 #  additional_information_response :text             default(""), not null
+#  children_comment                :text             default(""), not null
 #  children_response               :boolean
+#  contact_comment                 :text             default(""), not null
+#  contact_job                     :string           default(""), not null
+#  contact_name                    :string           default(""), not null
+#  contact_response                :boolean
+#  dates_comment                   :text             default(""), not null
 #  dates_response                  :boolean
+#  hours_comment                   :text             default(""), not null
 #  hours_response                  :boolean
+#  lessons_comment                 :text             default(""), not null
 #  lessons_response                :boolean
+#  misconduct_comment              :text             default(""), not null
+#  misconduct_response             :boolean
 #  passed                          :boolean
 #  received_at                     :datetime
+#  reports_comment                 :text             default(""), not null
 #  reports_response                :boolean
 #  reviewed_at                     :datetime
+#  satisfied_comment               :text             default(""), not null
+#  satisfied_response              :boolean
 #  slug                            :string           not null
 #  state                           :string           not null
 #  created_at                      :datetime         not null
@@ -60,28 +73,37 @@ FactoryBot.define do
     end
 
     trait :receivable do
+      contact_response { Faker::Boolean.boolean }
       dates_response { Faker::Boolean.boolean }
       hours_response { Faker::Boolean.boolean }
       children_response { Faker::Boolean.boolean }
       lessons_response { Faker::Boolean.boolean }
       reports_response { Faker::Boolean.boolean }
+      misconduct_response { Faker::Boolean.boolean }
+      satisfied_response { Faker::Boolean.boolean }
       additional_information_response { Faker::Lorem.sentence }
     end
 
     trait :responses_invalid do
+      contact_response { false }
       dates_response { false }
       hours_response { false }
       children_response { false }
       lessons_response { false }
       reports_response { false }
+      misconduct_response { false }
+      satisfied_response { false }
     end
 
     trait :responses_valid do
+      contact_response { true }
       dates_response { true }
       hours_response { true }
       children_response { true }
       lessons_response { true }
       reports_response { true }
+      misconduct_response { true }
+      satisfied_response { true }
     end
   end
 end

--- a/spec/forms/teacher_interface/reference_request_children_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_children_response_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe TeacherInterface::ReferenceRequestChildrenResponseForm,
 
     let(:children_response) { "true" }
 
-    it "saves the application form" do
+    it "saves the reference request" do
       expect { save }.to change(reference_request, :children_response).to(true)
     end
   end

--- a/spec/forms/teacher_interface/reference_request_children_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_children_response_form_spec.rb
@@ -6,22 +6,62 @@ RSpec.describe TeacherInterface::ReferenceRequestChildrenResponseForm,
                type: :model do
   let(:reference_request) { create(:reference_request) }
 
-  subject(:form) { described_class.new(reference_request:, children_response:) }
+  subject(:form) do
+    described_class.new(
+      reference_request:,
+      children_response:,
+      children_comment:,
+    )
+  end
 
   describe "validations" do
     let(:children_response) { "" }
+    let(:children_comment) { "" }
 
     it { is_expected.to validate_presence_of(:reference_request) }
     it { is_expected.to allow_values(true, false).for(:children_response) }
+    it { is_expected.to_not validate_presence_of(:children_comment) }
+
+    context "with a negative response" do
+      let(:children_response) { "false" }
+
+      it { is_expected.to validate_presence_of(:children_comment) }
+    end
   end
 
   describe "#save" do
     subject(:save) { form.save(validate: true) }
 
-    let(:children_response) { "true" }
+    context "with a positive response" do
+      let(:children_response) { "true" }
+      let(:children_comment) { "" }
 
-    it "saves the reference request" do
-      expect { save }.to change(reference_request, :children_response).to(true)
+      it "sets children_response" do
+        expect { save }.to change(reference_request, :children_response).to(
+          true,
+        )
+      end
+
+      it "ignores children_comment" do
+        expect { save }.to_not change(reference_request, :children_comment)
+      end
+    end
+
+    context "with a negative response" do
+      let(:children_response) { "false" }
+      let(:children_comment) { "Comment" }
+
+      it "sets children_response" do
+        expect { save }.to change(reference_request, :children_response).to(
+          false,
+        )
+      end
+
+      it "sets children_comment" do
+        expect { save }.to change(reference_request, :children_comment).to(
+          "Comment",
+        )
+      end
     end
   end
 end

--- a/spec/forms/teacher_interface/reference_request_contact_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_contact_response_form_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::ReferenceRequestContactResponseForm,
+               type: :model do
+  let(:reference_request) { create(:reference_request) }
+
+  subject(:form) do
+    described_class.new(
+      reference_request:,
+      contact_response:,
+      contact_name:,
+      contact_job:,
+      contact_comment:,
+    )
+  end
+
+  describe "validations" do
+    let(:contact_response) { "" }
+    let(:contact_name) { "" }
+    let(:contact_job) { "" }
+    let(:contact_comment) { "" }
+
+    it { is_expected.to validate_presence_of(:reference_request) }
+    it { is_expected.to allow_values(true, false).for(:contact_response) }
+    it { is_expected.to_not validate_presence_of(:contact_name) }
+    it { is_expected.to_not validate_presence_of(:contact_job) }
+    it { is_expected.to_not validate_presence_of(:contact_comment) }
+
+    context "with a negative response" do
+      let(:contact_response) { "false" }
+
+      it { is_expected.to validate_presence_of(:contact_name) }
+      it { is_expected.to validate_presence_of(:contact_job) }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save(validate: true) }
+
+    context "with a positive response" do
+      let(:contact_response) { "true" }
+      let(:contact_name) { "" }
+      let(:contact_job) { "" }
+      let(:contact_comment) { "" }
+
+      it "sets contact_response" do
+        expect { save }.to change(reference_request, :contact_response).to(true)
+      end
+
+      it "ignores contact_name" do
+        expect { save }.to_not change(reference_request, :contact_name)
+      end
+
+      it "ignores contact_job" do
+        expect { save }.to_not change(reference_request, :contact_job)
+      end
+
+      it "ignores contact_comment" do
+        expect { save }.to_not change(reference_request, :contact_comment)
+      end
+    end
+
+    context "with a negative response" do
+      let(:contact_response) { "false" }
+      let(:contact_name) { "Name" }
+      let(:contact_job) { "Job" }
+      let(:contact_comment) { "Comment" }
+
+      it "sets contact_response" do
+        expect { save }.to change(reference_request, :contact_response).to(
+          false,
+        )
+      end
+
+      it "sets contact_name" do
+        expect { save }.to change(reference_request, :contact_name).to("Name")
+      end
+
+      it "sets contact_job" do
+        expect { save }.to change(reference_request, :contact_job).to("Job")
+      end
+
+      it "sets contact_comment" do
+        expect { save }.to change(reference_request, :contact_comment).to(
+          "Comment",
+        )
+      end
+    end
+  end
+end

--- a/spec/forms/teacher_interface/reference_request_dates_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_dates_response_form_spec.rb
@@ -6,22 +6,54 @@ RSpec.describe TeacherInterface::ReferenceRequestDatesResponseForm,
                type: :model do
   let(:reference_request) { create(:reference_request) }
 
-  subject(:form) { described_class.new(reference_request:, dates_response:) }
+  subject(:form) do
+    described_class.new(reference_request:, dates_response:, dates_comment:)
+  end
 
   describe "validations" do
     let(:dates_response) { "" }
+    let(:dates_comment) { "" }
 
     it { is_expected.to validate_presence_of(:reference_request) }
     it { is_expected.to allow_values(true, false).for(:dates_response) }
+    it { is_expected.to_not validate_presence_of(:dates_comment) }
+
+    context "with a negative response" do
+      let(:dates_response) { "false" }
+
+      it { is_expected.to validate_presence_of(:dates_comment) }
+    end
   end
 
   describe "#save" do
     subject(:save) { form.save(validate: true) }
 
-    let(:dates_response) { "true" }
+    context "with a positive response" do
+      let(:dates_response) { "true" }
+      let(:dates_comment) { "" }
 
-    it "saves the reference request" do
-      expect { save }.to change(reference_request, :dates_response).to(true)
+      it "sets dates_response" do
+        expect { save }.to change(reference_request, :dates_response).to(true)
+      end
+
+      it "ignores dates_comment" do
+        expect { save }.to_not change(reference_request, :dates_comment)
+      end
+    end
+
+    context "with a negative response" do
+      let(:dates_response) { "false" }
+      let(:dates_comment) { "Comment" }
+
+      it "sets dates_response" do
+        expect { save }.to change(reference_request, :dates_response).to(false)
+      end
+
+      it "sets dates_comment" do
+        expect { save }.to change(reference_request, :dates_comment).to(
+          "Comment",
+        )
+      end
     end
   end
 end

--- a/spec/forms/teacher_interface/reference_request_dates_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_dates_response_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe TeacherInterface::ReferenceRequestDatesResponseForm,
 
     let(:dates_response) { "true" }
 
-    it "saves the application form" do
+    it "saves the reference request" do
       expect { save }.to change(reference_request, :dates_response).to(true)
     end
   end

--- a/spec/forms/teacher_interface/reference_request_hours_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_hours_response_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe TeacherInterface::ReferenceRequestHoursResponseForm,
 
     let(:hours_response) { "true" }
 
-    it "saves the application form" do
+    it "saves the reference request" do
       expect { save }.to change(reference_request, :hours_response).to(true)
     end
   end

--- a/spec/forms/teacher_interface/reference_request_hours_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_hours_response_form_spec.rb
@@ -6,22 +6,54 @@ RSpec.describe TeacherInterface::ReferenceRequestHoursResponseForm,
                type: :model do
   let(:reference_request) { create(:reference_request) }
 
-  subject(:form) { described_class.new(reference_request:, hours_response:) }
+  subject(:form) do
+    described_class.new(reference_request:, hours_response:, hours_comment:)
+  end
 
   describe "validations" do
     let(:hours_response) { "" }
+    let(:hours_comment) { "" }
 
     it { is_expected.to validate_presence_of(:reference_request) }
     it { is_expected.to allow_values(true, false).for(:hours_response) }
+    it { is_expected.to_not validate_presence_of(:hours_comment) }
+
+    context "with a negative response" do
+      let(:hours_response) { "false" }
+
+      it { is_expected.to validate_presence_of(:hours_comment) }
+    end
   end
 
   describe "#save" do
     subject(:save) { form.save(validate: true) }
 
-    let(:hours_response) { "true" }
+    context "with a positive response" do
+      let(:hours_response) { "true" }
+      let(:hours_comment) { "" }
 
-    it "saves the reference request" do
-      expect { save }.to change(reference_request, :hours_response).to(true)
+      it "sets hours_response" do
+        expect { save }.to change(reference_request, :hours_response).to(true)
+      end
+
+      it "ignores hours_comment" do
+        expect { save }.to_not change(reference_request, :hours_comment)
+      end
+    end
+
+    context "with a negative response" do
+      let(:hours_response) { "false" }
+      let(:hours_comment) { "Comment" }
+
+      it "sets hours_response" do
+        expect { save }.to change(reference_request, :hours_response).to(false)
+      end
+
+      it "sets hours_comment" do
+        expect { save }.to change(reference_request, :hours_comment).to(
+          "Comment",
+        )
+      end
     end
   end
 end

--- a/spec/forms/teacher_interface/reference_request_lessons_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_lessons_response_form_spec.rb
@@ -6,22 +6,56 @@ RSpec.describe TeacherInterface::ReferenceRequestLessonsResponseForm,
                type: :model do
   let(:reference_request) { create(:reference_request) }
 
-  subject(:form) { described_class.new(reference_request:, lessons_response:) }
+  subject(:form) do
+    described_class.new(reference_request:, lessons_response:, lessons_comment:)
+  end
 
   describe "validations" do
     let(:lessons_response) { "" }
+    let(:lessons_comment) { "" }
 
     it { is_expected.to validate_presence_of(:reference_request) }
     it { is_expected.to allow_values(true, false).for(:lessons_response) }
+    it { is_expected.to_not validate_presence_of(:lessons_comment) }
+
+    context "with a negative response" do
+      let(:lessons_response) { "false" }
+
+      it { is_expected.to validate_presence_of(:lessons_comment) }
+    end
   end
 
   describe "#save" do
     subject(:save) { form.save(validate: true) }
 
-    let(:lessons_response) { "true" }
+    context "with a positive response" do
+      let(:lessons_response) { "true" }
+      let(:lessons_comment) { "" }
 
-    it "saves the reference request" do
-      expect { save }.to change(reference_request, :lessons_response).to(true)
+      it "sets lessons_response" do
+        expect { save }.to change(reference_request, :lessons_response).to(true)
+      end
+
+      it "ignores lessons_comment" do
+        expect { save }.to_not change(reference_request, :lessons_comment)
+      end
+    end
+
+    context "with a negative response" do
+      let(:lessons_response) { "false" }
+      let(:lessons_comment) { "Comment" }
+
+      it "sets lessons_response" do
+        expect { save }.to change(reference_request, :lessons_response).to(
+          false,
+        )
+      end
+
+      it "sets lessons_comment" do
+        expect { save }.to change(reference_request, :lessons_comment).to(
+          "Comment",
+        )
+      end
     end
   end
 end

--- a/spec/forms/teacher_interface/reference_request_lessons_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_lessons_response_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe TeacherInterface::ReferenceRequestLessonsResponseForm,
 
     let(:lessons_response) { "true" }
 
-    it "saves the application form" do
+    it "saves the reference request" do
       expect { save }.to change(reference_request, :lessons_response).to(true)
     end
   end

--- a/spec/forms/teacher_interface/reference_request_misconduct_response_form.rb
+++ b/spec/forms/teacher_interface/reference_request_misconduct_response_form.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::ReferenceRequestMisconductResponseForm,
+               type: :model do
+  let(:reference_request) { create(:reference_request) }
+
+  subject(:form) do
+    described_class.new(reference_request:, misconduct_response:)
+  end
+
+  describe "validations" do
+    let(:misconduct_response) { "" }
+
+    it { is_expected.to validate_presence_of(:reference_request) }
+    it { is_expected.to allow_values(true, false).for(:misconduct_response) }
+  end
+
+  describe "#save" do
+    subject(:save) { form.save(validate: true) }
+
+    let(:misconduct_response) { "true" }
+
+    it "saves the reference request" do
+      expect { save }.to change(reference_request, :misconduct_response).to(
+        true,
+      )
+    end
+  end
+end

--- a/spec/forms/teacher_interface/reference_request_misconduct_response_form.rb
+++ b/spec/forms/teacher_interface/reference_request_misconduct_response_form.rb
@@ -7,25 +7,61 @@ RSpec.describe TeacherInterface::ReferenceRequestMisconductResponseForm,
   let(:reference_request) { create(:reference_request) }
 
   subject(:form) do
-    described_class.new(reference_request:, misconduct_response:)
+    described_class.new(
+      reference_request:,
+      misconduct_response:,
+      misconduct_comment:,
+    )
   end
 
   describe "validations" do
     let(:misconduct_response) { "" }
+    let(:misconduct_comment) { "" }
 
     it { is_expected.to validate_presence_of(:reference_request) }
     it { is_expected.to allow_values(true, false).for(:misconduct_response) }
+    it { is_expected.to_not validate_presence_of(:misconduct_comment) }
+
+    context "with a positive response" do
+      let(:misconduct_response) { "true" }
+
+      it { is_expected.to validate_presence_of(:misconduct_comment) }
+    end
   end
 
   describe "#save" do
     subject(:save) { form.save(validate: true) }
 
-    let(:misconduct_response) { "true" }
+    context "with a negative response" do
+      let(:misconduct_response) { "false" }
+      let(:misconduct_comment) { "" }
 
-    it "saves the reference request" do
-      expect { save }.to change(reference_request, :misconduct_response).to(
-        true,
-      )
+      it "sets misconduct_response" do
+        expect { save }.to change(reference_request, :misconduct_response).to(
+          false,
+        )
+      end
+
+      it "ignores misconduct_comment" do
+        expect { save }.to_not change(reference_request, :misconduct_comment)
+      end
+    end
+
+    context "with a positive response" do
+      let(:misconduct_response) { "true" }
+      let(:misconduct_comment) { "Comment" }
+
+      it "sets misconduct_response" do
+        expect { save }.to change(reference_request, :misconduct_response).to(
+          true,
+        )
+      end
+
+      it "sets misconduct_comment" do
+        expect { save }.to change(reference_request, :misconduct_comment).to(
+          "Comment",
+        )
+      end
     end
   end
 end

--- a/spec/forms/teacher_interface/reference_request_reports_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_reports_response_form_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe TeacherInterface::ReferenceRequestReportsResponseForm,
 
     let(:reports_response) { "true" }
 
-    it "saves the application form" do
+    it "saves the reference request" do
       expect { save }.to change(reference_request, :reports_response).to(true)
     end
   end

--- a/spec/forms/teacher_interface/reference_request_reports_response_form_spec.rb
+++ b/spec/forms/teacher_interface/reference_request_reports_response_form_spec.rb
@@ -6,22 +6,56 @@ RSpec.describe TeacherInterface::ReferenceRequestReportsResponseForm,
                type: :model do
   let(:reference_request) { create(:reference_request) }
 
-  subject(:form) { described_class.new(reference_request:, reports_response:) }
+  subject(:form) do
+    described_class.new(reference_request:, reports_response:, reports_comment:)
+  end
 
   describe "validations" do
     let(:reports_response) { "" }
+    let(:reports_comment) { "" }
 
     it { is_expected.to validate_presence_of(:reference_request) }
     it { is_expected.to allow_values(true, false).for(:reports_response) }
+    it { is_expected.to_not validate_presence_of(:reports_comment) }
+
+    context "with a negative response" do
+      let(:reports_response) { "false" }
+
+      it { is_expected.to validate_presence_of(:reports_comment) }
+    end
   end
 
   describe "#save" do
     subject(:save) { form.save(validate: true) }
 
-    let(:reports_response) { "true" }
+    context "with a positive response" do
+      let(:reports_response) { "true" }
+      let(:reports_comment) { "" }
 
-    it "saves the reference request" do
-      expect { save }.to change(reference_request, :reports_response).to(true)
+      it "sets reports_response" do
+        expect { save }.to change(reference_request, :reports_response).to(true)
+      end
+
+      it "ignores reports_comment" do
+        expect { save }.to_not change(reference_request, :reports_comment)
+      end
+    end
+
+    context "with a negative response" do
+      let(:reports_response) { "false" }
+      let(:reports_comment) { "Comment" }
+
+      it "sets reports_response" do
+        expect { save }.to change(reference_request, :reports_response).to(
+          false,
+        )
+      end
+
+      it "sets reports_comment" do
+        expect { save }.to change(reference_request, :reports_comment).to(
+          "Comment",
+        )
+      end
     end
   end
 end

--- a/spec/forms/teacher_interface/reference_request_satisfied_response_form.rb
+++ b/spec/forms/teacher_interface/reference_request_satisfied_response_form.rb
@@ -7,23 +7,61 @@ RSpec.describe TeacherInterface::ReferenceRequestSatisfiedResponseForm,
   let(:reference_request) { create(:reference_request) }
 
   subject(:form) do
-    described_class.new(reference_request:, satisfied_response:)
+    described_class.new(
+      reference_request:,
+      satisfied_response:,
+      satisfied_comment:,
+    )
   end
 
   describe "validations" do
     let(:satisfied_response) { "" }
+    let(:satisfied_comment) { "" }
 
     it { is_expected.to validate_presence_of(:reference_request) }
     it { is_expected.to allow_values(true, false).for(:satisfied_response) }
+    it { is_expected.to_not validate_presence_of(:satisfied_comment) }
+
+    context "with a negative response" do
+      let(:satisfied_response) { "false" }
+
+      it { is_expected.to validate_presence_of(:satisfied_comment) }
+    end
   end
 
   describe "#save" do
     subject(:save) { form.save(validate: true) }
 
-    let(:satisfied_response) { "true" }
+    context "with a positive response" do
+      let(:satisfied_response) { "true" }
+      let(:satisfied_comment) { "" }
 
-    it "saves the reference request" do
-      expect { save }.to change(reference_request, :satisfied_response).to(true)
+      it "sets satisfied_response" do
+        expect { save }.to change(reference_request, :satisfied_response).to(
+          true,
+        )
+      end
+
+      it "ignores satisfied_comment" do
+        expect { save }.to_not change(reference_request, :satisfied_comment)
+      end
+    end
+
+    context "with a negative response" do
+      let(:satisfied_response) { "false" }
+      let(:satisfied_comment) { "Comment" }
+
+      it "sets satisfied_response" do
+        expect { save }.to change(reference_request, :satisfied_response).to(
+          false,
+        )
+      end
+
+      it "sets satisfied_comment" do
+        expect { save }.to change(reference_request, :satisfied_comment).to(
+          "Comment",
+        )
+      end
     end
   end
 end

--- a/spec/forms/teacher_interface/reference_request_satisfied_response_form.rb
+++ b/spec/forms/teacher_interface/reference_request_satisfied_response_form.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::ReferenceRequestSatisfiedResponseForm,
+               type: :model do
+  let(:reference_request) { create(:reference_request) }
+
+  subject(:form) do
+    described_class.new(reference_request:, satisfied_response:)
+  end
+
+  describe "validations" do
+    let(:satisfied_response) { "" }
+
+    it { is_expected.to validate_presence_of(:reference_request) }
+    it { is_expected.to allow_values(true, false).for(:satisfied_response) }
+  end
+
+  describe "#save" do
+    subject(:save) { form.save(validate: true) }
+
+    let(:satisfied_response) { "true" }
+
+    it "saves the reference request" do
+      expect { save }.to change(reference_request, :satisfied_response).to(true)
+    end
+  end
+end

--- a/spec/models/reference_request_spec.rb
+++ b/spec/models/reference_request_spec.rb
@@ -101,23 +101,4 @@ RSpec.describe ReferenceRequest do
       it { is_expected.to be true }
     end
   end
-
-  describe "#responses_valid?" do
-    subject(:responses_valid?) { reference_request.responses_valid? }
-
-    context "when no responses are given" do
-      let(:reference_request) { build(:reference_request) }
-      it { is_expected.to be false }
-    end
-
-    context "when all responses are valid" do
-      let(:reference_request) { build(:reference_request, :responses_valid) }
-      it { is_expected.to be true }
-    end
-
-    context "when all responses are invalid" do
-      let(:reference_request) { build(:reference_request, :responses_invalid) }
-      it { is_expected.to be false }
-    end
-  end
 end

--- a/spec/models/reference_request_spec.rb
+++ b/spec/models/reference_request_spec.rb
@@ -6,14 +6,27 @@
 #
 #  id                              :bigint           not null, primary key
 #  additional_information_response :text             default(""), not null
+#  children_comment                :text             default(""), not null
 #  children_response               :boolean
+#  contact_comment                 :text             default(""), not null
+#  contact_job                     :string           default(""), not null
+#  contact_name                    :string           default(""), not null
+#  contact_response                :boolean
+#  dates_comment                   :text             default(""), not null
 #  dates_response                  :boolean
+#  hours_comment                   :text             default(""), not null
 #  hours_response                  :boolean
+#  lessons_comment                 :text             default(""), not null
 #  lessons_response                :boolean
+#  misconduct_comment              :text             default(""), not null
+#  misconduct_response             :boolean
 #  passed                          :boolean
 #  received_at                     :datetime
+#  reports_comment                 :text             default(""), not null
 #  reports_response                :boolean
 #  reviewed_at                     :datetime
+#  satisfied_comment               :text             default(""), not null
+#  satisfied_response              :boolean
 #  slug                            :string           not null
 #  state                           :string           not null
 #  created_at                      :datetime         not null

--- a/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_contact.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_contact.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class EditReferenceRequestContact < ReferenceRequestQuestionForm
+      set_url "/teacher/references/{slug}/contact"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_misconduct.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_misconduct.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class EditReferenceRequestMisconduct < ReferenceRequestQuestionForm
+      set_url "/teacher/references/{slug}/misconduct"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_satisfied.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/edit_reference_request_satisfied.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class EditReferenceRequestSatisfied < ReferenceRequestQuestionForm
+      set_url "/teacher/references/{slug}/satisfied"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/reference_request_question_form.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/reference_request_question_form.rb
@@ -4,23 +4,19 @@ module PageObjects
   module TeacherInterface
     class ReferenceRequestQuestionForm < SitePrism::Page
       section :form, "form" do
-        section :yes_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(1)"
-        section :no_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(2)"
-
+        sections :radio_items,
+                 PageObjects::GovukRadioItem,
+                 ".govuk-radios__item"
         element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
       end
 
       def submit_yes
-        form.yes_radio_item.choose
+        form.radio_items.first.choose
         form.continue_button.click
       end
 
       def submit_no
-        form.no_radio_item.choose
+        form.radio_items.second.choose
         form.continue_button.click
       end
     end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -283,6 +283,11 @@ module PageHelpers
       PageObjects::TeacherInterface::EditReferenceRequestChildren.new
   end
 
+  def teacher_edit_reference_request_contact_page
+    @teacher_edit_reference_request_contact_page ||=
+      PageObjects::TeacherInterface::EditReferenceRequestContact.new
+  end
+
   def teacher_edit_reference_request_dates_page
     @teacher_edit_reference_request_dates_page ||=
       PageObjects::TeacherInterface::EditReferenceRequestDates.new

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -298,9 +298,19 @@ module PageHelpers
       PageObjects::TeacherInterface::EditReferenceRequestLessons.new
   end
 
+  def teacher_edit_reference_request_misconduct_page
+    @teacher_edit_reference_request_misconduct_page ||=
+      PageObjects::TeacherInterface::EditReferenceRequestMisconduct.new
+  end
+
   def teacher_edit_reference_request_reports_page
     @teacher_edit_reference_request_reports_page ||=
       PageObjects::TeacherInterface::EditReferenceRequestReports.new
+  end
+
+  def teacher_edit_reference_request_satisfied_page
+    @teacher_edit_reference_request_satisfied_page ||=
+      PageObjects::TeacherInterface::EditReferenceRequestSatisfied.new
   end
 
   def teacher_edit_work_history_contact_page

--- a/spec/system/assessor_interface/verifying_references_spec.rb
+++ b/spec/system/assessor_interface/verifying_references_spec.rb
@@ -92,6 +92,16 @@ RSpec.describe "Assessor verifying references", type: :system do
       ),
     )
     expect(reference_request_page.responses.values[5].text).to eq(
+      I18n.t(
+        "assessor_interface.reference_requests.edit.response_value.#{reference_request.misconduct_response}",
+      ),
+    )
+    expect(reference_request_page.responses.values[6].text).to eq(
+      I18n.t(
+        "assessor_interface.reference_requests.edit.response_value.#{reference_request.satisfied_response}",
+      ),
+    )
+    expect(reference_request_page.responses.values[7].text).to eq(
       reference_request.additional_information_response,
     )
   end

--- a/spec/system/assessor_interface/verifying_references_spec.rb
+++ b/spec/system/assessor_interface/verifying_references_spec.rb
@@ -64,48 +64,20 @@ RSpec.describe "Assessor verifying references", type: :system do
     expect(reference_request_page.table.cells[2].text).to eq(
       reference_request.work_history.contact_name,
     )
-    expect(reference_request_page.responses.heading.text).to eq("Responses")
+    expect(reference_request_page.responses.heading.text).to eq(
+      "Reference requested",
+    )
 
     expect(reference_request_page.responses.values[0].text).to eq("John Smith")
     expect(reference_request_page.responses.values[1].text).to eq("Headteacher")
-    expect(reference_request_page.responses.values[2].text).to eq(
-      "None provided",
-    )
-    expect(reference_request_page.responses.values[3].text).to eq(
-      I18n.t(
-        "assessor_interface.reference_requests.edit.response_value.#{reference_request.dates_response}",
-      ),
-    )
-    expect(reference_request_page.responses.values[4].text).to eq(
-      I18n.t(
-        "assessor_interface.reference_requests.edit.response_value.#{reference_request.hours_response}",
-      ),
-    )
-    expect(reference_request_page.responses.values[5].text).to eq(
-      I18n.t(
-        "assessor_interface.reference_requests.edit.response_value.#{reference_request.children_response}",
-      ),
-    )
-    expect(reference_request_page.responses.values[6].text).to eq(
-      I18n.t(
-        "assessor_interface.reference_requests.edit.response_value.#{reference_request.lessons_response}",
-      ),
-    )
-    expect(reference_request_page.responses.values[7].text).to eq(
-      I18n.t(
-        "assessor_interface.reference_requests.edit.response_value.#{reference_request.reports_response}",
-      ),
-    )
-    expect(reference_request_page.responses.values[8].text).to eq(
-      I18n.t(
-        "assessor_interface.reference_requests.edit.response_value.#{reference_request.misconduct_response}",
-      ),
-    )
-    expect(reference_request_page.responses.values[9].text).to eq(
-      I18n.t(
-        "assessor_interface.reference_requests.edit.response_value.#{reference_request.satisfied_response}",
-      ),
-    )
+    expect(reference_request_page.responses.values[2].text).to eq("Yes")
+    expect(reference_request_page.responses.values[3].text).to eq("Yes")
+    expect(reference_request_page.responses.values[4].text).to eq("Yes")
+    expect(reference_request_page.responses.values[5].text).to eq("Yes")
+    expect(reference_request_page.responses.values[6].text).to eq("Yes")
+    expect(reference_request_page.responses.values[7].text).to eq("Yes")
+    expect(reference_request_page.responses.values[8].text).to eq("No")
+    expect(reference_request_page.responses.values[9].text).to eq("Yes")
     expect(reference_request_page.responses.values[10].text).to eq(
       reference_request.additional_information_response,
     )

--- a/spec/system/assessor_interface/verifying_references_spec.rb
+++ b/spec/system/assessor_interface/verifying_references_spec.rb
@@ -66,42 +66,47 @@ RSpec.describe "Assessor verifying references", type: :system do
     )
     expect(reference_request_page.responses.heading.text).to eq("Responses")
 
-    expect(reference_request_page.responses.values[0].text).to eq(
+    expect(reference_request_page.responses.values[0].text).to eq("John Smith")
+    expect(reference_request_page.responses.values[1].text).to eq("Headteacher")
+    expect(reference_request_page.responses.values[2].text).to eq(
+      "None provided",
+    )
+    expect(reference_request_page.responses.values[3].text).to eq(
       I18n.t(
         "assessor_interface.reference_requests.edit.response_value.#{reference_request.dates_response}",
       ),
     )
-    expect(reference_request_page.responses.values[1].text).to eq(
+    expect(reference_request_page.responses.values[4].text).to eq(
       I18n.t(
         "assessor_interface.reference_requests.edit.response_value.#{reference_request.hours_response}",
       ),
     )
-    expect(reference_request_page.responses.values[2].text).to eq(
+    expect(reference_request_page.responses.values[5].text).to eq(
       I18n.t(
         "assessor_interface.reference_requests.edit.response_value.#{reference_request.children_response}",
       ),
     )
-    expect(reference_request_page.responses.values[3].text).to eq(
+    expect(reference_request_page.responses.values[6].text).to eq(
       I18n.t(
         "assessor_interface.reference_requests.edit.response_value.#{reference_request.lessons_response}",
       ),
     )
-    expect(reference_request_page.responses.values[4].text).to eq(
+    expect(reference_request_page.responses.values[7].text).to eq(
       I18n.t(
         "assessor_interface.reference_requests.edit.response_value.#{reference_request.reports_response}",
       ),
     )
-    expect(reference_request_page.responses.values[5].text).to eq(
+    expect(reference_request_page.responses.values[8].text).to eq(
       I18n.t(
         "assessor_interface.reference_requests.edit.response_value.#{reference_request.misconduct_response}",
       ),
     )
-    expect(reference_request_page.responses.values[6].text).to eq(
+    expect(reference_request_page.responses.values[9].text).to eq(
       I18n.t(
         "assessor_interface.reference_requests.edit.response_value.#{reference_request.satisfied_response}",
       ),
     )
-    expect(reference_request_page.responses.values[7].text).to eq(
+    expect(reference_request_page.responses.values[10].text).to eq(
       reference_request.additional_information_response,
     )
   end
@@ -133,15 +138,27 @@ RSpec.describe "Assessor verifying references", type: :system do
       begin
         application_form =
           create(:application_form, :waiting_on, received_reference: true)
-        create(:work_history, :completed, application_form:)
+        create(
+          :work_history,
+          :completed,
+          application_form:,
+          contact_name: "John Smith",
+          contact_job: "Headteacher",
+        )
         assessment =
           create(
             :assessment,
             :with_received_professional_standing_request,
-            :with_received_reference_request,
             application_form:,
           )
         create(:assessment_section, :passed, assessment:)
+        create(
+          :reference_request,
+          :received,
+          :responses_valid,
+          assessment:,
+          work_history: assessment.application_form.work_histories.first,
+        )
         application_form
       end
   end

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -115,47 +115,48 @@ RSpec.describe "Teacher reference", type: :system do
     expect(summary_list.rows[1].key.text).to eq("Your job title")
     expect(summary_list.rows[1].value.text).to eq("Headteacher")
 
-    expect(summary_list.rows[2].key.text).to eq(
-      "Did the applicant work at School from 1 January 2020 to 1 January 2023?",
-    )
+    expect(summary_list.rows[2].key.text).to eq("Are these details correct?")
     expect(summary_list.rows[2].value.text).to eq("Yes")
 
     expect(summary_list.rows[3].key.text).to eq(
-      "Did the applicant normally work more than 30 hours per week in this role?",
+      "Did the applicant work at School from 1 January 2020 to 1 January 2023?",
     )
     expect(summary_list.rows[3].value.text).to eq("Yes")
 
     expect(summary_list.rows[4].key.text).to eq(
-      "Did the applicant work unsupervised with children aged somewhere between 5 and 16 years?",
+      "Did the applicant normally work more than 30 hours per week in this role?",
     )
     expect(summary_list.rows[4].value.text).to eq("Yes")
 
     expect(summary_list.rows[5].key.text).to eq(
-      "Was the applicant solely responsible for planning, preparing and delivering lessons" \
-        " to at least 4 students at a time?",
+      "Did the applicant teach children aged somewhere between 5 and 16 years?",
     )
     expect(summary_list.rows[5].value.text).to eq("Yes")
 
     expect(summary_list.rows[6].key.text).to eq(
-      "Was the applicant solely responsible for assessing and reporting on the progress of" \
-        " the students?",
+      "Did the applicant plan, prepare and deliver lessons to a class of at least 4 students?",
     )
     expect(summary_list.rows[6].value.text).to eq("Yes")
 
     expect(summary_list.rows[7].key.text).to eq(
-      "Do you know of any professional misconduct by the applicant, or any disciplinary action taken against them?",
+      "Was the applicant responsible for assessing and reporting on the progress of the students?",
     )
-    expect(summary_list.rows[7].value.text).to eq("No")
+    expect(summary_list.rows[7].value.text).to eq("Yes")
 
     expect(summary_list.rows[8].key.text).to eq(
-      "Are you satisfied that the applicant is suitable to work with children?",
+      "Do you know of any professional misconduct by the applicant, or any disciplinary action taken against them?",
     )
-    expect(summary_list.rows[8].value.text).to eq("Yes")
+    expect(summary_list.rows[8].value.text).to eq("No")
 
     expect(summary_list.rows[9].key.text).to eq(
+      "Are you satisfied that the applicant is suitable to work with children?",
+    )
+    expect(summary_list.rows[9].value.text).to eq("Yes")
+
+    expect(summary_list.rows[10].key.text).to eq(
       "Do you have any other concerns about this applicant? (optional)",
     )
-    expect(summary_list.rows[9].value.text).to eq("Some information.")
+    expect(summary_list.rows[10].value.text).to eq("Some information.")
   end
 
   def when_i_submit_the_response

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe "Teacher reference", type: :system do
     then_i_see_the(:teacher_edit_reference_request_reports_page, slug:)
 
     when_i_choose_yes_for_reports
+    then_i_see_the(:teacher_edit_reference_request_misconduct_page, slug:)
+
+    when_i_choose_no_for_misconduct
+    then_i_see_the(:teacher_edit_reference_request_satisfied_page, slug:)
+
+    when_i_choose_yes_for_satisfied
     then_i_see_the(
       :teacher_edit_reference_request_additional_information_page,
       slug:,
@@ -77,6 +83,14 @@ RSpec.describe "Teacher reference", type: :system do
     teacher_edit_reference_request_reports_page.submit_yes
   end
 
+  def when_i_choose_no_for_misconduct
+    teacher_edit_reference_request_misconduct_page.submit_no
+  end
+
+  def when_i_choose_yes_for_satisfied
+    teacher_edit_reference_request_satisfied_page.submit_yes
+  end
+
   def when_i_fill_in_additional_information
     teacher_edit_reference_request_additional_information_page.submit(
       additional_information: "Some information.",
@@ -89,7 +103,7 @@ RSpec.describe "Teacher reference", type: :system do
     expect(summary_list).to be_visible
 
     expect(summary_list.rows[0].key.text).to eq(
-      "Did the applicant work at the school for the dates they provided?",
+      "Did the applicant work at School from 1 January 2020 to 1 January 2023?",
     )
     expect(summary_list.rows[0].value.text).to eq("Yes")
 
@@ -116,9 +130,19 @@ RSpec.describe "Teacher reference", type: :system do
     expect(summary_list.rows[4].value.text).to eq("Yes")
 
     expect(summary_list.rows[5].key.text).to eq(
+      "Do you know of any professional misconduct by the applicant, or any disciplinary action taken against them?",
+    )
+    expect(summary_list.rows[5].value.text).to eq("No")
+
+    expect(summary_list.rows[6].key.text).to eq(
+      "Are you satisfied that the applicant is suitable to work with children?",
+    )
+    expect(summary_list.rows[6].value.text).to eq("Yes")
+
+    expect(summary_list.rows[7].key.text).to eq(
       "Is there anything else you’d like to tell us about this applicant?",
     )
-    expect(summary_list.rows[5].value.text).to eq("Some information.")
+    expect(summary_list.rows[7].value.text).to eq("Some information.")
   end
 
   def when_i_submit_the_response

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe "Teacher reference", type: :system do
     and_i_see_the_work_history_details
 
     when_i_click_start_now
+    then_i_see_the(:teacher_edit_reference_request_contact_page, slug:)
+
+    when_i_choose_yes_for_contact
     then_i_see_the(:teacher_edit_reference_request_dates_page, slug:)
 
     when_i_choose_yes_for_dates
@@ -63,6 +66,10 @@ RSpec.describe "Teacher reference", type: :system do
     teacher_reference_requested_page.start_button.click
   end
 
+  def when_i_choose_yes_for_contact
+    teacher_edit_reference_request_contact_page.submit_yes
+  end
+
   def when_i_choose_yes_for_dates
     teacher_edit_reference_request_dates_page.submit_yes
   end
@@ -102,47 +109,53 @@ RSpec.describe "Teacher reference", type: :system do
 
     expect(summary_list).to be_visible
 
-    expect(summary_list.rows[0].key.text).to eq(
-      "Did the applicant work at School from 1 January 2020 to 1 January 2023?",
-    )
-    expect(summary_list.rows[0].value.text).to eq("Yes")
+    expect(summary_list.rows[0].key.text).to eq("Your full name")
+    expect(summary_list.rows[0].value.text).to eq("John Smith")
 
-    expect(summary_list.rows[1].key.text).to eq(
-      "Did the applicant normally work more than 30 hours per week in this role?",
-    )
-    expect(summary_list.rows[1].value.text).to eq("Yes")
+    expect(summary_list.rows[1].key.text).to eq("Your job title")
+    expect(summary_list.rows[1].value.text).to eq("Headteacher")
 
     expect(summary_list.rows[2].key.text).to eq(
-      "Did the applicant work unsupervised with children aged somewhere between 5 and 16 years?",
+      "Did the applicant work at School from 1 January 2020 to 1 January 2023?",
     )
     expect(summary_list.rows[2].value.text).to eq("Yes")
 
     expect(summary_list.rows[3].key.text).to eq(
-      "Was the applicant solely responsible for planning, preparing and delivering lessons" \
-        " to at least 4 students at a time?",
+      "Did the applicant normally work more than 30 hours per week in this role?",
     )
     expect(summary_list.rows[3].value.text).to eq("Yes")
 
     expect(summary_list.rows[4].key.text).to eq(
-      "Was the applicant solely responsible for assessing and reporting on the progress of" \
-        " the students?",
+      "Did the applicant work unsupervised with children aged somewhere between 5 and 16 years?",
     )
     expect(summary_list.rows[4].value.text).to eq("Yes")
 
     expect(summary_list.rows[5].key.text).to eq(
-      "Do you know of any professional misconduct by the applicant, or any disciplinary action taken against them?",
+      "Was the applicant solely responsible for planning, preparing and delivering lessons" \
+        " to at least 4 students at a time?",
     )
-    expect(summary_list.rows[5].value.text).to eq("No")
+    expect(summary_list.rows[5].value.text).to eq("Yes")
 
     expect(summary_list.rows[6].key.text).to eq(
-      "Are you satisfied that the applicant is suitable to work with children?",
+      "Was the applicant solely responsible for assessing and reporting on the progress of" \
+        " the students?",
     )
     expect(summary_list.rows[6].value.text).to eq("Yes")
 
     expect(summary_list.rows[7].key.text).to eq(
+      "Do you know of any professional misconduct by the applicant, or any disciplinary action taken against them?",
+    )
+    expect(summary_list.rows[7].value.text).to eq("No")
+
+    expect(summary_list.rows[8].key.text).to eq(
+      "Are you satisfied that the applicant is suitable to work with children?",
+    )
+    expect(summary_list.rows[8].value.text).to eq("Yes")
+
+    expect(summary_list.rows[9].key.text).to eq(
       "Is there anything else you’d like to tell us about this applicant?",
     )
-    expect(summary_list.rows[7].value.text).to eq("Some information.")
+    expect(summary_list.rows[9].value.text).to eq("Some information.")
   end
 
   def when_i_submit_the_response
@@ -159,7 +172,13 @@ RSpec.describe "Teacher reference", type: :system do
         :reference_request,
         :requested,
         work_history:
-          create(:work_history, :completed, end_date: Date.new(2023, 1, 1)),
+          create(
+            :work_history,
+            :completed,
+            end_date: Date.new(2023, 1, 1),
+            contact_name: "John Smith",
+            contact_job: "Headteacher",
+          ),
       )
   end
 

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe "Teacher reference", type: :system do
     expect(summary_list.rows[8].value.text).to eq("Yes")
 
     expect(summary_list.rows[9].key.text).to eq(
-      "Is there anything else you’d like to tell us about this applicant?",
+      "Do you have any other concerns about this applicant? (optional)",
     )
     expect(summary_list.rows[9].value.text).to eq("Some information.")
   end


### PR DESCRIPTION
This improves the reference request flow according to the designs by adding additional comments to each question, and a question asking about the contact information of the referee.

## Screenshots

![Screenshot 2023-02-22 at 10 51 57](https://user-images.githubusercontent.com/510498/220599456-9236f894-29ec-422e-810e-7e7d4e197705.png)
![Screenshot 2023-02-22 at 10 52 00](https://user-images.githubusercontent.com/510498/220599463-d18c4e69-be84-4c7c-a78d-057258806815.png)
![Screenshot 2023-02-22 at 10 52 13](https://user-images.githubusercontent.com/510498/220599467-4e036e1f-00d0-47e3-88df-9869b90557da.png)
![Screenshot 2023-02-22 at 10 52 16](https://user-images.githubusercontent.com/510498/220599471-c0ea4529-28fb-4eaf-b29c-e69172bcd4ab.png)
![Screenshot 2023-02-22 at 11 02 26](https://user-images.githubusercontent.com/510498/220601839-868773bd-d1bf-49b1-aabb-8080673c46ad.png)
