### PR TITLE
Add add preliminary check decline reason to case notes

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -44,6 +44,24 @@
           </ul>
         <% end %>
       <% end %>
+    <% elsif timeline_event.quick_decline? %>
+      <% description_vars.each do |failed_section| %>
+        <h4><%= failed_section[:section_name] %></h4>
+        <% if (failure_reason = failed_section[:failure_reasons].first).present? %>
+          <%= govuk_inset_text do %>
+            <ul class="govuk-list--bullet">
+              <%= render "shared/assessor_failure_reason_list_item", failure_reason: %> 
+              <% if failed_section[:failure_reasons].size > 1 %>
+                <%= govuk_details(summary_text: "View additional reasons") do %>
+                  <% failed_section[:failure_reasons].drop(1).each do |failure_reason| %>                                
+                    <%= render "shared/assessor_failure_reason_list_item", failure_reason: %>
+                  <% end %>
+                <% end %>       
+              <% end %>
+            </ul>
+          <% end %>
+        <% end %>
+      <% end %>
     <% elsif timeline_event.requestable_assessed? && timeline_event.requestable.is_a?(FurtherInformationRequest) %>
       <p class="govuk-body">Further information request has been assessed.</p>
 

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -132,5 +132,17 @@ module TimelineEntry
         {}
       end
     end
+
+    def quick_decline_vars
+      failed_sections =
+        timeline_event.application_form.assessment.sections.select(&:failed)
+      failed_sections.map do |section|
+        {
+          section_name: section.key.titleize,
+          passed: section.passed,
+          failure_reasons: section.selected_failure_reasons,
+        }
+      end
+    end
   end
 end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -67,6 +67,7 @@ class TimelineEvent < ApplicationRecord
          requestable_received: "requestable_received",
          requestable_expired: "requestable_expired",
          requestable_assessed: "requestable_assessed",
+         quick_decline: "quick_decline",
        }
   validates :event_type, inclusion: { in: event_types.values }
 
@@ -122,6 +123,8 @@ class TimelineEvent < ApplicationRecord
             :subjects_note,
             absence: true,
             unless: :age_range_subjects_verified?
+
+  validates :application_form, presence: true, if: :quick_decline?
 
   belongs_to :requestable, polymorphic: true, optional: true
   validates :requestable_id, presence: true, if: :requestable_event_type?

--- a/app/services/create_quick_decline_timeline_event.rb
+++ b/app/services/create_quick_decline_timeline_event.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class CreateQuickDeclineTimelineEvent
+  include ServicePattern
+
+  def initialize(application_form:, user: nil)
+    @application_form = application_form
+    @user = user || Staff.find_by(support_console_permission: true)
+  end
+
+  def call
+    unless application_form.requires_preliminary_check &&
+             application_form.assessment&.preliminary_check_complete == false
+      return
+    end
+
+    TimelineEvent.create!(
+      application_form:,
+      event_type: :quick_decline,
+      creator: user,
+    )
+  end
+
+  private
+
+  attr_reader :application_form, :user
+end

--- a/app/services/decline_qts.rb
+++ b/app/services/decline_qts.rb
@@ -14,6 +14,9 @@ class DeclineQTS
     ActiveRecord::Base.transaction do
       application_form.update!(declined_at: Time.zone.now)
       ApplicationFormStatusUpdater.call(application_form:, user:)
+      if quick_decline?
+        CreateQuickDeclineTimelineEvent.call(application_form:, user:)
+      end
     end
 
     TeacherMailer.with(teacher:).application_declined.deliver_later
@@ -22,6 +25,10 @@ class DeclineQTS
   private
 
   attr_reader :application_form, :user
-
   delegate :teacher, to: :application_form
+
+  def quick_decline?
+    application_form.requires_preliminary_check &&
+      application_form.assessment&.preliminary_check_complete == false
+  end
 end

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -53,6 +53,7 @@ en:
           ProfessionalStandingRequest: Professional standing assessed
           QualificationRequest: Qualification assessed
           ReferenceRequest: Reference assessed
+        quick_decline: Declined in preliminary check
       description:
         assessor_assigned: "%{assignee_name} is assigned as the assessor."
         reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
@@ -79,3 +80,4 @@ en:
           ProfessionalStandingRequest: The professional standing request has been assessed.
           QualificationRequest: A qualification has been assessed.
           ReferenceRequest: A reference has been assessed.
+        quick_decline: Declined in preliminary check.

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -482,4 +482,55 @@ RSpec.describe TimelineEntry::Component, type: :component do
       expect(component.text).to include(creator.name)
     end
   end
+
+  context "quick decline" do
+    let(:assessment_sections) do
+      [
+        create(:assessment_section, :personal_information, :failed),
+        create(:assessment_section, :qualifications, :failed),
+      ]
+    end
+
+    let(:application_form) { create(:application_form, assessment:) }
+
+    let(:assessment) { create(:assessment, sections: assessment_sections) }
+
+    let(:timeline_event) do
+      create(:timeline_event, :quick_decline, application_form:)
+    end
+
+    let(:first_failure_reason) do
+      assessment_sections.first.selected_failure_reasons.first
+    end
+    let(:last_failure_reason) do
+      assessment_sections.last.selected_failure_reasons.first
+    end
+    let(:expected_first_failure_reason_text) do
+      I18n.t(
+        "assessor_interface.assessment_sections.show.failure_reasons.#{first_failure_reason.key}",
+      )
+    end
+
+    let(:expected_last_failure_reason_text) do
+      I18n.t(
+        "assessor_interface.assessment_sections.show.failure_reasons.#{last_failure_reason.key}",
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("Declined in preliminary check")
+
+      expect(component.text).to include("Personal Information")
+      expect(component.text).to include(expected_first_failure_reason_text)
+      expect(component.text).to include(first_failure_reason.assessor_feedback)
+
+      expect(component.text).to include("Qualifications")
+      expect(component.text).to include(expected_last_failure_reason_text)
+      expect(component.text).to include(last_failure_reason.assessor_feedback)
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
 end

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -84,6 +84,7 @@ RSpec.describe TimelineEvent do
         requestable_received: "requestable_received",
         requestable_expired: "requestable_expired",
         requestable_assessed: "requestable_assessed",
+        quick_decline: "quick_decline",
       ).backed_by_column_of_type(:string)
     end
 
@@ -334,6 +335,12 @@ RSpec.describe TimelineEvent do
           ],
         )
       end
+    end
+
+    context "with a quick decline event type" do
+      before { timeline_event.event_type = :quick_decline }
+
+      it { is_expected.to validate_presence_of(:application_form) }
     end
   end
 end

--- a/spec/services/create_quick_decline_timeline_event_spec.rb
+++ b/spec/services/create_quick_decline_timeline_event_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CreateQuickDeclineTimelineEvent do
+  let(:teacher) { create(:teacher) }
+  let(:user) { create(:staff, :confirmed) }
+
+  subject(:call) { described_class.call(application_form:, user:) }
+
+  context "with an application form which requires a preliminary check" do
+    let!(:application_form) do
+      create(
+        :application_form,
+        :submitted,
+        requires_preliminary_check: true,
+        teacher:,
+        assessment: create(:assessment, preliminary_check_complete: false),
+      )
+    end
+
+    it "creates a quick decline timeline event" do
+      expect { call }.to change(TimelineEvent, :count).by(1)
+      expect(TimelineEvent.last.event_type).to eq("quick_decline")
+    end
+  end
+
+  context "with an application form which doesn't require a preliminary check" do
+    let!(:application_form) { create(:application_form, :submitted, teacher:) }
+
+    it "doesn't create a quick decline timeline event" do
+      expect { call }.not_to change(TimelineEvent, :count)
+    end
+  end
+end

--- a/spec/services/decline_qts_spec.rb
+++ b/spec/services/decline_qts_spec.rb
@@ -49,4 +49,21 @@ RSpec.describe DeclineQTS do
       expect { call }.to_not change(application_form, :declined_at)
     end
   end
+
+  context "with a quick decline decision" do
+    let!(:application_form) do
+      create(
+        :application_form,
+        :submitted,
+        requires_preliminary_check: true,
+        teacher:,
+        assessment: create(:assessment, preliminary_check_complete: false),
+      )
+    end
+
+    it "creates a quick decline timeline event" do
+      expect { call }.to change(TimelineEvent, :count).by(2)
+      expect(TimelineEvent.last.event_type).to eq("quick_decline")
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/EsQDmzOG/1826-add-add-preliminary-check-decline-reason-to-case-notes)

![image](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/93511/316d690b-ded7-419d-a498-15c2b3e14161)

Adds a case note when an application is _quick declined_ via preliminary checks.
