### PR TITLE
Check for applicant in DQT when application is submitted

### DIFF
--- a/app/jobs/find_applicant_in_dqt_job.rb
+++ b/app/jobs/find_applicant_in_dqt_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class FindApplicantInDQTJob < ApplicationJob
+  def perform(application_form_id:)
+    application_form = ApplicationForm.find(application_form_id)
+    teachers = FindTeachersInDQT.call(application_form:, reverse_name: true)
+
+    application_form.update!(dqt_match: teachers.first) if teachers.any?
+  end
+end

--- a/app/lib/dqt/client/find_teachers.rb
+++ b/app/lib/dqt/client/find_teachers.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class DQT::Client::FindTeachers
+  include ServicePattern
+  include DQT::Client::Connection
+
+  attr_reader :application_form, :reverse_name
+  def initialize(application_form:, reverse_name: false)
+    @application_form = application_form
+    @reverse_name = reverse_name
+  end
+
+  def call
+    path = "/v2/teachers/find"
+    response =
+      connection.get(
+        path,
+        DQT::FindTeachersParams.call(application_form:, reverse_name:),
+      )
+    if response.success?
+      response.body["results"].map do |r|
+        r.transform_keys { |key| key.underscore.to_sym }
+      end
+    else
+      []
+    end
+  rescue Faraday::Error
+    []
+  end
+end

--- a/app/lib/dqt/find_teachers_params.rb
+++ b/app/lib/dqt/find_teachers_params.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module DQT
+  class FindTeachersParams
+    include ServicePattern
+
+    attr_reader :application_form, :reverse_name
+
+    def initialize(application_form:, reverse_name: false)
+      @application_form = application_form
+      @reverse_name = reverse_name
+    end
+
+    def call
+      {
+        dateOfBirth: application_form.date_of_birth&.to_date&.iso8601,
+        firstName:
+          (
+            if reverse_name
+              application_form.family_name
+            else
+              application_form.given_names
+            end
+          ),
+        lastName:
+          (
+            if reverse_name
+              application_form.given_names
+            else
+              application_form.family_name
+            end
+          ),
+      }
+    end
+  end
+end

--- a/app/lib/dqt/find_teachers_params.rb
+++ b/app/lib/dqt/find_teachers_params.rb
@@ -19,18 +19,24 @@ module DQT
             if reverse_name
               application_form.family_name
             else
-              application_form.given_names
+              first_name
             end
           ),
         lastName:
           (
             if reverse_name
-              application_form.given_names
+              first_name
             else
               application_form.family_name
             end
           ),
       }
+    end
+
+    private
+
+    def first_name
+      application_form.given_names.split(" ").first
     end
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -12,6 +12,7 @@
 #  confirmed_no_sanctions                        :boolean          default(FALSE)
 #  date_of_birth                                 :date
 #  declined_at                                   :datetime
+#  dqt_match                                     :jsonb
 #  english_language_citizenship_exempt           :boolean
 #  english_language_proof_method                 :string
 #  english_language_provider_other               :boolean          default(FALSE), not null

--- a/app/services/find_teachers_in_dqt.rb
+++ b/app/services/find_teachers_in_dqt.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class FindTeachersInDQT
+  include ServicePattern
+
+  attr_reader :application_form, :reverse_name
+
+  def initialize(application_form:, reverse_name: false)
+    @application_form = application_form
+    @reverse_name = reverse_name
+  end
+
+  def call
+    results = DQT::Client::FindTeachers.call(application_form:)
+    if results.empty? && reverse_name
+      results =
+        DQT::Client::FindTeachers.call(application_form:, reverse_name: true)
+    end
+    results
+  end
+end

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -49,6 +49,10 @@ class SubmitApplicationForm
         .application_submitted
         .deliver_later
     end
+
+    FindApplicantInDQTJob.perform_later(
+      application_form_id: application_form.id,
+    )
   end
 
   private

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -33,6 +33,16 @@
   <% end %>
 <% end %>
 
+<% if @view_object.application_form.dqt_match.present? %>
+  <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
+    <% notification_banner.with_heading(text: "The application details match a record in DQT") %>
+
+    <p class="govuk-body govuk-!-margin-bottom-1">
+      DQT contains a matching record for the name and date of birth of this applicant. <strong class="govuk-!-font-weight-bold">Teacher Reference Number: <%= @view_object.application_form.dqt_match["trn"] %>.
+    </p>
+  <% end %>
+<% end %>
+
 <%= render "shared/assessor_header", title: "Application", application_form: @view_object.application_form %>
 
 <%= render(ApplicationFormOverview::Component.new(@view_object.application_form, highlight_email: @view_object.highlight_email?)) %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -82,6 +82,7 @@
     - english_language_provider_reference
     - reduced_evidence_accepted
     - requires_preliminary_check
+    - dqt_match
   :assessment_sections:
     - id
     - assessment_id

--- a/db/migrate/20230523154213_add_dqt_match_to_application_forms.rb
+++ b/db/migrate/20230523154213_add_dqt_match_to_application_forms.rb
@@ -1,0 +1,5 @@
+class AddDQTMatchToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_forms, :dqt_match, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_23_084020) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_23_154213) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -103,6 +103,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_23_084020) do
     t.boolean "overdue_professional_standing", default: false, null: false
     t.boolean "overdue_qualification", default: false, null: false
     t.boolean "overdue_reference", default: false, null: false
+    t.jsonb "dqt_match", default: {}
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["english_language_provider_id"], name: "index_application_forms_on_english_language_provider_id"
     t.index ["family_name"], name: "index_application_forms_on_family_name"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -12,6 +12,7 @@
 #  confirmed_no_sanctions                        :boolean          default(FALSE)
 #  date_of_birth                                 :date
 #  declined_at                                   :datetime
+#  dqt_match                                     :jsonb
 #  english_language_citizenship_exempt           :boolean
 #  english_language_proof_method                 :string
 #  english_language_provider_other               :boolean          default(FALSE), not null

--- a/spec/jobs/find_applicant_in_dqt_job_spec.rb
+++ b/spec/jobs/find_applicant_in_dqt_job_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FindApplicantInDQTJob do
+  describe "#perform" do
+    let(:application_form) do
+      create(:application_form, :submitted, :with_personal_information)
+    end
+    let(:application_form_id) { application_form.id }
+
+    subject(:perform) { described_class.perform_now(application_form_id:) }
+
+    it "calls the FindTeachersInDQT service" do
+      expect(FindTeachersInDQT).to receive(:call).with(
+        application_form:,
+        reverse_name: true,
+      ).and_return([])
+
+      perform
+    end
+
+    it "does not update the application form if no results are returned" do
+      allow(FindTeachersInDQT).to receive(:call).with(
+        application_form:,
+        reverse_name: true,
+      ).and_return([])
+
+      perform
+
+      expect(application_form.reload.dqt_match).to eq({})
+    end
+
+    it "updates the application form with the TRN" do
+      result = {
+        date_of_birth: application_form.date_of_birth.iso8601.to_s,
+        first_name: "Jane",
+        last_name: "Smith",
+        trn: "1234567",
+      }
+
+      allow(FindTeachersInDQT).to receive(:call).and_return(
+        [
+          result,
+          {
+            date_of_birth: "1980-01-01",
+            first_name: "Janet",
+            last_name: "Jones",
+            trn: "7654321",
+          },
+        ],
+      )
+
+      perform
+
+      expect(application_form.reload.dqt_match).to eq(result.as_json)
+    end
+  end
+end

--- a/spec/lib/dqt/client/find_teachers_spec.rb
+++ b/spec/lib/dqt/client/find_teachers_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DQT::Client::FindTeachers do
+  let(:application_form) do
+    create(:application_form, :submitted, :with_personal_information)
+  end
+  let(:request_params) do
+    {
+      dateOfBirth: application_form.date_of_birth.iso8601.to_s,
+      firstName: application_form.given_names,
+      lastName: application_form.family_name,
+    }
+  end
+
+  subject(:call) { described_class.call(application_form:) }
+
+  context "with a successful response" do
+    before do
+      stub_request(
+        :get,
+        "https://test-teacher-qualifications-api.education.gov.uk/v2/teachers/find?#{request_params.to_query}",
+      ).with(headers: { "Authorization" => "Bearer test-api-key" }).to_return(
+        status: 200,
+        body: { results: [request_params.merge(trn: "1234567")] }.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+    end
+
+    it do
+      is_expected.to eq(
+        [
+          {
+            date_of_birth: application_form.date_of_birth.iso8601.to_s,
+            first_name: application_form.given_names,
+            last_name: application_form.family_name,
+            trn: "1234567",
+          },
+        ],
+      )
+    end
+  end
+
+  context "with an error response" do
+    before do
+      stub_request(
+        :get,
+        "https://test-teacher-qualifications-api.education.gov.uk/v2/teachers/find?#{request_params.to_query}",
+      ).with(headers: { "Authorization" => "Bearer test-api-key" }).to_return(
+        status: 500,
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+    end
+
+    it { is_expected.to eq([]) }
+  end
+end

--- a/spec/lib/dqt/client/find_teachers_spec.rb
+++ b/spec/lib/dqt/client/find_teachers_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe DQT::Client::FindTeachers do
   let(:request_params) do
     {
       dateOfBirth: application_form.date_of_birth.iso8601.to_s,
-      firstName: application_form.given_names,
+      firstName: application_form.given_names.split(" ").first,
       lastName: application_form.family_name,
     }
   end
@@ -35,7 +35,7 @@ RSpec.describe DQT::Client::FindTeachers do
         [
           {
             date_of_birth: application_form.date_of_birth.iso8601.to_s,
-            first_name: application_form.given_names,
+            first_name: application_form.given_names.split(" ").first,
             last_name: application_form.family_name,
             trn: "1234567",
           },

--- a/spec/lib/dqt/find_teachers_params_spec.rb
+++ b/spec/lib/dqt/find_teachers_params_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe DQT::FindTeachersParams do
+  describe "#call" do
+    let(:application_form) do
+      create(
+        :application_form,
+        date_of_birth: Date.new(1960, 1, 1),
+        given_names: "Given",
+        family_name: "Family",
+      )
+    end
+    let(:reverse_name) { false }
+
+    subject(:call) { described_class.call(application_form:, reverse_name:) }
+
+    it "returns camel case params" do
+      expect(call).to eq(
+        { dateOfBirth: "1960-01-01", firstName: "Given", lastName: "Family" },
+      )
+    end
+
+    context "when reverse_name is true" do
+      let(:reverse_name) { true }
+
+      it "returns camel case params with first and last name reversed" do
+        expect(call).to eq(
+          { dateOfBirth: "1960-01-01", firstName: "Family", lastName: "Given" },
+        )
+      end
+    end
+  end
+end

--- a/spec/lib/dqt/find_teachers_params_spec.rb
+++ b/spec/lib/dqt/find_teachers_params_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe DQT::FindTeachersParams do
       create(
         :application_form,
         date_of_birth: Date.new(1960, 1, 1),
-        given_names: "Given",
-        family_name: "Family",
+        given_names: "Rowdy Roddy",
+        family_name: "Piper",
       )
     end
     let(:reverse_name) { false }
@@ -16,7 +16,7 @@ RSpec.describe DQT::FindTeachersParams do
 
     it "returns camel case params" do
       expect(call).to eq(
-        { dateOfBirth: "1960-01-01", firstName: "Given", lastName: "Family" },
+        { dateOfBirth: "1960-01-01", firstName: "Rowdy", lastName: "Piper" },
       )
     end
 
@@ -25,7 +25,7 @@ RSpec.describe DQT::FindTeachersParams do
 
       it "returns camel case params with first and last name reversed" do
         expect(call).to eq(
-          { dateOfBirth: "1960-01-01", firstName: "Family", lastName: "Given" },
+          { dateOfBirth: "1960-01-01", firstName: "Piper", lastName: "Rowdy" },
         )
       end
     end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -12,6 +12,7 @@
 #  confirmed_no_sanctions                        :boolean          default(FALSE)
 #  date_of_birth                                 :date
 #  declined_at                                   :datetime
+#  dqt_match                                     :jsonb
 #  english_language_citizenship_exempt           :boolean
 #  english_language_proof_method                 :string
 #  english_language_provider_other               :boolean          default(FALSE), not null

--- a/spec/services/find_teachers_in_dqt_spec.rb
+++ b/spec/services/find_teachers_in_dqt_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe FindTeachersInDQT do
       expect(call).to eq([])
     end
 
-    context "with results in the API response" do
+    context "with matching results in the API response" do
       let(:results) do
         [
           {
             date_of_birth: application_form.date_of_birth.iso8601.to_s,
-            first_name: application_form.given_names,
+            first_name: application_form.given_names.split(" ").first,
             last_name: application_form.family_name,
             trn: "1234567",
           },
@@ -38,6 +38,32 @@ RSpec.describe FindTeachersInDQT do
       end
       before do
         allow(DQT::Client::FindTeachers).to receive(:call).and_return(results)
+      end
+
+      it "returns the results" do
+        expect(call).to eq(results)
+      end
+    end
+
+    context "with reversed name in API results" do
+      let(:results) do
+        [
+          {
+            date_of_birth: application_form.date_of_birth.iso8601.to_s,
+            first_name: application_form.family_name,
+            last_name: application_form.given_names,
+            trn: "1234567",
+          },
+        ]
+      end
+      before do
+        allow(DQT::Client::FindTeachers).to receive(:call).with(
+          application_form:,
+        ).and_return([])
+        allow(DQT::Client::FindTeachers).to receive(:call).with(
+          application_form:,
+          reverse_name: true,
+        ).and_return(results)
       end
 
       it "returns the results" do

--- a/spec/services/find_teachers_in_dqt_spec.rb
+++ b/spec/services/find_teachers_in_dqt_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FindTeachersInDQT do
+  describe "#call" do
+    let(:application_form) do
+      create(:application_form, :submitted, :with_personal_information)
+    end
+    let(:results) { [] }
+
+    subject(:call) do
+      described_class.call(application_form:, reverse_name: true)
+    end
+
+    it "calls the Find Teachers DQT API service" do
+      expect(DQT::Client::FindTeachers).to receive(:call).with(
+        application_form:,
+      ).and_return(results)
+      expect(DQT::Client::FindTeachers).to receive(:call).with(
+        application_form:,
+        reverse_name: true,
+      ).and_return(results)
+
+      expect(call).to eq([])
+    end
+
+    context "with results in the API response" do
+      let(:results) do
+        [
+          {
+            date_of_birth: application_form.date_of_birth.iso8601.to_s,
+            first_name: application_form.given_names,
+            last_name: application_form.family_name,
+            trn: "1234567",
+          },
+        ]
+      end
+      before do
+        allow(DQT::Client::FindTeachers).to receive(:call).and_return(results)
+      end
+
+      it "returns the results" do
+        expect(call).to eq(results)
+      end
+    end
+  end
+end

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -202,4 +202,12 @@ RSpec.describe SubmitApplicationForm do
       end
     end
   end
+
+  describe "finding matches in DQT" do
+    it "calls a background job to find matching DQT records" do
+      expect { call }.to have_enqueued_job(FindApplicantInDQTJob).with(
+        application_form_id: application_form.id,
+      )
+    end
+  end
 end

--- a/spec/system/assessor_interface/duplicate_applicant_application_form_spec.rb
+++ b/spec/system/assessor_interface/duplicate_applicant_application_form_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe "Assessor views duplicate applicant's application form",
+               type: :system do
+  it "displays information about the duplicate applicant" do
+    given_the_service_is_open
+    given_i_am_authorized_as_an_assessor_user
+    given_there_is_an_application_form
+    and_the_applicant_matches_a_record_in_dqt
+
+    when_i_visit_the(:assessor_application_page, application_id:)
+    then_i_see_the_application
+    and_i_see_the_warning_of_an_existing_record_in_dqt
+  end
+
+  private
+
+  def given_there_is_an_application_form
+    application_form
+  end
+
+  def when_i_click_back_link
+    assessor_application_page.back_link.click
+  end
+
+  def then_i_see_the_application
+    expect(assessor_application_page.overview.name.text).to eq(
+      "#{application_form.given_names} #{application_form.family_name}",
+    )
+  end
+
+  def and_i_see_the_warning_of_an_existing_record_in_dqt
+    expect(assessor_application_page).to have_content(
+      "The application details match a record in DQT",
+    )
+    expect(assessor_application_page).to have_content(
+      "Teacher Reference Number: 7654322",
+    )
+  end
+
+  def and_the_applicant_matches_a_record_in_dqt
+    application_form.update!(dqt_match:)
+  end
+
+  def application_form
+    @application_form ||=
+      begin
+        application_form =
+          create(
+            :application_form,
+            :with_personal_information,
+            :submitted,
+            :with_assessment,
+          )
+
+        create(
+          :assessment_section,
+          :personal_information,
+          assessment: application_form.assessment,
+        )
+
+        application_form
+      end
+  end
+
+  def application_id
+    application_form.id
+  end
+
+  def dqt_match
+    {
+      "firstName" => application_form.given_names,
+      "lastName" => application_form.family_name,
+      "dateOfBirth" => application_form.date_of_birth.iso8601.to_s,
+      "trn" => "7654322",
+    }
+  end
+end

--- a/spec/system/teacher_interface/submitting_spec.rb
+++ b/spec/system/teacher_interface/submitting_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe "Teacher submitting", type: :system do
   end
 
   def when_i_confirm_i_have_no_sanctions
+    allow(FindTeachersInDQT).to receive(:call).with(
+      application_form:,
+      reverse_name: true,
+    ).and_return([])
+
     check_your_answers_page
       .submission_declaration
       .form


### PR DESCRIPTION
https://trello.com/c/GXIBUN1U/1849-spike-upfront-duplication-check

When an application is submitted, query the DQT API with the applicant's details and save the first matched record on the application.

![image](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/93511/237d9e62-6daa-474e-a05e-2d96c5e14e4d)
