### PR TITLE
Refactor smoke tests

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: JSON object containing a service principal that can read from Azure Key Vault
     required: true
   pull-request-number:
-    description: The pull request number which triggered this deploy
+    description: The pull request number which triggered this deploy. If set, this will automatically seed the database.
     required: false
 
 outputs:
@@ -60,3 +60,33 @@ runs:
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure-credentials }}
         DOCKER_IMAGE: ${{ inputs.docker-image }}
         pr_id: ${{ inputs.pull-request-number }}
+
+    - uses: Azure/login@v1
+      with:
+        creds: ${{ inputs.azure-credentials }}
+
+    - name: Seed database
+      if: ${{ inputs.pull-request-number != '' }}
+      shell: bash
+      run: |
+        az aks get-credentials -g s189t01-tsc-ts-rg -n s189t01-tsc-test-aks
+        kubectl exec -n tra-development deployment/apply-for-qts-review-${{ inputs.pull-request-number }}-web -- sh -c "cd /app && /usr/local/bin/bundle exec rails db:seed example_data:generate review_app:configure"
+
+    - id: key-vault-name
+      shell: bash
+      run: echo "value=$(make -s ${{ inputs.environment }}_aks print-keyvault-name)" >> $GITHUB_OUTPUT
+      env:
+        pr_id: ${{ inputs.pull-request-number }}
+
+    - uses: DfE-Digital/keyvault-yaml-secret@v1
+      id: smoke-test-secrets
+      with:
+        keyvault: ${{ steps.key-vault-name.outputs.value }}
+        secret: APPLICATION
+        key: SUPPORT_USERNAME,SUPPORT_PASSWORD
+
+    - uses: ./.github/actions/smoke-test
+      with:
+        url: ${{ steps.apply-terraform.outputs.url }}
+        username: ${{ steps.smoke-test-secrets.outputs.SUPPORT_USERNAME }}
+        password: ${{ steps.smoke-test-secrets.outputs.SUPPORT_PASSWORD }}

--- a/.github/actions/deploy-environment-to-paas/action.yml
+++ b/.github/actions/deploy-environment-to-paas/action.yml
@@ -73,6 +73,19 @@ runs:
         pr_id: ${{ inputs.pr_id }}
       shell: bash
 
+    - uses: DfE-Digital/keyvault-yaml-secret@v1
+      id: smoke-test-secrets
+      with:
+        keyvault: ${{ steps.config.outputs.key_vault_name }}
+        secret: APPLY-QTS-APP-VARIABLES
+        key: SUPPORT_USERNAME,SUPPORT_PASSWORD
+
+    - uses: ./.github/actions/smoke-test
+      with:
+        url: ${{ steps.terraform.outputs.url }}
+        username: ${{ steps.smoke-test-secrets.outputs.SUPPORT_USERNAME }}
+        password: ${{ steps.smoke-test-secrets.outputs.SUPPORT_PASSWORD }}
+
     - uses: DFE-Digital/github-actions/setup-cf-cli@master
       with:
         CF_USERNAME: ${{ steps.get_secrets.outputs.PAAS-USER }}

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -1,44 +1,29 @@
-name: Run smoke test
+name: Smoke test
+description: Run the smoke tests against a live environment.
 
 inputs:
-  environment:
-    description: The name of the environment
+  url:
+    description: The URL of the deployed environment.
     required: true
-  azure_credentials:
-    description: JSON object containing a service principal that can read from Azure Key Vault
-    required: true
+  username:
+    description: The HTTP username to access the service.
+    required: false
+  password:
+    description: The HTTP password to access the service.
+    required: false
 
 runs:
   using: composite
 
   steps:
-    - uses: Azure/login@v1
-      with:
-        creds: ${{ inputs.azure_credentials }}
-
     - name: Prepare application environment
       uses: ./.github/actions/prepare-app-env
 
-    - name: Set environment variables
-      shell: bash
-      run: |
-        tf_vars_file=terraform/paas/workspace_variables/${{ inputs.environment }}.tfvars.json
-        echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
-        echo "PAAS_SPACE=$(jq -r '.paas_space' ${tf_vars_file})" >> $GITHUB_ENV
-
-    - uses: DfE-Digital/keyvault-yaml-secret@v1
-      id: keyvault-yaml-secret
-      with:
-        keyvault: ${{ env.KEY_VAULT_NAME }}
-        secret: APPLY-QTS-APP-VARIABLES
-        key: HOSTING_DOMAIN,GOVUK_NOTIFY_API_KEY,SUPPORT_USERNAME,SUPPORT_PASSWORD
-
-    - name: Run deployment smoke test
+    - name: Run smoke tests
       shell: bash
       run: bin/smoke
       env:
-        HOSTING_DOMAIN: ${{ steps.keyvault-yaml-secret.outputs.HOSTING_DOMAIN }}
-        RAILS_ENV: ${{ steps.keyvault-yaml-secret.outputs.HOSTING_ENVIRONMENT_NAME }}
-        GOVUK_NOTIFY_API_KEY: ${{ steps.keyvault-yaml-secret.outputs.GOVUK_NOTIFY_API_KEY }}
-        SUPPORT_USERNAME: ${{ steps.keyvault-yaml-secret.outputs.SUPPORT_USERNAME }}
-        SUPPORT_PASSWORD: ${{ steps.keyvault-yaml-secret.outputs.SUPPORT_PASSWORD }}
+        RAILS_ENV: test
+        SMOKE_URL: ${{ inputs.url }}
+        SMOKE_USERNAME: ${{ inputs.username }}
+        SMOKE_PASSWORD: ${{ inputs.password }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,16 +165,6 @@ jobs:
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
           pull-request-number: ${{ github.event.pull_request.number }}
 
-      - uses: Azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: Seed the DB
-        shell: bash
-        run: |
-          az aks get-credentials -g s189t01-tsc-ts-rg -n s189t01-tsc-test-aks
-          kubectl exec -n tra-development deployment/apply-for-qts-review-${{ github.event.pull_request.number }}-web -- sh -c "cd /app && /usr/local/bin/bundle exec rails db:seed example_data:generate review_app:configure"
-
       - name: Post sticky pull request comment
         if: github.event_name == 'pull_request'
         uses: marocchino/sticky-pull-request-comment@v2
@@ -208,11 +198,6 @@ jobs:
           environment_name: ${{ matrix.environment }}
           docker_image: ${{ needs.docker.outputs.docker_image }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-      - uses: ./.github/actions/smoke-test
-        id: smoke-test
-        with:
-          environment: ${{ matrix.environment }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
 
   deploy_nonprod_aks:
     name: Deploy to ${{ matrix.environment }} AKS environment
@@ -240,12 +225,6 @@ jobs:
           environment: ${{ matrix.environment }}
           docker-image: ${{ needs.docker.outputs.docker_image }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - uses: ./.github/actions/smoke-test
-        id: smoke-test
-        with:
-          environment: ${{ matrix.environment }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
 
   deploy_production:
     name: Deploy to production environment

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ read-keyvault-config:
 	$(if $(KEY_VAULT_SECRET_NAME), , $(error Missing environment variable "KEY_VAULT_SECRET_NAME"))
 	$(eval KEY_VAULT_NAME=$(AZURE_RESOURCE_PREFIX)-$(SERVICE_SHORT)-$(CONFIG_SHORT)-kv)
 
+.PHONY: print-keyvault-name
+print-keyvault-name: read-keyvault-config  ## Print the name of the key vault
+	echo ${KEY_VAULT_NAME}
+
 .PHONY: read-deployment-config
 read-deployment-config:
 	$(if $(PLATFORM), , $(error Missing environment variable "PLATFORM"))

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -24,10 +24,7 @@ Capybara.always_include_port = false
 
 describe "Smoke test", type: :system, js: true, smoke_test: true do
   before do
-    page.driver.basic_authorize(
-      ENV["SUPPORT_USERNAME"],
-      ENV["SUPPORT_PASSWORD"],
-    )
+    page.driver.basic_authorize(ENV["SMOKE_USERNAME"], ENV["SMOKE_PASSWORD"])
   end
 
   it "runs" do
@@ -47,7 +44,7 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
   private
 
   def when_i_visit_the_service_domain
-    page.visit(ENV["HOSTING_DOMAIN"])
+    page.visit(ENV["SMOKE_URL"])
   end
 
   def and_i_click_the_start_button


### PR DESCRIPTION
This refactors the smoke tests to allow them to work for both PaaS and AKS deployments. I've simplified the smoke test action itself to require only what is needed to run the smoke tests, and then extracted the credentials according to the logic of AKS or PaaS, automatically calling the smoke tests after each deployment.