### PR TITLE
Ignore work histories with no email address

### DIFF
--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -73,6 +73,8 @@ module AssessorInterface
     def work_history_application_forms_contact_email_used_as_teacher
       @work_history_application_forms_contact_email_used_as_teacher ||=
         begin
+          return {} if work_history_canonical_contact_emails.empty?
+
           application_forms =
             ApplicationForm
               .includes(:teacher)
@@ -97,6 +99,8 @@ module AssessorInterface
     def work_history_application_forms_contact_email_used_as_reference
       @work_history_application_forms_contact_email_used_as_reference ||=
         begin
+          return {} if work_history_canonical_contact_emails.empty?
+
           work_histories =
             WorkHistory
               .includes(:application_form)
@@ -166,7 +170,10 @@ module AssessorInterface
 
     def work_history_canonical_contact_emails
       if assessment_section.work_history?
-        application_form.work_histories.map(&:canonical_contact_email)
+        application_form
+          .work_histories
+          .map(&:canonical_contact_email)
+          .compact_blank
       else
         []
       end


### PR DESCRIPTION
Sometimes we allow work histories to be submitted without a contact email address (in the case of a reduced evidence journey), so we need to filter those out to avoid linking all the reduced evidence journey applications together.