### PR TITLE
Don't send LOPS received emails if declined

### DIFF
--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -36,7 +36,7 @@ class ProfessionalStandingRequest < ApplicationRecord
   end
 
   def after_received(*)
-    if application_form.teaching_authority_provides_written_statement
+    if should_send_received_email?
       TeacherMailer.with(teacher:).professional_standing_received.deliver_later
     end
   end
@@ -48,4 +48,11 @@ class ProfessionalStandingRequest < ApplicationRecord
   end
 
   delegate :teacher, to: :application_form
+
+  private
+
+  def should_send_received_email?
+    !application_form.declined? &&
+      application_form.teaching_authority_provides_written_statement
+  end
 end


### PR DESCRIPTION
If the application form is declined (because of a "quick decline") it's still possible for the assessors to received the professional standing request. In this case, we don't want to send out an email to the applicant since their application is already declined.

[Trello Card](https://trello.com/c/P0IO8FWl/1760-comms-to-applicant-post-decline-email-lops-received)