### PR TITLE
Add suspect file failure reason to age range / subjects section

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -164,6 +164,7 @@ class AssessmentFactory
     failure_reasons = [
       FailureReasons::NOT_QUALIFIED_TO_TEACH_MAINSTREAM,
       FailureReasons::AGE_RANGE,
+      FailureReasons::UPLOADED_FILE_SUSPECT,
     ]
 
     AssessmentSection.new(key: "age_range_subjects", checks:, failure_reasons:)

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -304,7 +304,11 @@ RSpec.describe AssessmentFactory do
               %w[qualified_in_mainstream_education age_range_subjects_matches],
             )
             expect(section.failure_reasons).to eq(
-              %w[not_qualified_to_teach_mainstream age_range],
+              %w[
+                not_qualified_to_teach_mainstream
+                age_range
+                uploaded_file_suspect
+              ],
             )
           end
         end
@@ -330,7 +334,11 @@ RSpec.describe AssessmentFactory do
             )
 
             expect(section.failure_reasons).to eq(
-              %w[not_qualified_to_teach_mainstream age_range],
+              %w[
+                not_qualified_to_teach_mainstream
+                age_range
+                uploaded_file_suspect
+              ],
             )
           end
         end


### PR DESCRIPTION
https://trello.com/c/hGTTuSIw/1770-update-ui-to-only-show-download-links-for-scanned-files

This was spotted in product review.