### PR TITLE
Add task to backfill quick decline cases

### DIFF
--- a/lib/tasks/quick_decline.rake
+++ b/lib/tasks/quick_decline.rake
@@ -1,0 +1,27 @@
+namespace :quick_decline do
+  desc "Backfill case notes for quick decline applications"
+  task backfill_case_notes: :environment do
+    scope =
+      ApplicationForm
+        .joins(assessment: :sections)
+        .where(
+          status: "declined",
+          requires_preliminary_check: true,
+          assessment: {
+            preliminary_check_complete: false,
+          },
+          sections: {
+            passed: nil,
+          },
+        )
+        .distinct
+
+    scope.find_each do |application_form|
+      if TimelineEvent.exists?(application_form:, event_type: "quick_decline")
+        next
+      end
+
+      CreateQuickDeclineTimelineEvent.call(application_form:)
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/DfuydigG/1854-backfill-quick-decline-case-notes)

Identify applications which have been declined, required a preliminary check and have one or more 'not started' assessment sections.
If there's no existing quick decline case note, add one to the application timeline.

There are currently ~2000 records matching the query criteria, though some may already have the case note added.