### PR TITLE
Ensure day of month is sanitised

### DIFF
--- a/app/forms/concerns/teacher_interface/sanitize_dates.rb
+++ b/app/forms/concerns/teacher_interface/sanitize_dates.rb
@@ -11,9 +11,15 @@ module TeacherInterface
         dates.each do |date|
           next if date.nil? || date[1].blank? || date[2].blank?
 
+          date[1] = today.year if date[1] > today.year || date[1] < 1900
+
           date[2] = 1 if date[2].to_i < 1 || date[2].to_i > 12
 
-          date[1] = today.year if date[1] > today.year || date[1] < 1900
+          begin
+            Time.utc(date[1], date[2], date[3])
+          rescue ArgumentError
+            date[3] = 1
+          end
         end
       end
     end

--- a/spec/forms/teacher_interface/name_and_date_of_birth_form_spec.rb
+++ b/spec/forms/teacher_interface/name_and_date_of_birth_form_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe TeacherInterface::NameAndDateOfBirthForm, type: :model do
       end
 
       context "when DOB is an invalid date" do
-        let(:date_of_birth) { { 1 => 1990, 2 => 13, 3 => 31 } }
+        let(:date_of_birth) { { 1 => 1990, 2 => 13, 3 => 40 } }
 
         it do
           is_expected.to eq(


### PR DESCRIPTION
This prevents users seeing errors if they press "save and come back" with an invalid date, we sanitise it so it saves to the database, but they won't be able to continue anyway as "save and continue" performs proper validation.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/3910417913/?project=6426061&query=is%3Aunresolved&referrer=issue-stream)