### PR TITLE
Add index on canonical email addresses

### DIFF
--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -20,8 +20,9 @@
 #
 # Indexes
 #
-#  index_teacher_on_lower_email  (lower((email)::text)) UNIQUE
-#  index_teachers_on_uuid        (uuid) UNIQUE
+#  index_teacher_on_lower_email       (lower((email)::text)) UNIQUE
+#  index_teachers_on_canonical_email  (canonical_email)
+#  index_teachers_on_uuid             (uuid) UNIQUE
 #
 class Teacher < ApplicationRecord
   include Emailable

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -25,7 +25,8 @@
 #
 # Indexes
 #
-#  index_work_histories_on_application_form_id  (application_form_id)
+#  index_work_histories_on_application_form_id      (application_form_id)
+#  index_work_histories_on_canonical_contact_email  (canonical_contact_email)
 #
 # Foreign Keys
 #

--- a/db/migrate/20230523084020_add_canonical_email_index.rb
+++ b/db/migrate/20230523084020_add_canonical_email_index.rb
@@ -1,0 +1,10 @@
+class AddCanonicalEmailIndex < ActiveRecord::Migration[7.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :teachers, :canonical_email, algorithm: :concurrently
+    add_index :work_histories,
+              :canonical_contact_email,
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_15_082603) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_23_084020) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -84,9 +84,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_082603) do
     t.bigint "english_language_provider_id"
     t.text "english_language_provider_reference", default: "", null: false
     t.datetime "awarded_at"
+    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "written_statement_confirmation", default: false, null: false
-    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "english_language_provider_other", default: false, null: false
     t.datetime "declined_at"
     t.boolean "waiting_on_professional_standing", default: false, null: false
@@ -97,8 +97,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_082603) do
     t.boolean "received_reference", default: false, null: false
     t.boolean "waiting_on_qualification", default: false, null: false
     t.boolean "received_qualification", default: false, null: false
-    t.boolean "requires_preliminary_check", default: false, null: false
     t.boolean "written_statement_optional", default: false, null: false
+    t.boolean "requires_preliminary_check", default: false, null: false
     t.boolean "overdue_further_information", default: false, null: false
     t.boolean "overdue_professional_standing", default: false, null: false
     t.boolean "overdue_qualification", default: false, null: false
@@ -164,8 +164,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_082603) do
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "eligibility_enabled", default: true, null: false
-    t.text "qualifications_information", default: "", null: false
     t.boolean "eligibility_skip_questions", default: false, null: false
+    t.text "qualifications_information", default: "", null: false
     t.boolean "requires_preliminary_check", default: false, null: false
     t.index ["code"], name: "index_countries_on_code", unique: true
   end
@@ -357,12 +357,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_082603) do
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
-    t.text "qualifications_information", default: "", null: false
     t.boolean "application_form_skip_work_history", default: false, null: false
+    t.text "qualifications_information", default: "", null: false
     t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_requires_submission_email", default: false, null: false
-    t.boolean "requires_preliminary_check", default: false, null: false
     t.boolean "written_statement_optional", default: false, null: false
+    t.boolean "requires_preliminary_check", default: false, null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
     t.index ["country_id"], name: "index_regions_on_country_id"
   end
@@ -449,6 +449,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_082603) do
     t.datetime "otp_created_at", precision: nil
     t.text "canonical_email", default: "", null: false
     t.index "lower((email)::text)", name: "index_teacher_on_lower_email", unique: true
+    t.index ["canonical_email"], name: "index_teachers_on_canonical_email"
     t.index ["uuid"], name: "index_teachers_on_uuid", unique: true
   end
 
@@ -512,6 +513,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_15_082603) do
     t.string "contact_job", default: "", null: false
     t.text "canonical_contact_email", default: "", null: false
     t.index ["application_form_id"], name: "index_work_histories_on_application_form_id"
+    t.index ["canonical_contact_email"], name: "index_work_histories_on_canonical_contact_email"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -20,8 +20,9 @@
 #
 # Indexes
 #
-#  index_teacher_on_lower_email  (lower((email)::text)) UNIQUE
-#  index_teachers_on_uuid        (uuid) UNIQUE
+#  index_teacher_on_lower_email       (lower((email)::text)) UNIQUE
+#  index_teachers_on_canonical_email  (canonical_email)
+#  index_teachers_on_uuid             (uuid) UNIQUE
 #
 FactoryBot.define do
   factory :teacher do

--- a/spec/factories/work_histories.rb
+++ b/spec/factories/work_histories.rb
@@ -23,7 +23,8 @@
 #
 # Indexes
 #
-#  index_work_histories_on_application_form_id  (application_form_id)
+#  index_work_histories_on_application_form_id      (application_form_id)
+#  index_work_histories_on_canonical_contact_email  (canonical_contact_email)
 #
 # Foreign Keys
 #

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -20,8 +20,9 @@
 #
 # Indexes
 #
-#  index_teacher_on_lower_email  (lower((email)::text)) UNIQUE
-#  index_teachers_on_uuid        (uuid) UNIQUE
+#  index_teacher_on_lower_email       (lower((email)::text)) UNIQUE
+#  index_teachers_on_canonical_email  (canonical_email)
+#  index_teachers_on_uuid             (uuid) UNIQUE
 #
 require "rails_helper"
 

--- a/spec/models/work_history_spec.rb
+++ b/spec/models/work_history_spec.rb
@@ -23,7 +23,8 @@
 #
 # Indexes
 #
-#  index_work_histories_on_application_form_id  (application_form_id)
+#  index_work_histories_on_application_form_id      (application_form_id)
+#  index_work_histories_on_canonical_contact_email  (canonical_contact_email)
 #
 # Foreign Keys
 #


### PR DESCRIPTION
Since we query this field to render the box showing the list of potentially linked applications I have a suspicion that this causing timeouts and slowdowns when assessors are using the service.