### PR TITLE
Allow anyone to see references

### DIFF
--- a/app/controllers/assessor_interface/reference_requests_controller.rb
+++ b/app/controllers/assessor_interface/reference_requests_controller.rb
@@ -2,7 +2,7 @@
 
 module AssessorInterface
   class ReferenceRequestsController < BaseController
-    before_action :authorize_assessor, except: %i[update_verify_references]
+    before_action :authorize_assessor, except: %i[edit update_verify_references]
 
     before_action :set_list_variables, only: %i[index update_verify_references]
     before_action :set_individual_variables, only: %i[edit update]
@@ -31,6 +31,8 @@ module AssessorInterface
     end
 
     def edit
+      authorize :assessor, :show?
+
       @form = RequestableReviewForm.new(requestable:)
     end
 


### PR DESCRIPTION
We will restrict the ability to edit the references, but it's okay for anyone to view the page where asssessors would review it. This matches how further information requests work.