### PR TITLE
Rescue `Faraday::TimeoutError` in upload form

### DIFF
--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -38,7 +38,7 @@ module TeacherInterface
 
     def save(validate:)
       super(validate:)
-    rescue Timeout::Error
+    rescue Faraday::TimeoutError, Timeout::Error
       @timeout_error = true
       false
     end

--- a/spec/forms/teacher_interface/upload_form_spec.rb
+++ b/spec/forms/teacher_interface/upload_form_spec.rb
@@ -122,13 +122,16 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
       end
     end
 
-    context "when Net::ReadTimeout is raised" do
+    context "when a Timeout is raised" do
       let(:original_attachment) do
         fixture_file_upload("upload.pdf", "application/pdf")
       end
+      let(:timeout_error) do
+        [Faraday::TimeoutError, Net::ReadTimeout, Net::WriteTimeout].sample
+      end
 
       before do
-        allow(upload_form).to receive(:update_model).and_raise(Net::ReadTimeout)
+        allow(upload_form).to receive(:update_model).and_raise(timeout_error)
       end
 
       it "sets the timeout_error attribute" do


### PR DESCRIPTION
This will cause the custom upload timeout error to be rendered rather than a 500.

https://dfe-teacher-services.sentry.io/issues/3967720631/