### PR TITLE
Test Defender for Azure malware scan results

### DIFF
--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -24,16 +24,24 @@ module TeacherInterface
     def update_model
       unless skippable?
         if original_attachment.present?
-          document.uploads.create!(
-            attachment: original_attachment,
-            translation: false,
+          upload =
+            document.uploads.create!(
+              attachment: original_attachment,
+              translation: false,
+            )
+          FetchUploadMalwareScanResultJob.set(wait: 1.minute).perform_later(
+            upload,
           )
         end
 
         if translated_attachment.present?
-          document.uploads.create!(
-            attachment: translated_attachment,
-            translation: true,
+          upload =
+            document.uploads.create!(
+              attachment: translated_attachment,
+              translation: true,
+            )
+          FetchUploadMalwareScanResultJob.set(wait: 1.minute).perform_later(
+            upload,
           )
         end
       end

--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -29,9 +29,7 @@ module TeacherInterface
               attachment: original_attachment,
               translation: false,
             )
-          FetchUploadMalwareScanResultJob.set(wait: 1.minute).perform_later(
-            upload,
-          )
+          FetchMalwareScanResultJob.set(wait: 1.minute).perform_later(upload)
         end
 
         if translated_attachment.present?
@@ -40,9 +38,7 @@ module TeacherInterface
               attachment: translated_attachment,
               translation: true,
             )
-          FetchUploadMalwareScanResultJob.set(wait: 1.minute).perform_later(
-            upload,
-          )
+          FetchMalwareScanResultJob.set(wait: 1.minute).perform_later(upload)
         end
       end
 

--- a/app/jobs/fetch_malware_scan_result_job.rb
+++ b/app/jobs/fetch_malware_scan_result_job.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class FetchMalwareScanResultJob < ApplicationJob
+  def perform(upload_id:)
+    upload = Upload.find(upload_id)
+    FetchMalwareScanResult.call(upload:)
+  end
+end

--- a/app/jobs/fetch_upload_malware_scan_result_job.rb
+++ b/app/jobs/fetch_upload_malware_scan_result_job.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class FetchUploadMalwareScanResultJob < ApplicationJob
-  def perform(upload)
-    FetchUploadMalwareScanResult.call(upload:)
-  end
-end

--- a/app/jobs/fetch_upload_malware_scan_result_job.rb
+++ b/app/jobs/fetch_upload_malware_scan_result_job.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class FetchUploadMalwareScanResultJob < ApplicationJob
+  def perform(upload)
+    FetchUploadMalwareScanResult.call(upload:)
+  end
+end

--- a/app/jobs/resend_stored_blob_data_job.rb
+++ b/app/jobs/resend_stored_blob_data_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ResendStoredBlobDataJob < ApplicationJob
+  # Resending the blob data will trigger a malware scan.
+  def perform(batch_size: 100)
+    Upload
+      .where(malware_scan_result: "pending")
+      .limit(batch_size)
+      .find_each { |upload| ResendStoredBlobData.call(upload:) }
+  end
+end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -2,11 +2,12 @@
 #
 # Table name: uploads
 #
-#  id          :bigint           not null, primary key
-#  translation :boolean          not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  document_id :bigint           not null
+#  id                  :bigint           not null, primary key
+#  malware_scan_result :string           default("pending"), not null
+#  translation         :boolean          not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  document_id         :bigint           not null
 #
 # Indexes
 #
@@ -21,6 +22,13 @@ class Upload < ApplicationRecord
 
   has_one_attached :attachment, dependent: :purge_later
   validates :attachment, presence: true
+
+  enum malware_scan_result: {
+         clean: "clean",
+         error: "error",
+         pending: "pending",
+         suspect: "suspect",
+       }
 
   def original?
     !translation?

--- a/app/services/fetch_malware_scan_result.rb
+++ b/app/services/fetch_malware_scan_result.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FetchUploadMalwareScanResult
+class FetchMalwareScanResult
   include ServicePattern
 
   # Only later versions of the Azure Storage REST API support tags operations.

--- a/app/services/fetch_upload_malware_scan_result.rb
+++ b/app/services/fetch_upload_malware_scan_result.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class FetchUploadMalwareScanResult
+  include ServicePattern
+
+  # Only later versions of the Azure Storage REST API support tags operations.
+  Kernel.silence_warnings do
+    Azure::Storage::Blob::Default::STG_VERSION = "2022-11-02"
+  end
+
+  def initialize(upload:)
+    @upload = upload
+  end
+
+  def call
+    return unless upload.malware_scan_result == "pending"
+
+    response = fetch_scan_result
+
+    if response.success?
+      if response.body =~ /Malware Scanning scan result/
+        upload.update!(
+          malware_scan_result: malware_scan_result_from_response(response),
+        )
+      end
+    else
+      upload.update!(malware_scan_result: "error")
+    end
+  rescue Azure::Core::Http::HTTPError
+    upload.update!(malware_scan_result: "error")
+  end
+
+  private
+
+  attr_reader :upload
+
+  def blob_service
+    @blob_service ||=
+      Azure::Storage::Blob::BlobService.new(
+        storage_account_name: ENV["AZURE_STORAGE_ACCOUNT_NAME"],
+        storage_access_key: ENV["AZURE_STORAGE_ACCESS_KEY"],
+      )
+  end
+
+  def fetch_scan_result
+    blob_service.call(:get, get_tags_for_blob_url)
+  end
+
+  def get_tags_for_blob_url
+    @get_tags_for_blob_url ||=
+      blob_service.generate_uri(
+        File.join("uploads", upload.attachment.key),
+        { comp: "tags" },
+      )
+  end
+
+  def malware_scan_result_from_response(response)
+    response.body =~ /No threats found/ ? "clean" : "suspect"
+  end
+end

--- a/app/services/resend_stored_blob_data.rb
+++ b/app/services/resend_stored_blob_data.rb
@@ -24,7 +24,10 @@ class ResendStoredBlobData
     response = blob_service.call(:put, url, attachment_data, headers)
 
     if response.success?
-      FetchMalwareScanResultJob.perform_later(upload_id: upload.id)
+      # Wait for 1 minute to allow the malware scan to complete.
+      FetchMalwareScanResultJob.set(wait: 1.minute).perform_later(
+        upload_id: upload.id,
+      )
     end
   end
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -381,6 +381,7 @@
     - translation
     - created_at
     - updated_at
+    - malware_scan_result
   :work_histories:
     - id
     - application_form_id

--- a/db/migrate/20230418180201_add_malware_scan_result_to_uploads.rb
+++ b/db/migrate/20230418180201_add_malware_scan_result_to_uploads.rb
@@ -1,0 +1,9 @@
+class AddMalwareScanResultToUploads < ActiveRecord::Migration[7.0]
+  def change
+    add_column :uploads,
+               :malware_scan_result,
+               :string,
+               null: false,
+               default: "pending"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_24_134509) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_18_180201) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -354,8 +354,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_24_134509) do
     t.string "teaching_authority_online_checker_url", default: "", null: false
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
-    t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.text "qualifications_information", default: "", null: false
+    t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "application_form_skip_work_history", default: false, null: false
     t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_requires_submission_email", default: false, null: false
@@ -486,6 +486,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_24_134509) do
     t.boolean "translation", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "malware_scan_result", default: "pending", null: false
     t.index ["document_id"], name: "index_uploads_on_document_id"
   end
 

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -2,11 +2,12 @@
 #
 # Table name: uploads
 #
-#  id          :bigint           not null, primary key
-#  translation :boolean          not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  document_id :bigint           not null
+#  id                  :bigint           not null, primary key
+#  malware_scan_result :string           default("pending"), not null
+#  translation         :boolean          not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  document_id         :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -2,11 +2,12 @@
 #
 # Table name: uploads
 #
-#  id          :bigint           not null, primary key
-#  translation :boolean          not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  document_id :bigint           not null
+#  id                  :bigint           not null, primary key
+#  malware_scan_result :string           default("pending"), not null
+#  translation         :boolean          not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  document_id         :bigint           not null
 #
 # Indexes
 #

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -92,6 +92,12 @@ module SystemHelpers
     sign_out @user
   end
 
+  def given_malware_scanning_is_enabled
+    allow(FetchMalwareScanResultJob).to receive(:set).and_return(
+      class_double(FetchMalwareScanResultJob, perform_later: true),
+    )
+  end
+
   alias_method :then_i_sign_out, :when_i_sign_out
 
   def given_the_test_user_is_disabled

--- a/spec/system/teacher_interface/back_links_spec.rb
+++ b/spec/system/teacher_interface/back_links_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Teacher back links", type: :system do
   before do
     given_the_service_is_open
+    given_malware_scanning_is_enabled
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
   end

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Teacher documents", type: :system do
   before do
     given_the_service_is_open
+    given_malware_scanning_is_enabled
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
   end

--- a/spec/system/teacher_interface/english_language_spec.rb
+++ b/spec/system/teacher_interface/english_language_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Teacher English language", type: :system do
   before do
     given_the_service_is_open
+    given_malware_scanning_is_enabled
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
   end

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Teacher further information", type: :system do
   before do
     given_the_service_is_open
+    given_malware_scanning_is_enabled
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
   end

--- a/spec/system/teacher_interface/personal_information_spec.rb
+++ b/spec/system/teacher_interface/personal_information_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Teacher personal information", type: :system do
   before do
     given_the_service_is_open
+    given_malware_scanning_is_enabled
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
   end

--- a/spec/system/teacher_interface/qualifications_spec.rb
+++ b/spec/system/teacher_interface/qualifications_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Teacher qualifications", type: :system do
   before do
     given_the_service_is_open
+    given_malware_scanning_is_enabled
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
   end

--- a/spec/system/teacher_interface/work_history_spec.rb
+++ b/spec/system/teacher_interface/work_history_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Teacher work history", type: :system do
   before do
     given_the_service_is_open
+    given_malware_scanning_is_enabled
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
   end

--- a/spec/system/teacher_interface/written_statement_spec.rb
+++ b/spec/system/teacher_interface/written_statement_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "Teacher written statement", type: :system do
   before do
     given_the_service_is_open
+    given_malware_scanning_is_enabled
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
   end


### PR DESCRIPTION
We have enabled a free trial of Defender for Azure on a per storage resource basis. Defender can run a malware scan on a storage account.
The malware scan is triggered on blob upload, the scan results are saved in a blob index tag.

There are a couple of commits in this PR which persist the result of the scan in `Upload#malware_scan_result`, the scan result is fetched in a background job once the upload is saved, the result isn't available via `ActiveStorage`, hence the additional API call.

We may be able to implement https://trello.com/c/5hRzWDXO/1769-store-virus-scan-state-on-the-upload-model this way.