### PR TITLE
Ensure link to verify references is always enabled

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -103,12 +103,10 @@ class AssessorInterface::ApplicationFormsShowViewObject
           qualification_request,
         )
       when :reference_requests
-        if application_form.received_reference
-          url_helpers.assessor_interface_application_form_assessment_verify_references_path(
-            application_form,
-            assessment,
-          )
-        end
+        url_helpers.assessor_interface_application_form_assessment_verify_references_path(
+          application_form,
+          assessment,
+        )
       end
     end
   end

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -218,7 +218,13 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
 
       context "with reference requests item" do
         let(:item) { :reference_requests }
-        it { is_expected.to be_nil }
+
+        it do
+          is_expected.to eq(
+            "/assessor/applications/#{application_form.id}/assessments/#{assessment.id}" \
+              "/verify-references",
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
There's no need to prevent it from being accessed, because we will limit the individual forms and an assessor can check what they're waiting for.