### PR TITLE
Add internal note prefix to fields

### DIFF
--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -16,7 +16,7 @@
     <%= f.govuk_radio_buttons_fieldset :passed, legend: { size: "s", text: t(".passed") } do %>
       <%= f.govuk_radio_button :passed, :true, link_errors: true %>
       <%= f.govuk_radio_button :passed, :false do %>
-        <%= f.govuk_text_area :failure_assessor_note, label: { text: t(".failure_assessor_note") } %>
+        <%= f.govuk_text_area :failure_assessor_note, label: { text: t(".failure_assessor_note").html_safe } %>
       <% end %>
     <% end %>
 

--- a/app/views/assessor_interface/reference_requests/edit.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit.html.erb
@@ -36,7 +36,7 @@
     <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: t(".passed"), size: "s" } do %>
       <%= f.govuk_radio_button :passed, :true, link_errors: true %>
       <%= f.govuk_radio_button :passed, :false do %>
-        <%= f.govuk_text_area :failure_assessor_note, label: { text: t(".failure_assessor_note") } %>
+        <%= f.govuk_text_area :failure_assessor_note, label: { text: t(".failure_assessor_note").html_safe } %>
       <% end %>
     <% end %>
 

--- a/app/views/shared/_age_range_subjects_form_fields.html.erb
+++ b/app/views/shared/_age_range_subjects_form_fields.html.erb
@@ -3,7 +3,7 @@
 
 <%= f.govuk_number_field :age_range_min, width: 3 %>
 <%= f.govuk_number_field :age_range_max, width: 3 %>
-<%= f.govuk_text_area :age_range_note %>
+<%= f.govuk_text_area :age_range_note, label: { text: t("helpers.label.assessor_interface_assessment_section_form.age_range_note").html_safe } %>
 
 <h2 class="govuk-heading-m">Which subjects can the applicant teach in England?</h2>
 <p class="govuk-hint">You can enter up to three</p>
@@ -23,4 +23,4 @@
   ) %>
 <% end %>
 
-<%= f.govuk_text_area :subjects_note %>
+<%= f.govuk_text_area :subjects_note, label: { text: t("helpers.label.assessor_interface_assessment_section_form.subjects_note").html_safe } %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -215,7 +215,7 @@ en:
         title: Review further information from applicant
         check_your_answers: Further information requested
         passed: Has the applicant completed this section to your satisfaction?
-        failure_assessor_note: Explain why this section is not completed to your satisfaction
+        failure_assessor_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> Explain why this section is not completed to your satisfaction'
 
     professional_standing_requests:
       edit:
@@ -229,7 +229,7 @@ en:
       edit:
         title: Review work reference
         passed: Are you satisfied that this reference should count towards the applicant’s work experience?
-        failure_assessor_note: Explain why this reference should not count towards the applicant’s work experience
+        failure_assessor_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> Explain why this reference should not count towards the applicant’s work experience'
     case_notes:
       preliminary_check:
         complete_waiting_for_professional_standing: |

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -63,23 +63,23 @@ en:
       assessor_interface_assessment_section_form:
         age_range_min: From
         age_range_max: To
-        age_range_note: If you've entered a new range please explain why (optional)
+        age_range_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> If you''ve entered a new range please explain why (optional)'
         subject_1: Subject 1
         subject_2: Subject 2 (optional)
         subject_3: Subject 3 (optional)
-        subjects_note: If you've edited the subjects please explain why (optional)
+        subjects_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> If you''ve edited the subjects please explain why (optional)'
         failure_reason_notes:
-          text: "Note to the applicant"
-          document: "Note to the applicant"
-          decline: "Note to the applicant (optional)"
+          text: Note to the applicant
+          document: Note to the applicant
+          decline: Note to the applicant (optional)
       assessor_interface_confirm_age_range_subjects_form:
         age_range_min: From
         age_range_max: To
-        age_range_note: If you've entered a new range please explain why (optional)
+        age_range_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> If you''ve entered a new range please explain why (optional)'
         subject_1: Subject 1
         subject_2: Subject 2 (optional)
         subject_3: Subject 3 (optional)
-        subjects_note: If you've edited the subjects please explain why (optional)
+        subjects_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> If you''ve edited the subjects please explain why (optional)'
       assessor_interface_create_note_form:
         text: Add a note to this application
       assessor_interface_filter_form:


### PR DESCRIPTION
If the field is not displayed to the applicant, we can add a prefix to those fields explaining that to the assessors.

[Trello Card](https://trello.com/c/RiTsLy6C/1708-clearly-mark-internal-notes-as-such)