### PR TITLE
Remove GitHub Actions warnings

### DIFF
--- a/.github/actions/prepare-app-env/action.yml
+++ b/.github/actions/prepare-app-env/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Yarn cache
       if: ${{ inputs.skip-node == 'false' }}
       id: yarn-cache
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       shell: bash
 
     - name: Set up yarn cache

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -30,8 +30,8 @@ jobs:
             exit 1
           fi
 
-          echo ::set-output name=key_vault_name::$KEY_VAULT_NAME
-          echo ::set-output name=paas_space::$PAAS_SPACE
+          echo "key_vault_name=$KEY_VAULT_NAME" >> $GITHUB_OUTPUT
+          echo "paas_space=$PAAS_SPACE" >> $GITHUB_OUTPUT
         shell: bash
         env:
           TFVARS: workspace_variables/review.tfvars.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -199,7 +199,6 @@ jobs:
           environment_name: ${{ matrix.environment }}
           docker_image: ${{ needs.docker.outputs.docker_image }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          terraform_vars: workspace_variables/${{ matrix.environment }}.tfvars.json
       - uses: ./.github/workflows/actions/smoke-test
         id: smoke-test
         with:
@@ -228,7 +227,6 @@ jobs:
           environment_name: production
           docker_image: ${{ needs.docker.outputs.docker_image }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          terraform_vars: workspace_variables/production.tfvars.json
 
   deploy_environment:
     name: Deploy to ${{ github.event.inputs.environment }} environment


### PR DESCRIPTION
This removes a couple of warnings we see when running the GitHub Actions workflows. One change fixes a deprecation warning and one removes unnecessary inputs, see individual commits for more details.

<img width="1101" alt="Screenshot 2023-04-12 at 17 05 02" src="https://user-images.githubusercontent.com/510498/231500125-1e6731d3-869a-4afd-b3a1-152260b83943.png">
<img width="1027" alt="Screenshot 2023-04-12 at 17 04 58" src="https://user-images.githubusercontent.com/510498/231500134-376ce5ba-aaac-4a6f-bdcb-82de226da6da.png">
