### PR TITLE
Allow editing staff permissions

### DIFF
--- a/app/controllers/support_interface/staff_controller.rb
+++ b/app/controllers/support_interface/staff_controller.rb
@@ -2,6 +2,29 @@
 
 class SupportInterface::StaffController < SupportInterface::BaseController
   def index
-    @staff = Staff.all
+    @staff = Staff.order(:name)
+  end
+
+  def edit
+    @staff = Staff.find(params[:id])
+  end
+
+  def update
+    @staff = Staff.find(params[:id])
+
+    if @staff.update(staff_params)
+      redirect_to %i[support_interface staff index]
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def staff_params
+    params.require(:staff).permit(
+      :award_decline_permission,
+      :support_console_permission,
+    )
   end
 end

--- a/app/views/staff/invitations/new.html.erb
+++ b/app/views/staff/invitations/new.html.erb
@@ -3,15 +3,13 @@
 <%= form_for(resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post }) do |f| %>
   <%= f.govuk_error_summary %>
 
-  <% resource.class.invite_key_fields.each do |field| -%>
+  <% resource.class.invite_key_fields.each do |field| %>
     <%= f.govuk_text_field field, label: { text: field.to_s.humanize } %>
-  <% end -%>
+  <% end %>
 
   <%= f.govuk_text_field :name %>
 
-   <%= f.govuk_check_boxes_fieldset :permissions, legend: { size: "s" }, small: true do %>
-      <%= f.govuk_check_box :support_console_permission, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Support console" } %>
-      <%= f.govuk_check_box :award_decline_permission , 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Assessor" } %>
-    <%- end -%>
+  <%= render "support_interface/staff/permissions_fields", f: %>
+
   <%= f.govuk_submit t("devise.invitations.new.submit_button") %>
 <% end %>

--- a/app/views/support_interface/staff/_permissions_fields.html.erb
+++ b/app/views/support_interface/staff/_permissions_fields.html.erb
@@ -1,0 +1,7 @@
+<%= f.govuk_check_boxes_fieldset :permissions do %>
+  <%= f.govuk_check_box :award_decline_permission, 1, 0, multiple: false,
+                        label: { text: t("activerecord.attributes.staff.award_decline_permission") } %>
+
+  <%= f.govuk_check_box :support_console_permission, 1, 0, multiple: false, link_errors: true,
+                        label: { text: t("activerecord.attributes.staff.support_console_permission") } %>
+<% end %>

--- a/app/views/support_interface/staff/edit.html.erb
+++ b/app/views/support_interface/staff/edit.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, @staff.name %>
+
+<h1 class="govuk-heading-l">Edit ‘<%= @staff.name %>’</h1>
+
+<%= form_with model: [:support_interface, @staff] do |f| %>
+  <%= render "permissions_fields", f: %>
+
+  <%= f.govuk_submit do %>
+    <%= govuk_link_to "Cancel", %i[support_interface staff index] %>
+  <% end %>
+<% end %>

--- a/app/views/support_interface/staff/index.html.erb
+++ b/app/views/support_interface/staff/index.html.erb
@@ -3,7 +3,7 @@
 <h1 class="govuk-heading-l">Staff</h1>
 
 <p class="govuk-body">
-  <%= govuk_button_link_to 'Invite staff user', new_staff_invitation_path %>
+  <%= govuk_button_link_to "Invite staff user", new_staff_invitation_path %>
 </p>
 
 <% @staff.find_each do |staff| %>
@@ -20,27 +20,38 @@
       row.with_value { staff.created_at.to_s }
     end
 
-      summary_list.with_row do |row|
-      row.with_key { "Assessor" }
+    summary_list.with_row do |row|
+      row.with_key { t("activerecord.attributes.staff.award_decline_permission") }
       row.with_value do
          if staff.award_decline_permission?
-          govuk_tag(text:"Yes", colour: "green")
+          govuk_tag(text: "Yes", colour: "green")
         else
-          govuk_tag(text:"No", colour: "red")
+          govuk_tag(text: "No", colour: "red")
         end
       end
+      row.with_action(
+        text: "Change",
+        href: edit_support_interface_staff_path(staff),
+        visually_hidden_text: t("activerecord.attributes.staff.award_decline_permission")
+      )
     end
 
     summary_list.with_row do |row|
-      row.with_key { "Support console access" }
+      row.with_key { t("activerecord.attributes.staff.support_console_permission") }
       row.with_value do
         if staff.support_console_permission?
-          govuk_tag(text:"Yes", colour: "green")
+          govuk_tag(text: "Yes", colour: "green")
         else
-          govuk_tag(text:"No", colour: "red")
+          govuk_tag(text: "No", colour: "red")
         end
       end
+      row.with_action(
+        text: "Change",
+        href: edit_support_interface_staff_path(staff),
+        visually_hidden_text: t("activerecord.attributes.staff.support_console_permission")
+      )
     end
+
     if staff.created_by_invite?
       summary_list.with_row do |row|
         row.with_key { "Invitation status" }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,10 @@ en:
       written_statement: written statement
 
   activerecord:
+    attributes:
+      staff:
+        support_console_permission: Support console access
+        award_decline_permission: Award/decline (assessor)
     errors:
       models:
         application_form:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -181,7 +181,7 @@ Rails.application.routes.draw do
       get "preview", on: :member
     end
 
-    resources :staff, only: %i[index]
+    resources :staff, only: %i[index edit update]
 
     devise_scope :staff do
       authenticate :staff do

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -66,7 +66,13 @@ module SystemHelpers
   end
 
   def given_i_am_authorized_as_a_support_user
-    user = create(:staff, :confirmed, :with_support_console_permission)
+    user =
+      create(
+        :staff,
+        :confirmed,
+        :with_support_console_permission,
+        name: "Admin",
+      )
     given_i_am_authorized_as_a_user(user)
   end
 

--- a/spec/system/support_interface/staff_spec.rb
+++ b/spec/system/support_interface/staff_spec.rb
@@ -34,7 +34,26 @@ RSpec.describe "Staff support", type: :system do
     then_i_see_the_accepted_staff_user
   end
 
+  it "allows editing permissions" do
+    given_i_am_authorized_as_a_support_user
+    given_a_helpdesk_user_exists
+    when_i_visit_the_staff_page
+    then_i_see_the_staff_index
+    and_i_see_the_helpdesk_user
+
+    when_i_click_on_the_helpdesk_user
+    then_i_see_the_staff_edit_form
+    when_i_choose_support_console_permission
+    and_i_submit_the_edit_form
+
+    then_i_see_the_changed_permission
+  end
+
   private
+
+  def given_a_helpdesk_user_exists
+    create(:staff, :confirmed, name: "Helpdesk")
+  end
 
   def when_i_visit_the_staff_page
     visit support_interface_staff_index_path
@@ -105,5 +124,28 @@ RSpec.describe "Staff support", type: :system do
 
   def and_i_set_password
     click_button "Set my password", visible: false
+  end
+
+  def and_i_see_the_helpdesk_user
+    expect(page).to have_content("Support console access\tNO")
+  end
+
+  def when_i_click_on_the_helpdesk_user
+    find(:xpath, "(//a[text()='Change'])[3]").click
+  end
+
+  def then_i_see_the_staff_edit_form
+    expect(page).to have_content("Edit ‘Helpdesk’")
+  end
+
+  alias_method :when_i_choose_support_console_permission,
+               :and_i_choose_support_console_permission
+
+  def and_i_submit_the_edit_form
+    click_button "Continue"
+  end
+
+  def then_i_see_the_changed_permission
+    expect(page).to_not have_content("Support console access\tNO")
   end
 end


### PR DESCRIPTION
This adds the ability for a user with access to the support console to modify the permissions of other users, specifically giving them access to award or decline applications (becoming an assessor) or access to the support console itself.

[Trello Card](https://trello.com/c/lVTc4jFk/1888-managing-users-in-support-console)

## Screenshots

<img width="1014" alt="Screenshot 2023-06-02 at 13 23 19" src="https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/47285444-ac90-4ed7-be51-6ae51ed11449">
<img width="407" alt="Screenshot 2023-06-02 at 13 23 23" src="https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/f6a658f8-730d-43b5-a9f6-fb5c79e9aeff">
