### PR TITLE
Add uploads storage container in AKS

### DIFF
--- a/terraform/aks/application.tf
+++ b/terraform/aks/application.tf
@@ -14,5 +14,9 @@ module "application_configuration" {
   secret_variables = {
     DATABASE_URL = module.postgres.url
     REDIS_URL    = module.redis.url
+
+    AZURE_STORAGE_ACCOUNT_NAME = azurerm_storage_account.uploads.name,
+    AZURE_STORAGE_ACCESS_KEY   = azurerm_storage_account.uploads.primary_access_key,
+    AZURE_STORAGE_CONTAINER    = azurerm_storage_container.uploads.name
   }
 }

--- a/terraform/aks/storage.tf
+++ b/terraform/aks/storage.tf
@@ -1,0 +1,41 @@
+locals {
+  uploads_storage_product_name = "Apply for QTS in England"
+}
+
+resource "azurerm_storage_account" "uploads" {
+  name                              = "${var.azure_resource_prefix}${var.service_short}uploads${var.config_short}sa"
+  resource_group_name               = "${var.azure_resource_prefix}-${var.service_short}-${var.config_short}-rg"
+  location                          = "UK South"
+  account_replication_type          = var.app_environment != "production" ? "LRS" : "GRS"
+  account_tier                      = "Standard"
+  account_kind                      = "StorageV2"
+  min_tls_version                   = "TLS1_2"
+  infrastructure_encryption_enabled = true
+
+  tags = {
+    Environment        = var.uploads_storage_environment_tag
+    Product            = local.uploads_storage_product_name
+    "Service Offering" = local.uploads_storage_product_name
+  }
+
+  blob_properties {
+    last_access_time_enabled = true
+
+    container_delete_retention_policy {
+      days = var.uploads_container_delete_retention_days
+    }
+  }
+}
+
+resource "azurerm_storage_encryption_scope" "uploads" {
+  name                               = "microsoftmanaged"
+  storage_account_id                 = azurerm_storage_account.uploads.id
+  source                             = "Microsoft.Storage"
+  infrastructure_encryption_required = true
+}
+
+resource "azurerm_storage_container" "uploads" {
+  name                  = "uploads"
+  storage_account_name  = azurerm_storage_account.uploads.name
+  container_access_type = "private"
+}

--- a/terraform/aks/variables.tf
+++ b/terraform/aks/variables.tf
@@ -41,3 +41,12 @@ variable "namespace" {
 variable "service_short" {
   type = string
 }
+
+variable "uploads_container_delete_retention_days" {
+  default = 7
+  type    = number
+}
+
+variable "uploads_storage_environment_tag" {
+  type = string
+}

--- a/terraform/aks/workspace_variables/dev_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/dev_aks.tfvars.json
@@ -2,5 +2,6 @@
   "app_environment": "dev",
   "cluster": "test",
   "enable_monitoring": false,
-  "namespace": "tra-development"
+  "namespace": "tra-development",
+  "uploads_storage_environment_tag": "Test"
 }

--- a/terraform/aks/workspace_variables/review_aks.tfvars.json
+++ b/terraform/aks/workspace_variables/review_aks.tfvars.json
@@ -3,5 +3,6 @@
   "cluster": "test",
   "deploy_azure_backing_services": false,
   "enable_monitoring": false,
-  "namespace": "tra-development"
+  "namespace": "tra-development",
+  "uploads_storage_environment_tag": "Test"
 }


### PR DESCRIPTION
We need a container for the new AKS environment so that the file uploading feature of Apply for QTS works correctly.

This is based on the version for PaaS: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/terraform/paas/storage.tf