### PR TITLE
Hide original contact name to referees

### DIFF
--- a/app/views/shared/_reference_request_summary.html.erb
+++ b/app/views/shared/_reference_request_summary.html.erb
@@ -5,26 +5,25 @@
   model: reference_request,
   title: "Reference requested",
   fields: {
-    original_contact_name: {
+    original_contact_name: !changeable ? {
       title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_name"),
       value: work_history.contact_name,
-    },
-    original_contact_job: {
+    } : nil,
+    original_contact_job: !changeable ? {
       title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_job"),
       value: work_history.contact_job,
-    },
-    contact_response: {
+    } : nil,
+    contact_response: !changeable ? {
       title: t("helpers.legend.teacher_interface_reference_request_contact_response_form.contact_response"),
-      href: contact_teacher_interface_reference_request_path(reference_request.slug),
-    },
-    contact_name: reference_request.contact_response ? nil : {
+    } : nil,
+    contact_name: reference_request.contact_response && !changeable ? nil : {
       title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_name"),
-      value: reference_request.contact_name.presence,
+      value: reference_request.contact_name.presence || work_history.contact_name,
       href: contact_teacher_interface_reference_request_path(reference_request.slug),
     },
-    contact_job: reference_request.contact_response ? nil : {
+    contact_job: reference_request.contact_response && !changeable ? nil : {
       title: t("helpers.label.teacher_interface_reference_request_contact_response_form.contact_job"),
-      value: reference_request.contact_job.presence,
+      value: reference_request.contact_job.presence || work_history.contact_job,
       href: contact_teacher_interface_reference_request_path(reference_request.slug),
     },
     contact_comment: reference_request.contact_response ? nil : {

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -115,48 +115,45 @@ RSpec.describe "Teacher reference", type: :system do
     expect(summary_list.rows[1].key.text).to eq("Your job title")
     expect(summary_list.rows[1].value.text).to eq("Headteacher")
 
-    expect(summary_list.rows[2].key.text).to eq("Are these details correct?")
+    expect(summary_list.rows[2].key.text).to eq(
+      "Did the applicant work at School from January 2020 to January 2023?",
+    )
     expect(summary_list.rows[2].value.text).to eq("Yes")
 
     expect(summary_list.rows[3].key.text).to eq(
-      "Did the applicant work at School from January 2020 to January 2023?",
+      "Did the applicant normally work approximately 30 hours per week in this role?",
     )
     expect(summary_list.rows[3].value.text).to eq("Yes")
 
     expect(summary_list.rows[4].key.text).to eq(
-      "Did the applicant normally work approximately 30 hours per week in this role?",
+      "Did the applicant teach children aged somewhere between 5 and 16 years?",
     )
     expect(summary_list.rows[4].value.text).to eq("Yes")
 
     expect(summary_list.rows[5].key.text).to eq(
-      "Did the applicant teach children aged somewhere between 5 and 16 years?",
+      "Did the applicant plan, prepare and deliver lessons to a class of at least 4 students?",
     )
     expect(summary_list.rows[5].value.text).to eq("Yes")
 
     expect(summary_list.rows[6].key.text).to eq(
-      "Did the applicant plan, prepare and deliver lessons to a class of at least 4 students?",
+      "Was the applicant responsible for assessing and reporting on the progress of the students?",
     )
     expect(summary_list.rows[6].value.text).to eq("Yes")
 
     expect(summary_list.rows[7].key.text).to eq(
-      "Was the applicant responsible for assessing and reporting on the progress of the students?",
-    )
-    expect(summary_list.rows[7].value.text).to eq("Yes")
-
-    expect(summary_list.rows[8].key.text).to eq(
       "Do you know of any professional misconduct by the applicant, or any disciplinary action taken against them?",
     )
-    expect(summary_list.rows[8].value.text).to eq("No")
+    expect(summary_list.rows[7].value.text).to eq("No")
 
-    expect(summary_list.rows[9].key.text).to eq(
+    expect(summary_list.rows[8].key.text).to eq(
       "Are you satisfied that the applicant is suitable to work with children?",
     )
-    expect(summary_list.rows[9].value.text).to eq("Yes")
+    expect(summary_list.rows[8].value.text).to eq("Yes")
 
-    expect(summary_list.rows[10].key.text).to eq(
+    expect(summary_list.rows[9].key.text).to eq(
       "Do you have any other concerns about this applicant? (optional)",
     )
-    expect(summary_list.rows[10].value.text).to eq("Some information.")
+    expect(summary_list.rows[9].value.text).to eq("Some information.")
   end
 
   def when_i_submit_the_response


### PR DESCRIPTION
If the referee has chosen to change the name on the work history, there's no need to show them the original name, since they've told us who they are.

[Trello Card](https://trello.com/c/s5I54WzR/1630-show-referee-their-correct-name)