### PR TITLE
Group linked applications by email address

### DIFF
--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -75,24 +75,18 @@ module AssessorInterface
         begin
           return {} if work_history_canonical_contact_emails.empty?
 
-          application_forms =
-            ApplicationForm
-              .includes(:teacher)
-              .not_draft
-              .where(
-                teacher: {
-                  canonical_email: work_history_canonical_contact_emails,
-                },
-              )
-              .where.not(id: application_form.id)
-              .to_a
-
-          application_form.work_histories.index_with do |work_history|
-            application_forms.select do |application_form|
-              application_form.teacher.canonical_email ==
-                work_history.canonical_contact_email
+          ApplicationForm
+            .includes(:teacher)
+            .not_draft
+            .where(
+              teacher: {
+                canonical_email: work_history_canonical_contact_emails,
+              },
+            )
+            .where.not(id: application_form.id)
+            .group_by do |application_form|
+              application_form.teacher.canonical_email
             end
-          end
         end
     end
 
@@ -101,43 +95,32 @@ module AssessorInterface
         begin
           return {} if work_history_canonical_contact_emails.empty?
 
-          work_histories =
-            WorkHistory
-              .includes(:application_form)
-              .where(
-                canonical_contact_email: work_history_canonical_contact_emails,
-              )
-              .where.not(application_form:)
-              .where.not(application_form: { status: "draft" })
-
-          application_form.work_histories.index_with do |work_history|
-            found_work_histories =
-              work_histories.select do |found_work_history|
-                found_work_history.canonical_contact_email ==
-                  work_history.canonical_contact_email
-              end
-
-            found_work_histories.map(&:application_form)
-          end
+          WorkHistory
+            .includes(:application_form)
+            .where(
+              canonical_contact_email: work_history_canonical_contact_emails,
+            )
+            .where.not(application_form:)
+            .where.not(application_form: { status: "draft" })
+            .group_by(&:canonical_contact_email)
+            .transform_values do |work_histories|
+              work_histories.map(&:application_form)
+            end
         end
     end
 
     def show_work_history_information_appears_in_other_applications?
-      work_history_application_forms_contact_email_used_as_teacher.values.any?(
-        &:present?
-      ) ||
-        work_history_application_forms_contact_email_used_as_reference.values.any?(
-          &:present?
-        )
+      work_history_application_forms_contact_email_used_as_teacher.present? ||
+        work_history_application_forms_contact_email_used_as_reference.present?
     end
 
     def highlighted_work_history_contact_emails
       application_form.work_histories.select do |work_history|
         work_history_application_forms_contact_email_used_as_teacher[
-          work_history
+          work_history.canonical_contact_email
         ].present? ||
           work_history_application_forms_contact_email_used_as_reference[
-            work_history
+            work_history.canonical_contact_email
           ].present?
       end
     end

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -8,11 +8,11 @@
 
     <p class="govuk-body">Check the applications listed below to review the matching information.</p>
 
-    <% @assessment_section_view_object.work_history_application_forms_contact_email_used_as_teacher.each do |work_history, application_forms| %>
+    <% @assessment_section_view_object.work_history_application_forms_contact_email_used_as_teacher.each do |email_address, application_forms| %>
       <% next unless application_forms.present? %>
 
       <p class="govuk-body govuk-!-margin-bottom-1">
-        <strong class="govuk-!-font-weight-bold"><%= work_history.contact_email %></strong> appears as an <strong class="govuk-!-font-weight-bold">applicant</strong> in these applications:
+        <strong class="govuk-!-font-weight-bold"><%= email_address %></strong> appears as an <strong class="govuk-!-font-weight-bold">applicant</strong> in these applications:
       </p>
 
       <ul class="govuk-list">
@@ -26,11 +26,11 @@
       </ul>
     <% end %>
 
-    <% @assessment_section_view_object.work_history_application_forms_contact_email_used_as_reference.each do |work_history, application_forms| %>
+    <% @assessment_section_view_object.work_history_application_forms_contact_email_used_as_reference.each do |email_address, application_forms| %>
       <% next unless application_forms.present? %>
 
       <p class="govuk-body govuk-!-margin-bottom-1">
-        <strong class="govuk-!-font-weight-bold"><%= work_history.contact_email %></strong> appears as a <strong class="govuk-!-font-weight-bold">reference</strong> in these applications:
+        <strong class="govuk-!-font-weight-bold"><%= email_address %></strong> appears as a <strong class="govuk-!-font-weight-bold">reference</strong> in these applications:
       </p>
 
       <ul class="govuk-list">

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -314,7 +314,7 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
         )
       end
 
-      it { is_expected.to eq({ work_history => [] }) }
+      it { is_expected.to eq({}) }
     end
 
     context "with an application form with the same email" do
@@ -326,7 +326,7 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
         )
       end
 
-      it { is_expected.to eq({ work_history => [other_application_form] }) }
+      it { is_expected.to eq({ "same@gmail.com" => [other_application_form] }) }
     end
   end
 
@@ -353,7 +353,7 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
         )
       end
 
-      it { is_expected.to eq({ work_history => [] }) }
+      it { is_expected.to eq({}) }
     end
 
     context "with an application form with the same email" do
@@ -365,7 +365,7 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
         )
       end
 
-      it { is_expected.to eq({ work_history => [other_application_form] }) }
+      it { is_expected.to eq({ "same@gmail.com" => [other_application_form] }) }
     end
   end
 


### PR DESCRIPTION
This should avoid a situation where two or more different work history items use the same email address, which leads to duplicate lists of linked applications being shown to the user as we were previously grouping them by the work history itself rather than the email address.