### PR TITLE
Handle nil application forms when redirecting

### DIFF
--- a/app/controllers/teacher_interface/base_controller.rb
+++ b/app/controllers/teacher_interface/base_controller.rb
@@ -34,7 +34,7 @@ class TeacherInterface::BaseController < ApplicationController
   end
 
   def redirect_unless_application_form_is_draft
-    unless application_form.draft?
+    if application_form.nil? || !application_form.draft?
       redirect_to %i[teacher_interface application_form]
     end
   end


### PR DESCRIPTION
We've had a few Sentry errors where the application form is nil, so we we can handle that situation to redirect the user to create a new application.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/3911193157/)