### PR TITLE
Make back links from malware scan content work for teachers and assessors

### DIFF
--- a/app/views/shared/malware_scan.html.erb
+++ b/app/views/shared/malware_scan.html.erb
@@ -1,8 +1,8 @@
 <% content_for :page_title, t("teacher_interface.uploads.malware_scan.#{@upload.malware_scan_result}.title") %>
-<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_document_path(@document)) %>
+<% content_for :back_link_url, url_for(:back) %>
 
 <h1 class="govuk-heading-l"><%= t("teacher_interface.uploads.malware_scan.#{@upload.malware_scan_result}.title") %></h1>
 
 <p class="govuk-body"><%= t("teacher_interface.uploads.malware_scan.#{@upload.malware_scan_result}.body") %></p>
 
-<p class="govuk-body"><%= govuk_link_to "Back to application", teacher_interface_application_form_document_path(@document) %></p>
+<p class="govuk-body"><%= govuk_link_to "Back to application", :back %></p>

--- a/spec/system/teacher_interface/malware_scanning_spec.rb
+++ b/spec/system/teacher_interface/malware_scanning_spec.rb
@@ -19,6 +19,12 @@ RSpec.describe "Malware scanning", type: :system do
     then_i_see_the_check_your_uploaded_files_page
     and_the_uploaded_files_have_been_marked_as_malware
     and_the_uploaded_files_have_been_removed
+
+    when_i_click_on_a_file_marked_as_malware
+    then_i_see_theres_a_problem_with_the_file
+
+    when_i_click_back_to_application
+    then_i_see_the_check_your_uploaded_files_page
   end
 
   def given_there_is_an_application_form
@@ -69,6 +75,22 @@ RSpec.describe "Malware scanning", type: :system do
     expect(written_statement.uploads.first.attachment.filename).to be_nil
     expect(written_statement.uploads.last.attachment.download).to be_nil
     expect(written_statement.uploads.last.attachment.filename).to be_nil
+  end
+
+  def when_i_click_on_a_file_marked_as_malware
+    first("a", text: "File upload error").click
+  end
+
+  def then_i_see_theres_a_problem_with_the_file
+    expect(page).to have_content("There’s a problem with this file")
+  end
+
+  def when_i_click_back_to_application
+    click_on "Back to application"
+  end
+
+  def then_i_see_the_check_your_uploaded_files_page
+    expect(check_uploaded_files_page).to have_title("Check your uploaded files")
   end
 
   def teacher


### PR DESCRIPTION
https://trello.com/c/gRJH1FRK/1855-pending-virus-check-back-to-application-goes-to-sign-in-page

Malware scan content can appear for assessors and teachers, the link back to the previous screen can be one of many different urls and we can't determine this easily for assessors. So use the Rails `:back` functionality.