### PR TITLE
Allow certain countries to skip verification

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
@@ -9,10 +9,6 @@ module AssessorInterface
 
     def edit
       @form = AssessmentDeclarationAwardForm.new
-
-      if assessment.induction_required.nil?
-        UpdateAssessmentInductionRequired.call(assessment:)
-      end
     end
 
     def update

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SubmitApplicationForm
   include ServicePattern
 
@@ -17,6 +19,10 @@ class SubmitApplicationForm
       assessment = AssessmentFactory.call(application_form:)
 
       create_professional_standing_request(assessment)
+
+      if application_form.reduced_evidence_accepted
+        UpdateAssessmentInductionRequired.call(assessment:)
+      end
 
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -160,6 +160,34 @@ RSpec.describe Assessment, type: :model do
 
         it { is_expected.to be true }
       end
+
+      context "with a passed assessment and reduced evidence" do
+        before do
+          application_form.update!(reduced_evidence_accepted: true)
+          assessment.update!(induction_required: false)
+          create(
+            :assessment_section,
+            :personal_information,
+            :passed,
+            assessment:,
+          )
+        end
+        it { is_expected.to be true }
+      end
+
+      context "with a passed assessment and work history not required" do
+        before do
+          application_form.update!(needs_work_history: false)
+          assessment.update!(induction_required: false)
+          create(
+            :assessment_section,
+            :personal_information,
+            :passed,
+            assessment:,
+          )
+        end
+        it { is_expected.to be true }
+      end
     end
   end
 
@@ -186,6 +214,32 @@ RSpec.describe Assessment, type: :model do
           )
         end
         it { is_expected.to be true }
+      end
+
+      context "with a passed assessment and reduced evidence" do
+        before do
+          application_form.update!(reduced_evidence_accepted: true)
+          create(
+            :assessment_section,
+            :personal_information,
+            :passed,
+            assessment:,
+          )
+        end
+        it { is_expected.to be false }
+      end
+
+      context "with a passed assessment and work history not required" do
+        before do
+          application_form.update!(needs_work_history: false)
+          create(
+            :assessment_section,
+            :personal_information,
+            :passed,
+            assessment:,
+          )
+        end
+        it { is_expected.to be false }
       end
 
       context "with a failed assessment" do

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -125,6 +125,22 @@ RSpec.describe SubmitApplicationForm do
     end
   end
 
+  describe "setting induction required" do
+    it "doesn't set induction required" do
+      expect(UpdateAssessmentInductionRequired).to_not receive(:call)
+      call
+    end
+
+    context "with reduced evidence accepted" do
+      before { application_form.update!(reduced_evidence_accepted: true) }
+
+      it "sets induction required" do
+        expect(UpdateAssessmentInductionRequired).to receive(:call)
+        call
+      end
+    end
+  end
+
   describe "sending application received email" do
     it "queues an email job" do
       expect { call }.to have_enqueued_mail(


### PR DESCRIPTION
This allows countries with reduced evidence, or those where work history is not required, to skip the verification step and proceed directly to the award step (provided induction required is set correctly).

At the moment this is only relevant for Ukraine, Scotland and Northern Ireland.

[Trello Card](https://trello.com/c/NaxY4uH0/1695-work-history-showing-for-scotland)