### PR TITLE
Change reference request assessor flow buttons

### DIFF
--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -83,11 +83,11 @@ en:
         heading: Request work history references
       preview_referee:
         heading: Check and send the reference request email
-        button: Send email to referee
+        button: Continue
         cancel: Cancel
       preview_teacher:
         heading: Check and send the email to applicant
-        button: Send email to applicant
+        button: Send emails
         cancel: Cancel
 
     assessment_sections:


### PR DESCRIPTION
This updates the content to be clear that the emails are only sent at the end.