### PR TITLE
Set format for error responses

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -5,22 +5,24 @@ class ErrorsController < ApplicationController
   layout "two_thirds"
 
   def forbidden
-    render "forbidden", status: :forbidden
+    render "forbidden", formats: :html, status: :forbidden
   end
 
   def not_found
-    render "not_found", status: :not_found
+    render "not_found", formats: :html, status: :not_found
   end
 
   def unprocessable_entity
-    render "unprocessable_entity", status: :unprocessable_entity
+    render "unprocessable_entity", formats: :html, status: :unprocessable_entity
   end
 
   def too_many_requests
-    render "too_many_requests", status: :too_many_requests
+    render "too_many_requests", formats: :html, status: :too_many_requests
   end
 
   def internal_server_error
-    render "internal_server_error", status: :internal_server_error
+    render "internal_server_error",
+           formats: :html,
+           status: :internal_server_error
   end
 end


### PR DESCRIPTION
Currently when we render the error response we use the format of the request, and this means if a user tries to access (for example) a CSS file at the wrong URL, it tries to render `errors/not_found.css` which doesn't exist.

We can an error like this:

```
12:46:39 web.1    | Error during failsafe response: Missing template errors/not_found, application/not_found with {:locale=>[:en], :formats=>[:css], :variants=>[], :handlers=>[:raw, :erb, :html, :builder, :ruby, :md]}.
12:46:39 web.1    |
12:46:39 web.1    | Searched in:
12:46:39 web.1    |   * "/Users/thomasleese/Developer/dfe/apply-for-qualified-teacher-status/app/views"
```

I've noticed this seems to be the main reason why we get 500 errors, so fixing this should make it easier to search for real errors in the logs.

This can be tested by [setting `consider_all_requests_local` to `false`](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/6d6f0f7269f76b313f16667dbc6054059fd09784/config/environments/development.rb#L15) and navigating to `/does-not-exist.css` and comparing before and after applying this PR.