### PR TITLE
Move database backup job

### DIFF
--- a/.github/workflows/database-backup.yml
+++ b/.github/workflows/database-backup.yml
@@ -2,8 +2,8 @@ name: Backup Database to Azure Storage
 
 on:
   workflow_dispatch:
-  schedule: # 01:00 UTC
-    - cron: "0 1 * * *"
+  schedule:
+    - cron: "0 4 * * *" # 04:00 UTC
 
 jobs:
   backup:


### PR DESCRIPTION
This moves the database backup job to a later in the morning to prevent conflicts with [various overnight jobs](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/config/schedule.yml). This should resolve a couple of Sentry issues:

- https://dfe-teacher-services.sentry.io/issues/3951206134/
- https://dfe-teacher-services.sentry.io/issues/3854703866/