### PR TITLE
Discard the scan result job if the upload is not found

### DIFF
--- a/app/jobs/fetch_malware_scan_result_job.rb
+++ b/app/jobs/fetch_malware_scan_result_job.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class FetchMalwareScanResultJob < ApplicationJob
+  discard_on ActiveRecord::RecordNotFound
+
   def perform(upload_id:)
     upload = Upload.find(upload_id)
     FetchMalwareScanResult.call(upload:)


### PR DESCRIPTION
This may have been deleted in the UI by the applicant before the delayed job could start.

We have some jobs retrying unnecessarily in Sidekiq because of this issue.