### PR TITLE
Schedule fetching malware scan results

### DIFF
--- a/app/jobs/fetch_malware_scan_results_job.rb
+++ b/app/jobs/fetch_malware_scan_results_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class FetchMalwareScanResultsJob < ApplicationJob
+  def perform
+    Upload
+      .where(malware_scan_result: "pending")
+      .where("created_at < ?", 5.minutes.ago)
+      .each { |upload| FetchMalwareScanResult.call(upload:) }
+  end
+end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -44,3 +44,7 @@ send_reference_request_reminders:
   cron: "40 3 * * *"
   class: SendReminderEmailsJob
   args: ["ReferenceRequest"]
+
+fetch_malware_scan_results:
+  cron: "*/30 * * * *"
+  class: FetchMalwareScanResultsJob

--- a/spec/jobs/fetch_malware_scan_results_job_spec.rb
+++ b/spec/jobs/fetch_malware_scan_results_job_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FetchMalwareScanResultsJob do
+  describe "#perform" do
+    let!(:stale_pending_upload) do
+      create(
+        :upload,
+        malware_scan_result: "pending",
+        created_at: 10.minutes.ago,
+      )
+    end
+    let!(:fresh_pending_upload) do
+      create(:upload, malware_scan_result: "pending")
+    end
+    let!(:clean_upload) do
+      create(:upload, malware_scan_result: "clean", created_at: 10.minutes.ago)
+    end
+
+    it "fetches malware scan results for stale pending uploads" do
+      expect(FetchMalwareScanResult).to receive(:call).with(
+        upload: stale_pending_upload,
+      )
+      described_class.perform_now
+    end
+  end
+end


### PR DESCRIPTION
Fetch malware scan results every 30 minutes for uploads created more than 5 minutes ago with a pending scan result. 
This should help catch any edge cases of uploads where we've attempted to fetch the scan result too soon, for instance if the malware scanning is overloaded with files to scan. 
We can't guarantee when the scan will run, so periodically fetch results for any apparently 'stuck' records.