### PR TITLE
Add task to change work history email address

### DIFF
--- a/app/services/update_work_history_contact_email.rb
+++ b/app/services/update_work_history_contact_email.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class UpdateWorkHistoryContactEmail
+  include ServicePattern
+
+  def initialize(application_form:, old_email_address:, new_email_address:)
+    @application_form = application_form
+    @old_email_address = old_email_address
+    @new_email_address = new_email_address
+  end
+
+  def call
+    work_histories.each do |work_history|
+      work_history.update!(
+        contact_email: new_email_address,
+        canonical_contact_email: EmailAddress.canonical(new_email_address),
+      )
+
+      if (reference_request = work_history.reference_request)
+        RefereeMailer.with(reference_request:).reference_requested.deliver_later
+      end
+    end
+  end
+
+  private
+
+  attr_reader :application_form, :old_email_address, :new_email_address
+
+  def work_histories
+    application_form.work_histories.where(
+      "LOWER(contact_email) = ?",
+      old_email_address.downcase,
+    )
+  end
+end

--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -15,4 +15,17 @@ namespace :application_forms do
     puts "There were #{original_count} draft applications and there are now #{new_count}."
     puts "There are #{ApplicationForm.count} applications overall."
   end
+
+  desc "Change the contact email address of work history associated with an application."
+  task :update_work_history_contact_email,
+       %i[reference old_email_address new_email_address] =>
+         :environment do |_task, args|
+    application_form = ApplicationForm.find_by!(reference: args[:reference])
+
+    UpdateWorkHistoryContactEmail.call(
+      application_form:,
+      old_email_address: args[:old_email_address],
+      new_email_address: args[:new_email_address],
+    )
+  end
 end

--- a/spec/services/update_work_history_contact_email_spec.rb
+++ b/spec/services/update_work_history_contact_email_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UpdateWorkHistoryContactEmail do
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:old_email_address) { "old@example.com" }
+  let(:new_email_address) { "new@example.com" }
+
+  subject(:call) do
+    described_class.call(
+      application_form:,
+      old_email_address:,
+      new_email_address:,
+    )
+  end
+
+  describe "with no work history" do
+    it "doesn't raise an error" do
+      expect { call }.to_not raise_error
+    end
+  end
+
+  describe "with one work history" do
+    let!(:work_history) do
+      create(:work_history, application_form:, contact_email: old_email_address)
+    end
+
+    it "changes the contact email" do
+      expect { call }.to change { work_history.reload.contact_email }.to(
+        new_email_address,
+      )
+    end
+
+    it "changes the canonical contact email" do
+      expect { call }.to change {
+        work_history.reload.canonical_contact_email
+      }.to(new_email_address)
+    end
+
+    it "doesn't send any emails" do
+      expect { call }.to_not have_enqueued_mail(
+        RefereeMailer,
+        :reference_requested,
+      )
+    end
+  end
+
+  describe "with multiple work histories" do
+    let!(:work_history) do
+      create(:work_history, application_form:, contact_email: old_email_address)
+    end
+    let!(:work_history_other) do
+      create(
+        :work_history,
+        application_form:,
+        contact_email: "different@example.com",
+      )
+    end
+
+    it "changes the contact email" do
+      expect { call }.to change { work_history.reload.contact_email }.to(
+        new_email_address,
+      )
+    end
+
+    it "changes the canonical contact email" do
+      expect { call }.to change {
+        work_history.reload.canonical_contact_email
+      }.to(new_email_address)
+    end
+
+    it "doesn't change the other contact email" do
+      expect { call }.to_not(change { work_history_other.reload.contact_email })
+    end
+
+    it "doesn't change the other canonical contact email" do
+      expect { call }.to_not(
+        change { work_history_other.reload.canonical_contact_email },
+      )
+    end
+
+    it "doesn't send any emails" do
+      expect { call }.to_not have_enqueued_mail(
+        RefereeMailer,
+        :reference_requested,
+      )
+    end
+  end
+
+  describe "when references already sent out" do
+    before do
+      work_history =
+        create(
+          :work_history,
+          application_form:,
+          contact_email: old_email_address,
+        )
+      create(:reference_request, work_history:)
+    end
+
+    it "sends an email" do
+      expect { call }.to have_enqueued_mail(RefereeMailer, :reference_requested)
+    end
+  end
+end


### PR DESCRIPTION
This adds a Rake task which makes it easy to change the email address of an item of work history. We don't have the means to do this in the interface, but it's a fairly common developer request so this should make it easier.