### PR TITLE
Remove ResendStoredBlobDataJob from schedule

### DIFF
--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -44,7 +44,3 @@ send_reference_request_reminders:
   cron: "40 3 * * *"
   class: SendReminderEmailsJob
   args: ["ReferenceRequest"]
-
-resend_upload_data:
-  cron: "50 * * * *"
-  class: ResendStoredBlobDataJob


### PR DESCRIPTION
All stored data has been resent for malware scanning purposes.

https://trello.com/c/itCez4ET/1768-virus-scan-existing-uploads