### PR TITLE
Increase DQT TRN Request retries

### DIFF
--- a/app/jobs/update_dqt_trn_request_job.rb
+++ b/app/jobs/update_dqt_trn_request_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UpdateDQTTRNRequestJob < ApplicationJob
-  sidekiq_options retry: 10
+  sidekiq_options retry: 14
 
   def perform(dqt_trn_request)
     return if dqt_trn_request.complete?


### PR DESCRIPTION
This increases the number of retries we make to DQT to avoid applications getting stuck. Recently we had an issue with the API wasn't working correctly for a couple of hours and this lead to applications getting stuck which would've eventually succeeded.