### PR TITLE
Handle upload errors

### DIFF
--- a/app/controllers/assessor_interface/uploads_controller.rb
+++ b/app/controllers/assessor_interface/uploads_controller.rb
@@ -3,6 +3,10 @@
 module AssessorInterface
   class UploadsController < BaseController
     include ActiveStorage::Streaming
+    include StreamedResponseAuthenticatable
+
+    skip_before_action :authenticate_staff!, only: :show
+    before_action -> { authenticate_or_redirect(:staff) }, only: :show
 
     before_action :authorize_assessor
 

--- a/app/controllers/concerns/streamed_response_authenticatable.rb
+++ b/app/controllers/concerns/streamed_response_authenticatable.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module StreamedResponseAuthenticatable
+  extend ActiveSupport::Concern
+
+  # ActionController::Live module changes the "process" method
+  # so that it runs inside a spawn thread.
+  # The "process" method will also handle all filters (before/around/after action hooks).
+  # Usually the authentication happens in a before action filter
+  # and if the user is not authentication Devise will throw :warden
+
+  def authenticate_or_redirect(scope)
+    redirect_to [:new, scope, :session] unless authenticated_user(scope)
+  end
+
+  def authenticated_user(scope)
+    catch(:warden) do
+      user = send("authenticate_#{scope}!")
+      return user
+    end
+    nil
+  end
+end

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -5,6 +5,10 @@ module TeacherInterface
     include ActiveStorage::Streaming
     include HandleApplicationFormSection
     include HistoryTrackable
+    include StreamedResponseAuthenticatable
+
+    skip_before_action :authenticate_teacher!, only: :show
+    before_action -> { authenticate_or_redirect(:teacher) }, only: :show
 
     before_action :redirect_unless_draft_or_further_information
     before_action :load_application_form

--- a/spec/controllers/assessor_interface/uploads_controller_spec.rb
+++ b/spec/controllers/assessor_interface/uploads_controller_spec.rb
@@ -42,5 +42,14 @@ RSpec.describe AssessorInterface::UploadsController, type: :controller do
         expect(response.status).to eq(404)
       end
     end
+
+    context "when the user session times out" do
+      before { sign_out staff }
+
+      it "redirects to the signin page" do
+        perform
+        expect(response).to redirect_to(new_staff_session_path)
+      end
+    end
   end
 end

--- a/spec/controllers/teacher_interface/uploads_controller_spec.rb
+++ b/spec/controllers/teacher_interface/uploads_controller_spec.rb
@@ -82,5 +82,14 @@ RSpec.describe TeacherInterface::UploadsController, type: :controller do
         expect(response.status).to eq(404)
       end
     end
+
+    context "when the user session times out" do
+      before { sign_out teacher }
+
+      it "redirects to the signin page" do
+        perform
+        expect(response).to redirect_to(new_teacher_session_path)
+      end
+    end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/H2i437GH/1740-handle-timeout-and-not-found-errors-in-upload-controllers)

ActionController::Live module changes the "process" method so that it runs inside a spawned thread.
The "process" method will also handle all filters (before/around/after action hooks)
Usually the authentication happens in a before action filter and if the user is not authenticated Devise will throw :warden
but since this is running in a spawn thread, the Warden middleware doesn't have the chance to catch this symbol and handle it properly.

See https://github.com/rosenfeld/devise-and-streaming

This PR adds some additional authentication methods in a module to
handle actions which could call `send_blob_stream` or other streaming
methods after a Devise `authenticate_teacher|staff!` before hook.
For the reasons explained above this won't handle an unauthenticated
user gracefully, hence the defensive code.