### PR TITLE
Capture age range and subjects on timeline events

### DIFF
--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -96,14 +96,12 @@ module TimelineEntry
     end
 
     def age_range_subjects_verified_vars
-      assessment = timeline_event.assessment
-
       {
-        age_range_min: assessment.age_range_min,
-        age_range_max: assessment.age_range_max,
-        age_range_note: assessment.age_range_note,
-        subjects: Subject.find(assessment.subjects).map(&:name).join(", "),
-        subjects_note: assessment.subjects_note,
+        age_range_min: timeline_event.age_range_min,
+        age_range_max: timeline_event.age_range_max,
+        age_range_note: timeline_event.age_range_note,
+        subjects: Subject.find(timeline_event.subjects).map(&:name).join(", "),
+        subjects_note: timeline_event.subjects_note,
       }
     end
 

--- a/app/forms/assessor_interface/age_range_subjects_form.rb
+++ b/app/forms/assessor_interface/age_range_subjects_form.rb
@@ -86,14 +86,14 @@ class AssessorInterface::AgeRangeSubjectsForm < AssessorInterface::AssessmentSec
       event_type: :age_range_subjects_verified,
       application_form:,
       assessment:,
+      age_range_min: assessment.age_range_min,
+      age_range_max: assessment.age_range_max,
+      age_range_note: assessment.age_range_note,
+      subjects: assessment.subjects,
+      subjects_note: assessment.subjects_note,
     )
   end
 
-  def assessment
-    @assessment ||= assessment_section.assessment
-  end
-
-  def application_form
-    @application_form ||= assessment.application_form
-  end
+  delegate :assessment, to: :assessment_section
+  delegate :application_form, to: :assessment
 end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -108,8 +108,20 @@ class TimelineEvent < ApplicationRecord
             unless: :email_sent?
 
   belongs_to :assessment, optional: true
-  validates :assessment, presence: true, if: :age_range_subjects_verified?
-  validates :assessment, absence: true, unless: :age_range_subjects_verified?
+  validates :assessment,
+            :age_range_min,
+            :age_range_max,
+            :subjects,
+            presence: true,
+            if: :age_range_subjects_verified?
+  validates :assessment,
+            :age_range_min,
+            :age_range_max,
+            :age_range_note,
+            :subjects,
+            :subjects_note,
+            absence: true,
+            unless: :age_range_subjects_verified?
 
   belongs_to :requestable, polymorphic: true, optional: true
   validates :requestable_id, presence: true, if: :requestable_event_type?

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -5,6 +5,9 @@
 # Table name: timeline_events
 #
 #  id                    :bigint           not null, primary key
+#  age_range_max         :integer
+#  age_range_min         :integer
+#  age_range_note        :text             default(""), not null
 #  annotation            :string           default(""), not null
 #  creator_name          :string           default(""), not null
 #  creator_type          :string
@@ -15,6 +18,8 @@
 #  new_state             :string           default(""), not null
 #  old_state             :string           default(""), not null
 #  requestable_type      :string
+#  subjects              :text             default([]), not null, is an Array
+#  subjects_note         :text             default(""), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  application_form_id   :bigint           not null

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -8,7 +8,6 @@
 #  age_range_max         :integer
 #  age_range_min         :integer
 #  age_range_note        :text             default(""), not null
-#  annotation            :string           default(""), not null
 #  creator_name          :string           default(""), not null
 #  creator_type          :string
 #  event_type            :string           not null

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -357,6 +357,11 @@
     - assessment_id
     - requestable_type
     - requestable_id
+    - age_range_min
+    - age_range_max
+    - age_range_note
+    - subjects
+    - subjects_note
   :uploads:
     - id
     - document_id

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -340,7 +340,6 @@
     - id
     - event_type
     - application_form_id
-    - annotation
     - creator_id
     - creator_type
     - creator_name

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -51,6 +51,9 @@
     - unconfirmed_email
     - current_sign_in_ip
     - last_sign_in_ip
+  :timeline_events:
+    - age_range_note
+    - subjects_note
   :work_histories:
     - school_name
     - city

--- a/db/migrate/20230302151105_add_age_range_and_subjects_to_timeline_events.rb
+++ b/db/migrate/20230302151105_add_age_range_and_subjects_to_timeline_events.rb
@@ -1,0 +1,11 @@
+class AddAgeRangeAndSubjectsToTimelineEvents < ActiveRecord::Migration[7.0]
+  def change
+    change_table :timeline_events, bulk: true do |t|
+      t.integer :age_range_min
+      t.integer :age_range_max
+      t.text :age_range_note, default: "", null: false
+      t.text :subjects, array: true, default: [], null: false
+      t.text :subjects_note, default: "", null: false
+    end
+  end
+end

--- a/db/migrate/20230302152024_remove_timeline_event_annotation.rb
+++ b/db/migrate/20230302152024_remove_timeline_event_annotation.rb
@@ -1,0 +1,9 @@
+class RemoveTimelineEventAnnotation < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :timeline_events,
+                  :annotation,
+                  :string,
+                  default: "",
+                  null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_02_151105) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_02_152024) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -438,7 +438,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_02_151105) do
   create_table "timeline_events", force: :cascade do |t|
     t.string "event_type", null: false
     t.bigint "application_form_id", null: false
-    t.string "annotation", default: "", null: false
     t.integer "creator_id"
     t.string "creator_type"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_28_160319) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_02_151105) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -455,6 +455,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_28_160319) do
     t.string "mailer_class_name", default: "", null: false
     t.string "requestable_type"
     t.bigint "requestable_id"
+    t.integer "age_range_min"
+    t.integer "age_range_max"
+    t.text "age_range_note", default: "", null: false
+    t.text "subjects", default: [], null: false, array: true
+    t.text "subjects_note", default: "", null: false
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
     t.index ["assessment_id"], name: "index_timeline_events_on_assessment_id"
     t.index ["assessment_section_id"], name: "index_timeline_events_on_assessment_section_id"

--- a/lib/tasks/timeline_events.rake
+++ b/lib/tasks/timeline_events.rake
@@ -1,0 +1,15 @@
+namespace :timeline_events do
+  desc "Fix missing age range and subjects."
+  task fix_age_range_subjects: :environment do
+    TimelineEvent.age_range_subjects_verified.find_each do |timeline_event|
+      assessment = timeline_event.assessment
+      timeline_event.update!(
+        age_range_min: assessment.age_range_min,
+        age_range_max: assessment.age_range_max,
+        age_range_note: assessment.age_range_note,
+        subjects: assessment.subjects,
+        subjects_note: assessment.subjects_note,
+      )
+    end
+  end
+end

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -151,6 +151,11 @@ RSpec.describe TimelineEntry::Component, type: :component do
             subjects: %w[ancient_hebrew],
             subjects_note: "Subjects note.",
           ),
+        age_range_min: 7,
+        age_range_max: 11,
+        age_range_note: "Age range note.",
+        subjects: %w[ancient_hebrew],
+        subjects_note: "Subjects note.",
       )
     end
 

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -142,15 +142,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
       create(
         :timeline_event,
         :age_range_subjects_verified,
-        assessment:
-          create(
-            :assessment,
-            age_range_min: 7,
-            age_range_max: 11,
-            age_range_note: "Age range note.",
-            subjects: %w[ancient_hebrew],
-            subjects_note: "Subjects note.",
-          ),
+        assessment: create(:assessment),
         age_range_min: 7,
         age_range_max: 11,
         age_range_note: "Age range note.",

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -6,7 +6,6 @@
 #  age_range_max         :integer
 #  age_range_min         :integer
 #  age_range_note        :text             default(""), not null
-#  annotation            :string           default(""), not null
 #  creator_name          :string           default(""), not null
 #  creator_type          :string
 #  event_type            :string           not null

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -3,6 +3,9 @@
 # Table name: timeline_events
 #
 #  id                    :bigint           not null, primary key
+#  age_range_max         :integer
+#  age_range_min         :integer
+#  age_range_note        :text             default(""), not null
 #  annotation            :string           default(""), not null
 #  creator_name          :string           default(""), not null
 #  creator_type          :string
@@ -13,6 +16,8 @@
 #  new_state             :string           default(""), not null
 #  old_state             :string           default(""), not null
 #  requestable_type      :string
+#  subjects              :text             default([]), not null, is an Array
+#  subjects_note         :text             default(""), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  application_form_id   :bigint           not null

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -6,7 +6,6 @@
 #  age_range_max         :integer
 #  age_range_min         :integer
 #  age_range_note        :text             default(""), not null
-#  annotation            :string           default(""), not null
 #  creator_name          :string           default(""), not null
 #  creator_type          :string
 #  event_type            :string           not null

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -3,6 +3,9 @@
 # Table name: timeline_events
 #
 #  id                    :bigint           not null, primary key
+#  age_range_max         :integer
+#  age_range_min         :integer
+#  age_range_note        :text             default(""), not null
 #  annotation            :string           default(""), not null
 #  creator_name          :string           default(""), not null
 #  creator_type          :string
@@ -13,6 +16,8 @@
 #  new_state             :string           default(""), not null
 #  old_state             :string           default(""), not null
 #  requestable_type      :string
+#  subjects              :text             default([]), not null, is an Array
+#  subjects_note         :text             default(""), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  application_form_id   :bigint           not null

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -99,6 +99,9 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:age_range_min) }
+      it { is_expected.to validate_absence_of(:age_range_max) }
+      it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
     end
@@ -115,6 +118,9 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:age_range_min) }
+      it { is_expected.to validate_absence_of(:age_range_max) }
+      it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
     end
@@ -131,6 +137,9 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:age_range_min) }
+      it { is_expected.to validate_absence_of(:age_range_max) }
+      it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
     end
@@ -147,6 +156,9 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:age_range_min) }
+      it { is_expected.to validate_absence_of(:age_range_max) }
+      it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
     end
@@ -163,6 +175,9 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:age_range_min) }
+      it { is_expected.to validate_absence_of(:age_range_max) }
+      it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
     end
@@ -179,6 +194,9 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:mailer_action_name) }
       it { is_expected.to validate_presence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:age_range_min) }
+      it { is_expected.to validate_absence_of(:age_range_max) }
+      it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
     end
@@ -195,6 +213,9 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_presence_of(:assessment) }
+      it { is_expected.to validate_presence_of(:age_range_min) }
+      it { is_expected.to validate_presence_of(:age_range_max) }
+      it { is_expected.to validate_presence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
     end
@@ -211,6 +232,9 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:age_range_min) }
+      it { is_expected.to validate_absence_of(:age_range_max) }
+      it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_presence_of(:requestable_id) }
       it { is_expected.to validate_presence_of(:requestable_type) }
       it do
@@ -237,6 +261,9 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:age_range_min) }
+      it { is_expected.to validate_absence_of(:age_range_max) }
+      it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_presence_of(:requestable_id) }
       it { is_expected.to validate_presence_of(:requestable_type) }
       it do
@@ -263,6 +290,9 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:age_range_min) }
+      it { is_expected.to validate_absence_of(:age_range_max) }
+      it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_presence_of(:requestable_id) }
       it { is_expected.to validate_presence_of(:requestable_type) }
       it do
@@ -289,6 +319,9 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:mailer_action_name) }
       it { is_expected.to validate_absence_of(:message_subject) }
       it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:age_range_min) }
+      it { is_expected.to validate_absence_of(:age_range_max) }
+      it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_presence_of(:requestable_id) }
       it { is_expected.to validate_presence_of(:requestable_type) }
       it do


### PR DESCRIPTION
This adds new fields on timeline events for capturing the age range/subjects as they were specified when the timeline event was created (rather than showing the latest ones from the assessment). We know it's possible that assessors will change the age range/subjects multiple times (once during initial assessment and once during awarding) so we want to see what the values were at that point in time.

I've split this out of #738 so it can be reviewed and deployed on its own. The backfill Rake task will need to be run immediately after deploying this.

[Trello Card](https://trello.com/c/nH6vrXoD/1643-allow-assessors-to-edit-age-range-and-subjects-during-initial-assessment-and-at-point-of-award)