### PR TITLE
Move authorize line to top of controller

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
@@ -118,6 +118,8 @@ module AssessorInterface
     end
 
     def edit_verify_professional_standing
+      authorize :assessor, :edit?
+
       if application_form.teaching_authority_provides_written_statement
         redirect_to [
                       :reference_requests,
@@ -129,7 +131,6 @@ module AssessorInterface
         return
       end
 
-      authorize :assessor, :edit?
       @form = VerifyProfessionalStandingForm.new
     end
 


### PR DESCRIPTION
This ensures we always perform this check and it prevents Pundit from raising the `AuthorizationNotPerformedError` error.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/4039593636/?project=6426061&referrer=slack)