### PR TITLE
Replace referee feedback forms

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class StaticController < ApplicationController
   include EligibilityCurrentNamespace
 

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -13,9 +13,11 @@ module HostingEnvironment
     end
 
     def phase_text
-      return I18n.t("service.phase_banner_text") if production?
-
-      "This is a '#{phase}' version of the service."
+      if production?
+        "This is a new service – <a href=\"#{I18n.t("service.form.feedback")}\">your feedback will help us to improve it</a>."
+      else
+        "This is a '#{phase}' version of the service."
+      end
     end
 
     def host

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HostingEnvironment
   class << self
     def name
@@ -10,14 +12,6 @@ module HostingEnvironment
       return "Pre-production" if preprod?
 
       name.capitalize
-    end
-
-    def phase_text
-      if production?
-        "This is a new service – <a href=\"#{I18n.t("service.form.feedback")}\">your feedback will help us to improve it</a>."
-      else
-        "This is a '#{phase}' version of the service."
-      end
     end
 
     def host

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -36,8 +36,13 @@
           <strong class="govuk-tag govuk-phase-banner__content__tag app-environment-tag--<%= HostingEnvironment.name %>">
             <%= HostingEnvironment.phase %>
           </strong>
+
           <span class="govuk-phase-banner__text">
-            <%= HostingEnvironment.phase_text.html_safe %>
+            <% if HostingEnvironment.production? %>
+              This is a new service - <%= link_to "your feedback will help us to improve it", t("service.form.feedback") %>.
+            <% else %>
+              This is a ‘<%= HostingEnvironment.phase %>’ version of the service.
+            <% end %>
           </span>
         </p>
       </div>

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -39,7 +39,7 @@
 
           <span class="govuk-phase-banner__text">
             <% if HostingEnvironment.production? %>
-              This is a new service - <%= link_to "your feedback will help us to improve it", t("service.form.feedback") %>.
+              This is a new service - <%= link_to "your feedback will help us to improve it", yield(:feedback_url).presence || t("service.form.feedback") %>.
             <% else %>
               This is a ‘<%= HostingEnvironment.phase %>’ version of the service.
             <% end %>

--- a/app/views/shared/_help_us_to_improve_this_service.html.erb
+++ b/app/views/shared/_help_us_to_improve_this_service.html.erb
@@ -6,7 +6,7 @@
   </p>
 
   <p class="govuk-body">
-    If you’d like to help, please <a class="govuk-link" href="https://docs.google.com/forms/d/e/1FAIpQLSfjsMHqaiNP2cUUpmbeOkHRM96afrsj1TmTIEs-k4yit0JqBA/viewform">complete this short form</a>.
+    If you’d like to help, please <%= govuk_link_to "complete this short form", t("service.form.research") %>.
   </p>
 
   <p class="govuk-body">

--- a/app/views/shared/teacher_mailer/_help_us_to_improve_this_service.text.erb
+++ b/app/views/shared/teacher_mailer/_help_us_to_improve_this_service.text.erb
@@ -4,6 +4,6 @@ We’re always trying to improve this service and boost teacher recruitment from
 
 If you’d like to help, please complete this form:
 
-https://docs.google.com/forms/d/e/1FAIpQLSdH_nfDnt9OUolI25fLs27uitWWn63KibNWsGFOYT-Os14PRg/viewform
+<%= t("service.form.teacher_research") %>
 
 If you match our search criteria, we’ll invite you to take part in research.

--- a/app/views/static/privacy.md.erb
+++ b/app/views/static/privacy.md.erb
@@ -101,7 +101,7 @@ They'll add the following data to the database of qualified teachers:
 
 We use some user data to improve our services. For example, we’ll look at any feedback you give us about our services so we can improve them.
 
-We may contact you to ask if you’d like to participate in user research. This helps us improve our services and policies. You do not have to participate, and choosing to participate or not will not affect your application in any way. You can opt out of being contacted for user research at any time using the form below – you’ll still receive all other communications about your application. [Opt out of the user research database](https://docs.google.com/forms/d/e/1FAIpQLSeTqO6uiA_pt38S9Hl3XMG2aQ05Z5TuoFhLFWXTW4Zhau2y-g/viewform).
+We may contact you to ask if you’d like to participate in user research. This helps us improve our services and policies. You do not have to participate, and choosing to participate or not will not affect your application in any way. You can opt out of being contacted for user research at any time using the form below – you’ll still receive all other communications about your application. [Opt out of the user research database](<%= t("service.form.opt_out_research") %>).
 
 ## Getting insight to make government policy better
 

--- a/app/views/teacher_interface/application_forms/show/_complete.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_complete.html.erb
@@ -22,7 +22,7 @@
 <h2 class="govuk-heading-s">Help us to improve this service</h2>
 
 <p class="govuk-body">
-  Please <a href="https://docs.google.com/forms/d/e/1FAIpQLSePiIC7xO1Dt6oxvIdL6jcGrlUkRDJDS1kxOcqvK-uspBED9w/viewform" class="govuk-link">give us feedback</a> about your experience of using this service. It should take less than 2 minutes to complete.
+  Please <%= govuk_link_to "give us feedback", t("service.form.feedback") %> about your experience of using this service. It should take less than 2 minutes to complete.
 </p>
 
 <p class="govuk-body">
@@ -30,7 +30,7 @@
 </p>
 
 <p class="govuk-body">
-  If you'd like to help, please <a href="https://docs.google.com/forms/d/e/1FAIpQLSdH_nfDnt9OUolI25fLs27uitWWn63KibNWsGFOYT-Os14PRg/viewform" class="govuk-link">complete this form</a>.
+  If you'd like to help, please <%= govuk_link_to "complete this form", t("service.form.teacher_research") %>.
 </p>
 
 <p class="govuk-body">If you match our search criteria, we'll invite you to take part in research.</p>

--- a/app/views/teacher_interface/reference_requests/edit.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, t(".title") %>
+<% content_for :feedback_url, t("service.form.referee_feedback") %>
 
 <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
 

--- a/app/views/teacher_interface/reference_requests/edit_additional_information.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_additional_information.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.label.teacher_interface_reference_request_additional_information_response_form.additional_information_response")}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+<% content_for :feedback_url, t("service.form.referee_feedback") %>
 
 <%= form_with model: @form, url: additional_information_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/teacher_interface/reference_requests/edit_children.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_children.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_children_response_form.children_response")}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+<% content_for :feedback_url, t("service.form.referee_feedback") %>
 
 <%= form_with model: @form, url: children_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/teacher_interface/reference_requests/edit_contact.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_contact.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t(".title")}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+<% content_for :feedback_url, t("service.form.referee_feedback") %>
 
 <%= form_with model: @form, url: contact_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/teacher_interface/reference_requests/edit_dates.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_dates.html.erb
@@ -13,6 +13,7 @@
 
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{title}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+<% content_for :feedback_url, t("service.form.referee_feedback") %>
 
 <%= form_with model: @form, url: dates_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/teacher_interface/reference_requests/edit_hours.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_hours.html.erb
@@ -2,6 +2,7 @@
 
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{title}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+<% content_for :feedback_url, t("service.form.referee_feedback") %>
 
 <%= form_with model: @form, url: hours_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/teacher_interface/reference_requests/edit_lessons.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_lessons.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_lessons_response_form.lessons_response")}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+<% content_for :feedback_url, t("service.form.referee_feedback") %>
 
 <%= form_with model: @form, url: lessons_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/teacher_interface/reference_requests/edit_misconduct.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_misconduct.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_misconduct_response_form.misconduct_response")}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+<% content_for :feedback_url, t("service.form.referee_feedback") %>
 
 <%= form_with model: @form, url: misconduct_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/teacher_interface/reference_requests/edit_reports.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_reports.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_reports_response_form.reports_response")}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+<% content_for :feedback_url, t("service.form.referee_feedback") %>
 
 <%= form_with model: @form, url: reports_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/teacher_interface/reference_requests/edit_satisfied.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_satisfied.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.teacher_interface_reference_request_satisfied_response_form.satisfied_response")}" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_reference_request_path) %>
+<% content_for :feedback_url, t("service.form.referee_feedback") %>
 
 <%= form_with model: @form, url: satisfied_teacher_interface_reference_request_path do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/teacher_interface/reference_requests/show.html.erb
+++ b/app/views/teacher_interface/reference_requests/show.html.erb
@@ -3,9 +3,23 @@
 <% if @reference_request.received? %>
   <%= govuk_panel(title_text: "You’ve successfully submitted your response") %>
 
-  <h3 class="govuk-heading-m">Thank you for submitting your response.</h3>
+  <h2 class="govuk-heading-m">Thank you for submitting your response.</h2>
 
   <p class="govuk-body">The QTS assessor will now review your response and continue their review of the applicant.</p>
+
+  <h3 class="govuk-heading-s">Help us to improve this service</h3>
+
+  <p class="govuk-body">
+    We're always trying to improve this service and boost teacher recruitment from overseas. So we'd like to talk to people about their experience of using this service.
+  </p>
+
+  <p class="govuk-body">
+    If you'd like to help, please <%= govuk_link_to "complete this short form", t("service.form.referee_research") %>.
+  </p>
+
+  <p class="govuk-body">
+    If you match our search criteria, we'll invite you to take part in research.
+  </p>
 
   <p class="govuk-body">You do not need to do anything else. You can now close this page.</p>
 <% else %>

--- a/app/views/teacher_interface/reference_requests/show.html.erb
+++ b/app/views/teacher_interface/reference_requests/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :page_title, t(".title") %>
+<% content_for :feedback_url, t("service.form.referee_feedback") %>
 
 <% if @reference_request.received? %>
   <%= govuk_panel(title_text: "You’ve successfully submitted your response") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
     form:
       feedback: https://docs.google.com/forms/d/e/1FAIpQLSePiIC7xO1Dt6oxvIdL6jcGrlUkRDJDS1kxOcqvK-uspBED9w/viewform
       opt_out_research: https://docs.google.com/forms/d/e/1FAIpQLSeTqO6uiA_pt38S9Hl3XMG2aQ05Z5TuoFhLFWXTW4Zhau2y-g/viewform
+      referee_research: https://forms.office.com/e/YhQmMgRNZM
       research: https://docs.google.com/forms/d/e/1FAIpQLSfjsMHqaiNP2cUUpmbeOkHRM96afrsj1TmTIEs-k4yit0JqBA/viewform
       teacher_research: https://docs.google.com/forms/d/e/1FAIpQLSdH_nfDnt9OUolI25fLs27uitWWn63KibNWsGFOYT-Os14PRg/viewform
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,7 @@ en:
     form:
       feedback: https://docs.google.com/forms/d/e/1FAIpQLSePiIC7xO1Dt6oxvIdL6jcGrlUkRDJDS1kxOcqvK-uspBED9w/viewform
       opt_out_research: https://docs.google.com/forms/d/e/1FAIpQLSeTqO6uiA_pt38S9Hl3XMG2aQ05Z5TuoFhLFWXTW4Zhau2y-g/viewform
+      referee_feedback: https://forms.office.com/e/kuDa4nsySt
       referee_research: https://forms.office.com/e/YhQmMgRNZM
       research: https://docs.google.com/forms/d/e/1FAIpQLSfjsMHqaiNP2cUUpmbeOkHRM96afrsj1TmTIEs-k4yit0JqBA/viewform
       teacher_research: https://docs.google.com/forms/d/e/1FAIpQLSdH_nfDnt9OUolI25fLs27uitWWn63KibNWsGFOYT-Os14PRg/viewform

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,12 @@ en:
       verification: ApplyQTS.Verification@education.gov.uk
 
     url: https://apply-for-qts-in-england.education.gov.uk
-    phase_banner_text: This is a new service – <a href="https://docs.google.com/forms/d/e/1FAIpQLSePiIC7xO1Dt6oxvIdL6jcGrlUkRDJDS1kxOcqvK-uspBED9w/viewform">your feedback will help us to improve it</a>.
+
+    form:
+      feedback: https://docs.google.com/forms/d/e/1FAIpQLSePiIC7xO1Dt6oxvIdL6jcGrlUkRDJDS1kxOcqvK-uspBED9w/viewform
+      opt_out_research: https://docs.google.com/forms/d/e/1FAIpQLSeTqO6uiA_pt38S9Hl3XMG2aQ05Z5TuoFhLFWXTW4Zhau2y-g/viewform
+      research: https://docs.google.com/forms/d/e/1FAIpQLSfjsMHqaiNP2cUUpmbeOkHRM96afrsj1TmTIEs-k4yit0JqBA/viewform
+      teacher_research: https://docs.google.com/forms/d/e/1FAIpQLSdH_nfDnt9OUolI25fLs27uitWWn63KibNWsGFOYT-Os14PRg/viewform
 
   teacher:
     registration:

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe HostingEnvironment do


### PR DESCRIPTION
This replaces the feedback and research form for referees with new ones using Microsoft Forms. I've also refactored the existing Google forms to keep them all defined in the locale file.

[Trello Card](https://trello.com/c/TjAseTVY/1583-reference-feedback-and-ur-recruitment-form-dev-card)