### PR TITLE
Catch Faraday::ConnectionFailed

### DIFF
--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -38,7 +38,7 @@ module TeacherInterface
 
     def save(validate:)
       super(validate:)
-    rescue Faraday::TimeoutError, Timeout::Error
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Timeout::Error
       @timeout_error = true
       false
     end

--- a/spec/forms/teacher_interface/upload_form_spec.rb
+++ b/spec/forms/teacher_interface/upload_form_spec.rb
@@ -127,7 +127,12 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
         fixture_file_upload("upload.pdf", "application/pdf")
       end
       let(:timeout_error) do
-        [Faraday::TimeoutError, Net::ReadTimeout, Net::WriteTimeout].sample
+        [
+          Faraday::ConnectionFailed,
+          Faraday::TimeoutError,
+          Net::ReadTimeout,
+          Net::WriteTimeout,
+        ].sample
       end
 
       before do


### PR DESCRIPTION
When reporting to the user that we were unable to upload a document, we should include Faraday::ConnectionFailed in the list of errors as we do occasionally see it in Sentry.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/3971098389/)