### PR TITLE
Upgrade to latest version of Terraform

### DIFF
--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -58,7 +58,7 @@ runs:
 
     - uses: hashicorp/setup-terraform@v1
       with:
-        terraform_version: 1.0.10
+        terraform_version: 1.4.5
         terraform_wrapper: false
 
     - name: Terraform

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -49,7 +49,7 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.0.10
+          terraform_version: 1.4.5
           terraform_wrapper: false
 
       - name: Set Environment variables

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup terraform
         uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: 1.0.10
+          terraform_version: 1.4.5
 
       - name: Check formatting
         run: terraform fmt -check

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,5 +2,5 @@ azure-cli 2.37.0
 nodejs 18.1.0
 postgres 13.5
 ruby 3.2.2
-terraform 1.0.10
+terraform 1.4.5
 yarn 1.22.19

--- a/terraform/paas/.terraform.lock.hcl
+++ b/terraform/paas/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/cloudfoundry-community/cloudfoundry" {
   constraints = "~> 0.15"
   hashes = [
     "h1:O0IZUYV1Ty/2GEzlDerCNUEB9MZBBR/eImISwzIGfIo=",
+    "h1:kCGHU5SeMWVBIs9HaPtNFkjt1NQJj73sVG/D2dcWt5I=",
     "zh:0a25a083320b44a8feb2db8197dc18dfba00a976c9d8f1890c8e819a9c88a0d4",
     "zh:0dc3761af036dd9e66247dc862969e74afc0dd7307c4b2c5be85b4a238390702",
     "zh:16482fe9caba561262e36d918d5500a4d11b416d663c13372e91375f05769a6b",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "2.99.0"
   constraints = "~> 2.84"
   hashes = [
+    "h1:/M8yLHqv0uOm9IbHRa4yZvQORr9ir1QyJyIyjGs4ryQ=",
     "h1:/ZY1j8YgB5GeqPnjT8avyRFjUcGH3rCk1xGLKcUCtWc=",
     "h1:FXBB5TkvZpZA+ZRtofPvp5IHZpz4Atw7w9J8GDgMhvk=",
     "zh:08d81e72e97351538ab4d15548942217bf0c4d3b79ad3f4c95d8f07f902d2fa6",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/statuscakedev/statuscake" {
   version     = "2.0.5"
   constraints = "2.0.5"
   hashes = [
+    "h1:atcYyVnomhERxQMA6zBd2t1TQQA9fBHwbYYU1tRIjfY=",
     "h1:xOdqOYEZQW9aqoBekGGMnqZueTAdhQ5XnfOfzeQnSc4=",
     "zh:0d4abab56a77562c8c347e4bec8ec5f9cb74cfa78e14485d1895dbae2d3e46d1",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",

--- a/terraform/paas/terraform.tf
+++ b/terraform/paas/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.0"
+  required_version = "~> 1.4"
 
   backend "azurerm" {
     container_name = "afqts-tfstate"

--- a/terraform/paas/workspace_variables/review.backend.tfvars
+++ b/terraform/paas/workspace_variables/review.backend.tfvars
@@ -1,3 +1,3 @@
 storage_account_name = "s165d01afqtstfstatedv"
 # The key is provided dynamically for each review app via the Makefile
-resource_group_name  = "s165d01-afqts-dv-rg"
+resource_group_name = "s165d01-afqts-dv-rg"


### PR DESCRIPTION
This is in advance of migrating to AKS and allows us to take advantage of the latest features in Terraform.

This is required by #1323.