### PR TITLE
Allow nil numerical validations

### DIFF
--- a/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
+++ b/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
@@ -13,12 +13,14 @@ module AssessorInterface::AgeRangeSubjectsForm
               numericality: {
                 only_integer: true,
                 greater_than_or_equal_to: 0,
+                allow_nil: true,
               }
     validates :age_range_max,
               presence: true,
               numericality: {
                 only_integer: true,
                 greater_than_or_equal_to: :age_range_min,
+                allow_nil: true,
               }
 
     attribute :subject_1, :string

--- a/app/forms/teacher_interface/age_range_form.rb
+++ b/app/forms/teacher_interface/age_range_form.rb
@@ -13,6 +13,7 @@ module TeacherInterface
                 only_integer: true,
                 greater_than_or_equal_to: 4,
                 less_than_or_equal_to: 18,
+                allow_nil: true,
               }
     validates :maximum,
               presence: true,
@@ -20,6 +21,7 @@ module TeacherInterface
                 only_integer: true,
                 greater_than_or_equal_to: :minimum,
                 less_than_or_equal_to: 18,
+                allow_nil: true,
               }
 
     def update_model


### PR DESCRIPTION
Since we already validate the presence of the number, we can allow the numericality validation to be nil. I'm hoping this will fix a Sentry issue we're seeing whether the input ends up being nil.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/3957060732/?project=6426061&query=is%3Aunresolved&referrer=issue-stream)