### PR TITLE
Ensure teaching authority name doesn't start with the

### DIFF
--- a/app/models/concerns/teaching_authority_contactable.rb
+++ b/app/models/concerns/teaching_authority_contactable.rb
@@ -1,5 +1,15 @@
+# frozen_string_literal: true
+
 module TeachingAuthorityContactable
   extend ActiveSupport::Concern
+
+  included do
+    validates :teaching_authority_name,
+              format: {
+                without: /\Athe.*\z/i,
+                message: "Teaching authority name shouldn't start with ‘the’.",
+              }
+  end
 
   def teaching_authority_emails_string
     teaching_authority_emails.join("\n")

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -28,15 +28,24 @@
 require "rails_helper"
 
 RSpec.describe Country, type: :model do
-  subject(:country) { build(:country) }
+  subject(:country) { build(:country, teaching_authority_name:) }
+
+  let(:teaching_authority_name) { "" }
 
   describe "validations" do
+    it { is_expected.to be_valid }
+
     it { is_expected.to validate_inclusion_of(:code).in_array(%w[GB-SCT FR]) }
     it { is_expected.to_not validate_inclusion_of(:code).in_array(%w[ABC]) }
     it do
       is_expected.to validate_url_of(
         :teaching_authority_online_checker_url,
       ).with_message("Enter a valid teaching authority online checker URL")
+    end
+
+    context "with a teaching authority name that starts with the" do
+      let(:teaching_authority_name) { "the authority" }
+      it { is_expected.to_not be_valid }
     end
   end
 

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -38,9 +38,13 @@
 require "rails_helper"
 
 RSpec.describe Region, type: :model do
-  subject(:region) { build(:region) }
+  subject(:region) { build(:region, teaching_authority_name:) }
+
+  let(:teaching_authority_name) { "" }
 
   describe "validations" do
+    it { is_expected.to be_valid }
+
     it { is_expected.to validate_uniqueness_of(:name).scoped_to(:country_id) }
     it do
       is_expected.to define_enum_for(:sanction_check)
@@ -58,6 +62,11 @@ RSpec.describe Region, type: :model do
       is_expected.to validate_url_of(
         :teaching_authority_online_checker_url,
       ).with_message("Enter a valid teaching authority online checker URL")
+    end
+
+    context "with a teaching authority name that starts with the" do
+      let(:teaching_authority_name) { "the authority" }
+      it { is_expected.to_not be_valid }
     end
   end
 


### PR DESCRIPTION
We render the name with a "The" automatically, so we should make sure the name doesn't include a "The" so avoid the word appearing twice.