### PR TITLE
Amend heading for EC qualified for subject step

### DIFF
--- a/app/views/eligibility_interface/qualified_for_subject/new.html.erb
+++ b/app/views/eligibility_interface/qualified_for_subject/new.html.erb
@@ -4,7 +4,7 @@
 <%= form_with model: @qualified_for_subject_form, url: eligibility_interface_qualified_for_subject_url, method: :post do |f| %>
   <%= f.govuk_error_summary %>
 
-  <h1 class="govuk-heading-l">Does your teaching qualification or university degree qualify you to teach one of the following subjects?</h1>
+  <h1 class="govuk-heading-l">Does your teaching qualification certificate or university degree certificate state that you’re qualified to teach one of the following subjects?</h1>
 
   <%= govuk_inset_text do %>
     <p class="govuk-body">


### PR DESCRIPTION
This was spotted in product review, an amendment to https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/1295

![image](https://user-images.githubusercontent.com/93511/229785747-1c3eb03c-2403-413d-b4e7-e98e97c50edf.png)
