### PR TITLE
Notification for LoPS applications which do not pass through preliminary check

### DIFF
--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -33,7 +33,8 @@ class SubmitApplicationForm
       .application_received
       .deliver_later
 
-    if application_form.teaching_authority_provides_written_statement
+    if !application_form.requires_preliminary_check &&
+         application_form.teaching_authority_provides_written_statement
       TeacherMailer
         .with(teacher: application_form.teacher)
         .initial_checks_passed

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -33,6 +33,13 @@ class SubmitApplicationForm
       .application_received
       .deliver_later
 
+    if application_form.teaching_authority_provides_written_statement
+      TeacherMailer
+        .with(teacher: application_form.teacher)
+        .initial_checks_passed
+        .deliver_later
+    end
+
     if region.teaching_authority_requires_submission_email
       TeachingAuthorityMailer
         .with(application_form:)

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -185,6 +185,7 @@ RSpec.describe SubmitApplicationForm do
     context "when teaching authority provides the written statement" do
       before do
         application_form.update!(
+          requires_preliminary_check: false,
           teaching_authority_provides_written_statement: true,
         )
       end

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -181,5 +181,20 @@ RSpec.describe SubmitApplicationForm do
         ).with(params: { application_form: }, args: [])
       end
     end
+
+    context "when teaching authority provides the written statement" do
+      before do
+        application_form.update!(
+          teaching_authority_provides_written_statement: true,
+        )
+      end
+
+      it "enqueues an initial checks email job" do
+        expect { call }.to have_enqueued_mail(
+          TeacherMailer,
+          :initial_checks_passed,
+        ).with(params: { teacher: application_form.teacher }, args: [])
+      end
+    end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/eQKqXYST/1684-notification-after-preliminary-check-passed)

We shouldn't merge this until the preliminary check feature is in use.

This covers the Hong Kong scenario of a country which doesn't require a preliminary check but has LoPS. The email advises the teacher to contact their teaching authority to obtain the certificate/letter.