### PR TITLE
Use /v3/teachers endpoint on DQT API

### DIFF
--- a/app/lib/dqt/client/find_teachers.rb
+++ b/app/lib/dqt/client/find_teachers.rb
@@ -11,7 +11,7 @@ class DQT::Client::FindTeachers
   end
 
   def call
-    path = "/v2/teachers/find"
+    path = "/v3/teachers"
     response =
       connection.get(
         path,

--- a/app/lib/dqt/find_teachers_params.rb
+++ b/app/lib/dqt/find_teachers_params.rb
@@ -14,30 +14,16 @@ module DQT
     def call
       {
         dateOfBirth: application_form.date_of_birth&.to_date&.iso8601,
-        emailAddress: application_form.teacher&.email,
-        firstName:
-          (
-            if reverse_name
-              application_form.family_name
-            else
-              first_name
-            end
-          ),
+        findBy: "LastNameAndDateOfBirth",
         lastName:
           (
             if reverse_name
-              first_name
+              application_form.given_names.split(" ").first
             else
               application_form.family_name
             end
           ),
       }
-    end
-
-    private
-
-    def first_name
-      application_form.given_names.split(" ").first
     end
   end
 end

--- a/spec/lib/dqt/client/find_teachers_spec.rb
+++ b/spec/lib/dqt/client/find_teachers_spec.rb
@@ -8,9 +8,8 @@ RSpec.describe DQT::Client::FindTeachers do
   end
   let(:request_params) do
     {
+      findBy: "LastNameAndDateOfBirth",
       dateOfBirth: application_form.date_of_birth.iso8601.to_s,
-      emailAddress: application_form.teacher.email,
-      firstName: application_form.given_names.split(" ").first,
       lastName: application_form.family_name,
     }
   end
@@ -18,13 +17,22 @@ RSpec.describe DQT::Client::FindTeachers do
   subject(:call) { described_class.call(application_form:) }
 
   context "with a successful response" do
+    let(:result) do
+      {
+        dateOfBirth: application_form.date_of_birth.iso8601.to_s,
+        firstName: application_form.given_names.split(" ").first,
+        lastName: application_form.family_name,
+        trn: "1234567",
+      }
+    end
+
     before do
       stub_request(
         :get,
-        "https://test-teacher-qualifications-api.education.gov.uk/v2/teachers/find?#{request_params.to_query}",
+        "https://test-teacher-qualifications-api.education.gov.uk/v3/teachers?#{request_params.to_query}",
       ).with(headers: { "Authorization" => "Bearer test-api-key" }).to_return(
         status: 200,
-        body: { results: [request_params.merge(trn: "1234567")] }.to_json,
+        body: { results: [result] }.to_json,
         headers: {
           "Content-Type" => "application/json",
         },
@@ -36,7 +44,6 @@ RSpec.describe DQT::Client::FindTeachers do
         [
           {
             date_of_birth: application_form.date_of_birth.iso8601.to_s,
-            email_address: application_form.teacher.email,
             first_name: application_form.given_names.split(" ").first,
             last_name: application_form.family_name,
             trn: "1234567",
@@ -50,7 +57,7 @@ RSpec.describe DQT::Client::FindTeachers do
     before do
       stub_request(
         :get,
-        "https://test-teacher-qualifications-api.education.gov.uk/v2/teachers/find?#{request_params.to_query}",
+        "https://test-teacher-qualifications-api.education.gov.uk/v3/teachers?#{request_params.to_query}",
       ).with(headers: { "Authorization" => "Bearer test-api-key" }).to_return(
         status: 500,
         headers: {

--- a/spec/lib/dqt/find_teachers_params_spec.rb
+++ b/spec/lib/dqt/find_teachers_params_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe DQT::FindTeachersParams do
       expect(call).to eq(
         {
           dateOfBirth: "1960-01-01",
-          emailAddress: application_form.teacher.email,
-          firstName: "Rowdy",
+          findBy: "LastNameAndDateOfBirth",
           lastName: "Piper",
         },
       )
@@ -32,8 +31,7 @@ RSpec.describe DQT::FindTeachersParams do
         expect(call).to eq(
           {
             dateOfBirth: "1960-01-01",
-            emailAddress: application_form.teacher.email,
-            firstName: "Piper",
+            findBy: "LastNameAndDateOfBirth",
             lastName: "Rowdy",
           },
         )


### PR DESCRIPTION
[The V3 teachers endpoint on the DQT API doesn't require as many query parameters](https://preprod-teacher-qualifications-api.education.gov.uk/swagger/v3.json) to search DQT for existing teacher records.

Use the new endpoint to give us a wider search of duplicate records.
