### PR TITLE
Send professional standing received emails to teachers

### DIFF
--- a/app/forms/assessor_interface/requestable_location_form.rb
+++ b/app/forms/assessor_interface/requestable_location_form.rb
@@ -19,14 +19,12 @@ class AssessorInterface::RequestableLocationForm
       requestable.location_note = location_note
 
       if received.present? && !requestable.received?
-        receive_professional_standing
+        ReceiveRequestable.call(requestable:, user:)
       elsif received.blank? && requestable.received?
-        request_professional_standing
+        request_requestable
       else
         requestable.save!
       end
-
-      ApplicationFormStatusUpdater.call(application_form:, user:)
     end
 
     true
@@ -36,20 +34,9 @@ class AssessorInterface::RequestableLocationForm
 
   private
 
-  def receive_professional_standing
-    requestable.received!
-
-    TimelineEvent.create!(
-      event_type: "requestable_received",
-      application_form:,
-      creator: user,
-      requestable:,
-    )
-  end
-
-  def request_professional_standing
+  def request_requestable
     requestable.requested!
-
     TimelineEvent.requestable_received.where(requestable:).destroy_all
+    ApplicationFormStatusUpdater.call(application_form:, user:)
   end
 end

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 class TeacherMailer < ApplicationMailer
+  include RegionHelper
+
   before_action :set_application_form
   before_action :set_further_information_request,
                 only: :further_information_reminder
   before_action :set_further_information_requested, only: :application_declined
 
-  helper :application_form
+  helper :application_form, :region
 
   def application_awarded
     view_mail(
@@ -69,6 +71,18 @@ class TeacherMailer < ApplicationMailer
     )
   end
 
+  def professional_standing_received
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: teacher.email,
+      subject:
+        I18n.t(
+          "mailer.teacher.professional_standing_received.subject",
+          certificate: region_certificate_name(region),
+        ),
+    )
+  end
+
   def references_requested
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
@@ -84,7 +98,7 @@ class TeacherMailer < ApplicationMailer
   end
 
   delegate :application_form, to: :teacher
-  delegate :assessment, to: :application_form
+  delegate :assessment, :region, to: :application_form
 
   def set_application_form
     @application_form = application_form

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -33,7 +33,13 @@ class ProfessionalStandingRequest < ApplicationRecord
     18.weeks # 90 working days
   end
 
+  def after_received(*)
+    TeacherMailer.with(teacher:).professional_standing_received.deliver_later
+  end
+
   def after_expired(user:)
     DeclineQTS.call(application_form:, user:)
   end
+
+  delegate :teacher, to: :application_form
 end

--- a/app/services/receive_requestable.rb
+++ b/app/services/receive_requestable.rb
@@ -30,9 +30,13 @@ class ReceiveRequestable
   delegate :application_form, to: :requestable
 
   def create_timeline_event
+    creator = user.is_a?(String) ? nil : user
+    creator_name = user.is_a?(String) ? user : ""
+
     TimelineEvent.create!(
       application_form:,
-      creator_name: user,
+      creator:,
+      creator_name:,
       event_type: "requestable_received",
       requestable:,
     )

--- a/app/views/shared/teacher_mailer/_any_questions_contact.text.erb
+++ b/app/views/shared/teacher_mailer/_any_questions_contact.text.erb
@@ -1,0 +1,1 @@
+If you have any questions, contact: <%= t("service.email.enquiries") %>

--- a/app/views/shared/teacher_mailer/_footer.text.erb
+++ b/app/views/shared/teacher_mailer/_footer.text.erb
@@ -1,0 +1,2 @@
+Kind regards,
+The Teacher Qualifications Team

--- a/app/views/shared/teacher_mailer/_reference_number.text.erb
+++ b/app/views/shared/teacher_mailer/_reference_number.text.erb
@@ -1,0 +1,3 @@
+Your reference number is:
+
+<%= @application_form.reference %>

--- a/app/views/teacher_mailer/application_awarded.text.erb
+++ b/app/views/teacher_mailer/application_awarded.text.erb
@@ -2,9 +2,7 @@ Dear <%= application_form_full_name(@application_form) %>
 
 # Your QTS application was successful
 
-Your reference number is:
-
-<%= @application_form.reference %>
+<%= render "shared/teacher_mailer/reference_number" %>
 
 We’re pleased to tell you that the assessor has now completed their review of your application and you’ve been awarded qualified teacher status (QTS).
 
@@ -14,5 +12,4 @@ You can sign in to get your Teacher Reference Number (TRN) and get some guidance
 
 <%= new_teacher_session_url %>
 
-Kind regards,
-The Teacher Qualifications Team
+<%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/application_declined.text.erb
+++ b/app/views/teacher_mailer/application_declined.text.erb
@@ -2,9 +2,7 @@ Dear <%= application_form_full_name(@application_form) %>
 
 # Your QTS application has been declined
 
-Your reference number is:
-
-<%= @application_form.reference %>
+<%= render "shared/teacher_mailer/reference_number" %>
 
 Thank you for applying for qualified teacher status (QTS) and for your patience while we reviewed your application.
 
@@ -24,5 +22,4 @@ You can sign in to find out why your application was declined:
 
 <%= render "shared/teacher_mailer/help_us_to_improve_this_service" %>
 
-Kind regards,
-The Teacher Qualifications Team
+<%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/application_not_submitted.text.erb
+++ b/app/views/teacher_mailer/application_not_submitted.text.erb
@@ -27,5 +27,4 @@ If you still want to apply for QTS you must do so before <%= @application_form.e
 
 If you no longer want to apply, you do not need to take any action.
 
-Kind regards,
-The Teacher Qualifications Team
+<%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/further_information_received.text.erb
+++ b/app/views/teacher_mailer/further_information_received.text.erb
@@ -1,18 +1,15 @@
 Dear <%= application_form_full_name(@application_form) %>
 
-The assessor has now resumed their review of your QTS application.
+# The assessor has now resumed their review of your QTS application.
 
-Your reference number is:
+<%= render "shared/teacher_mailer/reference_number" %>
 
-<%= @application_form.reference %>
-
-Thanks for sending the additional information we requested.The assessor will now continue reviewing your application.
+Thanks for sending the additional information we requested. The assessor will now continue reviewing your application.
 
 # What happens next
 
 We aim to reach a final decision on QTS applications within 80 working days (4 months) of submission.
 
-If you have any questions, contact: <%= t("service.email.enquiries") %>
+<%= render "shared/teacher_mailer/any_questions_contact" %>
 
-Kind regards,
-The Teacher Qualifications Team
+<%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/further_information_reminder.text.erb
+++ b/app/views/teacher_mailer/further_information_reminder.text.erb
@@ -2,9 +2,7 @@ Dear <%= application_form_full_name(@application_form) %>
 
 # The assessor reviewing your QTS application needs more information
 
-Your reference number is:
-
-<%= @application_form.reference %>
+<%= render "shared/teacher_mailer/reference_number" %>
 
 # What happens next
 
@@ -16,7 +14,6 @@ You can sign in to add the requested information to your application at:
 
 <%= new_teacher_session_url %>
 
-If you have any questions, contact: <%= t("service.email.enquiries") %>
+<%= render "shared/teacher_mailer/any_questions_contact" %>
 
-Kind regards,
-The Teacher Qualifications Team
+<%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/further_information_requested.text.erb
+++ b/app/views/teacher_mailer/further_information_requested.text.erb
@@ -12,9 +12,8 @@ You can sign in to add the requested information to your application at:
 
 <%= new_teacher_session_url %>
 
-If you have any questions, contact: <%= t("service.email.enquiries") %>
+<%= render "shared/teacher_mailer/any_questions_contact" %>
 
 <%= render "shared/teacher_mailer/help_us_to_improve_this_service" %>
 
-Kind regards,
-The Teacher Qualifications Team
+<%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/professional_standing_received.text.erb
+++ b/app/views/teacher_mailer/professional_standing_received.text.erb
@@ -1,23 +1,19 @@
 Dear <%= application_form_full_name(@application_form) %>
 
-# We’ve received your application for qualified teacher status (QTS)
+# We’ve received your <%= region_certificate_name(@application_form.region) %>
+
+Thank you for requesting your <%= region_certificate_name(@application_form.region) %> from <%= region_teaching_authority_name_phrase(@application_form.region) %>. We have now received this document and attached it to your application.
 
 <%= render "shared/teacher_mailer/reference_number" %>
 
 # What happens next
 
-<% if @application_form.teaching_authority_provides_written_statement %>
-When we’ve received the written evidence you’ve requested from your teaching authority, we’ll add your application to the queue to be assigned to a QTS assessor — this can take several weeks.
-<% else %>
 Your application will be entered into a queue and assigned a QTS assessor, which can take several weeks.
-<% end %>
 
 Once assigned, the assessor will aim to review your application within 1 month. If we need more information, we’ll email you again.
 
 We aim to reach a final decision on QTS applications within 80 working days (4 months) of submission.
 
 <%= render "shared/teacher_mailer/any_questions_contact" %>
-
-<%= render "shared/teacher_mailer/help_us_to_improve_this_service" %>
 
 <%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/references_requested.text.erb
+++ b/app/views/teacher_mailer/references_requested.text.erb
@@ -6,5 +6,4 @@ As part of your QTS application we’ve contacted the references that you provid
 
 Once they reply, we’ll review the references and proceed with assessing your application.
 
-Kind regards,
-The Teacher Qualifications Team
+<%= render "shared/teacher_mailer/footer" %>

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -23,6 +23,8 @@ en:
         subject: We need some more information to progress your QTS application
       further_information_reminder:
         subject: We still need some more information to progress your QTS application
+      professional_standing_received:
+        subject: Your qualified teacher status application – we’ve received your %{certificate}
       references_requested:
         subject: Your qualified teacher status application – we’ve contacted your references
     teaching_authority:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -251,7 +251,6 @@ COUNTRIES = {
       teaching_authority_name:
         "Teachers Registration Council of Nigeria (TRCN)",
       teaching_authority_certificate: "Letter of Professional Standing",
-      teaching_authority_emails: %w[LoPs@trcn.gov.ng],
     },
   ],
   "SG" => [{ status_check: "online" }],

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -359,6 +359,44 @@ RSpec.describe TeacherMailer, type: :mailer do
     it_behaves_like "an observable mailer", "further_information_reminder"
   end
 
+  describe "#professional_standing_received" do
+    subject(:mail) do
+      described_class.with(teacher:).professional_standing_received
+    end
+
+    describe "#subject" do
+      subject(:subject) { mail.subject }
+
+      it do
+        is_expected.to eq(
+          "Your qualified teacher status application – we’ve received your " \
+            "letter that proves you’re recognised as a teacher",
+        )
+      end
+    end
+
+    describe "#to" do
+      subject(:to) { mail.to }
+
+      it { is_expected.to eq(["teacher@example.com"]) }
+    end
+
+    describe "#body" do
+      subject(:body) { mail.body.encoded }
+
+      it { is_expected.to include("Dear First Last") }
+      it { is_expected.to include("abc") }
+      it do
+        is_expected.to include(
+          "Thank you for requesting your letter that proves you’re recognised as a teacher from " \
+            "the teaching authority. We have now received this document and attached it to your application.",
+        )
+      end
+    end
+
+    it_behaves_like "an observable mailer", "professional_standing_received"
+  end
+
   describe "#references_requested" do
     subject(:mail) { described_class.with(teacher:).references_requested }
 

--- a/spec/support/shared_examples/requestable.rb
+++ b/spec/support/shared_examples/requestable.rb
@@ -83,5 +83,21 @@ RSpec.shared_examples "a requestable" do
     end
   end
 
+  describe "#after_received" do
+    let(:after_received) { subject.after_received(user: "User") }
+
+    it "doesn't raise an error" do
+      expect { after_received }.to_not raise_error
+    end
+  end
+
+  describe "#after_reviewed" do
+    let(:after_reviewed) { subject.after_reviewed(user: "User") }
+
+    it "doesn't raise an error" do
+      expect { after_reviewed }.to_not raise_error
+    end
+  end
+
   include_examples "an expirable"
 end

--- a/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "Assessor awaiting professional standing", type: :system do
     when_i_fill_in_the_form
     then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_a_not_started_status
+    and_the_teacher_receives_a_professional_standing_received_email
   end
 
   private
@@ -49,6 +50,17 @@ RSpec.describe "Assessor awaiting professional standing", type: :system do
 
   def and_i_see_a_not_started_status
     expect(assessor_application_page.overview.status.text).to eq("NOT STARTED")
+  end
+
+  def and_the_teacher_receives_a_professional_standing_received_email
+    message = ActionMailer::Base.deliveries.last
+    expect(message).to_not be_nil
+
+    expect(message.subject).to eq(
+      "Your qualified teacher status application – we’ve received " \
+        "your letter that proves you’re recognised as a teacher",
+    )
+    expect(message.to).to include(application_form.teacher.email)
   end
 
   def application_form


### PR DESCRIPTION
This automatically sends an email to teachers when the professional standing is marked as having been received.

[Trello Card](https://trello.com/c/iB1ucqU4/1644-lopless-we-have-received-your-lops-notification)