### PR TITLE
Add withdrawn application form status

### DIFF
--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module StatusTag
   class Component < ViewComponent::Base
     def initialize(key:, status:, class_context: nil)
@@ -21,6 +23,7 @@ module StatusTag
 
     COLOURS = {
       accepted: "green",
+      assessment_in_progress: "blue",
       awarded: "green",
       awarded_pending_checks: "turquoise",
       cannot_start: "grey",
@@ -28,7 +31,6 @@ module StatusTag
       draft: "grey",
       expired: "pink",
       in_progress: "blue",
-      assessment_in_progress: "blue",
       invalid: "red",
       not_started: "grey",
       overdue: "pink",
@@ -40,6 +42,7 @@ module StatusTag
       submitted: "grey",
       valid: "green",
       waiting_on: "yellow",
+      withdrawn: "red",
     }.freeze
 
     def colour

--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -126,6 +126,8 @@ class ApplicationFormStatusUpdater
     @new_status ||=
       if dqt_trn_request&.potential_duplicate?
         "potential_duplicate_in_dqt"
+      elsif application_form.withdrawn_at.present?
+        "withdrawn"
       elsif application_form.declined_at.present?
         "declined"
       elsif application_form.awarded_at.present?

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -131,6 +131,7 @@ class ApplicationForm < ApplicationRecord
          awarded: "awarded",
          declined: "declined",
          potential_duplicate_in_dqt: "potential_duplicate_in_dqt",
+         withdrawn: "withdrawn",
        }
 
   delegate :country, to: :region, allow_nil: true

--- a/app/services/withdraw_application_form.rb
+++ b/app/services/withdraw_application_form.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class WithdrawApplicationForm
+  include ServicePattern
+
+  def initialize(application_form:, user:)
+    @application_form = application_form
+    @user = user
+  end
+
+  def call
+    return if application_form.withdrawn?
+
+    ActiveRecord::Base.transaction do
+      application_form.update!(withdrawn_at: Time.zone.now)
+      ApplicationFormStatusUpdater.call(application_form:, user:)
+    end
+  end
+
+  private
+
+  attr_reader :application_form, :user
+end

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -46,6 +46,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
       awarded
       declined
       potential_duplicate_in_dqt
+      withdrawn
     ]
 
     statuses.map do |status|

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -65,6 +65,7 @@
     - submitted_at
     - awarded_at
     - declined_at
+    - withdrawn_at
     - working_days_since_submission
     - needs_work_history
     - needs_written_statement

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -2,6 +2,7 @@ en:
   components:
     status_tag:
       accepted: Accepted
+      assessment_in_progress: Assessment in progress
       awarded: Awarded
       awarded_pending_checks: Award pending
       cannot_start: Cannot start
@@ -10,7 +11,6 @@ en:
       draft: Draft
       expired: Overdue
       in_progress: In progress
-      assessment_in_progress: Assessment in progress
       invalid: Invalid
       not_started: Not started
       overdue: Overdue
@@ -22,6 +22,7 @@ en:
       submitted: Not started
       valid: Valid
       waiting_on: Waiting on
+      withdrawn: Withdrawn
 
     timeline_entry:
       title:

--- a/db/migrate/20230607120948_add_withdrawn_at_to_application_forms.rb
+++ b/db/migrate/20230607120948_add_withdrawn_at_to_application_forms.rb
@@ -1,0 +1,5 @@
+class AddWithdrawnAtToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_forms, :withdrawn_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_23_154213) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_07_120948) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -104,6 +104,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_23_154213) do
     t.boolean "overdue_qualification", default: false, null: false
     t.boolean "overdue_reference", default: false, null: false
     t.jsonb "dqt_match", default: {}
+    t.datetime "withdrawn_at"
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["english_language_provider_id"], name: "index_application_forms_on_english_language_provider_id"
     t.index ["family_name"], name: "index_application_forms_on_family_name"

--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -28,4 +28,13 @@ namespace :application_forms do
       new_email_address: args[:new_email_address],
     )
   end
+
+  desc "Withdraw an application which has not yet been awarded or declined."
+  task :withdraw, %i[reference staff_email] => :environment do |_task, args|
+    application_form =
+      ApplicationForm.assessable.find_by(reference: args[:reference])
+    user = Staff.find_by(email: args[:staff_email])
+
+    WithdrawApplicationForm.call(application_form:, user:)
+  end
 end

--- a/spec/components/status_tag_spec.rb
+++ b/spec/components/status_tag_spec.rb
@@ -85,5 +85,11 @@ RSpec.describe StatusTag::Component, type: :component do
 
       it { is_expected.to eq("govuk-tag govuk-tag--red app-task-list__tag") }
     end
+
+    context "with a 'withdrawn' status" do
+      let(:status) { :withdrawn }
+
+      it { is_expected.to eq("govuk-tag govuk-tag--red app-task-list__tag") }
+    end
   end
 end

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -51,6 +51,7 @@
 #  waiting_on_professional_standing              :boolean          default(FALSE), not null
 #  waiting_on_qualification                      :boolean          default(FALSE), not null
 #  waiting_on_reference                          :boolean          default(FALSE), not null
+#  withdrawn_at                                  :datetime
 #  work_history_status                           :string           default("not_started"), not null
 #  working_days_since_submission                 :integer
 #  written_statement_confirmation                :boolean          default(FALSE), not null
@@ -184,6 +185,7 @@ FactoryBot.define do
     trait :withdrawn do
       status { "withdrawn" }
       submitted_at { Time.zone.now }
+      withdrawn_at { Time.zone.now }
     end
 
     trait :old_regs do

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -181,6 +181,11 @@ FactoryBot.define do
       submitted_at { Time.zone.now }
     end
 
+    trait :withdrawn do
+      status { "withdrawn" }
+      submitted_at { Time.zone.now }
+    end
+
     trait :old_regs do
       created_at { Date.new(2023, 1, 31) }
     end

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe ApplicationFormStatusUpdater do
       include_examples "changes status", "potential_duplicate_in_dqt"
     end
 
+    context "with a withdrawn_at date" do
+      before do
+        application_form.update!(
+          submitted_at: Time.zone.now,
+          withdrawn_at: Time.zone.now,
+        )
+      end
+
+      include_examples "changes status", "withdrawn"
+    end
+
     context "with a declined_at date" do
       before do
         application_form.update!(

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -51,6 +51,7 @@
 #  waiting_on_professional_standing              :boolean          default(FALSE), not null
 #  waiting_on_qualification                      :boolean          default(FALSE), not null
 #  waiting_on_reference                          :boolean          default(FALSE), not null
+#  withdrawn_at                                  :datetime
 #  work_history_status                           :string           default("not_started"), not null
 #  working_days_since_submission                 :integer
 #  written_statement_confirmation                :boolean          default(FALSE), not null

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe ApplicationForm, type: :model do
         awarded_pending_checks: "awarded_pending_checks",
         declined: "declined",
         potential_duplicate_in_dqt: "potential_duplicate_in_dqt",
+        withdrawn: "withdrawn",
       ).backed_by_column_of_type(:string)
     end
 

--- a/spec/services/withdraw_application_form_spec.rb
+++ b/spec/services/withdraw_application_form_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WithdrawApplicationForm do
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:user) { create(:staff, :confirmed) }
+
+  subject(:call) { described_class.call(application_form:, user:) }
+
+  describe "application form status" do
+    subject(:withdrawn?) { application_form.withdrawn? }
+
+    it { is_expected.to be false }
+
+    context "when calling the service" do
+      before { call }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "application form withdrawn_at" do
+    subject(:withdrawn_at) { application_form.withdrawn_at }
+
+    it { is_expected.to be_nil }
+
+    context "when calling the service" do
+      before { travel_to(Date.new(2020, 1, 1)) { call } }
+
+      it { is_expected.to eq(Date.new(2020, 1, 1)) }
+    end
+  end
+end

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -178,6 +178,7 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
             id: "potential_duplicate_in_dqt",
             label: "Potential duplication in DQT (0)",
           ),
+          OpenStruct.new(id: "withdrawn", label: "Withdrawn (0)"),
         ],
       )
     end
@@ -194,6 +195,7 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
         create_list(:application_form, 8, :awarded)
         create_list(:application_form, 9, :declined)
         create_list(:application_form, 10, :potential_duplicate_in_dqt)
+        create_list(:application_form, 11, :withdrawn)
       end
 
       it do
@@ -221,6 +223,7 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
               id: "potential_duplicate_in_dqt",
               label: "Potential duplication in DQT (10)",
             ),
+            OpenStruct.new(id: "withdrawn", label: "Withdrawn (11)"),
           ],
         )
       end


### PR DESCRIPTION
This adds the ability to mark an application as withdrawn, which is when the applicant no longer wishes to apply for QTS, and we don't want to decline the application.

[Trello Card](https://trello.com/c/Sf8x4nfk/1952-withdraw-application-2002210)

## Rake task

```sh
bundle exec rails application_forms:withdraw[abcdef,staff@example.com]
```

## Screenshots

![Screenshot 2023-06-07 at 13 43 16](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/e33a0d09-d36f-4568-95f2-edb1aa48b806)
![Screenshot 2023-06-07 at 13 43 11](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/7fa938d7-1520-46ba-bd43-8ce245212e21)
![Screenshot 2023-06-07 at 13 43 06](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/2d8a0163-177d-4107-a2f2-d0b66dc6a63f)
