### PR TITLE
Clarify failure reason hint text

### DIFF
--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -70,8 +70,17 @@ module AssessorInterface
 
     def build_key(failure_reason, key_section)
       key =
-        "helpers.#{key_section}.assessor_interface_assessment_section_form.failure_reason_notes"
-      FailureReasons.decline?(failure_reason:) ? "#{key}_decline" : key
+        if FailureReasons.decline?(failure_reason:)
+          "decline"
+        elsif FailureReasons.further_information_request_document_type(
+              failure_reason:,
+            ).present?
+          "document"
+        else
+          "text"
+        end
+
+      "helpers.#{key_section}.assessor_interface_assessment_section_form.failure_reason_notes.#{key}"
     end
 
     def professional_standing_request_received?

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -4,8 +4,10 @@ en:
     hint:
       assessor_interface_assessment_section_form:
         selected_failure_reasons: Select all options that are relevant to you.
-        failure_reason_notes: Use this space to tell the applicant what they need to do. Make sure your instructions are clear.
-        failure_reason_notes_decline: As this reason triggers a decline, you do not need to add a note, but you can use the space below to add anything you feel might be helpful, if you want to.
+        failure_reason_notes:
+          text: This FI reason gives the applicant a free text box. Use this space to give them clear instructions on what they need to provide.
+          document: This FI reason asks the applicant to upload a file. Use this space to give them clear instructions on what they need to provide.
+          decline: As this reason triggers a decline, you do not need to add a note, but you can use the space below to add anything you feel might be helpful, if you want to.
       assessor_interface_create_note_form:
         text: Use the text box to add a note to the application history. Other assessors will be able to see any notes you add, but they will not be visible to the applicant.
       eligibility_interface_country_form:
@@ -66,8 +68,10 @@ en:
         subject_2: Subject 2 (optional)
         subject_3: Subject 3 (optional)
         subjects_note: If you've edited the subjects please explain why (optional)
-        failure_reason_notes: "Note to the applicant"
-        failure_reason_notes_decline: "Note to the applicant (optional)"
+        failure_reason_notes:
+          text: "Note to the applicant"
+          document: "Note to the applicant"
+          decline: "Note to the applicant (optional)"
       assessor_interface_confirm_age_range_subjects_form:
         age_range_min: From
         age_range_max: To
@@ -211,8 +215,10 @@ en:
           false: "No"
     placeholder:
       assessor_interface_assessment_section_form:
-        failure_reason_notes: "Example: The right-hand section of your teaching qualification document is missing, please take a new image and upload it."
-        failure_reason_notes_decline: "Example: We declined this QTS application as you already have another application in progress."
+        failure_reason_notes:
+          text: "Example: The right-hand section of your teaching qualification document is missing, please take a new image and upload it."
+          document: "Example: The right-hand section of your teaching qualification document is missing, please take a new image and upload it."
+          decline: "Example: We declined this QTS application as you already have another application in progress."
       assessor_interface_filter_form:
         reference: "Example: 210245"
     legend:

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -55,17 +55,27 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
 
       it do
         is_expected.to eq(
-          "helpers.label.assessor_interface_assessment_section_form.failure_reason_notes_decline",
+          "helpers.label.assessor_interface_assessment_section_form.failure_reason_notes.decline",
         )
       end
     end
 
-    context "with a not decline failure reason" do
+    context "with a text failure reason" do
       let(:failure_reason) { "there-once-was-a-cat-with-a-hungry-belly" }
 
       it do
         is_expected.to eq(
-          "helpers.label.assessor_interface_assessment_section_form.failure_reason_notes",
+          "helpers.label.assessor_interface_assessment_section_form.failure_reason_notes.text",
+        )
+      end
+    end
+
+    context "with a document failure reason" do
+      let(:failure_reason) { "additional_degree_certificate_illegible" }
+
+      it do
+        is_expected.to eq(
+          "helpers.label.assessor_interface_assessment_section_form.failure_reason_notes.document",
         )
       end
     end
@@ -79,17 +89,27 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
 
       it do
         is_expected.to eq(
-          "helpers.hint.assessor_interface_assessment_section_form.failure_reason_notes_decline",
+          "helpers.hint.assessor_interface_assessment_section_form.failure_reason_notes.decline",
         )
       end
     end
 
-    context "with a not decline failure reason" do
+    context "with a text failure reason" do
       let(:failure_reason) { "soon-may-the-kitty-man-come" }
 
       it do
         is_expected.to eq(
-          "helpers.hint.assessor_interface_assessment_section_form.failure_reason_notes",
+          "helpers.hint.assessor_interface_assessment_section_form.failure_reason_notes.text",
+        )
+      end
+    end
+
+    context "with a document failure reason" do
+      let(:failure_reason) { "additional_degree_certificate_illegible" }
+
+      it do
+        is_expected.to eq(
+          "helpers.hint.assessor_interface_assessment_section_form.failure_reason_notes.document",
         )
       end
     end
@@ -103,17 +123,27 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
 
       it do
         is_expected.to eq(
-          "helpers.placeholder.assessor_interface_assessment_section_form.failure_reason_notes_decline",
+          "helpers.placeholder.assessor_interface_assessment_section_form.failure_reason_notes.decline",
         )
       end
     end
 
-    context "with a not decline failure reason" do
+    context "with a text failure reason" do
       let(:failure_reason) { "with-birds-and-mice-and-some-tasty-nums" }
 
       it do
         is_expected.to eq(
-          "helpers.placeholder.assessor_interface_assessment_section_form.failure_reason_notes",
+          "helpers.placeholder.assessor_interface_assessment_section_form.failure_reason_notes.text",
+        )
+      end
+    end
+
+    context "with a document failure reason" do
+      let(:failure_reason) { "additional_degree_certificate_illegible" }
+
+      it do
+        is_expected.to eq(
+          "helpers.placeholder.assessor_interface_assessment_section_form.failure_reason_notes.document",
         )
       end
     end


### PR DESCRIPTION
This clarifies the hint text for assessors when submitting failure reasons so the assessor knows what the applicant will see.

[Trello Card](https://trello.com/c/hYwsiaml/1687-assessors-know-if-an-fi-triggers-a-file-upload-or-text-box)

## Screenshots

<img width="616" alt="Screenshot 2023-03-10 at 08 27 53" src="https://user-images.githubusercontent.com/510498/224264119-d785e8ef-4d60-413c-a091-5498716ca826.png">
<img width="618" alt="Screenshot 2023-03-10 at 08 27 57" src="https://user-images.githubusercontent.com/510498/224264139-7ae621d3-f6c8-4c28-8c44-ead0c11681b5.png">
<img width="620" alt="Screenshot 2023-03-10 at 08 28 05" src="https://user-images.githubusercontent.com/510498/224264145-7e092c84-b663-435f-bca7-0c760bd0eb23.png">
