### PR TITLE
Notify Slack on non prod deployment or smoke test failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -204,6 +204,42 @@ jobs:
         with:
           environment: ${{ matrix.environment }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Extract keyvault name from tfvars
+        id: extract-keyvault-name
+        if: steps.deploy.outcome != 'success' || steps.smoke-test.outcome != 'success'
+        run: |
+          KEY_VAULT_NAME=$(jq -r '.key_vault_name' $TFVARS)
+
+          if [ -z "$KEY_VAULT_NAME" ]; then
+            echo "::error ::Failed to extract key_vault_name from $TFVARS"
+            exit 1
+          fi
+
+          echo "key_vault_name=$KEY_VAULT_NAME" >> $GITHUB_OUTPUT
+        shell: bash
+        env:
+          TFVARS: workspace_variables/${{ matrix.environment }}.tfvars.json
+        working-directory: terraform
+      - uses: DfE-Digital/keyvault-yaml-secret@v1
+        id: keyvault-yaml-secret
+        if: steps.deploy.outcome != 'success' || steps.smoke-test.outcome != 'success'
+        with:
+          keyvault: ${{ steps.extract-keyvault-name.outputs.key_vault_name }}
+          secret: MONITORING
+          key: SLACK_WEBHOOK
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Notify Slack channel on job failure
+        id: notify-slack-on-deploy-failure
+        if: steps.deploy.outcome != 'success' || steps.smoke-test.outcome != 'success'
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_TITLE: Deployment of apply-for-qualified-teacher-status to ${{ matrix.environment }} failed
+          SLACK_MESSAGE: |
+            Deployment of docker image ${{ needs.docker.outputs.docker_image }} to ${{ matrix.environment }} environment failed
+          SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK_WEBHOOK }}
+          SLACK_COLOR: failure
+          SLACK_FOOTER: Sent from deploy_nonprod job in deploy workflow
 
   deploy_production:
     name: Deploy to production environment


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/93511/230392876-e1d5bccf-607b-45bf-816d-df676d13882b.png)

There was an issue/bug with `non_prod` deployments in https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/1298 where the keyvault name could not be resolved.
In this PR I've based this keyvault name lookup on [similar steps in our github workflows](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/.github/workflows/actions/deploy-environment/action.yml#L25-L46) and have tested this on a review app deployment.

There's still a risk than one of our non prod environments won't have the appropriate `SLACK_WEBHOOK` secret.