### PR TITLE
Prevent reviewing a reference request which hasn't been received

### DIFF
--- a/app/services/review_requestable.rb
+++ b/app/services/review_requestable.rb
@@ -11,6 +11,8 @@ class ReviewRequestable
   end
 
   def call
+    raise NotReceived unless requestable.received?
+
     ActiveRecord::Base.transaction do
       requestable.assign_attributes(attributes)
       requestable.reviewed!(passed)
@@ -20,6 +22,9 @@ class ReviewRequestable
 
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end
+  end
+
+  class NotReceived < StandardError
   end
 
   private

--- a/app/views/assessor_interface/reference_requests/edit.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit.html.erb
@@ -1,13 +1,16 @@
-<% work_history = @reference_request.work_history %>
-
-<h1 class="govuk-heading-xl"><%= t("assessor_interface.reference_requests.edit.title") %></h1>
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t(".title")}" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@form.application_form) %>
 
 <%= form_with(
-  model: @form,
-  url: [:assessor_interface, @form.application_form, @form.assessment, @reference_request],
-  method: :put
-) do |f| %>
+      model: @form,
+      url: [:assessor_interface, @form.application_form, @form.assessment, @reference_request],
+      method: :put
+    ) do |f| %>
   <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
+
+  <% work_history = @reference_request.work_history %>
 
   <table class="govuk-table">
     <caption class="govuk-table__caption govuk-table__caption--m">Reference details</caption>
@@ -27,28 +30,16 @@
     </tbody>
   </table>
 
-  <%= render "shared/reference_request_summary", reference_request: @reference_request, changeable: false %>
+  <% if @reference_request.received? %>
+    <%= render "shared/reference_request_summary", reference_request: @reference_request, changeable: false %>
 
-  <%= f.govuk_radio_buttons_fieldset(
-    :passed,
-    legend: {
-      text: "Are you satisfied that this reference should count towards the applicant’s work experience?",
-      size: "s"
-    }) do %>
-    <%= f.govuk_radio_button(
-        :passed,
-        :true,
-        link_errors: true,
-        label: { text: "Yes" },
-      ) %>
-    <%= f.govuk_radio_button(
-      :passed,
-      :false,
-      label: { text: "No" },
-    ) %>
-  <% end %>
+    <%= f.govuk_radio_buttons_fieldset :passed, legend: { size: "s" } do %>
+      <%= f.govuk_radio_button :passed, :true, link_errors: true, label: { text: "Yes" } %>
+      <%= f.govuk_radio_button :passed, :false, label: { text: "No" } %>
+    <% end %>
 
-  <%= f.govuk_submit prevent_double_click: false do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @form.application_form] %>
+    <%= f.govuk_submit do %>
+      <%= govuk_link_to "Cancel", [:assessor_interface, @form.application_form] %>
+    <% end %>
   <% end %>
 <% end %>

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -82,6 +82,10 @@ en:
           true: "Yes"
           false: "No"
         failure_assessor_note: Explain why this section is not completed to your satisfaction
+      assessor_interface_requestable_form:
+        passed_options:
+          true: "Yes"
+          false: "No"
       assessor_interface_requestable_location_form:
         received:
           professional_standing_request: The letter of professional standing has been received.
@@ -230,6 +234,8 @@ en:
         submitted_at_before: End date
       assessor_interface_further_information_request_form:
         passed: Has the applicant completed this section to your satisfaction?
+      assessor_interface_requestable_form:
+        passed: Are you satisfied that this reference should count towards the applicant’s work experience?
       assessor_interface_work_history_reference_request_form:
         work_history_ids: School
       eligibility_interface_region_form:

--- a/spec/forms/assessor_interface/further_information_request_form_spec.rb
+++ b/spec/forms/assessor_interface/further_information_request_form_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 RSpec.describe AssessorInterface::FurtherInformationRequestForm, type: :model do
-  let(:further_information_request) { create(:further_information_request) }
+  let(:further_information_request) do
+    create(:further_information_request, :received)
+  end
   let(:user) { create(:staff, :confirmed) }
   let(:attributes) { {} }
 

--- a/spec/services/review_requestable_spec.rb
+++ b/spec/services/review_requestable_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe ReviewRequestable do
-  let(:requestable) { create(:further_information_request) }
+  let(:requestable) { create(:further_information_request, :received) }
   let(:user) { create(:staff) }
   let(:passed) { true }
 
@@ -27,5 +27,21 @@ RSpec.describe ReviewRequestable do
       creator: user,
       requestable:,
     )
+  end
+
+  context "with a requested requestabled" do
+    let(:requestable) { create(:reference_request, :requested) }
+
+    it "raises an error" do
+      expect { call }.to raise_error(ReviewRequestable::NotReceived)
+    end
+  end
+
+  context "with an expired requestabled" do
+    let(:requestable) { create(:qualification_request, :expired) }
+
+    it "raises an error" do
+      expect { call }.to raise_error(ReviewRequestable::NotReceived)
+    end
   end
 end


### PR DESCRIPTION
This updates the reference request review flow to prevent reviewing the request if it hasn't yet been received.

[Trello Card](https://trello.com/c/PReQJDj0/1633-reference-request-form-showing-when-waiting-on)