### PR TITLE
Add Redis in AKS (1 of 4)

### DIFF
--- a/terraform/aks/.terraform.lock.hcl
+++ b/terraform/aks/.terraform.lock.hcl
@@ -20,3 +20,22 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version = "2.20.0"
+  hashes = [
+    "h1:E7VAZorKe5oXn6h1nxP3ROwWNiQSrZlTawzix1sh8kM=",
+    "zh:30bc224c94d2c90a7d44554f2ad30e3b62c7ffc6ddb7d4fd31b9acafb8b5ad77",
+    "zh:3903cc9f0c3169a24265c4920d925ed7e37cbc4312237b29bd5b4ddcd6bdc535",
+    "zh:512240f6dad36c0116a8717487a4ea12a6b4191028782c5b6749037892e2c6ed",
+    "zh:57d5f77dcde7781803b465205aec3507780bfaa77031f5b893ae7cbebd4789b6",
+    "zh:6274ab8c3b59634c344c337218223640e9d954996b9299587ca924e4dfb77aa4",
+    "zh:6d838a25f3e3c696cf894f0adb44b41b461a2c76f914f1ae2c318ccbb1ec4e36",
+    "zh:92f09e3e03311c4e24601b704d85de57677f49e29f42cc3479fafa68f5de300a",
+    "zh:abb3cd606e485a46c076d6f60d37b5e5ecaa128c0150c8235627b484f2fac902",
+    "zh:afc07f5c0d7ce2cc907600e4f87a1290203a36221951e19e5d3f1409a0502377",
+    "zh:d9c01e4f12fabf5d6d9d11ceb409585b71c2abcad478496446de6ff18bbf2f5f",
+    "zh:f40faba2269184b305f229503945400ed6eeafec7ac395c23f243bccab7b11b2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/aks/cluster_data.tf
+++ b/terraform/aks/cluster_data.tf
@@ -1,0 +1,4 @@
+module "cluster_data" {
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/cluster_data?ref=testing"
+  name   = var.cluster
+}

--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -1,0 +1,14 @@
+module "redis" {
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/redis?ref=testing"
+
+  namespace             = var.namespace
+  environment           = "${var.app_environment}${var.app_suffix}"
+  azure_resource_prefix = var.azure_resource_prefix
+  service_short         = var.service_short
+  config_short          = var.config_short
+
+  cluster_configuration_map = module.cluster_data.configuration_map
+
+  use_azure               = var.deploy_azure_backing_services
+  azure_enable_monitoring = var.enable_monitoring
+}

--- a/terraform/aks/providers.tf
+++ b/terraform/aks/providers.tf
@@ -11,3 +11,10 @@ provider "azurerm" {
 
   features {}
 }
+
+provider "kubernetes" {
+  host                   = module.cluster_data.kubernetes_host
+  client_certificate     = module.cluster_data.kubernetes_client_certificate
+  client_key             = module.cluster_data.kubernetes_client_key
+  cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
+}

--- a/terraform/aks/terraform.tf
+++ b/terraform/aks/terraform.tf
@@ -8,5 +8,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "3.53.0"
     }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.20.0"
+    }
   }
 }

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -1,8 +1,43 @@
+variable "app_environment" {
+  type = string
+}
+
+variable "app_suffix" {
+  type    = string
+  default = ""
+}
+
+variable "azure_resource_prefix" {
+  type = string
+}
+
 variable "azure_sp_credentials_json" {
   type    = string
   default = null
 }
 
 variable "cluster" {
+  type = string
+}
+
+variable "config_short" {
+  type = string
+}
+
+variable "deploy_azure_backing_services" {
+  type    = string
+  default = true
+}
+
+variable "enable_monitoring" {
+  type    = bool
+  default = true
+}
+
+variable "namespace" {
+  type = string
+}
+
+variable "service_short" {
   type = string
 }

--- a/terraform/aks/workspace_variables/dev_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/dev_aks.tfvars.json
@@ -1,3 +1,6 @@
 {
-  "cluster": "test"
+  "app_environment": "dev",
+  "cluster": "test",
+  "enable_monitoring": false,
+  "namespace": "tra-development"
 }

--- a/terraform/aks/workspace_variables/review_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/review_aks.tfvars.json
@@ -1,3 +1,7 @@
 {
-  "cluster": "test"
+  "app_environment": "review",
+  "cluster": "test",
+  "deploy_azure_backing_services": false,
+  "enable_monitoring": false,
+  "namespace": "tra-development"
 }


### PR DESCRIPTION
This adds a Redis instance in the AKS infrastructure using the [AKS Redis module](https://github.com/DFE-Digital/terraform-modules/pull/16). I've also set up the Kubernetes provider and cluster data.

Depends on https://github.com/DFE-Digital/terraform-modules/pull/16

[Trello Card](https://trello.com/c/HnBgB2Ix/1784-add-redis-to-aks)