### PR TITLE
Fix uncaught warden errors in uploads controller

### DIFF
--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -8,8 +8,8 @@ module TeacherInterface
     include StreamedResponseAuthenticatable
     include RescueActiveStorageErrors
 
-    skip_before_action :authenticate_teacher!, only: :show
-    before_action -> { authenticate_or_redirect(:teacher) }, only: :show
+    skip_before_action :authenticate_teacher!, only: %i[show new]
+    before_action -> { authenticate_or_redirect(:teacher) }, only: %i[show new]
 
     before_action :redirect_unless_draft_or_further_information
     before_action :load_application_form


### PR DESCRIPTION
We seem to be getting Sentry errors for the new controller method so I've extended the logic we've added for the show method to include the new method.

https://dfe-teacher-services.sentry.io/issues/4031065239/