### PR TITLE
Generate reference number in factory

### DIFF
--- a/app/lib/application_form_factory.rb
+++ b/app/lib/application_form_factory.rb
@@ -9,24 +9,41 @@ class ApplicationFormFactory
   end
 
   def call
-    ApplicationForm.create!(
-      needs_registration_number:,
-      needs_work_history:,
-      needs_written_statement:,
-      reduced_evidence_accepted:,
-      region:,
-      teacher:,
-      teaching_authority_provides_written_statement:,
-      written_statement_optional:,
-      requires_preliminary_check:,
-    )
+    ActiveRecord::Base.transaction do
+      ApplicationForm.create!(
+        needs_registration_number:,
+        needs_work_history:,
+        needs_written_statement:,
+        reduced_evidence_accepted:,
+        reference:,
+        region:,
+        requires_preliminary_check:,
+        teacher:,
+        teaching_authority_provides_written_statement:,
+        written_statement_optional:,
+      )
+    end
   end
 
   private
 
   attr_reader :teacher, :region
 
-  delegate :reduced_evidence_accepted, to: :region
+  delegate :reduced_evidence_accepted,
+           :teaching_authority_provides_written_statement,
+           :written_statement_optional,
+           to: :region
+
+  def reference
+    ActiveRecord::Base.connection.execute(
+      "LOCK TABLE application_forms IN EXCLUSIVE MODE",
+    )
+
+    max_reference = ApplicationForm.maximum(:reference)&.to_i
+    max_reference = 2_000_000 if max_reference.nil? || max_reference.zero?
+
+    (max_reference + 1).to_s.rjust(7, "0")
+  end
 
   def needs_work_history
     !region.application_form_skip_work_history
@@ -35,10 +52,6 @@ class ApplicationFormFactory
   def needs_written_statement
     region.status_check_written? || region.sanction_check_written?
   end
-
-  delegate :teaching_authority_provides_written_statement,
-           :written_statement_optional,
-           to: :region
 
   def needs_registration_number
     region.status_check_online? || region.sanction_check_online?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -95,7 +95,6 @@ class ApplicationForm < ApplicationRecord
 
   before_save :build_documents, if: :new_record?
 
-  before_validation :assign_reference
   validates :reference, presence: true, uniqueness: true, length: 3..31
 
   belongs_to :assessor, class_name: "Staff", optional: true
@@ -177,19 +176,6 @@ class ApplicationForm < ApplicationRecord
         }
 
   scope :remindable, -> { draft }
-
-  def assign_reference
-    return if reference.present?
-
-    ActiveRecord::Base.connection.execute(
-      "LOCK TABLE application_forms IN EXCLUSIVE MODE",
-    )
-
-    max_reference = ApplicationForm.maximum(:reference)&.to_i
-    max_reference = 2_000_000 if max_reference.nil? || max_reference.zero?
-
-    self.reference = (max_reference + 1).to_s.rjust(7, "0")
-  end
 
   def teaching_qualification
     qualifications.find(&:is_teaching_qualification?)

--- a/spec/lib/application_form_factory_spec.rb
+++ b/spec/lib/application_form_factory_spec.rb
@@ -4,20 +4,47 @@ require "rails_helper"
 
 RSpec.describe ApplicationFormFactory do
   let(:teacher) { create(:teacher) }
-  let(:region) { nil }
+  let(:region) { create(:region) }
 
   describe "#call" do
     subject(:call) { described_class.call(teacher:, region:) }
+    let(:application_form) { call }
+
+    it "creates an application form" do
+      expect { call }.to change(ApplicationForm, :count).by(1)
+    end
+
+    describe "reference" do
+      let!(:application_form1) { described_class.call(teacher:, region:) }
+      let!(:application_form2) { described_class.call(teacher:, region:) }
+      let!(:application_form3) { described_class.call(teacher:, region:) }
+
+      context "the first application" do
+        subject(:reference) { application_form1.reference }
+
+        it { is_expected.to_not be_nil }
+        it { is_expected.to eq("2000001") }
+      end
+
+      context "the second application" do
+        subject(:reference) { application_form2.reference }
+
+        it { is_expected.to_not be_nil }
+        it { is_expected.to eq("2000002") }
+      end
+
+      context "the third application" do
+        subject(:reference) { application_form3.reference }
+
+        it { is_expected.to_not be_blank }
+        it { is_expected.to eq("2000003") }
+      end
+    end
 
     context "with a none checks region" do
       let(:region) { create(:region, :none_checks) }
 
-      it "creates an application form" do
-        expect { call }.to change(ApplicationForm, :count).by(1)
-      end
-
       it "sets the rules" do
-        application_form = call
         expect(application_form.needs_work_history).to be true
         expect(application_form.needs_written_statement).to be false
         expect(application_form.needs_registration_number).to be false
@@ -30,12 +57,7 @@ RSpec.describe ApplicationFormFactory do
     context "with a region which skips work history" do
       let(:region) { create(:region, application_form_skip_work_history: true) }
 
-      it "creates an application form" do
-        expect { call }.to change(ApplicationForm, :count).by(1)
-      end
-
       it "sets the rules" do
-        application_form = call
         expect(application_form.needs_work_history).to be false
         expect(application_form.needs_written_statement).to be false
         expect(application_form.needs_registration_number).to be false
@@ -48,12 +70,7 @@ RSpec.describe ApplicationFormFactory do
     context "with a written checks region" do
       let(:region) { create(:region, :written_checks) }
 
-      it "creates an application form" do
-        expect { call }.to change(ApplicationForm, :count).by(1)
-      end
-
       it "sets the rules" do
-        application_form = call
         expect(application_form.needs_work_history).to be true
         expect(application_form.needs_written_statement).to be true
         expect(
@@ -70,8 +87,7 @@ RSpec.describe ApplicationFormFactory do
           region.update!(teaching_authority_provides_written_statement: true)
         end
 
-        it "sets the rules" do
-          application_form = call
+        it "sets teaching authority provides written statement" do
           expect(
             application_form.teaching_authority_provides_written_statement,
           ).to be true
@@ -81,8 +97,7 @@ RSpec.describe ApplicationFormFactory do
       context "when the written statement is optional" do
         before { region.update!(written_statement_optional: true) }
 
-        it "sets the rules" do
-          application_form = call
+        it "sets written statement optional" do
           expect(application_form.written_statement_optional).to be true
         end
       end
@@ -91,12 +106,7 @@ RSpec.describe ApplicationFormFactory do
     context "with an online checks region" do
       let(:region) { create(:region, :online_checks) }
 
-      it "creates an application form" do
-        expect { call }.to change(ApplicationForm, :count).by(1)
-      end
-
       it "sets the rules" do
-        application_form = call
         expect(application_form.needs_work_history).to be true
         expect(application_form.needs_written_statement).to be false
         expect(application_form.needs_registration_number).to be true
@@ -109,12 +119,7 @@ RSpec.describe ApplicationFormFactory do
     context "when reduced evidence is accepted" do
       let(:region) { create(:region, :reduced_evidence_accepted) }
 
-      it "creates an application form" do
-        expect { call }.to change(ApplicationForm, :count).by(1)
-      end
-
-      it "sets the rules" do
-        application_form = call
+      it "sets reduced evidence accepted" do
         expect(application_form.reduced_evidence_accepted).to be true
       end
     end
@@ -122,12 +127,7 @@ RSpec.describe ApplicationFormFactory do
     context "when preliminary check is required" do
       let(:region) { create(:region, requires_preliminary_check: true) }
 
-      it "creates an application form" do
-        expect { call }.to change(ApplicationForm, :count).by(1)
-      end
-
-      it "sets the rules" do
-        application_form = call
+      it "sets requires preliminary check" do
         expect(application_form.requires_preliminary_check).to be true
       end
     end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -434,33 +434,6 @@ RSpec.describe ApplicationForm, type: :model do
     expect(application_form.written_statement_document).to_not be_nil
   end
 
-  describe "#reference" do
-    let!(:application_form1) { create(:application_form, reference: nil) }
-    let!(:application_form2) { create(:application_form, reference: nil) }
-    let!(:application_form3) { create(:application_form, reference: "") }
-
-    context "the first application" do
-      subject(:reference) { application_form1.reference }
-
-      it { is_expected.to_not be_nil }
-      it { is_expected.to eq("2000001") }
-    end
-
-    context "the second application" do
-      subject(:reference) { application_form2.reference }
-
-      it { is_expected.to_not be_nil }
-      it { is_expected.to eq("2000002") }
-    end
-
-    context "the third application" do
-      subject(:reference) { application_form3.reference }
-
-      it { is_expected.to_not be_blank }
-      it { is_expected.to eq("2000003") }
-    end
-  end
-
   describe "#created_under_new_regulations?" do
     subject(:created_under_new_regulations?) do
       application_form.created_under_new_regulations?


### PR DESCRIPTION
This refactors the code related to generating reference numbers for applications so it happens in the factory rather than in a callback in the model which might be unexpected. This makes the behaviour more explicit and clearer.

[Trello Card](https://trello.com/c/Xyc01WJo/1697-rethink-the-applicationform-locking-for-reference-number-generation)