### PR TITLE
Limit Slack notification to dev environment build failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -215,7 +215,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Notify Slack channel on job failure
-        if: failure()
+        if: failure() && ${{ matrix.environment }} == 'dev'
         id: notify-slack-on-deploy-failure
         uses: rtCamp/action-slack-notify@v2
         env:


### PR DESCRIPTION
This step failed on `test` because of a missing env var. Restrict the notification to `dev` builds for now.