### PR TITLE
Redirect to eligible/ineligible page

### DIFF
--- a/app/controllers/eligibility_interface/finish_controller.rb
+++ b/app/controllers/eligibility_interface/finish_controller.rb
@@ -4,11 +4,18 @@ class EligibilityInterface::FinishController < EligibilityInterface::BaseControl
   before_action :load_eligibility_check
 
   def eligible
+    unless eligibility_check.eligible?
+      redirect_to %i[eligibility_interface ineligible]
+    end
+
     @region = eligibility_check.region
     session[:eligibility_check_complete] = true
   end
 
   def ineligible
+    if eligibility_check.eligible?
+      redirect_to %i[eligibility_interface eligible]
+    end
   end
 
   private


### PR DESCRIPTION
If the user has gone to the wrong page (either by clicking on a link directly or in a bookmark) which doesn't match the status of the eligibility check, we should redirect them to the right place.

I think this'll fix a potential Sentry issue where the region isn't set because it's ineligible, but the user is on the eligible page.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/3930908705/)