### PR TITLE
Specify infrastructure_encryption_required

### DIFF
--- a/terraform/paas/storage.tf
+++ b/terraform/paas/storage.tf
@@ -17,13 +17,12 @@ resource "azurerm_storage_account" "forms" {
   }
 }
 
-
 resource "azurerm_storage_encryption_scope" "forms-encryption" {
-  name               = "microsoftmanaged"
-  storage_account_id = azurerm_storage_account.forms.id
-  source             = "Microsoft.Storage"
+  name                               = "microsoftmanaged"
+  storage_account_id                 = azurerm_storage_account.forms.id
+  source                             = "Microsoft.Storage"
+  infrastructure_encryption_required = true
 }
-
 
 resource "azurerm_storage_container" "uploads" {
   name                  = "uploads"


### PR DESCRIPTION
This prevents the resource from being recreated in Terraform as the parameter goes from `true` to `nil`, but Azure sets it to `true` by default so actually nothing changes.

```
-/+ resource "azurerm_storage_encryption_scope" "forms-encryption" ***
      ~ id                                 = "/subscriptions/***/resourceGroups/s165p01-afqts-pd-rg/providers/Microsoft.Storage/storageAccounts/s165p01afqtsformspd/encryptionScopes/microsoftmanaged" -> (known after apply)
      - infrastructure_encryption_required = true -> null # forces replacement
        name                               = "microsoftmanaged"
        # (2 unchanged attributes hidden)
    \***
```

[Trello Card](https://trello.com/c/2vi3rsUd/1886-deployment-on-paas-generates-a-issue)