### PR TITLE
Add failure assessor note fields

### DIFF
--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -4,15 +4,16 @@
 #
 # Table name: professional_standing_requests
 #
-#  id            :bigint           not null, primary key
-#  location_note :text             default(""), not null
-#  passed        :boolean
-#  received_at   :datetime
-#  reviewed_at   :datetime
-#  state         :string           not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  assessment_id :bigint           not null
+#  id                    :bigint           not null, primary key
+#  failure_assessor_note :string           default(""), not null
+#  location_note         :text             default(""), not null
+#  passed                :boolean
+#  received_at           :datetime
+#  reviewed_at           :datetime
+#  state                 :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  assessment_id         :bigint           not null
 #
 # Indexes
 #

--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -4,16 +4,17 @@
 #
 # Table name: qualification_requests
 #
-#  id               :bigint           not null, primary key
-#  location_note    :text             default(""), not null
-#  passed           :boolean
-#  received_at      :datetime
-#  reviewed_at      :datetime
-#  state            :string           not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  assessment_id    :bigint           not null
-#  qualification_id :bigint           not null
+#  id                    :bigint           not null, primary key
+#  failure_assessor_note :string           default(""), not null
+#  location_note         :text             default(""), not null
+#  passed                :boolean
+#  received_at           :datetime
+#  reviewed_at           :datetime
+#  state                 :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  assessment_id         :bigint           not null
+#  qualification_id      :bigint           not null
 #
 # Indexes
 #

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -229,6 +229,7 @@
     - updated_at
     - reviewed_at
     - passed
+    - failure_assessor_note
   :reference_requests:
     - id
     - slug

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -206,6 +206,7 @@
     - updated_at
     - reviewed_at
     - passed
+    - failure_assessor_note
   :qualifications:
     - id
     - application_form_id

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -35,6 +35,7 @@
     - part_of_university_degree
   :qualification_requests:
     - location_note
+    - failure_assessor_note
   :reference_requests:
     - additional_information_response
     - failure_assessor_note

--- a/db/migrate/20230303151647_add_failure_assessor_note_to_qualification_request.rb
+++ b/db/migrate/20230303151647_add_failure_assessor_note_to_qualification_request.rb
@@ -1,0 +1,11 @@
+class AddFailureAssessorNoteToQualificationRequest < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    add_column :qualification_requests,
+               :failure_assessor_note,
+               :string,
+               default: "",
+               null: false
+  end
+end

--- a/db/migrate/20230310103312_add_failure_assessor_note_to_professional_standing_request.rb
+++ b/db/migrate/20230310103312_add_failure_assessor_note_to_professional_standing_request.rb
@@ -1,0 +1,11 @@
+class AddFailureAssessorNoteToProfessionalStandingRequest < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    add_column :professional_standing_requests,
+               :failure_assessor_note,
+               :string,
+               default: "",
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_02_152024) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_03_151647) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -273,6 +273,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_02_152024) do
     t.datetime "updated_at", null: false
     t.datetime "reviewed_at", precision: nil
     t.boolean "passed"
+    t.string "failure_assessor_note", default: "", null: false
     t.index ["assessment_id"], name: "index_qualification_requests_on_assessment_id"
     t.index ["qualification_id"], name: "index_qualification_requests_on_qualification_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_03_151647) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_10_103312) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -260,6 +260,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_03_151647) do
     t.datetime "updated_at", null: false
     t.datetime "reviewed_at", precision: nil
     t.boolean "passed"
+    t.string "failure_assessor_note", default: "", null: false
     t.index ["assessment_id"], name: "index_professional_standing_requests_on_assessment_id"
   end
 

--- a/spec/factories/professional_standing_requests.rb
+++ b/spec/factories/professional_standing_requests.rb
@@ -4,15 +4,16 @@
 #
 # Table name: professional_standing_requests
 #
-#  id            :bigint           not null, primary key
-#  location_note :text             default(""), not null
-#  passed        :boolean
-#  received_at   :datetime
-#  reviewed_at   :datetime
-#  state         :string           not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  assessment_id :bigint           not null
+#  id                    :bigint           not null, primary key
+#  failure_assessor_note :string           default(""), not null
+#  location_note         :text             default(""), not null
+#  passed                :boolean
+#  received_at           :datetime
+#  reviewed_at           :datetime
+#  state                 :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  assessment_id         :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/qualification_requests.rb
+++ b/spec/factories/qualification_requests.rb
@@ -4,16 +4,17 @@
 #
 # Table name: qualification_requests
 #
-#  id               :bigint           not null, primary key
-#  location_note    :text             default(""), not null
-#  passed           :boolean
-#  received_at      :datetime
-#  reviewed_at      :datetime
-#  state            :string           not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  assessment_id    :bigint           not null
-#  qualification_id :bigint           not null
+#  id                    :bigint           not null, primary key
+#  failure_assessor_note :string           default(""), not null
+#  location_note         :text             default(""), not null
+#  passed                :boolean
+#  received_at           :datetime
+#  reviewed_at           :datetime
+#  state                 :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  assessment_id         :bigint           not null
+#  qualification_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/professional_standing_request_spec.rb
+++ b/spec/models/professional_standing_request_spec.rb
@@ -4,15 +4,16 @@
 #
 # Table name: professional_standing_requests
 #
-#  id            :bigint           not null, primary key
-#  location_note :text             default(""), not null
-#  passed        :boolean
-#  received_at   :datetime
-#  reviewed_at   :datetime
-#  state         :string           not null
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  assessment_id :bigint           not null
+#  id                    :bigint           not null, primary key
+#  failure_assessor_note :string           default(""), not null
+#  location_note         :text             default(""), not null
+#  passed                :boolean
+#  received_at           :datetime
+#  reviewed_at           :datetime
+#  state                 :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  assessment_id         :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -4,16 +4,17 @@
 #
 # Table name: qualification_requests
 #
-#  id               :bigint           not null, primary key
-#  location_note    :text             default(""), not null
-#  passed           :boolean
-#  received_at      :datetime
-#  reviewed_at      :datetime
-#  state            :string           not null
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  assessment_id    :bigint           not null
-#  qualification_id :bigint           not null
+#  id                    :bigint           not null, primary key
+#  failure_assessor_note :string           default(""), not null
+#  location_note         :text             default(""), not null
+#  passed                :boolean
+#  received_at           :datetime
+#  reviewed_at           :datetime
+#  state                 :string           not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  assessment_id         :bigint           not null
+#  qualification_id      :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
This adds the failure assessor note fields to the two remaining requestables which don't have one, as we'll be needing it to record when an assessor reviews either type of request.

I've partially extracted this from #1194 