### PR TITLE
Helpful file upload error message

### DIFF
--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -18,6 +18,8 @@ module TeacherInterface
               unless: -> { document&.translatable? }
     validate :attachments_present
 
+    attr_reader :timeout_error
+
     def update_model
       if original_attachment.present?
         document.uploads.create!(
@@ -32,6 +34,13 @@ module TeacherInterface
           translation: true,
         )
       end
+    end
+
+    def save(validate:)
+      super(validate:)
+    rescue Timeout::Error
+      @timeout_error = true
+      false
     end
 
     delegate :application_form, to: :document

--- a/app/views/teacher_interface/uploads/_upload_timeout_error.html.erb
+++ b/app/views/teacher_interface/uploads/_upload_timeout_error.html.erb
@@ -1,0 +1,18 @@
+<div class="govuk-error-summary" data-module="govuk-error-summary">
+  <div role="alert">
+    <h2 class="govuk-error-summary__title">
+      There was a problem uploading your document
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li>
+          <a href="#teacher-interface-upload-form-original-attachment-field">Please try uploading it again.</a>
+        </li>
+        <li>
+          If you still experience this problem, email us at 
+          <%= govuk_link_to "QTS.Enquiries@education.gov.uk", "mailto:QTS.Enquiries@education.gov.uk" %>.
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/teacher_interface/uploads/_upload_timeout_error.html.erb
+++ b/app/views/teacher_interface/uploads/_upload_timeout_error.html.erb
@@ -10,7 +10,7 @@
         </li>
         <li>
           If you still experience this problem, email us at 
-          <%= govuk_link_to "QTS.Enquiries@education.gov.uk", "mailto:QTS.Enquiries@education.gov.uk" %>.
+          <%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %>
         </li>
       </ul>
     </div>

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -1,6 +1,8 @@
 <% content_for :page_title, "#{"Error: " if @upload_form.errors.any?}Upload a document" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
+<%= render "upload_timeout_error" if @upload_form.timeout_error %>
+
 <% if @document.uploads.empty? %>
   <% if @document.identification? %>
     <h1 class="govuk-heading-l">Upload a valid identification document</h1>

--- a/spec/forms/teacher_interface/upload_form_spec.rb
+++ b/spec/forms/teacher_interface/upload_form_spec.rb
@@ -121,5 +121,20 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
         expect(document.uploads.second.translation).to be(true)
       end
     end
+
+    context "when Net::ReadTimeout is raised" do
+      let(:original_attachment) do
+        fixture_file_upload("upload.pdf", "application/pdf")
+      end
+
+      before do
+        allow(upload_form).to receive(:update_model).and_raise(Net::ReadTimeout)
+      end
+
+      it "sets the timeout_error attribute" do
+        expect(upload_form.save(validate: true)).to be false
+        expect(upload_form.timeout_error).to be true
+      end
+    end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/5LbGY5ax/1639-helpful-file-upload-error-message)

When a file upload times out the user currently sees a 500 page, we should make the error more user friendly and make it easier for them to re-attempt the upload as this is often an intermittent problem.

Rescue `Timeout::Error` in the upload form and render an explanation of the problem on the form.

![image](https://user-images.githubusercontent.com/93511/222102145-a24458ad-c5cf-4669-8ae7-17fcc11dac6a.png)
