### PR TITLE
Reduce statuscake check interval

### DIFF
--- a/terraform/paas/statuscake.tf
+++ b/terraform/paas/statuscake.tf
@@ -5,7 +5,7 @@ resource "statuscake_uptime_check" "alert" {
   contact_groups = each.value.contact_group
   confirmation   = each.value.confirmations
   trigger_rate   = 0
-  check_interval = 30
+  check_interval = 300
   regions        = ["london", "dublin"]
 
   http_check {


### PR DESCRIPTION
We're currently checking every 30 seconds which feels a little unnecessary for this service, sending unnecessary traffic to the service. Reducing it to 2 minutes should still allow us to respond quickly to incidents.