### PR TITLE
Refactor RequestableReviewForm

### DIFF
--- a/app/forms/assessor_interface/requestable_review_form.rb
+++ b/app/forms/assessor_interface/requestable_review_form.rb
@@ -7,17 +7,38 @@ class AssessorInterface::RequestableReviewForm
   attr_accessor :requestable, :user
   validates :requestable, :user, presence: true
 
+  attribute :reviewed, :boolean
+  validates :reviewed, inclusion: [true, false], if: :validate_reviewed?
+
   attribute :passed, :boolean
-  validates :passed, inclusion: [true, false]
+  validates :passed, inclusion: [true, false], if: :validate_passed?
 
   attribute :failure_assessor_note, :string
-  validates :failure_assessor_note, presence: true, if: -> { passed == false }
+  validates :failure_assessor_note,
+            presence: true,
+            if: :validate_failure_assessor_note?
 
   def save
     return false if invalid?
 
+    self.passed = nil if reviewed == false
+
     ReviewRequestable.call(requestable:, user:, passed:, failure_assessor_note:)
 
     true
+  end
+
+  private
+
+  def validate_reviewed?
+    requestable.is_a?(Locatable)
+  end
+
+  def validate_passed?
+    validate_reviewed? ? reviewed == true : true
+  end
+
+  def validate_failure_assessor_note?
+    validate_passed? && passed == false
   end
 end

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -352,8 +352,10 @@ en:
               blank: Enter where the assessor can find it
         assessor_interface/requestable_review_form:
           attributes:
+            reviewed:
+              inclusion: Select whether you have reviewed the request
             passed:
-              inclusion: Select whether the you are satisfied
+              inclusion: Select whether you are satisfied with the request
             failure_assessor_note:
               blank: Enter why you are not satisfied
         assessor_interface/work_history_reference_request_form:

--- a/spec/forms/assessor_interface/requestable_review_form_spec.rb
+++ b/spec/forms/assessor_interface/requestable_review_form_spec.rb
@@ -5,22 +5,49 @@ require "rails_helper"
 RSpec.describe AssessorInterface::RequestableReviewForm, type: :model do
   let(:requestable) { create(:reference_request, :received) }
   let(:user) { create(:staff) }
+  let(:reviewed) { nil }
   let(:passed) { nil }
   let(:failure_assessor_note) { "" }
 
   subject(:form) do
-    described_class.new(requestable:, user:, passed:, failure_assessor_note:)
+    described_class.new(
+      requestable:,
+      user:,
+      reviewed:,
+      passed:,
+      failure_assessor_note:,
+    )
+  end
+
+  describe "validations" do
+    it { is_expected.to allow_values(true, false).for(:reviewed) }
+    it { is_expected.to allow_values(true, false).for(:passed) }
+
+    context "when locatable" do
+      let(:requestable) { create(:qualification_request) }
+
+      it { is_expected.to_not allow_values(nil).for(:reviewed) }
+
+      context "when reviewed" do
+        let(:reviewed) { "true" }
+
+        it { is_expected.to_not allow_values(nil).for(:passed) }
+      end
+    end
+
+    context "when not locatable" do
+      it { is_expected.to_not allow_values(nil).for(:passed) }
+    end
+
+    context "when not passed" do
+      let(:passed) { "false" }
+
+      it { is_expected.to validate_presence_of(:failure_assessor_note) }
+    end
   end
 
   describe "#save" do
     subject(:save) { form.save }
-
-    context "when passed is nil" do
-      it "fails validation" do
-        expect(save).to be false
-        expect(form.errors).to have_key(:passed)
-      end
-    end
 
     context "when passed is true" do
       let(:passed) { true }
@@ -37,7 +64,7 @@ RSpec.describe AssessorInterface::RequestableReviewForm, type: :model do
         end
       end
 
-      it "updated induction required" do
+      it "updates induction required" do
         expect(UpdateAssessmentInductionRequired).to receive(:call)
         save # rubocop:disable Rails/SaveBang
       end
@@ -59,15 +86,32 @@ RSpec.describe AssessorInterface::RequestableReviewForm, type: :model do
 
       it "sets reviewed at" do
         freeze_time do
-          expect { form.save }.to change(requestable, :reviewed_at).from(
-            nil,
-          ).to(Time.zone.now)
+          expect { save }.to change(requestable, :reviewed_at).from(nil).to(
+            Time.zone.now,
+          )
         end
       end
 
-      it "updated induction required" do
+      it "updates induction required" do
         expect(UpdateAssessmentInductionRequired).to receive(:call)
         save # rubocop:disable Rails/SaveBang
+      end
+    end
+
+    context "when not reviewed and passed" do
+      let(:reviewed) { "false" }
+      let(:passed) { "true" }
+
+      it "updates passed field" do
+        expect { save }.to_not change(requestable, :passed).from(nil)
+      end
+
+      it "sets reviewed at" do
+        freeze_time do
+          expect { save }.to change(requestable, :reviewed_at).from(nil).to(
+            Time.zone.now,
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
This changes the requestable review form to allow reviewing requestables which are also locatable, meaning there needs to be an extra radio button asking the assessor whether they have gone to review the requestable before they can mark whether they are satisfied with it.

This logic is necessary for professional standing requests and qualification requests, but not reference requests.

I've extracted this from #1194.