### PR TITLE
Set induction required for reduced evidence applications

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
@@ -9,6 +9,10 @@ module AssessorInterface
 
     def edit
       @form = AssessmentDeclarationAwardForm.new
+
+      if assessment.induction_required.nil?
+        UpdateAssessmentInductionRequired.call(assessment:)
+      end
     end
 
     def update

--- a/app/services/update_assessment_induction_required.rb
+++ b/app/services/update_assessment_induction_required.rb
@@ -15,6 +15,8 @@ class UpdateAssessmentInductionRequired
 
   attr_reader :assessment
 
+  delegate :application_form, to: :assessment
+
   def induction_required
     passed_months_count < 20
   end
@@ -26,11 +28,15 @@ class UpdateAssessmentInductionRequired
 
   def work_history_relation
     @work_history_relation ||=
-      WorkHistory.joins(:reference_request).where(
-        reference_requests: {
-          passed: true,
-          assessment:,
-        },
-      )
+      if application_form.reduced_evidence_accepted
+        WorkHistory.where(application_form:)
+      else
+        WorkHistory.joins(:reference_request).where(
+          reference_requests: {
+            passed: true,
+            assessment:,
+          },
+        )
+      end
   end
 end

--- a/app/services/update_assessment_induction_required.rb
+++ b/app/services/update_assessment_induction_required.rb
@@ -8,7 +8,9 @@ class UpdateAssessmentInductionRequired
   end
 
   def call
-    assessment.update!(induction_required:)
+    if application_form.needs_work_history
+      assessment.update!(induction_required:)
+    end
   end
 
   private

--- a/spec/services/update_assessment_induction_required_spec.rb
+++ b/spec/services/update_assessment_induction_required_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe UpdateAssessmentInductionRequired do
     end
 
     include_examples "induction required"
+
+    context "when reduced evidence is accepted" do
+      before { application_form.update!(reduced_evidence_accepted: true) }
+
+      include_examples "induction not required"
+    end
   end
 
   context "with 24 months of approved work history" do

--- a/spec/services/update_assessment_induction_required_spec.rb
+++ b/spec/services/update_assessment_induction_required_spec.rb
@@ -59,4 +59,12 @@ RSpec.describe UpdateAssessmentInductionRequired do
 
     include_examples "induction not required"
   end
+
+  context "if work history is not required" do
+    before { application_form.update!(needs_work_history: false) }
+
+    it "doesn't change induction required" do
+      expect { call }.to_not change(assessment, :induction_required)
+    end
+  end
 end


### PR DESCRIPTION
This ensures that the induction required value is set for applications with reduced evidence, where there are no work references, and therefore no opportunity to validate the work history.