### PR TITLE
Send whether application is under new regulations to DQT

### DIFF
--- a/app/lib/dqt/trn_request_params.rb
+++ b/app/lib/dqt/trn_request_params.rb
@@ -31,6 +31,8 @@ module DQT
           ),
         qtsDate: qts_decision_at.to_date.iso8601,
         inductionRequired: induction_required,
+        underNewOverseasRegulations:
+          application_form.created_under_new_regulations?,
       }
     end
 

--- a/spec/lib/dqt/trn_request_params_spec.rb
+++ b/spec/lib/dqt/trn_request_params_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe DQT::TRNRequestParams do
           },
           recognitionRoute: "OverseasTrainedTeachers",
           teacherType: "OverseasQualifiedTeacher",
+          underNewOverseasRegulations: false,
         },
       )
     end
@@ -91,6 +92,10 @@ RSpec.describe DQT::TRNRequestParams do
 
       it "should use the assessment recommendation date" do
         expect(call[:qtsDate]).to eq("2020-01-07")
+      end
+
+      it "sends the new regulations field" do
+        expect(call[:underNewOverseasRegulations]).to be true
       end
 
       describe "induction required" do


### PR DESCRIPTION
This sends a field to the DQT API specifying whether the application is under the new regulations.