### PR TITLE
Remove negative contractions from ineligible reasons

### DIFF
--- a/config/locales/eligibility_interface.en.yml
+++ b/config/locales/eligibility_interface.en.yml
@@ -43,8 +43,9 @@ en:
           misconduct: To teach in England, you must not have any findings of misconduct or restrictions on your employment record.
           qualification: You have not completed a formal teaching qualification in %{country_name}, for example, an undergraduate teaching degree or postgraduate teaching qualification.
           teach_children: You are not qualified to teach children who are aged somewhere between 5 and 16 years.
-          teach_children_secondary: You’re not qualified to teach children aged 11-16 years.
-          qualified_for_subject: You’re not qualified to teach one of the subjects for which we currently accept applications.
+          teach_children_secondary: You are not qualified to teach children aged 11-16 years.
+          qualified_for_subject: You are not qualified to teach one of the subjects for which we currently accept applications.
           work_experience: You do not have sufficient work experience as a teacher.
+
   eligibility_interface:
     three_months_before_applying: This must be dated within 3 months of you applying for QTS.


### PR DESCRIPTION
We should be consistent with the wording here and the advice from GDS is to avoid negative contractions.

https://www.gov.uk/service-manual/design/writing-for-user-interfaces#style

[Trello Card](https://trello.com/c/jdYMazaZ/456-eligibility-checker-not-eligible-reasons)