### PR TITLE
Restrict adding notes to applications where no sections are started

### DIFF
--- a/lib/tasks/quick_decline.rake
+++ b/lib/tasks/quick_decline.rake
@@ -21,7 +21,9 @@ namespace :quick_decline do
         next
       end
 
-      CreateQuickDeclineTimelineEvent.call(application_form:)
+      if application_form.assessment.sections.map(&:passed).all?(nil)
+        CreateQuickDeclineTimelineEvent.call(application_form:)
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/DfuydigG/1854-backfill-quick-decline-case-notes

We only need to add case notes for declined applications where ALL of the assessment sections are not started. (Currently ~85 in production)
Is there a better way to do this filtering in SQL?