### PR TITLE
Increase delay before fetching scan result

### DIFF
--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -81,7 +81,7 @@ module TeacherInterface
     def fetch_and_update_malware_scan_results
       document.uploads.each do |upload|
         # We need a delay here to ensure that the upload has been scanned before fetching the result.
-        FetchMalwareScanResultJob.set(wait: 1.minute).perform_later(
+        FetchMalwareScanResultJob.set(wait: 2.minutes).perform_later(
           upload_id: upload.id,
         )
       end


### PR DESCRIPTION
We are seeing a number of uploads where the scan result is stuck in the pending state (110 in production), this is likely to mean  we have attempted to fetch the scan result too quickly. 
This PR increases the delay from 1 minute to 2 minutes to give malware scanning more time before attempting to fetch the result.