### PR TITLE
Remove code relating to initial assessment status

### DIFF
--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -29,7 +29,6 @@ module StatusTag
       expired: "pink",
       in_progress: "blue",
       assessment_in_progress: "blue",
-      initial_assessment: "blue",
       invalid: "red",
       not_started: "grey",
       overdue: "pink",

--- a/app/lib/filters/status.rb
+++ b/app/lib/filters/status.rb
@@ -9,14 +9,6 @@ class Filters::Status < Filters::Base
   private
 
   def statuses
-    Array(params[:statuses])
-      .reject(&:blank?)
-      .flat_map do |status|
-        if status == "assessment_in_progress"
-          %w[initial_assessment assessment_in_progress]
-        else
-          status
-        end
-      end
+    Array(params[:statuses]).reject(&:blank?)
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -123,7 +123,6 @@ class ApplicationForm < ApplicationRecord
          submitted: "submitted",
          preliminary_check: "preliminary_check",
          assessment_in_progress: "assessment_in_progress",
-         initial_assessment: "initial_assessment",
          waiting_on: "waiting_on",
          received: "received",
          overdue: "overdue",
@@ -161,13 +160,12 @@ class ApplicationForm < ApplicationRecord
             status: %i[
               preliminary_check
               submitted
-              initial_assessment
+              assessment_in_progress
               waiting_on
               received
               overdue
               awarded_pending_checks
               potential_duplicate_in_dqt
-              assessment_in_progress
             ],
           ).or(awarded.where("awarded_at >= ?", 90.days.ago)).or(
             declined.where("declined_at >= ?", 90.days.ago),

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -49,15 +49,8 @@ class AssessorInterface::ApplicationFormsIndexViewObject
     ]
 
     statuses.map do |status|
-      count =
-        if status == "assessment_in_progress"
-          counts.fetch("assessment_in_progress", 0) +
-            counts.fetch("initial_assessment", 0)
-        else
-          counts.fetch(status, 0)
-        end
       text = I18n.t(status, scope: %i[components status_tag])
-      OpenStruct.new(id: status, label: "#{text} (#{count})")
+      OpenStruct.new(id: status, label: "#{text} (#{counts.fetch(status, 0)})")
     end
   end
 

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -11,7 +11,6 @@ en:
       expired: Overdue
       in_progress: In progress
       assessment_in_progress: Assessment in progress
-      initial_assessment: Assessment in progress
       invalid: Invalid
       not_started: Not started
       overdue: Overdue

--- a/lib/tasks/update_application_form_status.rake
+++ b/lib/tasks/update_application_form_status.rake
@@ -1,8 +1,0 @@
-desc "Update application status"
-task update_application_form_status_initial_assessment: :environment do
-  # fetch all application forms with 'initial assessment' status
-  forms = ApplicationForm.where(status: "initial_assessment")
-
-  # update the status for each form
-  forms.update_all(status: "assessment_in_progress")
-end

--- a/spec/components/status_tag_spec.rb
+++ b/spec/components/status_tag_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe StatusTag::Component, type: :component do
       it { is_expected.to eq("govuk-tag app-task-list__tag") }
     end
 
-    context "with an 'initial_assessment' status" do
-      let(:status) { :initial_assessment }
+    context "with an 'assessment_in_progress' status" do
+      let(:status) { :assessment_in_progress }
 
       it { is_expected.to eq("govuk-tag govuk-tag--blue app-task-list__tag") }
     end

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -138,11 +138,6 @@ FactoryBot.define do
       submitted_at { Time.zone.now }
     end
 
-    trait :initial_assessment do
-      status { "initial_assessment" }
-      submitted_at { Time.zone.now }
-    end
-
     trait :assessment_in_progress do
       status { "assessment_in_progress" }
       submitted_at { Time.zone.now }

--- a/spec/lib/filters/status_spec.rb
+++ b/spec/lib/filters/status_spec.rb
@@ -53,25 +53,4 @@ RSpec.describe Filters::Status do
       expect(subject).to eq(scope)
     end
   end
-
-  context "with assessment_in_progress status" do
-    let(:params) { { statuses: "assessment_in_progress" } }
-    let(:scope) { ApplicationForm.all }
-
-    let!(:included) do
-      [
-        create(:application_form, :initial_assessment),
-        create(:application_form, :assessment_in_progress),
-      ]
-    end
-
-    let!(:filtered) do
-      create(:application_form, :draft)
-      create(:application_form, :submitted)
-    end
-
-    it "returns a filtered scope including initial_assessment and assessment_in_progress statuses" do
-      expect(subject).to match_array(included)
-    end
-  end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -104,7 +104,6 @@ RSpec.describe ApplicationForm, type: :model do
         submitted: "submitted",
         preliminary_check: "preliminary_check",
         assessment_in_progress: "assessment_in_progress",
-        initial_assessment: "initial_assessment",
         waiting_on: "waiting_on",
         received: "received",
         overdue: "overdue",

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -187,14 +187,13 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
         create_list(:application_form, 1, :preliminary_check)
         create_list(:application_form, 2, :submitted)
         create_list(:application_form, 3, :assessment_in_progress)
-        create_list(:application_form, 4, :initial_assessment)
-        create_list(:application_form, 5, :waiting_on)
-        create_list(:application_form, 6, :received)
-        create_list(:application_form, 7, :overdue)
-        create_list(:application_form, 8, :awarded_pending_checks)
-        create_list(:application_form, 9, :awarded)
-        create_list(:application_form, 10, :declined)
-        create_list(:application_form, 11, :potential_duplicate_in_dqt)
+        create_list(:application_form, 4, :waiting_on)
+        create_list(:application_form, 5, :received)
+        create_list(:application_form, 6, :overdue)
+        create_list(:application_form, 7, :awarded_pending_checks)
+        create_list(:application_form, 8, :awarded)
+        create_list(:application_form, 9, :declined)
+        create_list(:application_form, 10, :potential_duplicate_in_dqt)
       end
 
       it do
@@ -207,20 +206,20 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
             OpenStruct.new(id: "submitted", label: "Not started (2)"),
             OpenStruct.new(
               id: "assessment_in_progress",
-              label: "Assessment in progress (7)",
+              label: "Assessment in progress (3)",
             ),
-            OpenStruct.new(id: "waiting_on", label: "Waiting on (5)"),
-            OpenStruct.new(id: "received", label: "Received (6)"),
-            OpenStruct.new(id: "overdue", label: "Overdue (7)"),
+            OpenStruct.new(id: "waiting_on", label: "Waiting on (4)"),
+            OpenStruct.new(id: "received", label: "Received (5)"),
+            OpenStruct.new(id: "overdue", label: "Overdue (6)"),
             OpenStruct.new(
               id: "awarded_pending_checks",
-              label: "Award pending (8)",
+              label: "Award pending (7)",
             ),
-            OpenStruct.new(id: "awarded", label: "Awarded (9)"),
-            OpenStruct.new(id: "declined", label: "Declined (10)"),
+            OpenStruct.new(id: "awarded", label: "Awarded (8)"),
+            OpenStruct.new(id: "declined", label: "Declined (9)"),
             OpenStruct.new(
               id: "potential_duplicate_in_dqt",
-              label: "Potential duplication in DQT (11)",
+              label: "Potential duplication in DQT (10)",
             ),
           ],
         )


### PR DESCRIPTION
Remove rake task and any code relating to the 'initial_assessment' status as it has been superseded by 'assessment_in_progress'

This is pr 3/3 of https://trello.com/c/8Uzg5EM5/1749-rename-internal-initial-assessment-status-to-in-progress


pr 1 https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/1332

pr 2 https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/1344

pr2.1 (repair mistake in pr 2) https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/1346