### PR TITLE
Fix bug with being unable to award

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -209,7 +209,7 @@ class Assessment < ApplicationRecord
 
   def all_qualification_requests_passed?
     if qualification_requests.present?
-      qualification_requests.all?(:passed)
+      qualification_requests.all?(&:passed)
     else
       true
     end


### PR DESCRIPTION
This fixes a bug where if an assessment has asked to verify the qualifications, they can't award it as this method will always be false.