### PR TITLE
Add suspect file failure reason

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -53,6 +53,7 @@ class AssessmentFactory
           FailureReasons::EL_EXEMPTION_BY_CITIZENSHIP_ID_UNCONFIRMED
         end
       ),
+      FailureReasons::UPLOADED_FILE_SUSPECT,
       FailureReasons::DUPLICATE_APPLICATION,
       FailureReasons::APPLICANT_ALREADY_QTS,
       FailureReasons::APPLICANT_ALREADY_DQT,
@@ -138,6 +139,7 @@ class AssessmentFactory
       FailureReasons::DEGREE_TRANSCRIPT_ILLEGIBLE,
       FailureReasons::ADDITIONAL_DEGREE_CERTIFICATE_ILLEGIBLE,
       FailureReasons::ADDITIONAL_DEGREE_TRANSCRIPT_ILLEGIBLE,
+      FailureReasons::UPLOADED_FILE_SUSPECT,
     ].compact
 
     AssessmentSection.new(key: "qualifications", checks:, failure_reasons:)
@@ -185,6 +187,7 @@ class AssessmentFactory
           [
             FailureReasons::EL_MOI_NOT_TAUGHT_IN_ENGLISH,
             FailureReasons::EL_MOI_INVALID_FORMAT,
+            FailureReasons::UPLOADED_FILE_SUSPECT,
           ]
         else
           [

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -59,6 +59,7 @@ class FailureReasons
     SCHOOL_DETAILS_CANNOT_BE_VERIFIED = "school_details_cannot_be_verified",
     TEACHING_CERTIFICATE_ILLEGIBLE = "teaching_certificate_illegible",
     TEACHING_TRANSCRIPT_ILLEGIBLE = "teaching_transcript_illegible",
+    UPLOADED_FILE_SUSPECT = "uploaded_file_suspect",
     UNRECOGNISED_REFERENCES = "unrecognised_references",
     WORK_HISTORY_BREAK = "work_history_break",
     WRITTEN_STATEMENT_ILLEGIBLE = "written_statement_illegible",

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -200,6 +200,7 @@ en:
           teaching_qualifications_from_ineligible_country: Teaching qualifications were completed in an ineligible country.
           teaching_qualifications_not_at_required_level: Teaching qualifications do not meet the required academic level (level 6).
           teaching_transcript_illegible: The teaching qualification transcript (or translation) is illegible or in a format that we cannot accept.
+          uploaded_file_suspect: We were unable to open one of the files provided. The applicant will need to submit a new file.
           unrecognised_references: Application contained 1 or more references that cannot be considered.
           work_history_break: There is an unexplained break in the applicant’s work history.
           written_statement_illegible: The letter is illegible or in a format that we cannot accept.

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe AssessmentFactory do
               identification_document_expired
               identification_document_illegible
               identification_document_mismatch
+              uploaded_file_suspect
               duplicate_application
               applicant_already_qts
               applicant_already_dqt
@@ -122,6 +123,7 @@ RSpec.describe AssessmentFactory do
                   degree_transcript_illegible
                   additional_degree_certificate_illegible
                   additional_degree_transcript_illegible
+                  uploaded_file_suspect
                 ],
               )
             end
@@ -170,6 +172,7 @@ RSpec.describe AssessmentFactory do
                   degree_transcript_illegible
                   additional_degree_certificate_illegible
                   additional_degree_transcript_illegible
+                  uploaded_file_suspect
                 ],
               )
             end
@@ -222,6 +225,7 @@ RSpec.describe AssessmentFactory do
                   degree_transcript_illegible
                   additional_degree_certificate_illegible
                   additional_degree_transcript_illegible
+                  uploaded_file_suspect
                 ],
               )
             end
@@ -274,6 +278,7 @@ RSpec.describe AssessmentFactory do
                   degree_transcript_illegible
                   additional_degree_certificate_illegible
                   additional_degree_transcript_illegible
+                  uploaded_file_suspect
                 ],
               )
             end


### PR DESCRIPTION
[Trello](https://trello.com/c/hGTTuSIw/1770-update-ui-to-only-show-download-links-for-scanned-files)

![image](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/93511/53aa5a54-a494-4524-87a8-2c1882725320)

Adds a failure reason specific to suspect uploads.