### PR TITLE
Don't fetch malware scan results if attachment is not present

### DIFF
--- a/app/services/fetch_malware_scan_result.rb
+++ b/app/services/fetch_malware_scan_result.rb
@@ -17,6 +17,7 @@ class FetchMalwareScanResult
 
   def call
     return unless upload.scan_result_pending?
+    return if upload.attachment.blank?
 
     response = fetch_scan_result
 

--- a/spec/services/fetch_malware_scan_result_spec.rb
+++ b/spec/services/fetch_malware_scan_result_spec.rb
@@ -70,5 +70,14 @@ RSpec.describe FetchMalwareScanResult do
         expect(upload.malware_scan_result).to eq("error")
       end
     end
+
+    context "with a missing attachment" do
+      before { allow(upload).to receive(:attachment).and_return(nil) }
+
+      it "does not call the Azure Storage REST API" do
+        expect(stubbed_blob_service).not_to receive(:call)
+        fetch_malware_scan_result
+      end
+    end
   end
 end


### PR DESCRIPTION
https://dfe-teacher-services.sentry.io/issues/4189548018/?project=6426061

We're seeing errors from a scheduled job attempting to find scan results for uploads with a `nil` attachment.
Not sure what causes an upload record to lose it's attachment like this but we can't fetch malware scan results for these records so ignore them.
