### PR TITLE
Add task to move submitted applications to preliminary check state

### DIFF
--- a/lib/tasks/preliminary_checks.rake
+++ b/lib/tasks/preliminary_checks.rake
@@ -1,0 +1,14 @@
+namespace :preliminary_checks do
+  desc "Apply 'preliminary_check' status to existing submitted applications"
+  task update_submitted_applications: :environment do
+    ApplicationForm
+      .submitted
+      .joins(region: :country)
+      .where(assessor_id: nil)
+      .where(
+        "countries.requires_preliminary_check = true OR \
+             regions.requires_preliminary_check = true",
+      )
+      .update_all(status: :preliminary_check)
+  end
+end


### PR DESCRIPTION
If the application country or region requires a preliminary check but the application was submitted before this feature was enabled we need to update the status of these applications.