### PR TITLE
Don't attempt to process uploads without an attachment key

### DIFF
--- a/app/services/resend_stored_blob_data.rb
+++ b/app/services/resend_stored_blob_data.rb
@@ -15,7 +15,7 @@ class ResendStoredBlobData
   end
 
   def call
-    return unless upload.scan_result_pending?
+    return unless upload.scan_result_pending? && upload.attachment&.key.present?
 
     response = blob_service.call(:put, put_blob_url, attachment_data, headers)
 

--- a/spec/services/resend_stored_blob_data_spec.rb
+++ b/spec/services/resend_stored_blob_data_spec.rb
@@ -62,5 +62,17 @@ RSpec.describe ResendStoredBlobData do
         expect(upload.reload.malware_scan_result).to eq("error")
       end
     end
+
+    context "when the upload attachment key is nil" do
+      let(:attachment) { instance_double(ActiveStorage::Blob, key: nil) }
+      before { allow(upload).to receive(:attachment).and_return(attachment) }
+
+      it "returns without update" do
+        expect { resend_stored_blob_data }.not_to change(
+          upload.reload,
+          :malware_scan_result,
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
We're getting a few Sentry errors for this edge case.

https://dfe-teacher-services.sentry.io/issues/4147677206/?project=6426061&referrer=slack