### PR TITLE
Revert "Bump dfe-analytics from `37708fd` to `f51ae13`"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: f51ae13d3070242d11f323dc9c2148f471ad2999
+  revision: 37708fd403148edeefa305fbdf6b91bbd55354c3
   specs:
     dfe-analytics (1.7.0)
       google-cloud-bigquery (~> 1.38)
@@ -205,7 +205,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.1.0)
       activesupport (>= 5.0)
-    google-apis-bigquery_v2 (0.50.0)
+    google-apis-bigquery_v2 (0.48.0)
       google-apis-core (>= 0.11.0, < 2.a)
     google-apis-core (0.11.0)
       addressable (~> 2.5, >= 2.5.1)
@@ -228,7 +228,7 @@ GEM
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
     google-cloud-errors (1.3.1)
-    googleauth (1.5.0)
+    googleauth (1.3.0)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-qualified-teacher-status#1297

This seems to be causing issues with deployments, I've left a comment on the `dfe-analytics` repo: https://github.com/DFE-Digital/dfe-analytics/pull/67/files#r1158323213