### PR TITLE
Restrict download to clean scanned uploads

### DIFF
--- a/app/controllers/assessor_interface/uploads_controller.rb
+++ b/app/controllers/assessor_interface/uploads_controller.rb
@@ -5,6 +5,7 @@ module AssessorInterface
     include ActiveStorage::Streaming
     include StreamedResponseAuthenticatable
     include RescueActiveStorageErrors
+    include UploadHelper
 
     skip_before_action :authenticate_staff!
     before_action -> { authenticate_or_redirect(:staff) }
@@ -12,13 +13,21 @@ module AssessorInterface
     before_action :authorize_assessor
 
     def show
-      send_blob_stream(upload.attachment, disposition: :inline)
+      if downloadable?(upload)
+        send_blob_stream(upload.attachment, disposition: :inline)
+      else
+        render "shared/malware_scan"
+      end
     end
 
     private
 
     def upload
-      @upload ||= Document.find(params[:document_id]).uploads.find(params[:id])
+      @upload ||= document.uploads.find(params[:id])
+    end
+
+    def document
+      @document ||= Document.find(params[:document_id])
     end
   end
 end

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -7,6 +7,7 @@ module TeacherInterface
     include HistoryTrackable
     include StreamedResponseAuthenticatable
     include RescueActiveStorageErrors
+    include UploadHelper
 
     skip_before_action :authenticate_teacher!
     before_action -> { authenticate_or_redirect(:teacher) }
@@ -17,7 +18,11 @@ module TeacherInterface
     before_action :load_upload, only: %i[delete destroy show]
 
     def show
-      send_blob_stream(@upload.attachment, disposition: :inline)
+      if downloadable?(@upload)
+        send_blob_stream(@upload.attachment, disposition: :inline)
+      else
+        render "shared/malware_scan"
+      end
     end
 
     def new

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -36,6 +36,8 @@ class Upload < ApplicationRecord
   end
 
   def name
+    return "File upload error" if scan_result_suspect?
+
     attachment.filename.to_s
   end
 

--- a/app/views/shared/malware_scan.html.erb
+++ b/app/views/shared/malware_scan.html.erb
@@ -1,0 +1,8 @@
+<% content_for :page_title, t("teacher_interface.uploads.malware_scan.#{@upload.malware_scan_result}.title") %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
+
+<h1 class="govuk-heading-l"><%= t("teacher_interface.uploads.malware_scan.#{@upload.malware_scan_result}.title") %></h1>
+
+<p class="govuk-body"><%= t("teacher_interface.uploads.malware_scan.#{@upload.malware_scan_result}.body") %></p>
+
+<p class="govuk-body"><%= govuk_link_to "Back to application", teacher_interface_application_form_path %></p>

--- a/app/views/shared/malware_scan.html.erb
+++ b/app/views/shared/malware_scan.html.erb
@@ -1,8 +1,8 @@
 <% content_for :page_title, t("teacher_interface.uploads.malware_scan.#{@upload.malware_scan_result}.title") %>
-<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_document_path(@document)) %>
 
 <h1 class="govuk-heading-l"><%= t("teacher_interface.uploads.malware_scan.#{@upload.malware_scan_result}.title") %></h1>
 
 <p class="govuk-body"><%= t("teacher_interface.uploads.malware_scan.#{@upload.malware_scan_result}.body") %></p>
 
-<p class="govuk-body"><%= govuk_link_to "Back to application", teacher_interface_application_form_path %></p>
+<p class="govuk-body"><%= govuk_link_to "Back to application", teacher_interface_application_form_document_path(@document) %></p>

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -48,6 +48,17 @@ en:
         title: Check your answers
       edit_contact:
         title: About you
+    uploads:
+      malware_scan:
+        error:
+          title: There’s a problem with your file
+          body: There’s a problem with this file. You’ll need to take another image of the document you want to upload, then try again.
+        pending:
+          title: We’re checking your file
+          body: We’re carrying out some checks on the file you’ve uploaded. Once we’ve successfully completed these checks, you’ll be able to preview your file.
+        suspect:
+          title: There’s a problem with your file
+          body: There’s a problem with this file. You’ll need to take another image of the document you want to upload, then try again.
     work_histories:
       add_another:
         title: Add another role

--- a/spec/controllers/assessor_interface/uploads_controller_spec.rb
+++ b/spec/controllers/assessor_interface/uploads_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe AssessorInterface::UploadsController, type: :controller do
 
   describe "GET show" do
     let(:document) { create(:document, documentable: application_form) }
-    let(:upload) { create(:upload, document:) }
+    let(:upload) { create(:upload, :clean, document:) }
 
     subject(:perform) do
       get :show, params: { document_id: document.id, id: upload.id }
@@ -62,6 +62,18 @@ RSpec.describe AssessorInterface::UploadsController, type: :controller do
       it "redirects to the signin page" do
         perform
         expect(response).to redirect_to(new_staff_session_path)
+      end
+    end
+
+    context "when the upload malware scan is not clean" do
+      render_views true
+      let(:upload) { create(:upload, :suspect, document:) }
+
+      before { FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result) }
+
+      it "responds with information about the malware scan" do
+        perform
+        expect(response.body).to include("There’s a problem with your file")
       end
     end
   end

--- a/spec/controllers/teacher_interface/uploads_controller_spec.rb
+++ b/spec/controllers/teacher_interface/uploads_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe TeacherInterface::UploadsController, type: :controller do
 
   describe "GET show" do
     let(:document) { create(:document, documentable: application_form) }
-    let(:upload) { create(:upload, document:) }
+    let(:upload) { create(:upload, :clean, document:) }
 
     subject(:perform) do
       get :show, params: { document_id: document.id, id: upload.id }
@@ -102,6 +102,18 @@ RSpec.describe TeacherInterface::UploadsController, type: :controller do
       it "redirects to the signin page" do
         perform
         expect(response).to redirect_to(new_teacher_session_path)
+      end
+    end
+
+    context "when the upload malware scan is not clean" do
+      render_views true
+      let(:upload) { create(:upload, :suspect, document:) }
+
+      before { FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result) }
+
+      it "renders information about the scan result" do
+        perform
+        expect(response.body).to include("There’s a problem with your file")
       end
     end
   end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -31,13 +31,15 @@ FactoryBot.define do
 
     trait :with_upload do
       completed
-      after(:create) { |document, _evaluator| create(:upload, document:) }
+      after(:create) do |document, _evaluator|
+        create(:upload, :clean, document:)
+      end
     end
 
     trait :with_translation do
       completed
       after(:create) do |document, _evaluator|
-        create(:upload, :translation, document:)
+        create(:upload, :translation, :clean, document:)
       end
     end
 

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -39,6 +39,14 @@ FactoryBot.define do
       end
     end
 
+    trait :clean do
+      malware_scan_result { "clean" }
+    end
+
+    trait :suspect do
+      malware_scan_result { "suspect" }
+    end
+
     after(:create) do |upload, _evaluator|
       upload.document.update!(completed: true)
     end

--- a/spec/helpers/upload_helper_spec.rb
+++ b/spec/helpers/upload_helper_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe UploadHelper do
   describe "#upload_link_to" do
-    let(:upload) { build_stubbed(:upload) }
+    let(:upload) { build_stubbed(:upload, :clean) }
 
     it "returns a link to the upload" do
       link = helper.upload_link_to(upload)
@@ -15,6 +15,37 @@ RSpec.describe UploadHelper do
             upload,
           ),
       )
+    end
+
+    context "when the upload malware scan is pending" do
+      let(:upload) { build_stubbed(:upload, :pending) }
+      before { FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result) }
+      it "returns text for a pending scan" do
+        link = helper.upload_link_to(upload)
+        expect(link).to have_link(
+          upload.name,
+          href:
+            teacher_interface_application_form_document_upload_path(
+              upload.document,
+              upload,
+            ),
+        )
+      end
+    end
+
+    context "when the upload malware scan is suspect" do
+      let(:upload) { build_stubbed(:upload, :suspect) }
+      before { FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result) }
+      it "appends an error for a suspect scan" do
+        link = helper.upload_link_to(upload)
+        expect(link).to have_content(
+          "#{upload.name}There’s a problem with this file",
+        )
+        expect(link).to have_css(
+          "p.govuk-error-message",
+          text: "There’s a problem with this file",
+        )
+      end
     end
 
     context "via the assessors interface" do

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe Upload, type: :model do
     subject(:name) { upload.name }
 
     it { is_expected.to eq("upload.pdf") }
+
+    context "when a malware scan is suspect" do
+      before { upload.malware_scan_result = "suspect" }
+      it { is_expected.to eq("File upload error") }
+    end
   end
 
   describe "#url" do

--- a/spec/system/teacher_interface/malware_scanning_spec.rb
+++ b/spec/system/teacher_interface/malware_scanning_spec.rb
@@ -55,10 +55,10 @@ RSpec.describe "Malware scanning", type: :system do
 
   def and_the_uploaded_files_have_been_marked_as_malware
     expect(check_uploaded_files_page.files).to have_content(
-      "File 1\tSuspected malware. File removed.",
+      "File 1\tFile upload error\nThere’s a problem with this file",
     )
     expect(check_uploaded_files_page.files).to have_content(
-      "File 2\tSuspected malware. File removed.",
+      "File 2\tFile upload error\nThere’s a problem with this file",
     )
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/hGTTuSIw/1770-update-ui-to-only-show-download-links-for-scanned-files)

Once we have scanned all existing uploads and scan results are populated on the Upload model we can restrict downloads and present content to the user when the file is not downloadable.

### Upload page where a suspect item is found

![image](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/93511/f8b65cc8-f542-498c-b464-aa25a2c4a59f)

This links to:

![image](https://user-images.githubusercontent.com/93511/236249903-f35c5211-9883-4e33-a052-a7c8c7199f5c.png)


### Content page for pending malware scan

![image](https://user-images.githubusercontent.com/93511/236249492-cfbec1d2-0be8-4127-86cc-d4b3fcc2aa6c.png)
