### PR TITLE
Change references_verified to be nullable

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -10,7 +10,7 @@
 #  recommendation                            :string           default("unknown"), not null
 #  recommendation_assessor_note              :text             default(""), not null
 #  recommended_at                            :datetime
-#  references_verified                       :boolean          default(FALSE), not null
+#  references_verified                       :boolean
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null

--- a/db/migrate/20230224141607_change_assessment_references_verified.rb
+++ b/db/migrate/20230224141607_change_assessment_references_verified.rb
@@ -1,0 +1,9 @@
+class ChangeAssessmentReferencesVerified < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :assessments, :references_verified, true
+    change_column_default :assessments,
+                          :references_verified,
+                          from: false,
+                          to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_21_111216) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_24_141607) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -138,7 +138,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_21_111216) do
     t.integer "working_days_since_started"
     t.boolean "induction_required"
     t.text "recommendation_assessor_note", default: "", null: false
-    t.boolean "references_verified", default: false, null: false
+    t.boolean "references_verified"
     t.index ["application_form_id"], name: "index_assessments_on_application_form_id"
   end
 

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -10,7 +10,7 @@
 #  recommendation                            :string           default("unknown"), not null
 #  recommendation_assessor_note              :text             default(""), not null
 #  recommended_at                            :datetime
-#  references_verified                       :boolean          default(FALSE), not null
+#  references_verified                       :boolean
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null

--- a/spec/forms/assessor_interface/verify_references_form_spec.rb
+++ b/spec/forms/assessor_interface/verify_references_form_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe AssessorInterface::VerifyReferencesForm, type: :model do
 
       it "updates ApplicationForm#verify_references_status" do
         expect { form.save }.to change(assessment, :references_verified).from(
-          false,
+          nil,
         ).to(true)
       end
     end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -12,7 +12,7 @@
 #  recommendation                            :string           default("unknown"), not null
 #  recommendation_assessor_note              :text             default(""), not null
 #  recommended_at                            :datetime
-#  references_verified                       :boolean          default(FALSE), not null
+#  references_verified                       :boolean
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null


### PR DESCRIPTION
This is what it should be before an assessor has explicitly selected an option, so we can leave it as blank, and show their previous selection if it's not.