### PR TITLE
Add locatable concern

### DIFF
--- a/app/forms/assessor_interface/requestable_location_form.rb
+++ b/app/forms/assessor_interface/requestable_location_form.rb
@@ -10,7 +10,9 @@ class AssessorInterface::RequestableLocationForm
   attribute :received, :boolean
 
   attribute :location_note, :string
-  validates :location_note, presence: true, if: -> { received.present? }
+  validates :location_note,
+            presence: true,
+            if: -> { received.present? && requestable.location_note_required? }
 
   def save
     return false unless valid?

--- a/app/models/concerns/locatable.rb
+++ b/app/models/concerns/locatable.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Locatable
+  extend ActiveSupport::Concern
+
+  included do
+    validates :location_note,
+              presence: true,
+              if: -> { received? && location_note_required? }
+  end
+
+  def location_note_required?
+    true
+  end
+end

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -24,10 +24,7 @@
 #
 class ProfessionalStandingRequest < ApplicationRecord
   include Requestable
-
-  with_options if: :received? do
-    validates :location_note, presence: true
-  end
+  include Locatable
 
   def expires_after
     18.weeks # 90 working days

--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -27,15 +27,15 @@
 #
 class QualificationRequest < ApplicationRecord
   include Requestable
+  include Locatable
 
-  belongs_to :assessment
   belongs_to :qualification
-
-  with_options if: :received? do
-    validates :location_note, presence: true
-  end
 
   def expires_after
     nil
+  end
+
+  def location_note_required?
+    false
   end
 end

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -364,7 +364,3 @@ en:
           attributes:
             references_verified:
               inclusion: Select whether enough valid work references been received for this application to progress to either an award or decline
-        assessor_interface/reference_request_form:
-          attributes:
-            passed:
-              inclusion: Select whether this reference should count towards the applicant’s work experience

--- a/spec/forms/assessor_interface/requestable_location_form_spec.rb
+++ b/spec/forms/assessor_interface/requestable_location_form_spec.rb
@@ -18,16 +18,30 @@ RSpec.describe AssessorInterface::RequestableLocationForm, type: :model do
     it { is_expected.to validate_presence_of(:user) }
     it { is_expected.to allow_values(true, false).for(:received) }
 
-    context "when received" do
-      let(:received) { "true" }
+    context "when a location note is required" do
+      context "when received" do
+        let(:received) { "true" }
+        it { is_expected.to validate_presence_of(:location_note) }
+      end
 
-      it { is_expected.to validate_presence_of(:location_note) }
+      context "when not received" do
+        let(:received) { "" }
+        it { is_expected.to_not validate_presence_of(:location_note) }
+      end
     end
 
-    context "when not received" do
-      let(:received) { "" }
+    context "when a location note is not required" do
+      let(:requestable) { create(:qualification_request) }
 
-      it { is_expected.to_not validate_presence_of(:location_note) }
+      context "when received" do
+        let(:received) { "true" }
+        it { is_expected.to_not validate_presence_of(:location_note) }
+      end
+
+      context "when not received" do
+        let(:received) { "" }
+        it { is_expected.to_not validate_presence_of(:location_note) }
+      end
     end
   end
 

--- a/spec/models/professional_standing_request_spec.rb
+++ b/spec/models/professional_standing_request_spec.rb
@@ -29,6 +29,8 @@ RSpec.describe ProfessionalStandingRequest, type: :model do
     subject { create(:professional_standing_request, :receivable) }
   end
 
+  it_behaves_like "a locatable"
+
   describe "validations" do
     context "when received" do
       subject { build(:professional_standing_request, :received) }

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -32,11 +32,13 @@ RSpec.describe QualificationRequest, type: :model do
     subject { create(:qualification_request, :receivable) }
   end
 
+  it_behaves_like "a locatable"
+
   describe "validations" do
     context "when received" do
       subject { build(:qualification_request, :received) }
 
-      it { is_expected.to validate_presence_of(:location_note) }
+      it { is_expected.to_not validate_presence_of(:location_note) }
     end
   end
 end

--- a/spec/support/shared_examples/locatable.rb
+++ b/spec/support/shared_examples/locatable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for "a locatable" do
+  describe "#location_note_required?" do
+    let(:location_note_required?) { subject.location_note_required? }
+
+    it "returns a boolean" do
+      expect(location_note_required?).to be_in([true, false])
+    end
+  end
+end


### PR DESCRIPTION
This adds a new concern which handles the logic related to models which can be "located" by an assessor. 

I've extracted this from #1194.