### PR TITLE
Handle ActiveStorage::FileNotFound errors coming from `uploads#show`

### DIFF
--- a/app/controllers/assessor_interface/uploads_controller.rb
+++ b/app/controllers/assessor_interface/uploads_controller.rb
@@ -8,6 +8,8 @@ module AssessorInterface
 
     def show
       send_blob_stream(upload.attachment, disposition: :inline)
+    rescue ActiveStorage::FileNotFoundError
+      render "errors/not_found", status: :not_found
     end
 
     private

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -13,6 +13,8 @@ module TeacherInterface
 
     def show
       send_blob_stream(@upload.attachment, disposition: :inline)
+    rescue ActiveStorage::FileNotFoundError
+      render "errors/not_found", status: :not_found
     end
 
     def new

--- a/spec/controllers/assessor_interface/uploads_controller_spec.rb
+++ b/spec/controllers/assessor_interface/uploads_controller_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::UploadsController, type: :controller do
+  before { FeatureFlags::FeatureFlag.activate(:service_open) }
+
+  let(:staff) { create(:staff, :with_award_decline_permission, :confirmed) }
+  let(:application_form) { create(:application_form) }
+
+  before { sign_in staff, scope: :staff }
+
+  describe "GET show" do
+    let(:document) { create(:document, documentable: application_form) }
+    let(:upload) { create(:upload, document:) }
+
+    subject(:perform) do
+      get :show, params: { document_id: document.id, id: upload.id }
+    end
+
+    context "when the upload is present and user is authenticated" do
+      it "renders the upload" do
+        perform
+        expect(response.status).to eq(200)
+      end
+
+      it "sends the blob stream" do
+        perform
+        expect(response.body).to eq(upload.attachment.blob.download)
+      end
+    end
+
+    context "when the upload is not found" do
+      before do
+        allow(controller).to receive(:send_blob_stream).and_raise(
+          ActiveStorage::FileNotFoundError,
+        )
+      end
+
+      it "renders not found" do
+        perform
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+end

--- a/spec/controllers/teacher_interface/uploads_controller_spec.rb
+++ b/spec/controllers/teacher_interface/uploads_controller_spec.rb
@@ -47,4 +47,40 @@ RSpec.describe TeacherInterface::UploadsController, type: :controller do
 
     include_examples "redirect unless application form is draft"
   end
+
+  describe "GET show" do
+    let(:document) { create(:document, documentable: application_form) }
+    let(:upload) { create(:upload, document:) }
+
+    subject(:perform) do
+      get :show, params: { document_id: document.id, id: upload.id }
+    end
+
+    include_examples "redirect unless application form is draft"
+
+    context "when the upload is present and user is authenticated" do
+      it "renders the upload" do
+        perform
+        expect(response.status).to eq(200)
+      end
+
+      it "sends the blob stream" do
+        perform
+        expect(response.body).to eq(upload.attachment.blob.download)
+      end
+    end
+
+    context "when the upload is not found" do
+      before do
+        allow(controller).to receive(:send_blob_stream).and_raise(
+          ActiveStorage::FileNotFoundError,
+        )
+      end
+
+      it "renders not found" do
+        perform
+        expect(response.status).to eq(404)
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/H2i437GH/1740-handle-timeout-and-not-found-errors-in-upload-controllers)
also related: https://trello.com/c/ECagONuF/1700-issue-with-opening-files

These errors are thrown when `ActiveStorage::Blob#download` is called on a blob where the backing file is no longer present in its service. We've seen a bunch of these in Sentry: https://dfe-teacher-services.sentry.io/issues/4047323435/?project=6426061&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=4