### PR TITLE
Update DQT recognition route for new regulations

### DIFF
--- a/app/lib/dqt/recognition_route.rb
+++ b/app/lib/dqt/recognition_route.rb
@@ -2,12 +2,13 @@
 
 class DQT::RecognitionRoute
   class << self
-    def for_country_code(country_code)
+    def for_country_code(country_code, under_new_regulations:)
       if CountryCode.scotland?(country_code)
         "Scotland"
       elsif CountryCode.northern_ireland?(country_code)
         "NorthernIreland"
-      elsif CountryCode.european_economic_area?(country_code)
+      elsif !under_new_regulations &&
+            CountryCode.european_economic_area?(country_code)
         "EuropeanEconomicArea"
       else
         "OverseasTrainedTeachers"

--- a/app/lib/dqt/trn_request_params.rb
+++ b/app/lib/dqt/trn_request_params.rb
@@ -26,6 +26,8 @@ module DQT
         recognitionRoute:
           RecognitionRoute.for_country_code(
             application_form.region.country.code,
+            under_new_regulations:
+              application_form.created_under_new_regulations?,
           ),
         qtsDate: qts_decision_at.to_date.iso8601,
         inductionRequired: induction_required,

--- a/spec/lib/dqt/recognition_route_spec.rb
+++ b/spec/lib/dqt/recognition_route_spec.rb
@@ -5,8 +5,10 @@ require "rails_helper"
 RSpec.describe DQT::RecognitionRoute do
   describe "#for_code" do
     subject(:recognition_route) do
-      described_class.for_country_code(country_code)
+      described_class.for_country_code(country_code, under_new_regulations:)
     end
+
+    let(:under_new_regulations) { false }
 
     context "with Scotland" do
       let(:country_code) { "GB-SCT" }
@@ -18,20 +20,35 @@ RSpec.describe DQT::RecognitionRoute do
       it { is_expected.to eq("NorthernIreland") }
     end
 
-    Country::CODES_IN_EUROPEAN_ECONOMIC_AREA.each do |country_code|
-      context "with #{country_code}" do
-        let(:country_code) { country_code }
-        it { is_expected.to eq("EuropeanEconomicArea") }
+    context "under the new regulations" do
+      let(:under_new_regulations) { true }
+
+      (Country::CODES - %w[GB-SCT GB-NIR]).each do |country_code|
+        context "with #{country_code}" do
+          let(:country_code) { country_code }
+          it { is_expected.to eq("OverseasTrainedTeachers") }
+        end
       end
     end
 
-    (
-      Country::CODES - %w[GB-SCT GB-NIR] -
-        Country::CODES_IN_EUROPEAN_ECONOMIC_AREA
-    ).each do |country_code|
-      context "with #{country_code}" do
-        let(:country_code) { country_code }
-        it { is_expected.to eq("OverseasTrainedTeachers") }
+    context "under the old regulations" do
+      let(:under_new_regulations) { false }
+
+      Country::CODES_IN_EUROPEAN_ECONOMIC_AREA.each do |country_code|
+        context "with #{country_code}" do
+          let(:country_code) { country_code }
+          it { is_expected.to eq("EuropeanEconomicArea") }
+        end
+      end
+
+      (
+        Country::CODES - %w[GB-SCT GB-NIR] -
+          Country::CODES_IN_EUROPEAN_ECONOMIC_AREA
+      ).each do |country_code|
+        context "with #{country_code}" do
+          let(:country_code) { country_code }
+          it { is_expected.to eq("OverseasTrainedTeachers") }
+        end
       end
     end
   end


### PR DESCRIPTION
If the application was submitted under the new regulations we're going to stop sending the recognition route as `EuropeanEconomicArea` and all applications will follow the same `OverseasTrainedTeachers` route.