### PR TITLE
Store malware scan state on the upload model

### DIFF
--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -38,6 +38,8 @@ module TeacherInterface
         end
       end
 
+      fetch_and_update_malware_scan_results
+
       document.update!(completed: skippable? || !document.uploads.empty?)
     end
 
@@ -71,6 +73,15 @@ module TeacherInterface
         if written_in_english == false
           errors.add(:translated_attachment, :blank)
         end
+      end
+    end
+
+    def fetch_and_update_malware_scan_results
+      document.uploads.each do |upload|
+        # We need a delay here to ensure that the upload has been scanned before fetching the result.
+        FetchMalwareScanResultJob.set(wait: 1.minute).perform_later(
+          upload_id: upload.id,
+        )
       end
     end
   end

--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -38,7 +38,9 @@ module TeacherInterface
         end
       end
 
-      fetch_and_update_malware_scan_results
+      if FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
+        fetch_and_update_malware_scan_results
+      end
 
       document.update!(completed: skippable? || !document.uploads.empty?)
     end

--- a/app/helpers/upload_helper.rb
+++ b/app/helpers/upload_helper.rb
@@ -1,5 +1,7 @@
 module UploadHelper
   def upload_link_to(upload)
+    return "Suspected malware. File removed." if upload.scan_result_suspect?
+
     govuk_link_to(
       "#{upload.name} (opens in a new tab)",
       [interface, :application_form, upload.document, upload],

--- a/app/jobs/fetch_malware_scan_result_job.rb
+++ b/app/jobs/fetch_malware_scan_result_job.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class FetchMalwareScanResultJob < ApplicationJob
+  def perform(upload_id:)
+    upload = Upload.find(upload_id)
+    FetchMalwareScanResult.call(upload:)
+  end
+end

--- a/app/jobs/remove_malware_blob_job.rb
+++ b/app/jobs/remove_malware_blob_job.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class RemoveMalwareBlobJob < ApplicationJob
+  def perform(upload_id:)
+    upload = Upload.find(upload_id)
+    RemoveMalwareBlob.call(upload:)
+  end
+end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -2,11 +2,12 @@
 #
 # Table name: uploads
 #
-#  id          :bigint           not null, primary key
-#  translation :boolean          not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  document_id :bigint           not null
+#  id                  :bigint           not null, primary key
+#  malware_scan_result :string           default("pending"), not null
+#  translation         :boolean          not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  document_id         :bigint           not null
 #
 # Indexes
 #
@@ -21,6 +22,14 @@ class Upload < ApplicationRecord
 
   has_one_attached :attachment, dependent: :purge_later
   validates :attachment, presence: true
+
+  enum malware_scan_result: {
+         clean: "clean",
+         error: "error",
+         pending: "pending",
+         suspect: "suspect",
+       },
+       _prefix: :scan_result
 
   def original?
     !translation?

--- a/app/services/fetch_malware_scan_result.rb
+++ b/app/services/fetch_malware_scan_result.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+class FetchMalwareScanResult
+  include ServicePattern
+
+  # Only later versions of the Azure Storage REST API support tags operations.
+  Kernel.silence_warnings do
+    Azure::Storage::Blob::Default::STG_VERSION = "2022-11-02"
+  end
+
+  SCAN_RESULT_TAG_KEY = /Malware Scanning scan result/
+  SCAN_RESULT_TAG_VALUE_CLEAN = /No threats found/
+
+  def initialize(upload:)
+    @upload = upload
+  end
+
+  def call
+    return unless upload.scan_result_pending?
+
+    response = fetch_scan_result
+
+    if response.success?
+      if response.body =~ SCAN_RESULT_TAG_KEY
+        upload.update!(
+          malware_scan_result: malware_scan_result_from_response(response),
+        )
+        if upload.scan_result_suspect?
+          RemoveMalwareBlobJob.perform_later(upload_id: upload.id)
+        end
+      end
+    else
+      upload.update!(malware_scan_result: "error")
+    end
+  rescue Azure::Core::Http::HTTPError
+    upload.update!(malware_scan_result: "error")
+  end
+
+  private
+
+  attr_reader :upload
+
+  def blob_service
+    @blob_service ||=
+      Azure::Storage::Blob::BlobService.new(
+        storage_account_name: ENV["AZURE_STORAGE_ACCOUNT_NAME"],
+        storage_access_key: ENV["AZURE_STORAGE_ACCESS_KEY"],
+      )
+  end
+
+  def fetch_scan_result
+    blob_service.call(:get, get_tags_for_blob_url)
+  end
+
+  def get_tags_for_blob_url
+    @get_tags_for_blob_url ||=
+      blob_service.generate_uri(
+        File.join("uploads", upload.attachment.key),
+        { comp: "tags" },
+      )
+  end
+
+  def malware_scan_result_from_response(response)
+    response.body =~ SCAN_RESULT_TAG_VALUE_CLEAN ? "clean" : "suspect"
+  end
+end

--- a/app/services/remove_malware_blob.rb
+++ b/app/services/remove_malware_blob.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class RemoveMalwareBlob
+  include ServicePattern
+
+  attr_reader :upload
+
+  def initialize(upload:)
+    @upload = upload
+  end
+
+  def call
+    return unless upload.scan_result_suspect?
+
+    upload.attachment.purge
+  end
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -381,6 +381,7 @@
     - translation
     - created_at
     - updated_at
+    - malware_scan_result
   :work_histories:
     - id
     - application_form_id

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -24,4 +24,10 @@ feature_flags:
       Allow starting an application on this service directly after completing
       an eligibility check.
 
+  fetch_malware_scan_result:
+    author: Steve Laing
+    description: >
+      Fetch malware scan results for uploaded files.
+      This flag should only be active for environments where malware scanning is enabled.
+
 parent_controller: "SupportInterface::BaseController"

--- a/db/migrate/20230418180201_add_malware_scan_result_to_uploads.rb
+++ b/db/migrate/20230418180201_add_malware_scan_result_to_uploads.rb
@@ -1,0 +1,9 @@
+class AddMalwareScanResultToUploads < ActiveRecord::Migration[7.0]
+  def change
+    add_column :uploads,
+               :malware_scan_result,
+               :string,
+               null: false,
+               default: "pending"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_24_134509) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_18_180201) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -354,8 +354,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_24_134509) do
     t.string "teaching_authority_online_checker_url", default: "", null: false
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
-    t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.text "qualifications_information", default: "", null: false
+    t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "application_form_skip_work_history", default: false, null: false
     t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_requires_submission_email", default: false, null: false
@@ -486,6 +486,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_24_134509) do
     t.boolean "translation", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "malware_scan_result", default: "pending", null: false
     t.index ["document_id"], name: "index_uploads_on_document_id"
   end
 

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -2,11 +2,12 @@
 #
 # Table name: uploads
 #
-#  id          :bigint           not null, primary key
-#  translation :boolean          not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  document_id :bigint           not null
+#  id                  :bigint           not null, primary key
+#  malware_scan_result :string           default("pending"), not null
+#  translation         :boolean          not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  document_id         :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -2,11 +2,12 @@
 #
 # Table name: uploads
 #
-#  id          :bigint           not null, primary key
-#  translation :boolean          not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
-#  document_id :bigint           not null
+#  id                  :bigint           not null, primary key
+#  malware_scan_result :string           default("pending"), not null
+#  translation         :boolean          not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  document_id         :bigint           not null
 #
 # Indexes
 #

--- a/spec/services/fetch_malware_scan_result_spec.rb
+++ b/spec/services/fetch_malware_scan_result_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FetchMalwareScanResult do
+  describe "#call" do
+    let(:upload) { create(:upload) }
+    let(:tags_url) { "https://example.com/uploads/xyz123?comp=tags" }
+    let(:response_success) { true }
+    let(:scan_result) { "No threats found" }
+    let(:response_body) { <<-XML.squish }
+      <Tags>
+        <Tag>
+          <Key>Malware Scanning scan result</Key>
+          <Value>#{scan_result}</Value>
+        </Tag>
+      </Tags>
+      XML
+    let(:stubbed_blob_service) do
+      instance_double(Azure::Storage::Blob::BlobService, generate_uri: tags_url)
+    end
+    let(:stubbed_response) do
+      instance_double(
+        Azure::Core::Http::HttpResponse,
+        success?: response_success,
+        body: response_body,
+      )
+    end
+    subject(:fetch_malware_scan_result) { described_class.call(upload:) }
+
+    before do
+      allow(Azure::Storage::Blob::BlobService).to receive(:new).and_return(
+        stubbed_blob_service,
+      )
+      allow(stubbed_blob_service).to receive(:call).and_return(stubbed_response)
+    end
+
+    it "calls the Azure Storage REST API for the scan result" do
+      expect(stubbed_blob_service).to receive(:call).with(:get, tags_url)
+      fetch_malware_scan_result
+    end
+
+    context "with a successful scan result" do
+      it "saves the result" do
+        fetch_malware_scan_result
+        expect(upload.malware_scan_result).to eq("clean")
+      end
+    end
+
+    context "with a failed scan result" do
+      let(:scan_result) { "Malicious" }
+
+      it "saves the result" do
+        fetch_malware_scan_result
+        expect(upload.malware_scan_result).to eq("suspect")
+      end
+
+      it "enqueues a job to remove the file" do
+        expect(RemoveMalwareBlobJob).to receive(:perform_later).with(
+          upload_id: upload.id,
+        )
+        fetch_malware_scan_result
+      end
+    end
+
+    context "with an unsuccessful response" do
+      let(:response_success) { false }
+      it "saves an error result" do
+        fetch_malware_scan_result
+        expect(upload.malware_scan_result).to eq("error")
+      end
+    end
+  end
+end

--- a/spec/services/remove_malware_blob_spec.rb
+++ b/spec/services/remove_malware_blob_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RemoveMalwareBlob do
+  describe "#call" do
+    let(:result) { "suspect" }
+    let(:upload) { create(:upload, malware_scan_result: result) }
+    subject(:remove_malware_blob) { described_class.call(upload:) }
+
+    it "removes the upload attachment" do
+      remove_malware_blob
+
+      expect(upload.reload.attachment.filename).to be_nil
+      expect(upload.reload.attachment.download).to be_nil
+    end
+
+    context "when the upload does not have a suspect scan result" do
+      let(:result) { "clean" }
+
+      it "does not remove the malware blob" do
+        remove_malware_blob
+
+        expect(upload.reload.attachment.filename).to be_present
+        expect(upload.reload.attachment.download).to be_present
+      end
+    end
+  end
+end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -82,6 +82,7 @@ module SystemHelpers
   end
 
   def given_malware_scanning_is_enabled(scan_result: "No threats found")
+    FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result)
     tags_url = "https://example.com/uploads/abc987xyz123?comp=tags"
     response_body = <<-XML.squish
       <Tags>

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -81,6 +81,25 @@ module SystemHelpers
     given_i_am_authorized_as_a_user(user)
   end
 
+  def given_malware_scanning_is_enabled
+    tags_url = "https://example.com/uploads/abc987xyz123?comp=tags"
+    response_body = <<-XML.squish
+      <Tags><Tag><Key>Malware Scanning scan result</Key><Value>No threats found</Value><Tag></Tags>"
+    XML
+    stubbed_service =
+      instance_double(Azure::Storage::Blob::BlobService, generate_uri: tags_url)
+    stubbed_response =
+      instance_double(
+        Azure::Core::Http::HttpResponse,
+        success?: true,
+        body: response_body,
+      )
+    allow(Azure::Storage::Blob::BlobService).to receive(:new).and_return(
+      stubbed_service,
+    )
+    allow(stubbed_service).to receive(:call).and_return(stubbed_response)
+  end
+
   def when_i_am_authorized_as_a_test_user
     page.driver.basic_authorize(
       ENV.fetch("TEST_USERNAME", "test"),

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -81,10 +81,15 @@ module SystemHelpers
     given_i_am_authorized_as_a_user(user)
   end
 
-  def given_malware_scanning_is_enabled
+  def given_malware_scanning_is_enabled(scan_result: "No threats found")
     tags_url = "https://example.com/uploads/abc987xyz123?comp=tags"
     response_body = <<-XML.squish
-      <Tags><Tag><Key>Malware Scanning scan result</Key><Value>No threats found</Value><Tag></Tags>"
+      <Tags>
+        <Tag>
+          <Key>Malware Scanning scan result</Key>
+          <Value>#{scan_result}</Value>
+        </Tag>
+      </Tags>
     XML
     stubbed_service =
       instance_double(Azure::Storage::Blob::BlobService, generate_uri: tags_url)

--- a/spec/system/teacher_interface/back_links_spec.rb
+++ b/spec/system/teacher_interface/back_links_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Teacher back links", type: :system do
     given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
+    given_malware_scanning_is_enabled
   end
 
   it "back links follow user" do

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Teacher documents", type: :system do
     given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
+    given_malware_scanning_is_enabled
   end
 
   it "uploading and deleting files" do

--- a/spec/system/teacher_interface/english_language_spec.rb
+++ b/spec/system/teacher_interface/english_language_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Teacher English language", type: :system do
     given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
+    given_malware_scanning_is_enabled
   end
 
   it "citizenship exempt" do

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "Teacher further information", type: :system do
     given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
+    given_malware_scanning_is_enabled
   end
 
   it "save and sign out" do

--- a/spec/system/teacher_interface/malware_scanning_spec.rb
+++ b/spec/system/teacher_interface/malware_scanning_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe "Malware scanning", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_a_user(teacher)
+    given_there_is_an_application_form
+    given_malware_scanning_is_enabled(scan_result: "Malicious")
+  end
+
+  it "uploading an infected file" do
+    when_i_visit_the(:teacher_application_page)
+
+    when_i_click_written_statement
+    then_i_see_document_form
+
+    when_i_upload_a_document
+    and_i_click_continue
+    then_i_see_the_check_your_uploaded_files_page
+    and_the_uploaded_files_have_been_marked_as_malware
+    and_the_uploaded_files_have_been_removed
+  end
+
+  def given_there_is_an_application_form
+    application_form
+  end
+
+  def when_i_click_written_statement
+    click_link "Upload your written statement"
+  end
+
+  def when_i_upload_a_document
+    teacher_upload_document_page.form.original_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
+    )
+    teacher_upload_document_page.form.written_in_english_items.second.choose
+    teacher_upload_document_page.form.translated_attachment.attach_file Rails.root.join(
+      file_fixture("upload.pdf"),
+    )
+  end
+
+  def then_i_see_document_form
+    expect(teacher_check_document_page).to have_title("Upload a document")
+    expect(teacher_check_document_page.heading.text).to eq(
+      "Upload your written statement",
+    )
+  end
+
+  def then_i_see_the_check_your_uploaded_files_page
+    expect(check_uploaded_files_page).to have_title("Check your uploaded files")
+    expect(check_uploaded_files_page.heading.text).to eq(
+      "Check your uploaded files – written statement document",
+    )
+  end
+
+  def and_the_uploaded_files_have_been_marked_as_malware
+    expect(check_uploaded_files_page.files).to have_content(
+      "File 1\tSuspected malware. File removed.",
+    )
+    expect(check_uploaded_files_page.files).to have_content(
+      "File 2\tSuspected malware. File removed.",
+    )
+  end
+
+  def and_the_uploaded_files_have_been_removed
+    written_statement =
+      application_form.documents.find_by(document_type: "written_statement")
+    expect(written_statement.uploads.first.attachment.download).to be_nil
+    expect(written_statement.uploads.first.attachment.filename).to be_nil
+    expect(written_statement.uploads.last.attachment.download).to be_nil
+    expect(written_statement.uploads.last.attachment.filename).to be_nil
+  end
+
+  def teacher
+    @teacher ||= create(:teacher)
+  end
+
+  def application_form
+    @application_form ||=
+      create(:application_form, teacher:, needs_written_statement: true)
+  end
+end

--- a/spec/system/teacher_interface/personal_information_spec.rb
+++ b/spec/system/teacher_interface/personal_information_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Teacher personal information", type: :system do
     given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
+    given_malware_scanning_is_enabled
   end
 
   it "without an alternative name" do

--- a/spec/system/teacher_interface/qualifications_spec.rb
+++ b/spec/system/teacher_interface/qualifications_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Teacher qualifications", type: :system do
     given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
+    given_malware_scanning_is_enabled
   end
 
   it "records qualifications" do

--- a/spec/system/teacher_interface/work_history_spec.rb
+++ b/spec/system/teacher_interface/work_history_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Teacher work history", type: :system do
     given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
+    given_malware_scanning_is_enabled
   end
 
   it "records work history" do

--- a/spec/system/teacher_interface/written_statement_spec.rb
+++ b/spec/system/teacher_interface/written_statement_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "Teacher written statement", type: :system do
     given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
+    given_malware_scanning_is_enabled
   end
 
   it "teacher provides document" do


### PR DESCRIPTION
[Trello](https://trello.com/c/5hRzWDXO/1769-store-virus-scan-state-on-the-upload-model)

Microsoft Defender for Azure Storage runs a malware scan on files when they are uploaded. 
The result of the scan is stored on an index tag on the uploaded blob. ActiveStorage doesn't provide an API for reading index tags.
It is possible to use the `azure-storage-ruby` gem to call the Azure Storage REST API and fetch blob index tags. This is how we retrieve malware scan results.

This PR:

- Adds the field `Upload#malware_scan_result` with an associated enum on the model.
- Adds a service to fetch the malware scan result via the Azure Storage REST API
- Updates the `Upload#malware_scan_result` field with the scan result.
- If the scan result was not clean, removes the suspected malware blob from storage.

We continue to serve files with a "pending" malware scan result, a follow up PR will handle scanning existing stored blobs.
Also we will implement a design for detected malware (for now we will have placeholder text instead of a link to the file).
 

