### PR TITLE
Catch timeout errors before rendering uploads

### DIFF
--- a/app/controllers/assessor_interface/uploads_controller.rb
+++ b/app/controllers/assessor_interface/uploads_controller.rb
@@ -4,6 +4,7 @@ module AssessorInterface
   class UploadsController < BaseController
     include ActiveStorage::Streaming
     include StreamedResponseAuthenticatable
+    include RescueActiveStorageErrors
 
     skip_before_action :authenticate_staff!, only: :show
     before_action -> { authenticate_or_redirect(:staff) }, only: :show
@@ -12,8 +13,6 @@ module AssessorInterface
 
     def show
       send_blob_stream(upload.attachment, disposition: :inline)
-    rescue ActiveStorage::FileNotFoundError
-      render "errors/not_found", status: :not_found
     end
 
     private

--- a/app/controllers/concerns/rescue_active_storage_errors.rb
+++ b/app/controllers/concerns/rescue_active_storage_errors.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module RescueActiveStorageErrors
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from ActiveStorage::FileNotFoundError, with: :error_not_found
+    rescue_from Faraday::TimeoutError, with: :error_internal_server_error
+    rescue_from IOError, with: :error_internal_server_error
+  end
+
+  def error_not_found
+    render "errors/not_found", status: :not_found
+  end
+
+  def error_internal_server_error
+    render "errors/internal_server_error", status: :internal_server_error
+  end
+end

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -6,6 +6,7 @@ module TeacherInterface
     include HandleApplicationFormSection
     include HistoryTrackable
     include StreamedResponseAuthenticatable
+    include RescueActiveStorageErrors
 
     skip_before_action :authenticate_teacher!, only: :show
     before_action -> { authenticate_or_redirect(:teacher) }, only: :show
@@ -17,8 +18,6 @@ module TeacherInterface
 
     def show
       send_blob_stream(@upload.attachment, disposition: :inline)
-    rescue ActiveStorage::FileNotFoundError
-      render "errors/not_found", status: :not_found
     end
 
     def new

--- a/spec/controllers/assessor_interface/uploads_controller_spec.rb
+++ b/spec/controllers/assessor_interface/uploads_controller_spec.rb
@@ -43,6 +43,19 @@ RSpec.describe AssessorInterface::UploadsController, type: :controller do
       end
     end
 
+    context "when the upload times out" do
+      before do
+        allow(controller).to receive(:send_blob_stream).and_raise(
+          Faraday::TimeoutError,
+        )
+      end
+
+      it "renders internal server error" do
+        perform
+        expect(response.status).to eq(500)
+      end
+    end
+
     context "when the user session times out" do
       before { sign_out staff }
 

--- a/spec/controllers/teacher_interface/uploads_controller_spec.rb
+++ b/spec/controllers/teacher_interface/uploads_controller_spec.rb
@@ -83,6 +83,19 @@ RSpec.describe TeacherInterface::UploadsController, type: :controller do
       end
     end
 
+    context "when the upload times out" do
+      before do
+        allow(controller).to receive(:send_blob_stream).and_raise(
+          Faraday::TimeoutError,
+        )
+      end
+
+      it "renders internal server error" do
+        perform
+        expect(response.status).to eq(500)
+      end
+    end
+
     context "when the user session times out" do
       before { sign_out teacher }
 


### PR DESCRIPTION
Sometimes we get timeout errors when downloading a file from Azure to show it to the user, and there isn't much we can do to handle this case. Rather than seeing the error in Sentry, this proposes that we simply render the internal server error page right away. This is no different to what users are seeing currently, but it avoids us having Sentry issues which we can't solve.