### PR TITLE
Refactor various requestable services

### DIFF
--- a/app/forms/assessor_interface/requestable_review_form.rb
+++ b/app/forms/assessor_interface/requestable_review_form.rb
@@ -21,9 +21,16 @@ class AssessorInterface::RequestableReviewForm
   def save
     return false if invalid?
 
-    self.passed = nil if reviewed == false
-
-    ReviewRequestable.call(requestable:, user:, passed:, failure_assessor_note:)
+    if passed.nil? || reviewed == false
+      requestable.update!(passed: nil, reviewed_at: nil)
+    else
+      ReviewRequestable.call(
+        requestable:,
+        user:,
+        passed:,
+        failure_assessor_note:,
+      )
+    end
 
     true
   end

--- a/app/jobs/expire_requestable_job.rb
+++ b/app/jobs/expire_requestable_job.rb
@@ -2,6 +2,9 @@
 
 class ExpireRequestableJob < ApplicationJob
   def perform(requestable)
-    ExpireRequestable.call(requestable:)
+    if requestable.requested? && requestable.expired_at.present? &&
+         Time.zone.now > requestable.expired_at
+      ExpireRequestable.call(requestable:, user: "Expirer")
+    end
   end
 end

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -32,6 +32,10 @@ module Requestable
     passed != nil
   end
 
+  def overdue?
+    expired? || (received? && expired_at.present? && received_at > expired_at)
+  end
+
   def failed
     return nil if passed.nil?
     passed == false

--- a/app/services/receive_requestable.rb
+++ b/app/services/receive_requestable.rb
@@ -9,7 +9,7 @@ class ReceiveRequestable
   end
 
   def call
-    raise AlreadySubmitted if requestable.received?
+    raise AlreadyReceived if requestable.received?
 
     ActiveRecord::Base.transaction do
       requestable.received!
@@ -20,7 +20,7 @@ class ReceiveRequestable
     requestable.after_received(user:)
   end
 
-  class AlreadySubmitted < StandardError
+  class AlreadyReceived < StandardError
   end
 
   private

--- a/app/services/review_requestable.rb
+++ b/app/services/review_requestable.rb
@@ -32,14 +32,12 @@ class ReviewRequestable
   attr_reader :requestable, :user, :passed, :failure_assessor_note
 
   def create_timeline_event
-    unless requestable.passed.nil?
-      TimelineEvent.create!(
-        creator: user,
-        event_type: "requestable_assessed",
-        requestable:,
-        application_form:,
-      )
-    end
+    TimelineEvent.create!(
+      creator: user,
+      event_type: "requestable_assessed",
+      requestable:,
+      application_form:,
+    )
   end
 
   delegate :application_form, to: :requestable

--- a/app/services/review_requestable.rb
+++ b/app/services/review_requestable.rb
@@ -11,7 +11,7 @@ class ReviewRequestable
   end
 
   def call
-    raise NotReceived unless requestable.received?
+    raise StillRequested if requestable.requested?
 
     ActiveRecord::Base.transaction do
       requestable.failure_assessor_note = failure_assessor_note
@@ -24,7 +24,7 @@ class ReviewRequestable
     end
   end
 
-  class NotReceived < StandardError
+  class StillRequested < StandardError
   end
 
   private

--- a/spec/forms/assessor_interface/requestable_review_form_spec.rb
+++ b/spec/forms/assessor_interface/requestable_review_form_spec.rb
@@ -102,15 +102,13 @@ RSpec.describe AssessorInterface::RequestableReviewForm, type: :model do
       let(:reviewed) { "false" }
       let(:passed) { "true" }
 
-      it "updates passed field" do
+      it "doesn't set passed" do
         expect { save }.to_not change(requestable, :passed).from(nil)
       end
 
-      it "sets reviewed at" do
+      it "doesn't set reviewed at" do
         freeze_time do
-          expect { save }.to change(requestable, :reviewed_at).from(nil).to(
-            Time.zone.now,
-          )
+          expect { save }.to_not change(requestable, :reviewed_at).from(nil)
         end
       end
     end

--- a/spec/jobs/expire_requestable_job_spec.rb
+++ b/spec/jobs/expire_requestable_job_spec.rb
@@ -4,14 +4,153 @@ require "rails_helper"
 
 RSpec.describe ExpireRequestableJob do
   describe "#perform" do
+    let(:region) { create(:region, :in_country, country_code: "FR") }
+    let(:application_form) { create(:application_form, :submitted, region:) }
+    let(:assessment) { create(:assessment, application_form:) }
+
     subject(:perform) { described_class.new.perform(requestable) }
 
-    let(:requestable) { build(:further_information_request) }
+    shared_examples_for "not expired requestable" do
+      it "doesn't expire" do
+        expect(ExpireRequestable).to_not receive(:call).with(
+          requestable:,
+          user: a_kind_of(String),
+        )
+        perform
+      end
+    end
 
-    it "calls the ExpireRequestable" do
-      expect(ExpireRequestable).to receive(:call).with(requestable:)
+    shared_examples_for "expired requestable" do
+      it "expires" do
+        expect(ExpireRequestable).to receive(:call).with(
+          requestable:,
+          user: a_kind_of(String),
+        )
+        perform
+      end
+    end
 
-      perform
+    context "with requested FI request" do
+      let(:requestable) do
+        create(:further_information_request, created_at:, assessment:)
+      end
+
+      context "when less than six weeks old" do
+        let(:created_at) { (6.weeks - 1.hour).ago }
+        it_behaves_like "not expired requestable"
+      end
+
+      context "when it is more than six weeks old" do
+        let(:created_at) { (6.weeks + 1.hour).ago }
+        it_behaves_like "expired requestable"
+      end
+
+      context "when the applicant is from a country with a 4 week expiry" do
+        let(:application_form) do
+          create(:application_form, :submitted, :old_regs, region:)
+        end
+
+        # Australia, Canada, Gibraltar, New Zealand, US
+        %w[AU CA GI NZ US].each do |country_code|
+          context "from country_code #{country_code}" do
+            let(:region) { create(:region, :in_country, country_code:) }
+
+            context "when it is less than four weeks old" do
+              let(:created_at) { (4.weeks - 1.hour).ago }
+              it_behaves_like "not expired requestable"
+            end
+
+            context "when it is more than four weeks old from #{country_code}" do
+              let(:created_at) { (4.weeks + 1.hour).ago }
+              it_behaves_like "expired requestable"
+            end
+          end
+        end
+      end
+    end
+
+    context "with any received FI request" do
+      let(:requestable) do
+        create(:further_information_request, :received, created_at: 1.year.ago)
+      end
+
+      it_behaves_like "not expired requestable"
+    end
+
+    context "with any expired FI request" do
+      let(:requestable) do
+        create(:further_information_request, :expired, created_at: 1.year.ago)
+      end
+
+      it_behaves_like "not expired requestable"
+    end
+
+    context "with a requested professional standing request" do
+      let(:requestable) { create(:professional_standing_request, created_at:) }
+
+      context "when less than 18 weeks old" do
+        let(:created_at) { (18.weeks - 1.hour).ago }
+
+        it_behaves_like "not expired requestable"
+      end
+
+      context "when it is more than 18 weeks old" do
+        let(:created_at) { (18.weeks + 1.hour).ago }
+
+        it_behaves_like "expired requestable"
+      end
+    end
+
+    context "with any received professional standing request" do
+      let(:requestable) do
+        create(
+          :professional_standing_request,
+          :received,
+          created_at: 1.year.ago,
+        )
+      end
+
+      it_behaves_like "not expired requestable"
+    end
+
+    context "with any expired professional standing request" do
+      let(:requestable) do
+        create(:professional_standing_request, :expired, created_at: 1.year.ago)
+      end
+
+      it_behaves_like "not expired requestable"
+    end
+
+    context "with a requested reference request" do
+      let(:requestable) { create(:reference_request, created_at:) }
+
+      context "when less than six weeks old" do
+        let(:created_at) { (6.weeks - 1.hour).ago }
+
+        it_behaves_like "not expired requestable"
+      end
+
+      context "when it is more than six weeks old" do
+        let(:created_at) { (6.weeks + 1.hour).ago }
+
+        it_behaves_like "expired requestable"
+      end
+    end
+
+    context "with any received reference request" do
+      let(:requestable) do
+        create(:reference_request, :received, created_at: 1.year.ago)
+      end
+
+      it_behaves_like "not expired requestable"
+    end
+
+    context "with any expired reference request" do
+      let(:requestable) do
+        create(:reference_request, :expired, created_at: 1.year.ago)
+      end
+
+      it_behaves_like "not expired requestable"
     end
   end
 end

--- a/spec/services/receive_requestable_spec.rb
+++ b/spec/services/receive_requestable_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ReceiveRequestable do
     before { requestable.received! }
 
     it "raises an error" do
-      expect { call }.to raise_error(ReceiveRequestable::AlreadySubmitted)
+      expect { call }.to raise_error(ReceiveRequestable::AlreadyReceived)
     end
   end
 

--- a/spec/services/review_requestable_spec.rb
+++ b/spec/services/review_requestable_spec.rb
@@ -48,15 +48,7 @@ RSpec.describe ReviewRequestable do
     let(:requestable) { create(:reference_request, :requested) }
 
     it "raises an error" do
-      expect { call }.to raise_error(ReviewRequestable::NotReceived)
-    end
-  end
-
-  context "with an expired requestabled" do
-    let(:requestable) { create(:qualification_request, :expired) }
-
-    it "raises an error" do
-      expect { call }.to raise_error(ReviewRequestable::NotReceived)
+      expect { call }.to raise_error(ReviewRequestable::StillRequested)
     end
   end
 end


### PR DESCRIPTION
This makes a few changes to the requestable services, to better support the manual expiration of qualification requests, and reviewing qualification requests after they have expired.