### PR TITLE
Stop download links expiring

### DIFF
--- a/app/controllers/assessor_interface/uploads_controller.rb
+++ b/app/controllers/assessor_interface/uploads_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module AssessorInterface
+  class UploadsController < BaseController
+    include ActiveStorage::Streaming
+
+    def show
+      send_blob_stream(upload.attachment, disposition: :inline)
+    end
+
+    private
+
+    def upload
+      @upload ||= Document.find(params[:document_id]).uploads.find(params[:id])
+    end
+  end
+end

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -2,13 +2,18 @@
 
 module TeacherInterface
   class UploadsController < BaseController
+    include ActiveStorage::Streaming
     include HandleApplicationFormSection
     include HistoryTrackable
 
     before_action :redirect_unless_draft_or_further_information
     before_action :load_application_form
     before_action :load_document
-    before_action :load_upload, only: %i[delete destroy]
+    before_action :load_upload, only: %i[delete destroy show]
+
+    def show
+      send_blob_stream(@upload.attachment, disposition: :inline)
+    end
 
     def new
       @upload_form =

--- a/app/helpers/upload_helper.rb
+++ b/app/helpers/upload_helper.rb
@@ -2,9 +2,17 @@ module UploadHelper
   def upload_link_to(upload)
     govuk_link_to(
       "#{upload.name} (opens in a new tab)",
-      upload.url,
+      [interface, :application_form, upload.document, upload],
       target: :_blank,
       rel: :noopener,
     )
+  end
+
+  def interface
+    if request.path.start_with?("/assessor/")
+      :assessor_interface
+    else
+      :teacher_interface
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,10 @@ Rails.application.routes.draw do
         end
       end
     end
+
+    get "/application/documents/:document_id/uploads/:id",
+        to: "uploads#show",
+        as: :application_form_document_upload
   end
 
   namespace :eligibility_interface, path: "/eligibility" do
@@ -273,7 +277,7 @@ Rails.application.routes.draw do
       resource :written_statement, only: %i[edit update]
 
       resources :documents, only: %i[show edit update] do
-        resources :uploads, only: %i[new create destroy] do
+        resources :uploads, only: %i[show new create destroy] do
           get "delete", on: :member
         end
       end

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe CheckYourAnswersSummary::Component, type: :component do
+  include Rails.application.routes.url_helpers
+
   subject(:component) do
     render_inline(
       described_class.new(
@@ -265,8 +267,11 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       expect(row.at_css(".govuk-summary-list__value a").text).to eq(
         "upload.pdf (opens in a new tab)",
       )
-      expect(row.at_css(".govuk-summary-list__value a")[:href]).to include(
-        "upload.pdf",
+      expect(row.at_css(".govuk-summary-list__value a")[:href]).to eq(
+        teacher_interface_application_form_document_upload_path(
+          model.document,
+          model.document.uploads.last,
+        ),
       )
     end
 
@@ -311,8 +316,11 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
         expect(row.at_css(".govuk-summary-list__value a").text).to eq(
           "upload.pdf (opens in a new tab)",
         )
-        expect(row.at_css(".govuk-summary-list__value a")[:href]).to include(
-          "upload.pdf",
+        expect(row.at_css(".govuk-summary-list__value a")[:href]).to eq(
+          teacher_interface_application_form_document_upload_path(
+            model.translatable_document,
+            model.translatable_document.uploads.last,
+          ),
         )
       end
 
@@ -338,7 +346,10 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
           "translation_upload.pdf (opens in a new tab)",
         )
         expect(row.at_css(".govuk-summary-list__value a")[:href]).to include(
-          "translation_upload.pdf",
+          teacher_interface_application_form_document_upload_path(
+            model.translatable_document,
+            model.translatable_document.uploads.first,
+          ),
         )
       end
 

--- a/spec/helpers/upload_helper_spec.rb
+++ b/spec/helpers/upload_helper_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe UploadHelper do
+  describe "#upload_link_to" do
+    let(:upload) { build_stubbed(:upload) }
+
+    it "returns a link to the upload" do
+      link = helper.upload_link_to(upload)
+
+      expect(link).to have_link(
+        "#{upload.name} (opens in a new tab)",
+        href:
+          teacher_interface_application_form_document_upload_path(
+            upload.document,
+            upload,
+          ),
+      )
+    end
+
+    context "via the assessors interface" do
+      it "returns a link to the upload" do
+        allow(helper.request).to receive(:path).and_return(
+          assessor_interface_application_form_document_upload_path(
+            upload.document,
+            upload,
+          ),
+        )
+
+        link = helper.upload_link_to(upload)
+
+        expect(link).to have_link(
+          "#{upload.name} (opens in a new tab)",
+          href:
+            assessor_interface_application_form_document_upload_path(
+              upload.document,
+              upload,
+            ),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/2bpQBrpc/1170-download-links-expiring)

This PR adds an action to stream the `Upload#attachment` to the client in the response of `uploads#show` action.

## Notes on implementation

I've ended up with 2 namespaced controllers which handle requests from assessors and teachers differently.

I originally attempted to use one namespace-less controller for both assessors and teachers, this approach was hampered by authentication problems as we need the uploads controller to call either `authenticate_staff!` or `authenticate_teacher!` and I couldn't find a sensible way of doing this.