### PR TITLE
Alert slack when the Rspec job in deploy pipeline fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -187,6 +187,7 @@ jobs:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy.outputs.environment_url }}
     outputs:
+      environment_name: ${{ matrix.environment }}
       environment_url: ${{ steps.deploy.outputs.environment_url }}
 
     steps:
@@ -204,42 +205,6 @@ jobs:
         with:
           environment: ${{ matrix.environment }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-      - name: Extract keyvault name from tfvars
-        id: extract-keyvault-name
-        if: steps.deploy.outcome != 'success' || steps.smoke-test.outcome != 'success'
-        run: |
-          KEY_VAULT_NAME=$(jq -r '.key_vault_name' $TFVARS)
-
-          if [ -z "$KEY_VAULT_NAME" ]; then
-            echo "::error ::Failed to extract key_vault_name from $TFVARS"
-            exit 1
-          fi
-
-          echo "key_vault_name=$KEY_VAULT_NAME" >> $GITHUB_OUTPUT
-        shell: bash
-        env:
-          TFVARS: workspace_variables/${{ matrix.environment }}.tfvars.json
-        working-directory: terraform
-      - uses: DfE-Digital/keyvault-yaml-secret@v1
-        id: keyvault-yaml-secret
-        if: steps.deploy.outcome != 'success' || steps.smoke-test.outcome != 'success'
-        with:
-          keyvault: ${{ steps.extract-keyvault-name.outputs.key_vault_name }}
-          secret: MONITORING
-          key: SLACK_WEBHOOK
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Notify Slack channel on job failure
-        id: notify-slack-on-deploy-failure
-        if: steps.deploy.outcome != 'success' || steps.smoke-test.outcome != 'success'
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_TITLE: Deployment of apply-for-qualified-teacher-status to ${{ matrix.environment }} failed
-          SLACK_MESSAGE: |
-            Deployment of docker image ${{ needs.docker.outputs.docker_image }} to ${{ matrix.environment }} environment failed
-          SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK_WEBHOOK }}
-          SLACK_COLOR: failure
-          SLACK_FOOTER: Sent from deploy_nonprod job in deploy workflow
 
   deploy_production:
     name: Deploy to production environment
@@ -286,3 +251,43 @@ jobs:
           environment_name: ${{ github.event.inputs.environment }}
           docker_image: ${{ needs.docker.outputs.docker_image }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
+  notify_slack_of_failures:
+    name: Notify Slack of failures
+    runs-on: ubuntu-latest
+    needs: [docker, rspec, deploy_nonprod]
+    environment: ${{ needs.deploy_nonprod.outputs.environment_name || 'dev'  }}
+    env:
+      ENVIRONMENT_NAME: ${{ needs.deploy_nonprod.outputs.environment_name || 'dev'  }}
+    if: ${{ failure() }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Extract keyvault name from tfvars
+        id: extract-keyvault-name
+        run: |
+          tf_vars_file=terraform/workspace_variables/${{ env.ENVIRONMENT_NAME }}.tfvars.json
+          echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
+
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: DfE-Digital/keyvault-yaml-secret@v1
+        id: keyvault-yaml-secret
+        with:
+          keyvault: ${{ env.KEY_VAULT_NAME }}
+          secret: MONITORING
+          key: SLACK_WEBHOOK
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Notify Slack channel on job failure
+        id: notify-slack-on-deploy-failure
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_TITLE: Deployment of apply-for-qualified-teacher-status to ${{ env.ENVIRONMENT_NAME }} failed
+          SLACK_MESSAGE: |
+            Deployment to ${{ env.ENVIRONMENT_NAME }} environment failed
+          SLACK_WEBHOOK: ${{ steps.keyvault-yaml-secret.outputs.SLACK_WEBHOOK }}
+          SLACK_COLOR: failure
+          SLACK_FOOTER: Sent from notify_slack_of_failures job in deploy workflow


### PR DESCRIPTION
We currently only notify via Slack when the `deploy` or `smoke-test` steps fail for a non production deploy.

This PR moves the Slack notification to its own job and makes it dependent on `docker`, `rspec` and `deploy_nonprod`, only triggering when it detects a failure in one of its dependencies.

Tested here https://ukgovernmentdfe.slack.com/archives/C02JFQ8M3UY/p1681221438701639 on a review app deployment.