### PR TITLE
Improve handling of withdrawn applications

### DIFF
--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -63,7 +63,7 @@ class FurtherInformationRequest < ApplicationRecord
   end
 
   def after_expired(user:)
-    DeclineQTS.call(application_form:, user:)
+    DeclineQTS.call(application_form:, user:) unless application_form.withdrawn?
   end
 
   delegate :teacher, to: :application_form

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -36,7 +36,8 @@ class Teacher < ApplicationRecord
   before_create { self.canonical_email = EmailAddress.canonical(email) }
 
   def application_form
-    @application_form ||= application_forms.order(created_at: :desc).first
+    @application_form ||=
+      application_forms.not_withdrawn.order(created_at: :desc).first
   end
 
   def send_otp(*)


### PR DESCRIPTION
This makes a couple of small changes to the logic to better handle the withdrawn application status added in #1460.

It should also fix https://dfe-teacher-services.sentry.io/issues/4244072035/?project=6426061&query=is%3Aunresolved&referrer=issue-stream&stream_index=0.