### PR TITLE
Set review app DQT_API_URL env var

### DIFF
--- a/config/dqt.yml
+++ b/config/dqt.yml
@@ -1,5 +1,5 @@
 development:
-  url: https://qualified-teachers-api-dev.london.cloudapps.digital
+  url: <%= ENV.fetch("DQT_API_URL", "https://qualified-teachers-api-dev.london.cloudapps.digital") %>
   api_key: <%= ENV["DQT_API_KEY"] %>
 
 production:

--- a/terraform/workspace_variables/review.tfvars.json
+++ b/terraform/workspace_variables/review.tfvars.json
@@ -3,5 +3,5 @@
   "key_vault_name": "s165d01-afqts-dv-kv",
   "resource_group_name": "s165d01-afqts-dv-rg",
   "paas_space": "tra-dev",
-  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital"
+  "dqt_api_url": "https://preprod-teacher-qualifications-api.education.gov.uk"
 }


### PR DESCRIPTION
[Trello](https://trello.com/c/6hhL2RMN/1702-review-apps-dqt-integration)

This was pointing to the dev DQT API which is not suitable for review apps because of network limitations.