### PR TITLE
Increase resend stored data batch size to 1000

### DIFF
--- a/app/jobs/resend_stored_blob_data_job.rb
+++ b/app/jobs/resend_stored_blob_data_job.rb
@@ -2,7 +2,7 @@
 
 class ResendStoredBlobDataJob < ApplicationJob
   # Resending the blob data will trigger a malware scan.
-  def perform(batch_size: 500)
+  def perform(batch_size: 1000)
     return unless FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
 
     Upload


### PR DESCRIPTION
https://trello.com/c/itCez4ET/1768-virus-scan-existing-uploads

The malware scanning of existing data is working but will take several days to complete. Production has been stable with the lower batch size, we've increased intervals to mitigate rate limiting, so increase the batch size again to enqueue more uploads per run.