### PR TITLE
Raise not found error when viewing draft application

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -7,7 +7,10 @@ class AssessorInterface::ApplicationFormsShowViewObject
 
   def application_form
     @application_form ||=
-      ApplicationForm.includes(assessment: :sections).find(params[:id])
+      ApplicationForm
+        .includes(assessment: :sections)
+        .not_draft
+        .find(params[:id])
   end
 
   def assessment_tasks

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -16,8 +16,16 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       expect { application_form }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
-    context "with an application form" do
-      let(:params) { { id: create(:application_form).id } }
+    context "with a draft application form" do
+      let(:params) { { id: create(:application_form, :draft).id } }
+
+      it "raise an error" do
+        expect { application_form }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "with a submitted application form" do
+      let(:params) { { id: create(:application_form, :submitted).id } }
 
       it { is_expected.to_not be_nil }
     end
@@ -26,7 +34,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
   describe "#assessment_tasks" do
     subject(:assessment_tasks) { view_object.assessment_tasks }
 
-    let(:application_form) { create(:application_form) }
+    let(:application_form) { create(:application_form, :submitted) }
     let(:assessment) { create(:assessment, application_form:) }
     before do
       create(:assessment_section, :personal_information, assessment:)
@@ -142,7 +150,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       view_object.assessment_task_path(section, item, index)
     end
 
-    let(:application_form) { create(:application_form) }
+    let(:application_form) { create(:application_form, :submitted) }
     let!(:assessment) { create(:assessment, application_form:) }
 
     let(:params) { { id: application_form.id } }
@@ -246,7 +254,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
   end
 
   describe "#assessment_task_status" do
-    let(:application_form) { create(:application_form) }
+    let(:application_form) { create(:application_form, :submitted) }
     let(:assessment) { create(:assessment, application_form:) }
     let!(:assessment_section) do
       create(:assessment_section, :personal_information, assessment:)


### PR DESCRIPTION
If an assessor tries to view a draft application it should raise a not found error, whereas at the moment we get an unhandled exception which ends up in Sentry.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/3989828241/?project=6426061&query=is%3Aunresolved&referrer=issue-stream)