### PR TITLE
Fix uncaught warden errors in uploads controller

### DIFF
--- a/app/controllers/assessor_interface/uploads_controller.rb
+++ b/app/controllers/assessor_interface/uploads_controller.rb
@@ -6,8 +6,8 @@ module AssessorInterface
     include StreamedResponseAuthenticatable
     include RescueActiveStorageErrors
 
-    skip_before_action :authenticate_staff!, only: :show
-    before_action -> { authenticate_or_redirect(:staff) }, only: :show
+    skip_before_action :authenticate_staff!
+    before_action -> { authenticate_or_redirect(:staff) }
 
     before_action :authorize_assessor
 

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -8,8 +8,8 @@ module TeacherInterface
     include StreamedResponseAuthenticatable
     include RescueActiveStorageErrors
 
-    skip_before_action :authenticate_teacher!, only: %i[show new]
-    before_action -> { authenticate_or_redirect(:teacher) }, only: %i[show new]
+    skip_before_action :authenticate_teacher!
+    before_action -> { authenticate_or_redirect(:teacher) }
 
     before_action :redirect_unless_draft_or_further_information
     before_action :load_application_form


### PR DESCRIPTION
This expands upon 8ac1e12f39759c0cd21bb4bf987539dabae6ef49 to use the before action for all controller methods. I'm not sure why we weren't seeing this issue before, but now we seem to be seeing it for all the controller methods.

[Sentry issue](https://dfe-teacher-services.sentry.io/issues/4031065239/)