### PR TITLE
Allow assessing sections before professional standing

### DIFF
--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -20,8 +20,13 @@ module AssessorInterface
     end
 
     delegate :assessment, to: :assessment_section
-    delegate :application_form, :professional_standing_request, to: :assessment
-    delegate :registration_number, to: :application_form
+    delegate :application_form,
+             :preliminary_check_complete,
+             :professional_standing_request,
+             to: :assessment
+    delegate :registration_number,
+             :requires_preliminary_check,
+             to: :application_form
     delegate :checks, to: :assessment_section
     delegate :region, :country, to: :application_form
 
@@ -38,7 +43,18 @@ module AssessorInterface
     end
 
     def render_form?
-      professional_standing_request_received? && !render_section_content?
+      if requires_preliminary_check && preliminary_check_complete.nil?
+        return false
+      end
+
+      return false if render_section_content?
+
+      if assessment_section.professional_standing? &&
+           !professional_standing_request_received?
+        return false
+      end
+
+      true
     end
 
     def render_section_content?

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -154,7 +154,31 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
 
     it { is_expected.to be true }
 
-    context "with a requested professional standing request" do
+    context "when a preliminary check is required" do
+      let(:application_form) do
+        create(:application_form, region:, requires_preliminary_check: true)
+      end
+
+      it { is_expected.to be false }
+
+      context "and preliminary check is complete" do
+        let(:assessment) do
+          create(
+            :assessment,
+            application_form:,
+            preliminary_check_complete: true,
+          )
+        end
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "with a the professional standing section and a requested professional standing request" do
+      let(:assessment_section) do
+        create(:assessment_section, :professional_standing, assessment:)
+      end
+
       before { create(:professional_standing_request, :requested, assessment:) }
 
       it { is_expected.to be false }


### PR DESCRIPTION
We only need to limit the professional standing section from being assessed before the professional standing has been received. This also fixes a bug currently where countries with preliminary checks aren't able to assess the qualifications section before receiving the professional standing, but in the case of a "quick decline" we'd want them to be able to assess the qualification section.