### PR TITLE
Expire applications after 6 months

### DIFF
--- a/app/jobs/destroy_application_form_job.rb
+++ b/app/jobs/destroy_application_form_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DestroyApplicationFormJob < ApplicationJob
+  def perform(application_form)
+    DestroyApplicationForm.call(application_form:)
+  end
+end

--- a/app/jobs/destroy_application_forms_job.rb
+++ b/app/jobs/destroy_application_forms_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DestroyApplicationFormsJob < ApplicationJob
+  def perform
+    ApplicationForm.destroyable.find_each do |application_form|
+      DestroyApplicationFormJob.perform_later(application_form)
+    end
+  end
+end

--- a/app/jobs/expire_requestable_job.rb
+++ b/app/jobs/expire_requestable_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ExpireRequestableJob < ApplicationJob
-  def perform(requestable:)
+  def perform(requestable)
     ExpireRequestable.call(requestable:)
   end
 end

--- a/app/jobs/expire_requestables_job.rb
+++ b/app/jobs/expire_requestables_job.rb
@@ -3,7 +3,7 @@
 class ExpireRequestablesJob < ApplicationJob
   def perform(requestable_class_name)
     requestable_class_name.constantize.requested.find_each do |requestable|
-      ExpireRequestableJob.perform_later(requestable:)
+      ExpireRequestableJob.perform_later(requestable)
     end
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -162,6 +162,14 @@ class ApplicationForm < ApplicationRecord
           )
         }
 
+  scope :destroyable,
+        -> {
+          draft
+            .where("created_at < ?", 6.months.ago)
+            .or(awarded.where("awarded_at < ?", 5.years.ago))
+            .or(declined.where("declined_at < ?", 5.years.ago))
+        }
+
   def assign_reference
     return if reference.present?
 

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -2,6 +2,10 @@ trim_sessions_job:
   cron: "0 1 * * *"
   class: TrimSessionsJob
 
+destroy_application_forms:
+  cron: "15 1 * * *"
+  class: DestroyApplicationFormsJobs
+
 update_working_days_since_submission:
   cron: "30 1 * * *"
   class: UpdateWorkingDaysJob

--- a/spec/jobs/destroy_application_form_job_spec.rb
+++ b/spec/jobs/destroy_application_form_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DestroyApplicationFormJob do
+  describe "#perform" do
+    subject(:perform) { described_class.new.perform(application_form) }
+
+    let(:application_form) { build(:application_form) }
+
+    it "calls DestroyApplicationForm" do
+      expect(DestroyApplicationForm).to receive(:call).with(application_form:)
+
+      perform
+    end
+  end
+end

--- a/spec/jobs/destroy_application_forms_job_spec.rb
+++ b/spec/jobs/destroy_application_forms_job_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DestroyApplicationFormsJob, type: :job do
+  describe "#perform" do
+    subject(:perform) { described_class.new.perform }
+
+    let!(:draft_application_form) do
+      create(:application_form, :draft, created_at: 6.months.ago)
+    end
+    let!(:awarded_application_form) do
+      create(:application_form, :awarded, awarded_at: 5.years.ago)
+    end
+    let!(:declined_application_form) do
+      create(:application_form, :declined, declined_at: 5.years.ago)
+    end
+    let!(:submitted_application_form) { create(:application_form, :submitted) }
+
+    it "expires the draft application form" do
+      expect { perform }.to have_enqueued_job(DestroyApplicationFormJob).with(
+        draft_application_form,
+      )
+    end
+
+    it "expires the awarded application form" do
+      expect { perform }.to have_enqueued_job(DestroyApplicationFormJob).with(
+        awarded_application_form,
+      )
+    end
+
+    it "expires the declined application form" do
+      expect { perform }.to have_enqueued_job(DestroyApplicationFormJob).with(
+        declined_application_form,
+      )
+    end
+
+    it "doesn't expire the submitted application form" do
+      expect { perform }.to_not have_enqueued_job(
+        DestroyApplicationFormJob,
+      ).with(submitted_application_form)
+    end
+  end
+end

--- a/spec/jobs/expire_requestable_job_spec.rb
+++ b/spec/jobs/expire_requestable_job_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe ExpireRequestableJob do
   describe "#perform" do
-    subject(:perform) { described_class.new.perform(requestable:) }
+    subject(:perform) { described_class.new.perform(requestable) }
 
     let(:requestable) { build(:further_information_request) }
 

--- a/spec/jobs/expire_requestables_spec.rb
+++ b/spec/jobs/expire_requestables_spec.rb
@@ -5,31 +5,28 @@ require "rails_helper"
 RSpec.describe ExpireRequestablesJob, type: :job do
   shared_examples "a job which expires requestables" do |class_name, factory_name|
     describe "#perform" do
-      subject { described_class.new.perform(class_name) }
+      subject(:perform) { described_class.new.perform(class_name) }
 
       let!(:requested_requestable) { create(factory_name, :requested) }
       let!(:received_requestable) { create(factory_name, :received) }
       let!(:expired_requestable) { create(factory_name, :expired) }
 
       it "enqueues a job for each 'requested' #{class_name}s" do
-        expect(ExpireRequestableJob).to receive(:perform_later).with(
-          requestable: requested_requestable,
+        expect { perform }.to have_enqueued_job(ExpireRequestableJob).with(
+          requested_requestable,
         )
-        subject
       end
 
       it "doesn't enqueue a job for 'received' #{class_name}s" do
-        expect(ExpireRequestableJob).not_to receive(:perform_later).with(
-          requestable: received_requestable,
+        expect { perform }.to_not have_enqueued_job(ExpireRequestableJob).with(
+          received_requestable,
         )
-        subject
       end
 
       it "doesn't enqueue a job for 'expired' #{class_name}s" do
-        expect(ExpireRequestableJob).not_to receive(:perform_later).with(
-          requestable: expired_requestable,
+        expect { perform }.to_not have_enqueued_job(ExpireRequestableJob).with(
+          expired_requestable,
         )
-        subject
       end
     end
   end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -348,6 +348,68 @@ RSpec.describe ApplicationForm, type: :model do
         end
       end
     end
+
+    describe "#destroyable" do
+      subject(:destroyable) { described_class.destroyable }
+
+      it { is_expected.to be_empty }
+
+      context "draft" do
+        let!(:application_form) { create(:application_form, :draft) }
+
+        it { is_expected.to be_empty }
+
+        context "older than 6 months" do
+          let!(:application_form) do
+            create(:application_form, :draft, created_at: 6.months.ago)
+          end
+
+          it { is_expected.to include(application_form) }
+        end
+      end
+
+      context "submitted" do
+        let!(:application_form) { create(:application_form, :submitted) }
+
+        it { is_expected.to be_empty }
+
+        context "older than 90 days" do
+          let!(:application_form) do
+            create(:application_form, :submitted, created_at: 90.days.ago)
+          end
+
+          it { is_expected.to be_empty }
+        end
+      end
+
+      context "awarded" do
+        let!(:application_form) { create(:application_form, :awarded) }
+
+        it { is_expected.to be_empty }
+
+        context "older than 5 years" do
+          let!(:application_form) do
+            create(:application_form, :awarded, awarded_at: 5.years.ago)
+          end
+
+          it { is_expected.to include(application_form) }
+        end
+      end
+
+      context "declined" do
+        let!(:application_form) { create(:application_form, :declined) }
+
+        it { is_expected.to be_empty }
+
+        context "older than 5 years" do
+          let!(:application_form) do
+            create(:application_form, :declined, declined_at: 5.years.ago)
+          end
+
+          it { is_expected.to include(application_form) }
+        end
+      end
+    end
   end
 
   it "attaches empty documents" do


### PR DESCRIPTION
This adds functionality which automatically expires (and deletes) applications after 6 months if they're draft, and 5 years if they're awarded or declined.

[Trello Card](https://trello.com/c/LNxcvYTa/1602-expire-draft-applications-at-6-months)