### PR TITLE
Limit Slack notifications about Github workflow failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -257,7 +257,7 @@ jobs:
     environment: ${{ needs.deploy_nonprod.outputs.environment_name || 'dev'  }}
     env:
       ENVIRONMENT_NAME: ${{ needs.deploy_nonprod.outputs.environment_name || 'dev'  }}
-    if: ${{ failure() }}
+    if: ${{ failure() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
We want these for build, rspec and deploy_nonprod but only when the main branch is pushed, otherwise an rspec failure on a PR branch will notify.