### PR TITLE
Allow documents to be optional (part 1 of 2)

### DIFF
--- a/app/forms/teacher_interface/delete_upload_form.rb
+++ b/app/forms/teacher_interface/delete_upload_form.rb
@@ -10,8 +10,10 @@ module TeacherInterface
 
     def update_model
       upload.destroy! if confirm
+
+      document.update!(completed: false) if document.uploads.empty?
     end
 
-    delegate :application_form, to: :upload
+    delegate :application_form, :document, to: :upload
   end
 end

--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -34,6 +34,10 @@ module TeacherInterface
           translation: true,
         )
       end
+
+      if original_attachment.present? || translated_attachment.present?
+        document.update!(completed: true)
+      end
     end
 
     def save(validate:)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # == Schema Information
 #
 # Table name: documents
@@ -27,6 +29,9 @@ class Document < ApplicationRecord
   has_many :translated_uploads,
            -> { where(translation: true) },
            class_name: "Upload"
+
+  scope :completed, -> { where(completed: true) }
+  scope :not_completed, -> { where(completed: false) }
 
   UNTRANSLATABLE_TYPES = %w[
     identification

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -3,6 +3,7 @@
 # Table name: documents
 #
 #  id                :bigint           not null, primary key
+#  completed         :boolean          default(FALSE)
 #  document_type     :string           not null
 #  documentable_type :string
 #  created_at        :datetime         not null

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -128,6 +128,7 @@
     - document_type
     - documentable_type
     - documentable_id
+    - completed
     - created_at
     - updated_at
   :dqt_trn_requests:

--- a/db/migrate/20230314083755_add_completed_to_documents.rb
+++ b/db/migrate/20230314083755_add_completed_to_documents.rb
@@ -1,0 +1,5 @@
+class AddCompletedToDocuments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :documents, :completed, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_10_103312) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_14_083755) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -168,6 +168,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_10_103312) do
     t.bigint "documentable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "completed", default: false
     t.index ["document_type"], name: "index_documents_on_document_type"
     t.index ["documentable_type", "documentable_id"], name: "index_documents_on_documentable"
   end

--- a/lib/tasks/documents.rake
+++ b/lib/tasks/documents.rake
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+namespace :documents do
+  desc "Sets the completed value on the documents."
+  task set_completed: :environment do
+    Document
+      .joins(:uploads)
+      .group("documents.id")
+      .having("COUNT(uploads.id) > 1")
+      .update_all(completed: true)
+
+    Document
+      .joins(:uploads)
+      .group("documents.id")
+      .having("COUNT(uploads.id) <= 1")
+      .update_all(completed: false)
+
+    puts "Completed documents: #{Document.completed.count}"
+    puts "Incomplete documents: #{Document.not_completed.count}"
+  end
+end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -3,6 +3,7 @@
 # Table name: documents
 #
 #  id                :bigint           not null, primary key
+#  completed         :boolean          default(FALSE)
 #  document_type     :string           not null
 #  documentable_type :string
 #  created_at        :datetime         not null
@@ -18,16 +19,23 @@ FactoryBot.define do
   factory :document do
     association :documentable, factory: :application_form
     sequence :document_type, Document::UNTRANSLATABLE_TYPES.cycle
+    completed { false }
+
+    trait :completed do
+      completed { true }
+    end
 
     trait :translatable do
       sequence :document_type, Document::TRANSLATABLE_TYPES.cycle
     end
 
     trait :with_upload do
+      completed
       after(:create) { |document, _evaluator| create(:upload, document:) }
     end
 
     trait :with_translation do
+      completed
       after(:create) do |document, _evaluator|
         create(:upload, :translation, document:)
       end

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -18,7 +18,7 @@
 #
 FactoryBot.define do
   factory :upload do
-    association :document
+    association :document, :completed
 
     attachment do
       Rack::Test::UploadedFile.new(
@@ -36,6 +36,10 @@ FactoryBot.define do
           "application/pdf",
         )
       end
+    end
+
+    after(:create) do |upload, _evaluator|
+      upload.document.update!(completed: true)
     end
   end
 end

--- a/spec/forms/teacher_interface/delete_upload_form_spec.rb
+++ b/spec/forms/teacher_interface/delete_upload_form_spec.rb
@@ -20,13 +20,26 @@ RSpec.describe TeacherInterface::DeleteUploadForm, type: :model do
   describe "#save" do
     subject(:save) { form.save(validate: true) }
 
-    let!(:upload) { create(:upload) }
+    let(:document) { create(:document, :completed) }
+    let!(:upload) { create(:upload, document:) }
 
     context "when confirm is true" do
       let(:confirm) { "true" }
 
       it "deletes the upload" do
         expect { save }.to change(Upload, :count).by(-1)
+      end
+
+      it "marks the document as incomplete" do
+        expect { save }.to change(document, :completed).from(true).to(false)
+      end
+
+      context "with another upload" do
+        before { create(:upload, document:) }
+
+        it "doesn't mark the document as incomplete" do
+          expect { save }.to_not change(document, :completed).from(true)
+        end
       end
     end
 

--- a/spec/forms/teacher_interface/upload_form_spec.rb
+++ b/spec/forms/teacher_interface/upload_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe TeacherInterface::UploadForm, type: :model do
@@ -105,6 +107,10 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
         expect(document.uploads.count).to eq(1)
         expect(document.uploads.first.translation).to be(false)
       end
+
+      it "marks the document as complete" do
+        expect(document.completed?).to be true
+      end
     end
 
     context "with a translated attachment" do
@@ -119,6 +125,10 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
       it "creates two uploads" do
         expect(document.uploads.count).to eq(2)
         expect(document.uploads.second.translation).to be(true)
+      end
+
+      it "marks the document as complete" do
+        expect(document.completed?).to be true
       end
     end
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -3,6 +3,7 @@
 # Table name: documents
 #
 #  id                :bigint           not null, primary key
+#  completed         :boolean          default(FALSE)
 #  document_type     :string           not null
 #  documentable_type :string
 #  created_at        :datetime         not null

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -37,6 +37,25 @@ RSpec.describe Document, type: :model do
     end
   end
 
+  describe "scopes" do
+    let!(:incomplete_document) { create(:document) }
+    let!(:complete_document) { create(:document, :completed) }
+
+    describe "completed" do
+      it "includes only complete documents" do
+        expect(Document.completed).to include(complete_document)
+        expect(Document.completed).to_not include(incomplete_document)
+      end
+    end
+
+    describe "not_completed" do
+      it "includes only incomplete documents" do
+        expect(Document.not_completed).to include(incomplete_document)
+        expect(Document.not_completed).to_not include(complete_document)
+      end
+    end
+  end
+
   describe "#original_uploads" do
     subject(:original_uploads) { document.original_uploads }
 


### PR DESCRIPTION
We need to make it possible for some users to skip uploading a document if they don't have one, specifically the "Letter of Successful Completion of Induction" from Northern Ireland

This PR is the first step in that by adding a new field to documents which captures whether the document is "complete" which can either mean that an upload has been provided, or will be used when the applicant indicates that they don't have the document.

The second step will be to start using this field as the status of the document, and to allow applicants to "skip" uploading a document by setting this field to true directly.

[Trello Card](https://trello.com/c/wpqPHYrF/1691-update-checker-and-form-content-for-northern-ireland)