### PR TITLE
Rename application secrets name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ aks:
 	$(eval PLATFORM=aks)
 	$(eval REGION=UK South)
 	$(eval STORAGE_ACCOUNT_SUFFIX=sa)
-	$(eval KEY_VAULT_SECRET_NAME=APPLICATION-SECRETS)
+	$(eval KEY_VAULT_SECRET_NAME=APPLICATION)
 
 .PHONY: dev
 dev: paas


### PR DESCRIPTION
We don't need "secrets" in the name since we're already in a secret key vault, this makes the naming consistent with `MONITORING` and `INFRASTRUCTURE`.