### PR TITLE
Update status according to reviewable requests

### DIFF
--- a/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe "Assessor awaiting professional standing", type: :system do
         :application_form,
         :waiting_on,
         assessment: create(:assessment, :with_professional_standing_request),
+        teaching_authority_provides_written_statement: true,
       )
   end
 


### PR DESCRIPTION
If we've received a request, but it's been reviewed, we want the status to change back to waiting on otherwise the assessor assumes there's something to be done when there might not be. If we're not waiting on anything else, then we should fallback to a received status.