### PR TITLE
Remove PaaS review environment

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -59,7 +59,7 @@ runs:
       env:
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure-credentials }}
         DOCKER_IMAGE: ${{ inputs.docker-image }}
-        pr_id: ${{ inputs.pull-request-number }}
+        PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
 
     - uses: Azure/login@v1
       with:

--- a/.github/actions/deploy-environment-to-paas/action.yml
+++ b/.github/actions/deploy-environment-to-paas/action.yml
@@ -11,9 +11,6 @@ inputs:
   azure_credentials:
     description: "JSON object containing a service principal that can read from Azure Key Vault"
     required: true
-  pr_id:
-    description: "Pull Request number"
-    required: false
 
 outputs:
   environment_url:
@@ -70,7 +67,6 @@ runs:
         ARM_ACCESS_KEY: ${{ steps.get_secrets.outputs.TFSTATE-CONTAINER-ACCESS-KEY }}
         DOCKER_IMAGE: ${{ inputs.docker_image }}
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure_credentials }}
-        pr_id: ${{ inputs.pr_id }}
       shell: bash
 
     - uses: DfE-Digital/keyvault-yaml-secret@v1

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           TF_VAR_azure_sp_credentials_json: ${{ secrets.AZURE_CREDENTIALS }}
           DOCKER_IMAGE: "ghcr.io/dfe-digital/apply-for-qualified-teacher-status:no-tag"
-          pr_id: ${{ github.event.pull_request.number }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
 
       - name: Delete Terraform state file
         if: env.TF_STATE_EXISTS == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Set KV environment variables
         if: github.actor != 'dependabot[bot]'
         run: |
-          # tag build to the review env for vars and secrets
-          tf_vars_file=terraform/paas/workspace_variables/review.tfvars.json
+          # tag build to the dev env for vars and secrets
+          tf_vars_file=terraform/paas/workspace_variables/dev.tfvars.json
           echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
           echo ${{ steps.image.outputs.tag }}
 

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,11 @@ development_aks: aks ## Specify dev AKS environment
 
 .PHONY: review_aks
 review_aks: aks ## Specify review AKS environment
-	$(if $(pr_id), , $(error Missing environment variable "pr_id"))
+	$(if $(PULL_REQUEST_NUMBER), , $(error Missing environment variable "PULL_REQUEST_NUMBER"))
 	$(eval include global_config/review_aks.sh)
-	$(eval backend_config=-backend-config="key=terraform-$(pr_id).tfstate")
-	$(eval export TF_VAR_app_suffix=-$(pr_id))
-	$(eval export TF_VAR_uploads_storage_account_name=$(AZURE_RESOURCE_PREFIX)afqtsrv$(pr_id)sa)
+	$(eval backend_config=-backend-config="key=terraform-$(PULL_REQUEST_NUMBER).tfstate")
+	$(eval export TF_VAR_app_suffix=-$(PULL_REQUEST_NUMBER))
+	$(eval export TF_VAR_uploads_storage_account_name=$(AZURE_RESOURCE_PREFIX)afqtsrv$(PULL_REQUEST_NUMBER)sa)
 
 .PHONY: read-keyvault-config
 read-keyvault-config:

--- a/Makefile
+++ b/Makefile
@@ -55,19 +55,6 @@ production: paas ## Specify production PaaS environment
 	$(eval AZURE_BACKUP_STORAGE_ACCOUNT_NAME=s165p01afqtsdbbackuppd)
 	$(eval AZURE_BACKUP_STORAGE_CONTAINER_NAME=apply-for-qts)
 
-.PHONY: review
-review: paas ## Specify review PaaS environment
-	$(if $(pr_id), , $(error Missing environment variable "pr_id"))
-	$(eval DEPLOY_ENV=review)
-	$(eval AZURE_SUBSCRIPTION=s165-teachingqualificationsservice-development)
-	$(eval AZURE_RESOURCE_PREFIX=s165d01)
-	$(eval CONFIG_SHORT=rv)
-	$(eval ENV_TAG=rev)
-	$(eval env=-pr-$(pr_id))
-	$(eval backend_config=-backend-config="key=review/review$(env).tfstate")
-	$(eval export TF_VAR_app_suffix=$(env))
-	$(eval export TF_VAR_forms_storage_account_name=$(AZURE_RESOURCE_PREFIX)afqtsformspr$(pr_id))
-
 .PHONY: development_aks
 development_aks: aks ## Specify dev AKS environment
 	$(eval include global_config/development_aks.sh)

--- a/terraform/paas/workspace_variables/review.backend.tfvars
+++ b/terraform/paas/workspace_variables/review.backend.tfvars
@@ -1,3 +1,0 @@
-storage_account_name = "s165d01afqtstfstatedv"
-# The key is provided dynamically for each review app via the Makefile
-resource_group_name = "s165d01-afqts-dv-rg"

--- a/terraform/paas/workspace_variables/review.tfvars.json
+++ b/terraform/paas/workspace_variables/review.tfvars.json
@@ -1,7 +1,0 @@
-{
-  "environment_name": "review",
-  "key_vault_name": "s165d01-afqts-dv-kv",
-  "resource_group_name": "s165d01-afqts-dv-rg",
-  "paas_space": "tra-dev",
-  "dqt_api_url": "https://preprod-teacher-qualifications-api.education.gov.uk"
-}


### PR DESCRIPTION
This removes the old PaaS-based `review` environment which is no longer being used as review apps are now deployed to AKS since #1388.

I've also renamed `pr_id` to `PULL_REQUEST_NUMBER` to be clearer on the variable name.