### PR TITLE
Change maximum age validation

### DIFF
--- a/app/forms/teacher_interface/age_range_form.rb
+++ b/app/forms/teacher_interface/age_range_form.rb
@@ -20,7 +20,6 @@ module TeacherInterface
               numericality: {
                 only_integer: true,
                 greater_than_or_equal_to: :minimum,
-                less_than_or_equal_to: 18,
                 allow_nil: true,
               }
 

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -162,7 +162,6 @@ en:
               not_a_number: Enter age to
               not_an_integer: Enter age to
               greater_than_or_equal_to: Age to must be %{count} or more
-              less_than_or_equal_to: Age to must be %{count} or less
         teacher_interface/alternative_name_form:
           attributes:
             alternative_given_names:


### PR DESCRIPTION
Remove the max limit for entering age range
All other validations for the field are the same


<img width="1728" alt="Screenshot 2023-04-24 at 11 24 51" src="https://user-images.githubusercontent.com/45995847/233970101-356d4aaa-1c22-4d15-b7f6-548f50451417.png">

<img width="1676" alt="Screenshot 2023-04-24 at 11 25 11" src="https://user-images.githubusercontent.com/45995847/233970186-06b1a616-d9de-4e60-ab42-166efabd08d4.png">

<img width="1728" alt="Screenshot 2023-04-24 at 11 25 41" src="https://user-images.githubusercontent.com/45995847/233970290-bb898db9-2097-4e21-be09-23351001d2c9.png">


https://trello.com/c/XCYctl2D/1791-remove-maximum-limit-to-age-qualified-to-teach