### PR TITLE
Unassign assessor when preliminary check is completed

### DIFF
--- a/app/controllers/assessor_interface/preliminary_checks_controller.rb
+++ b/app/controllers/assessor_interface/preliminary_checks_controller.rb
@@ -20,6 +20,7 @@ module AssessorInterface
         if @form.preliminary_check_complete
           notify_teacher
           create_note
+          unassign_assessor!
         end
 
         redirect_to assessor_interface_application_form_path(application_form)
@@ -58,6 +59,14 @@ module AssessorInterface
 
     def update_application_form_status
       ApplicationFormStatusUpdater.call(application_form:, user: current_staff)
+    end
+
+    def unassign_assessor!
+      AssignApplicationFormAssessor.call(
+        application_form:,
+        user: current_staff,
+        assessor: nil,
+      )
     end
   end
 end

--- a/spec/system/assessor_interface/performing_pre_assessment_checks_spec.rb
+++ b/spec/system/assessor_interface/performing_pre_assessment_checks_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Assessor performing pre-assessment checks", type: :system do
     and_i_see_a_completed_preliminary_check_task
     and_a_note_has_been_created
     and_an_email_has_been_sent_to_the_teacher
+    and_the_assessor_is_unassigned
   end
 
   private
@@ -79,6 +80,10 @@ RSpec.describe "Assessor performing pre-assessment checks", type: :system do
     )
   end
 
+  def and_the_assessor_is_unassigned
+    expect(application_form.reload.assessor).to be_nil
+  end
+
   def application_form
     @application_form ||=
       begin
@@ -86,6 +91,7 @@ RSpec.describe "Assessor performing pre-assessment checks", type: :system do
           create(
             :application_form,
             :preliminary_check,
+            assessor: Staff.last,
             teaching_authority_provides_written_statement: true,
           )
         create(


### PR DESCRIPTION
https://trello.com/c/C84erU7D/1836-case-should-be-unassigned-after-a-preliminary-check

This A/C was not scoped in https://trello.com/c/bU8bW4GT/1599-build-triage-preliminary-checks

We should unassign the assessor when a preliminary check is completed.