### PR TITLE
Include email address in find teachers params

### DIFF
--- a/app/lib/dqt/find_teachers_params.rb
+++ b/app/lib/dqt/find_teachers_params.rb
@@ -14,6 +14,7 @@ module DQT
     def call
       {
         dateOfBirth: application_form.date_of_birth&.to_date&.iso8601,
+        emailAddress: application_form.teacher&.email,
         firstName:
           (
             if reverse_name

--- a/spec/lib/dqt/client/find_teachers_spec.rb
+++ b/spec/lib/dqt/client/find_teachers_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe DQT::Client::FindTeachers do
   let(:request_params) do
     {
       dateOfBirth: application_form.date_of_birth.iso8601.to_s,
+      emailAddress: application_form.teacher.email,
       firstName: application_form.given_names.split(" ").first,
       lastName: application_form.family_name,
     }
@@ -35,6 +36,7 @@ RSpec.describe DQT::Client::FindTeachers do
         [
           {
             date_of_birth: application_form.date_of_birth.iso8601.to_s,
+            email_address: application_form.teacher.email,
             first_name: application_form.given_names.split(" ").first,
             last_name: application_form.family_name,
             trn: "1234567",

--- a/spec/lib/dqt/find_teachers_params_spec.rb
+++ b/spec/lib/dqt/find_teachers_params_spec.rb
@@ -16,7 +16,12 @@ RSpec.describe DQT::FindTeachersParams do
 
     it "returns camel case params" do
       expect(call).to eq(
-        { dateOfBirth: "1960-01-01", firstName: "Rowdy", lastName: "Piper" },
+        {
+          dateOfBirth: "1960-01-01",
+          emailAddress: application_form.teacher.email,
+          firstName: "Rowdy",
+          lastName: "Piper",
+        },
       )
     end
 
@@ -25,7 +30,12 @@ RSpec.describe DQT::FindTeachersParams do
 
       it "returns camel case params with first and last name reversed" do
         expect(call).to eq(
-          { dateOfBirth: "1960-01-01", firstName: "Piper", lastName: "Rowdy" },
+          {
+            dateOfBirth: "1960-01-01",
+            emailAddress: application_form.teacher.email,
+            firstName: "Piper",
+            lastName: "Rowdy",
+          },
         )
       end
     end


### PR DESCRIPTION
The V2 DQT API endpoint requires 3 parameters and treats name fields as 1 parameter.

We will be moving to the V3 find teachers endpoint once available, but this additional param is necessary to make the query work for v2.