### PR TITLE
Hide awarded or declined applications after 90 days

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -146,7 +146,21 @@ class ApplicationForm < ApplicationRecord
 
   STATUS_COLUMNS.each { |column| enum column, STATUS_VALUES, prefix: column }
 
-  scope :active, -> { not_draft }
+  scope :active,
+        -> {
+          where(
+            status: %i[
+              submitted
+              initial_assessment
+              waiting_on
+              received
+              awarded_pending_checks
+              potential_duplicate_in_dqt
+            ],
+          ).or(awarded.where("awarded_at >= ?", 90.days.ago)).or(
+            declined.where("declined_at >= ?", 90.days.ago),
+          )
+        }
 
   def assign_reference
     return if reference.present?

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe ApplicationForm, type: :model do
   end
 
   describe "scopes" do
-    describe ".active" do
+    describe "#active" do
       subject { described_class.active }
 
       context "draft" do
@@ -324,12 +324,28 @@ RSpec.describe ApplicationForm, type: :model do
         let!(:application_form) { create(:application_form, :awarded) }
 
         it { is_expected.to eq([application_form]) }
+
+        context "older than 90 days" do
+          let!(:application_form) do
+            create(:application_form, :awarded, awarded_at: 90.days.ago)
+          end
+
+          it { is_expected.to be_empty }
+        end
       end
 
       context "declined" do
         let!(:application_form) { create(:application_form, :declined) }
 
         it { is_expected.to eq([application_form]) }
+
+        context "older than 90 days" do
+          let!(:application_form) do
+            create(:application_form, :declined, declined_at: 90.days.ago)
+          end
+
+          it { is_expected.to be_empty }
+        end
       end
     end
   end


### PR DESCRIPTION
We want to reduce the number of applications shown to assessors after 90 days as the appeal window will have closed.