### PR TITLE
Fix incorrect environment variable

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -76,7 +76,7 @@ runs:
       shell: bash
       run: echo "value=$(make -s ${{ inputs.environment }}_aks print-keyvault-name)" >> $GITHUB_OUTPUT
       env:
-        pr_id: ${{ inputs.pull-request-number }}
+        PULL_REQUEST_NUMBER: ${{ inputs.pull-request-number }}
 
     - uses: DfE-Digital/keyvault-yaml-secret@v1
       id: smoke-test-secrets


### PR DESCRIPTION
This was missed in #1445 and is preventing review apps from deploying correctly.

An example failed build: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/actions/runs/5156267300/jobs/9287479433?pr=1446