### PR TITLE
Update requires preliminary check when submitting

### DIFF
--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -58,7 +58,7 @@ class SubmitApplicationForm
   delegate :region, to: :application_form
 
   def create_professional_standing_request(assessment)
-    return unless region.teaching_authority_provides_written_statement
+    return unless application_form.teaching_authority_provides_written_statement
 
     requestable = ProfessionalStandingRequest.create!(assessment:)
 

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -13,8 +13,10 @@ class SubmitApplicationForm
 
     ActiveRecord::Base.transaction do
       application_form.subjects.compact_blank!
-      application_form.submitted_at = Time.zone.now
       application_form.working_days_since_submission = 0
+      application_form.requires_preliminary_check =
+        region.requires_preliminary_check
+      application_form.submitted_at = Time.zone.now
 
       assessment = AssessmentFactory.call(application_form:)
 

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -98,7 +98,9 @@ RSpec.describe SubmitApplicationForm do
 
     context "when teaching authority provides the written statement" do
       before do
-        region.update!(teaching_authority_provides_written_statement: true)
+        application_form.update!(
+          teaching_authority_provides_written_statement: true,
+        )
         call
       end
 
@@ -127,7 +129,9 @@ RSpec.describe SubmitApplicationForm do
 
     context "when teaching authority provides the written statement" do
       before do
-        region.update!(teaching_authority_provides_written_statement: true)
+        application_form.update!(
+          teaching_authority_provides_written_statement: true,
+        )
       end
 
       it "records a timeline event" do

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe SubmitApplicationForm do
   describe "preliminary check note" do
     before do
       create(:staff, support_console_permission: true)
-      application_form.update!(requires_preliminary_check: true)
+      region.update!(requires_preliminary_check: true)
     end
 
     it "creates a note" do
@@ -184,8 +184,8 @@ RSpec.describe SubmitApplicationForm do
 
     context "when teaching authority provides the written statement" do
       before do
+        region.update!(requires_preliminary_check: false)
         application_form.update!(
-          requires_preliminary_check: false,
           teaching_authority_provides_written_statement: true,
         )
       end


### PR DESCRIPTION
We want this value to be updated when submitting to ensure that it's correct if the option is changed before the application is submitted.

[Trello Card](https://trello.com/c/ZXNzW44a/1715-status-error)