### PR TITLE
Restrict quick decline case notes

### DIFF
--- a/app/services/create_quick_decline_timeline_event.rb
+++ b/app/services/create_quick_decline_timeline_event.rb
@@ -10,7 +10,8 @@ class CreateQuickDeclineTimelineEvent
 
   def call
     unless application_form.requires_preliminary_check &&
-             application_form.assessment&.preliminary_check_complete == false
+             application_form.assessment&.preliminary_check_complete == false &&
+             application_form.assessment.sections.map(&:passed).all?(nil)
       return
     end
 

--- a/app/services/decline_qts.rb
+++ b/app/services/decline_qts.rb
@@ -14,9 +14,7 @@ class DeclineQTS
     ActiveRecord::Base.transaction do
       application_form.update!(declined_at: Time.zone.now)
       ApplicationFormStatusUpdater.call(application_form:, user:)
-      if quick_decline?
-        CreateQuickDeclineTimelineEvent.call(application_form:, user:)
-      end
+      CreateQuickDeclineTimelineEvent.call(application_form:, user:)
     end
 
     TeacherMailer.with(teacher:).application_declined.deliver_later
@@ -26,9 +24,4 @@ class DeclineQTS
 
   attr_reader :application_form, :user
   delegate :teacher, to: :application_form
-
-  def quick_decline?
-    application_form.requires_preliminary_check &&
-      application_form.assessment&.preliminary_check_complete == false
-  end
 end

--- a/spec/services/create_quick_decline_timeline_event_spec.rb
+++ b/spec/services/create_quick_decline_timeline_event_spec.rb
@@ -32,4 +32,28 @@ RSpec.describe CreateQuickDeclineTimelineEvent do
       expect { call }.not_to change(TimelineEvent, :count)
     end
   end
+
+  context "with an application declined via an assessment section" do
+    let!(:application_form) do
+      application_form =
+        create(
+          :application_form,
+          :submitted,
+          requires_preliminary_check: true,
+          teacher:,
+          assessment: create(:assessment, preliminary_check_complete: false),
+        )
+
+      application_form.assessment.sections << create(
+        :assessment_section,
+        selected_failure_reasons: [create(:selected_failure_reason)],
+        passed: false,
+      )
+      application_form
+    end
+
+    it "does not create a quick decline timeline event" do
+      expect { call }.not_to change(TimelineEvent, :count)
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/DfuydigG/1854-backfill-quick-decline-case-notes

We should only add these case notes to applications where none of the assessment sections have been started.