### PR TITLE
Handle uploads with no attachments when resending stored data to trigger a malware scan

### DIFF
--- a/app/services/resend_stored_blob_data.rb
+++ b/app/services/resend_stored_blob_data.rb
@@ -24,6 +24,8 @@ class ResendStoredBlobData
         upload_id: upload.id,
       )
     end
+  rescue ActiveStorage::FileNotFoundError
+    upload.update!(malware_scan_result: "error")
   end
 
   private

--- a/spec/services/resend_stored_blob_data_spec.rb
+++ b/spec/services/resend_stored_blob_data_spec.rb
@@ -47,5 +47,20 @@ RSpec.describe ResendStoredBlobData do
       )
       resend_stored_blob_data
     end
+
+    context "when the upload attachment is missing" do
+      let(:attachment) { instance_double(ActiveStorage::Blob) }
+      before do
+        allow(upload).to receive(:attachment).and_return(attachment)
+        allow(attachment).to receive(:key).and_raise(
+          ActiveStorage::FileNotFoundError,
+        )
+      end
+
+      it "updates to the malware scan result field to 'error'" do
+        resend_stored_blob_data
+        expect(upload.reload.malware_scan_result).to eq("error")
+      end
+    end
   end
 end


### PR DESCRIPTION
https://dfe-teacher-services.sentry.io/issues/4132298353/?project=6426061&referrer=slack

Our production data contains upload records with no attached file, we're not sure why but when it comes to resending the file data to trigger a malware scan we should mark these uploads with 'error' for their malware scan result, they will be ignored by subsequent job runs.