### PR TITLE
Allow analytics on qualifications

### DIFF
--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -26,13 +26,11 @@
   :professional_standing_requests:
     - location_note
   :qualifications:
-    - title
     - institution_name
     - institution_country_code
     - start_date
     - complete_date
     - certificate_date
-    - part_of_university_degree
   :qualification_requests:
     - location_note
     - failure_assessor_note


### PR DESCRIPTION
We'd like to allow certain analytics on qualifications, so we need to be able to see the title and whether it was part of a university degree. This information won't be considered PII, especially as other forms of identification for the qualification will remain obfuscated.