### PR TITLE
Change text on "Check your answers" button

### DIFF
--- a/app/views/teacher_interface/application_forms/show/_draft.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_draft.html.erb
@@ -50,7 +50,7 @@
 
 <div class="govuk-button-group">
   <%- if view_object.can_submit? -%>
-    <%= govuk_button_link_to "Check your answers", edit_teacher_interface_application_form_path %>
+    <%= govuk_button_link_to t("teacher_interface.application_forms.show.draft.check"), edit_teacher_interface_application_form_path %>
   <%- end -%>
-  <%= govuk_button_link_to "Save and sign out", destroy_teacher_session_path, secondary: true %>
+  <%= govuk_button_link_to t("teacher_interface.application_forms.show.draft.save"), destroy_teacher_session_path, secondary: true %>
 </div>

--- a/app/views/teacher_interface/further_information_requests/show.html.erb
+++ b/app/views/teacher_interface/further_information_requests/show.html.erb
@@ -26,7 +26,7 @@
 </ol>
 
 <% if @view_object.can_check_answers? %>
-  <%= govuk_button_link_to "Check your answers", edit_teacher_interface_application_form_further_information_request_path(@view_object.further_information_request) %>
+  <%= govuk_button_link_to t("teacher_interface.application_forms.show.draft.check"), edit_teacher_interface_application_form_further_information_request_path(@view_object.further_information_request) %>
 <% end %>
 
-<%= govuk_button_link_to "Save and sign out", destroy_teacher_session_path, secondary: true %>
+<%= govuk_button_link_to t("teacher_interface.application_forms.show.draft.save"), destroy_teacher_session_path, secondary: true %>

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -11,6 +11,9 @@ en:
         declined:
           further_information_request_expired: Your application has been declined as you did not respond to the assessor’s request for further information within the specified time.
           professional_standing_request_expired: Your application has been declined as we did not receive your %{certificate_name} from %{teaching_authority_name} within the 90-day period.
+        draft:
+          check: Check your application
+          save: Save and sign out
     english_language:
       check:
         heading: Check your answers


### PR DESCRIPTION
We want it to say "Check your application" instead. I've also extracted the strings to the locale file and updated where they're used for further information requests.