### PR TITLE
Ensure assessors are authorised to view uploads

### DIFF
--- a/app/controllers/assessor_interface/uploads_controller.rb
+++ b/app/controllers/assessor_interface/uploads_controller.rb
@@ -4,6 +4,8 @@ module AssessorInterface
   class UploadsController < BaseController
     include ActiveStorage::Streaming
 
+    before_action :authorize_assessor
+
     def show
       send_blob_stream(upload.attachment, disposition: :inline)
     end


### PR DESCRIPTION
This ensures that only assessors with the right permissions have access to the uploads, and it clears the `AuthorizationNotPerformedError` error we're seeing in Sentry.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/4043529356/?project=6426061&referrer=slack)