### PR TITLE
Only resend stored blob data where malware scan feature is active.

### DIFF
--- a/app/jobs/resend_stored_blob_data_job.rb
+++ b/app/jobs/resend_stored_blob_data_job.rb
@@ -3,6 +3,8 @@
 class ResendStoredBlobDataJob < ApplicationJob
   # Resending the blob data will trigger a malware scan.
   def perform(batch_size: 1000)
+    return unless FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
+
     Upload
       .where(malware_scan_result: "pending")
       .limit(batch_size)


### PR DESCRIPTION
We've scheduled resending stored blob data to kick off malware scanning but this is only necessary where the feature flag is active.