### PR TITLE
Allow filling in expired reference requests

### DIFF
--- a/app/controllers/teacher_interface/reference_requests_controller.rb
+++ b/app/controllers/teacher_interface/reference_requests_controller.rb
@@ -14,7 +14,13 @@ module TeacherInterface
 
     def show
       @reference_request =
-        ReferenceRequest.not_expired.find_by!(slug: params[:slug])
+        ReferenceRequest
+          .joins(:application_form)
+          .received
+          .or(ReferenceRequest.respondable)
+          .includes(:work_history, :application_form)
+          .find_by!(slug: params[:slug])
+
       @application_form = reference_request.application_form
       @work_history = reference_request.work_history
     end
@@ -260,9 +266,11 @@ module TeacherInterface
 
     def load_requested_reference_request
       @reference_request =
-        ReferenceRequest.where(state: %i[requested expired]).find_by!(
-          slug: params[:slug],
-        )
+        ReferenceRequest
+          .joins(:application_form)
+          .respondable
+          .includes(:work_history, :application_form)
+          .find_by!(slug: params[:slug])
     end
 
     def contact_response_form_params

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -154,7 +154,7 @@ class ApplicationForm < ApplicationRecord
 
   STATUS_COLUMNS.each { |column| enum column, STATUS_VALUES, prefix: column }
 
-  scope :active,
+  scope :assessable,
         -> {
           where(
             status: %i[
@@ -164,12 +164,17 @@ class ApplicationForm < ApplicationRecord
               waiting_on
               received
               overdue
-              awarded_pending_checks
-              potential_duplicate_in_dqt
             ],
-          ).or(awarded.where("awarded_at >= ?", 90.days.ago)).or(
-            declined.where("declined_at >= ?", 90.days.ago),
           )
+        }
+
+  scope :active,
+        -> {
+          assessable
+            .or(awarded_pending_checks)
+            .or(potential_duplicate_in_dqt)
+            .or(awarded.where("awarded_at >= ?", 90.days.ago))
+            .or(declined.where("declined_at >= ?", 90.days.ago))
         }
 
   scope :destroyable,

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -17,6 +17,8 @@ module Requestable
     validates :received_at, presence: true, if: :received?
     validates :reviewed_at, presence: true, unless: -> { passed.nil? }
 
+    scope :respondable, -> { not_received.merge(ApplicationForm.assessable) }
+
     define_method :requested! do
       update!(state: "requested", received_at: nil)
     end


### PR DESCRIPTION
This updated the queries to allow viewing the reference request page if the application hasn't been awarded or declined, meaning that referees can still fill in a reference after it's expired.

We sometimes want this if the applicant provided an incorrect email address and we've re-sent the email, the expiration date may have passed, but the assessors haven't declined the application.

This was the intended behaviour but it wasn't working correctly.

[Trello Card](https://trello.com/c/Hi4rbICA/1865-resent-referee-link-wont-work-2001871)