### PR TITLE
Add app config in AKS (3 of 4)

### DIFF
--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -1,0 +1,18 @@
+locals {
+  environment = "${var.app_environment}${var.app_suffix}"
+}
+
+module "application_configuration" {
+  source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/application_configuration?ref=testing"
+
+  namespace             = var.namespace
+  environment           = local.environment
+  azure_resource_prefix = var.azure_resource_prefix
+  service_short         = var.service_short
+  config_short          = var.config_short
+
+  secret_variables = {
+    DATABASE_URL = module.postgres.url
+    REDIS_URL    = module.redis.url
+  }
+}

--- a/terraform/aks/databases.tf
+++ b/terraform/aks/databases.tf
@@ -1,7 +1,3 @@
-locals {
-  environment = "${var.app_environment}${var.app_suffix}"
-}
-
 module "redis" {
   source = "git::https://github.com/DFE-Digital/terraform-modules.git//aks/redis?ref=testing"
 


### PR DESCRIPTION
This adds the application secrets and configuration map to Kubernetes ahead of deploying the app itself.

Depends on #1358 and https://github.com/DFE-Digital/terraform-modules/pull/15

[Trello Card](https://trello.com/c/3nj3nZTC/1800-deploy-app-to-aks)