### PR TITLE
Ensure we record emails for all mailers

### DIFF
--- a/spec/lib/application_mailer_observer_spec.rb
+++ b/spec/lib/application_mailer_observer_spec.rb
@@ -3,30 +3,57 @@
 require "rails_helper"
 
 RSpec.describe ApplicationMailerObserver do
-  let(:teacher) { create(:teacher) }
-  let!(:application_form) { create(:application_form, teacher:) }
-  let(:message) { TeacherMailer.with(teacher:).application_received }
+  shared_examples "observes mail" do
+    subject(:delivered_email) { described_class.delivered_email(message) }
 
-  subject(:delivered_email) { described_class.delivered_email(message) }
+    it "records a timeline event" do
+      expect { delivered_email }.to have_recorded_timeline_event(
+        :email_sent,
+        application_form:,
+      )
+    end
 
-  it "records a timeline event" do
-    expect { delivered_email }.to have_recorded_timeline_event(
-      :email_sent,
-      application_form:,
-      mailer_class_name: "TeacherMailer",
-      mailer_action_name: "application_received",
-      message_subject:
-        "We’ve received your application for qualified teacher status (QTS)",
-    )
+    it "is called when an email is sent" do
+      expect(ApplicationMailerObserver).to receive(:delivered_email).with(
+        message,
+      )
+      message.deliver_now
+    end
   end
 
-  it "is called when an email is sent" do
-    application_form = create(:application_form, :submitted)
-    message =
+  context "with a referee mailer" do
+    let(:reference_request) { create(:reference_request) }
+    let(:application_form) { reference_request.assessment.application_form }
+    let(:message) { RefereeMailer.with(reference_request:).reference_requested }
+
+    include_examples "observes mail"
+  end
+
+  context "with a teacher mailer" do
+    let(:application_form) { create(:application_form) }
+    let(:message) do
       TeacherMailer.with(teacher: application_form.teacher).application_received
+    end
 
-    expect(ApplicationMailerObserver).to receive(:delivered_email).with(message)
+    include_examples "observes mail"
+  end
 
-    message.deliver_now
+  context "with a teaching authority mailer" do
+    let(:region) do
+      create(:region, teaching_authority_emails: ["authority@region.com"])
+    end
+    let(:application_form) do
+      create(
+        :application_form,
+        :with_personal_information,
+        :with_completed_qualification,
+        region:,
+      )
+    end
+    let(:message) do
+      TeachingAuthorityMailer.with(application_form:).application_submitted
+    end
+
+    include_examples "observes mail"
   end
 end

--- a/spec/support/shared_examples/observable_mailer.rb
+++ b/spec/support/shared_examples/observable_mailer.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples "an observable mailer" do |expected_action_name|
-  describe "#mailer_class_name" do
-    subject(:mailer_class_name) { mail.mailer_class_name }
+RSpec.shared_examples_for "an observable mailer" do |expected_action_name|
+  describe "#application_form_id" do
+    subject(:application_form_id) { mail.application_form_id }
 
-    it { is_expected.to eq(described_class.name) }
+    it { is_expected.to eq(application_form.id) }
   end
 
   describe "#mailer_action_name" do
@@ -13,9 +13,15 @@ RSpec.shared_examples "an observable mailer" do |expected_action_name|
     it { is_expected.to eq(expected_action_name) }
   end
 
-  describe "#application_form_id" do
-    subject(:application_form_id) { mail.application_form_id }
+  describe "#mailer_class_name" do
+    subject(:mailer_class_name) { mail.mailer_class_name }
 
-    it { is_expected.to eq(application_form.id) }
+    it { is_expected.to eq(described_class.name) }
+  end
+
+  describe "#subject" do
+    subject(:subject) { mail.subject }
+
+    it { is_expected.to be_present }
   end
 end


### PR DESCRIPTION
This improves the tests to ensure that we're recording emails for all the different mailers, as we've had reports that certain emails aren't being recorded in the timeline.

[Trello Card](https://trello.com/c/gvxZNDpn/1646-record-email-is-sent-to-teaching-authority)