### PR TITLE
Improve verify references task item status

### DIFF
--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -120,7 +120,7 @@ class ApplicationFormStatusUpdater
   end
 
   def waiting_on?(requestables:)
-    requestables.any?(&:requested?)
+    requestables.any?(&:requested?) || requestables.any?(&:expired?)
   end
 
   def received?(requestables:)

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -30,6 +30,10 @@ module Requestable
     update!(passed:, reviewed_at: Time.zone.now)
   end
 
+  def reviewed?
+    passed != nil
+  end
+
   def failed
     return nil if passed.nil?
     passed == false

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -103,10 +103,13 @@ class AssessorInterface::ApplicationFormsShowViewObject
           qualification_request,
         )
       when :reference_requests
-        url_helpers.assessor_interface_application_form_assessment_verify_references_path(
-          application_form,
-          assessment,
-        )
+        if application_form.received_reference ||
+             application_form.waiting_on_reference
+          url_helpers.assessor_interface_application_form_assessment_verify_references_path(
+            application_form,
+            assessment,
+          )
+        end
       end
     end
   end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -136,7 +136,19 @@ class AssessorInterface::ApplicationFormsShowViewObject
       case item
       when :reference_requests
         return :completed if assessment.references_verified
-        application_form.received_reference ? :received : :waiting_on
+
+        if application_form.received_reference &&
+             application_form.waiting_on_reference
+          unreviewed_requests =
+            reference_requests.filter(&:received?).reject(&:reviewed?)
+          unreviewed_requests.empty? ? :waiting_on : :received
+        elsif application_form.received_reference
+          :received
+        elsif application_form.waiting_on_reference
+          :waiting_on
+        else
+          :cannot_start
+        end
       when :qualification_requests
         application_form.received_qualification ? :received : :waiting_on
       when :assessment_recommendation

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -219,6 +219,11 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       context "with reference requests item" do
         let(:item) { :reference_requests }
 
+        before do
+          create(:reference_request, :requested, assessment:)
+          application_form.update!(waiting_on_reference: true)
+        end
+
         it do
           is_expected.to eq(
             "/assessor/applications/#{application_form.id}/assessments/#{assessment.id}" \


### PR DESCRIPTION
This makes a few changes to the statuses around reference requests as requested by our designers following a review of how it works.