### PR TITLE
Reminder notifications for outstanding references

### DIFF
--- a/app/jobs/send_reference_request_reminder_job.rb
+++ b/app/jobs/send_reference_request_reminder_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SendReferenceRequestReminderJob < ApplicationJob
+  def perform(reference_request:)
+    ReferenceRequestReminder.call(reference_request:)
+  end
+end

--- a/app/jobs/send_reference_request_reminders_job.rb
+++ b/app/jobs/send_reference_request_reminders_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class SendReferenceRequestRemindersJob < ApplicationJob
+  def perform
+    ReferenceRequest.requested.find_each do |reference_request|
+      SendReferenceRequestReminderJob.perform_later(reference_request:)
+    end
+  end
+end

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -27,7 +27,7 @@ class FurtherInformationRequest < ApplicationRecord
            inverse_of: :further_information_request,
            dependent: :destroy
 
-  has_many :reminder_emails
+  has_many :reminder_emails, as: :requestable
 
   FOUR_WEEK_COUNTRY_CODES = %w[AU CA GI NZ US].freeze
 

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -52,6 +52,7 @@ class ReferenceRequest < ApplicationRecord
   has_secure_token :slug
 
   belongs_to :work_history
+  has_many :reminder_emails, as: :requestable
 
   with_options if: :received? do
     validates :contact_response, inclusion: [true, false]

--- a/app/models/reminder_email.rb
+++ b/app/models/reminder_email.rb
@@ -4,19 +4,16 @@
 #
 # Table name: reminder_emails
 #
-#  id                             :bigint           not null, primary key
-#  created_at                     :datetime         not null
-#  updated_at                     :datetime         not null
-#  further_information_request_id :bigint           not null
+#  id               :bigint           not null, primary key
+#  requestable_type :string           default(""), not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  requestable_id   :bigint           not null
 #
 # Indexes
 #
-#  index_reminder_emails_on_further_information_request_id  (further_information_request_id)
-#
-# Foreign Keys
-#
-#  fk_rails_...  (further_information_request_id => further_information_requests.id)
+#  index_reminder_emails_on_requestable_type_and_requestable_id  (requestable_type,requestable_id)
 #
 class ReminderEmail < ApplicationRecord
-  belongs_to :further_information_request, inverse_of: :reminder_emails
+  belongs_to :requestable, inverse_of: :reminder_emails, polymorphic: true
 end

--- a/app/services/reference_request_reminder.rb
+++ b/app/services/reference_request_reminder.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class ReferenceRequestReminder
+  include ServicePattern
+
+  def initialize(reference_request:)
+    @reference_request = reference_request
+  end
+
+  def call
+    if send_reminder?
+      send_email
+      record_reminder
+    end
+  end
+
+  private
+
+  attr_reader :reference_request
+
+  delegate :application_form, :assessment, :expired_at, to: :reference_request
+
+  def send_reminder?
+    four_weeks? || two_weeks?
+  end
+
+  def number_of_reminders_sent
+    reference_request.reminder_emails.count
+  end
+
+  def days_until_expired
+    today = Time.zone.today
+    (expired_at.to_date - today).to_i
+  end
+
+  def four_weeks?
+    days_until_expired <= 28 && number_of_reminders_sent.zero?
+  end
+
+  def two_weeks?
+    days_until_expired <= 14 && number_of_reminders_sent.zero?
+  end
+
+  def send_email
+    RefereeMailer
+      .with(reference_request:, due_date: expired_at.to_date)
+      .reference_reminder
+      .deliver_later
+  end
+
+  def record_reminder
+    reference_request.reminder_emails.create!
+  end
+end

--- a/app/views/referee_mailer/reference_reminder.text.erb
+++ b/app/views/referee_mailer/reference_reminder.text.erb
@@ -2,7 +2,7 @@ Dear <%= @work_history.contact_name %>
 
 We still need you to confirm some information about <%= application_form_full_name(@application_form) %> as part of their application for qualified teacher status (QTS) in England.
 
-We recently contacted you to ask you to help us confirm that the information [Applicant name] has provided about their work history and experience is accurate.
+We recently contacted you to ask you to help us confirm that the information <%= application_form_full_name(@application_form) %> has provided about their work history and experience is accurate.
 
 Please follow the link below and answer the questions by <%= @reference_request.expired_at.to_date.to_fs(:long_ordinal_uk) %>. If we do not receive your response by this date, it could affect the outcome for the applicant.
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -286,7 +286,8 @@
     - id
     - created_at
     - updated_at
-    - further_information_request_id
+    - requestable_id
+    - requestable_type
   :selected_failure_reasons:
     - id
     - created_at

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -28,3 +28,7 @@ expire_reference_requests:
 send_further_information_request_reminders:
   cron: "0 3 * * *"
   class: SendFurtherInformationRequestRemindersJob
+
+send_reference_request_reminders:
+  cron: "30 3 * * *"
+  class: SendReferenceRequestRemindersJob

--- a/db/migrate/20230227152913_change_reminder_emails_to_polymorphic_association.rb
+++ b/db/migrate/20230227152913_change_reminder_emails_to_polymorphic_association.rb
@@ -1,0 +1,20 @@
+class ChangeReminderEmailsToPolymorphicAssociation < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    change_table :reminder_emails, bulk: true do |t|
+      t.remove_foreign_key :further_information_requests
+      t.remove_index [:further_information_request_id]
+      t.rename :further_information_request_id, :requestable_id
+      t.string :requestable_type,
+               null: false,
+               default: "FurtherInformationRequest"
+      t.index %i[requestable_type requestable_id]
+    end
+
+    change_column_default :reminder_emails,
+                          :requestable_type,
+                          from: "FurtherInformationRequest",
+                          to: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_27_101444) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_27_152913) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -84,9 +84,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_27_101444) do
     t.bigint "english_language_provider_id"
     t.text "english_language_provider_reference", default: "", null: false
     t.datetime "awarded_at"
-    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "written_statement_confirmation", default: false, null: false
+    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "english_language_provider_other", default: false, null: false
     t.datetime "declined_at"
     t.boolean "waiting_on_professional_standing", default: false, null: false
@@ -157,8 +157,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_27_101444) do
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "eligibility_enabled", default: true, null: false
-    t.boolean "eligibility_skip_questions", default: false, null: false
     t.text "qualifications_information", default: "", null: false
+    t.boolean "eligibility_skip_questions", default: false, null: false
     t.index ["code"], name: "index_countries_on_code", unique: true
   end
 
@@ -342,9 +342,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_27_101444) do
     t.string "teaching_authority_online_checker_url", default: "", null: false
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
+    t.text "qualifications_information", default: "", null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "application_form_skip_work_history", default: false, null: false
-    t.text "qualifications_information", default: "", null: false
     t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_requires_submission_email", default: false, null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
@@ -352,10 +352,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_27_101444) do
   end
 
   create_table "reminder_emails", force: :cascade do |t|
-    t.bigint "further_information_request_id", null: false
+    t.bigint "requestable_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["further_information_request_id"], name: "index_reminder_emails_on_further_information_request_id"
+    t.string "requestable_type", default: "", null: false
+    t.index ["requestable_type", "requestable_id"], name: "index_reminder_emails_on_requestable_type_and_requestable_id"
   end
 
   create_table "selected_failure_reasons", force: :cascade do |t|
@@ -510,7 +511,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_27_101444) do
   add_foreign_key "reference_requests", "assessments"
   add_foreign_key "reference_requests", "work_histories"
   add_foreign_key "regions", "countries"
-  add_foreign_key "reminder_emails", "further_information_requests"
   add_foreign_key "selected_failure_reasons", "assessment_sections"
   add_foreign_key "timeline_events", "application_forms"
   add_foreign_key "timeline_events", "assessment_sections"

--- a/spec/jobs/send_reference_request_reminder_job_spec.rb
+++ b/spec/jobs/send_reference_request_reminder_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SendReferenceRequestReminderJob do
+  describe "#perform" do
+    subject { described_class.new.perform(reference_request:) }
+
+    let(:reference_request) { build(:reference_request) }
+
+    it "calls the ReferenceRequestReminder" do
+      expect(ReferenceRequestReminder).to receive(:call).with(
+        reference_request:,
+      )
+      subject
+    end
+  end
+end

--- a/spec/jobs/send_reference_request_reminders_job_spec.rb
+++ b/spec/jobs/send_reference_request_reminders_job_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SendReferenceRequestRemindersJob do
+  describe "#perform" do
+    subject { described_class.new.perform }
+
+    let!(:received_reference_request) { create(:reference_request, :received) }
+    let!(:requested_reference_request) do
+      create(:reference_request, :requested)
+    end
+    let!(:expired_reference_request) { create(:reference_request, :expired) }
+
+    it "enqueues a job for each 'requested' reference request" do
+      expect(SendReferenceRequestReminderJob).to receive(:perform_later).with(
+        reference_request: requested_reference_request,
+      )
+      subject
+    end
+
+    it "doesn't enqueue a job for 'received' reference requests" do
+      expect(SendReferenceRequestReminderJob).not_to receive(
+        :perform_later,
+      ).with(reference_request: received_reference_request)
+      subject
+    end
+
+    it "doesn't enqueue a job for 'expired' reference requests" do
+      expect(SendReferenceRequestReminderJob).not_to receive(
+        :perform_later,
+      ).with(reference_request: received_reference_request)
+      subject
+    end
+  end
+end

--- a/spec/services/further_information_request_reminder_spec.rb
+++ b/spec/services/further_information_request_reminder_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe FurtherInformationRequestReminder do
     shared_examples_for "an FI request that triggers a reminder" do
       it "logs an email" do
         expect { subject }.to change {
-          ReminderEmail.where(further_information_request:).count
+          ReminderEmail.where(requestable: further_information_request).count
         }.by(1)
       end
 

--- a/spec/services/reference_request_reminder_spec.rb
+++ b/spec/services/reference_request_reminder_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReferenceRequestReminder do
+  describe ".call" do
+    subject { described_class.call(reference_request:) }
+
+    shared_examples_for "an ignored reference request" do
+      it "doesn't log any email" do
+        expect { subject }.not_to(change { ReminderEmail.count })
+      end
+
+      it "doesn't send any email" do
+        expect { subject }.to_not have_enqueued_mail(
+          RefereeMailer,
+          :reference_reminder,
+        )
+      end
+    end
+
+    shared_examples_for "a reference request that triggers a reminder" do
+      it "logs an email" do
+        expect { subject }.to change {
+          ReminderEmail.where(requestable: reference_request).count
+        }.by(1)
+      end
+
+      it "sends an email" do
+        expect { subject }.to have_enqueued_mail(
+          RefereeMailer,
+          :reference_reminder,
+        ).with(params: { reference_request:, due_date: }, args: [])
+      end
+    end
+
+    shared_examples_for "a reference request with less than four weeks remaining" do
+      context "when no previous reminder has been sent" do
+        it_behaves_like "a reference request that triggers a reminder"
+      end
+
+      context "when a previous reminder has been sent" do
+        before { reference_request.reminder_emails.create }
+
+        it_behaves_like "an ignored reference request"
+      end
+    end
+
+    shared_examples_for "a reference request with less than two weeks remaining" do
+      context "when no previous reminder has been sent" do
+        it_behaves_like "a reference request that triggers a reminder"
+      end
+
+      context "when a previous reminder has been sent" do
+        before { reference_request.reminder_emails.create }
+
+        it_behaves_like "an ignored reference request"
+      end
+    end
+
+    shared_examples_for "a request that is allowed 6 weeks to complete" do
+      context "with less than four weeks remaining" do
+        let(:reference_requested_at) { (6.weeks - 27.days).ago }
+
+        it_behaves_like "a reference request with less than four weeks remaining"
+      end
+
+      context "with less than two weeks remaining" do
+        let(:reference_requested_at) { (6.weeks - 13.days).ago }
+
+        it_behaves_like "a reference request with less than two weeks remaining"
+      end
+    end
+
+    context "with a requested reference request" do
+      let(:application_form) do
+        create(:application_form, :submitted, :old_regs, region:)
+      end
+      let(:assessment) { create(:assessment, application_form:) }
+      let(:region) { create(:region, :in_country, country_code: "FR") }
+      let(:work_history) { reference_request.work_history }
+
+      let(:reference_request) do
+        create(
+          :reference_request,
+          created_at: reference_requested_at,
+          assessment:,
+        )
+      end
+
+      context "that allows 6 weeks to complete" do
+        let(:due_date) { (reference_request.created_at + 6.weeks).to_date }
+
+        it_behaves_like "a request that is allowed 6 weeks to complete"
+      end
+    end
+
+    context "with a received reference request" do
+      let(:reference_request) { create(:reference_request, :received) }
+
+      it_behaves_like "an ignored reference request"
+    end
+
+    context "with an expired reference request" do
+      let(:reference_request) { create(:reference_request, :expired) }
+
+      it_behaves_like "an ignored reference request"
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/xTeS3ggL/1593-reminder-notifications-to-outstanding-references)

## Context

Referees have 6 weeks to provide references.
Reminders sent at frequency: 2 weeks and 4 weeks

## Changes

- Makes `ReminderEmail` use a polymorphic association to requestables (ie. `FurtherInformationRequest` and `ReferenceRequest`)
- Adds service class and job to send reference request reminders
- Schedules triggering of reference request reminder job
