### PR TITLE
Add PostgreSQL in AKS (2 of 4)

### DIFF
--- a/terraform/aks/.terraform.lock.hcl
+++ b/terraform/aks/.terraform.lock.hcl
@@ -39,3 +39,22 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -1,8 +1,12 @@
+locals {
+  environment = "${var.app_environment}${var.app_suffix}"
+}
+
 module "redis" {
   source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/redis?ref=testing"
 
   namespace             = var.namespace
-  environment           = "${var.app_environment}${var.app_suffix}"
+  environment           = local.environment
   azure_resource_prefix = var.azure_resource_prefix
   service_short         = var.service_short
   config_short          = var.config_short
@@ -11,4 +15,20 @@ module "redis" {
 
   use_azure               = var.deploy_azure_backing_services
   azure_enable_monitoring = var.enable_monitoring
+}
+
+module "postgres" {
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/postgres?ref=testing"
+
+  namespace             = var.namespace
+  environment           = local.environment
+  azure_resource_prefix = var.azure_resource_prefix
+  service_short         = var.service_short
+  config_short          = var.config_short
+
+  cluster_configuration_map = module.cluster_data.configuration_map
+
+  use_azure               = var.deploy_azure_backing_services
+  azure_enable_monitoring = var.enable_monitoring
+  azure_extensions        = ["pg_stat_statements"]
 }


### PR DESCRIPTION
This adds a PostgreSQL instance in the AKS infrastructure using the [AKS PostgreSQL module](https://github.com/DFE-Digital/terraform-modules/pull/17). I've also set up the Kubernetes provider and cluster data.

Depends on #1356 and https://github.com/DFE-Digital/terraform-modules/pull/17

[Trello Card](https://trello.com/c/RMNY6zKF/1785-add-postgres-to-aks)