### PR TITLE
Refactor reviewer/assessor validation

### DIFF
--- a/app/forms/assessor_interface/assessor_assignment_form.rb
+++ b/app/forms/assessor_interface/assessor_assignment_form.rb
@@ -8,6 +8,7 @@ class AssessorInterface::AssessorAssignmentForm
   attribute :assessor_id, :string
 
   validates :application_form, :staff, presence: true
+  validate :assessor_not_reviewer
 
   def save
     return false unless valid?
@@ -23,5 +24,11 @@ class AssessorInterface::AssessorAssignmentForm
 
   def assessor
     assessor_id.present? ? Staff.find(assessor_id) : nil
+  end
+
+  def assessor_not_reviewer
+    if (reviewer = application_form&.reviewer).present? && assessor == reviewer
+      errors.add(:assessor_id, :inclusion)
+    end
   end
 end

--- a/app/forms/assessor_interface/reviewer_assignment_form.rb
+++ b/app/forms/assessor_interface/reviewer_assignment_form.rb
@@ -8,6 +8,7 @@ class AssessorInterface::ReviewerAssignmentForm
   attribute :reviewer_id, :string
 
   validates :application_form, :staff, presence: true
+  validate :reviewer_not_assessor
 
   def save
     return false unless valid?
@@ -23,5 +24,11 @@ class AssessorInterface::ReviewerAssignmentForm
 
   def reviewer
     reviewer_id.present? ? Staff.find(reviewer_id) : nil
+  end
+
+  def reviewer_not_assessor
+    if (assessor = application_form&.assessor).present? && reviewer == assessor
+      errors.add(:reviewer_id, :inclusion)
+    end
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -99,7 +99,6 @@ class ApplicationForm < ApplicationRecord
 
   belongs_to :assessor, class_name: "Staff", optional: true
   belongs_to :reviewer, class_name: "Staff", optional: true
-  validate :assessor_and_reviewer_must_be_different
 
   validates :submitted_at, presence: true, unless: :draft?
   validates :awarded_at, presence: true, if: :awarded?
@@ -248,12 +247,5 @@ class ApplicationForm < ApplicationRecord
     documents.build(document_type: :medium_of_instruction)
     documents.build(document_type: :english_language_proficiency)
     documents.build(document_type: :written_statement)
-  end
-
-  def assessor_and_reviewer_must_be_different
-    if assessor_id.present? && reviewer_id.present? &&
-         assessor_id == reviewer_id
-      errors.add(:reviewer, :same_as_assessor)
-    end
   end
 end

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -246,6 +246,7 @@ en:
           attributes:
             assessor_id:
               blank: Select an assessor to assign
+              inclusion: Assessor must be different to reviewer
         assessor_interface/assessment_confirmation_form:
           attributes:
             confirmation:
@@ -385,3 +386,8 @@ en:
           attributes:
             preliminary_check_complete:
               inclusion: Select whether you want to move this application to a full assessment
+        assessor_interface/reviewer_assignment_form:
+          attributes:
+            reviewer_id:
+              blank: Select an reviewer to assign
+              inclusion: Reviewer must be different to assessor

--- a/spec/forms/assessor_interface/assessor_assignment_form_spec.rb
+++ b/spec/forms/assessor_interface/assessor_assignment_form_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe AssessorInterface::AssessorAssignmentForm, type: :model do
     it { is_expected.to validate_presence_of(:application_form) }
     it { is_expected.to validate_presence_of(:staff) }
     it { is_expected.to_not validate_presence_of(:assessor_id) }
+
+    context "if assessor matches reviewer" do
+      before { application_form.update!(reviewer_id: assessor_id) }
+
+      it { is_expected.to be_invalid }
+    end
   end
 
   describe "#save" do

--- a/spec/forms/assessor_interface/reviewer_assignment_form_spec.rb
+++ b/spec/forms/assessor_interface/reviewer_assignment_form_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe AssessorInterface::ReviewerAssignmentForm, type: :model do
     it { is_expected.to validate_presence_of(:application_form) }
     it { is_expected.to validate_presence_of(:staff) }
     it { is_expected.to_not validate_presence_of(:reviewer_id) }
+
+    context "if reviewer matches assessor" do
+      before { application_form.update!(assessor_id: reviewer_id) }
+
+      it { is_expected.to be_invalid }
+    end
   end
 
   describe "#save" do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -251,17 +251,6 @@ RSpec.describe ApplicationForm, type: :model do
       it { is_expected.to validate_absence_of(:english_language_provider) }
     end
 
-    context "with the same assessor and reviewer" do
-      let(:staff) { create(:staff) }
-
-      before do
-        application_form.assessor = staff
-        application_form.reviewer = staff
-      end
-
-      it { is_expected.to_not be_valid }
-    end
-
     context "when submitted" do
       before { application_form.status = "submitted" }
 


### PR DESCRIPTION
This changes where the validation happens to move it to the forms directly, rather than being validation on the model. This allows us to show a better error to users and fixes a Sentry issue.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/3949760684/?project=6426061&query=is%3Aunresolved&referrer=issue-stream)

## Screenshot

![Screenshot 2023-03-23 at 10 41 57](https://user-images.githubusercontent.com/510498/227178897-3cfae8a9-7793-485e-843b-98818094235a.png)
