### PR TITLE
Add service for rolling back an assessment

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -107,15 +107,12 @@ class ApplicationForm < ApplicationRecord
   belongs_to :reviewer, class_name: "Staff", optional: true
 
   validates :submitted_at, presence: true, unless: :draft?
-  validates :awarded_at, presence: true, if: :awarded?
-  validates :awarded_at, absence: true, if: :declined?
-  validates :awarded_at, absence: true, if: :withdrawn?
-  validates :declined_at, presence: true, if: :declined?
-  validates :declined_at, absence: true, if: :awarded?
-  validates :declined_at, absence: true, if: :withdrawn?
-  validates :withdrawn_at, presence: true, if: :withdrawn?
-  validates :withdrawn_at, absence: true, if: :awarded?
-  validates :withdrawn_at, absence: true, if: :declined?
+  validates :awarded_at, absence: true, if: :declined_at?
+  validates :awarded_at, absence: true, if: :withdrawn_at?
+  validates :declined_at, absence: true, if: :awarded_at?
+  validates :declined_at, absence: true, if: :withdrawn_at?
+  validates :withdrawn_at, absence: true, if: :awarded_at?
+  validates :withdrawn_at, absence: true, if: :declined_at?
 
   enum :english_language_proof_method,
        { medium_of_instruction: "medium_of_instruction", provider: "provider" },

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -56,6 +56,10 @@ class Assessment < ApplicationRecord
               in: recommendations.values,
             }
 
+  def unknown!
+    update!(recommendation: "unknown", recommended_at: nil)
+  end
+
   def award!
     update!(recommendation: "award", recommended_at: Time.zone.now)
   end

--- a/app/services/rollback_assessment.rb
+++ b/app/services/rollback_assessment.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class RollbackAssessment
+  include ServicePattern
+
+  def initialize(assessment:, user:)
+    @assessment = assessment
+    @user = user
+  end
+
+  def call
+    unless assessment.award? || assessment.decline?
+      raise RecommendationNotAwardOrDecline
+    end
+
+    ActiveRecord::Base.transaction do
+      update_assessment
+      update_application_form
+    end
+  end
+
+  private
+
+  attr_reader :assessment, :user
+
+  def update_assessment
+    if previously_verified?
+      assessment.verify!
+    elsif previously_further_information_requested?
+      assessment.request_further_information!
+    else
+      assessment.unknown!
+    end
+  end
+
+  def previously_verified?
+    assessment.reference_requests.exists?
+  end
+
+  def previously_further_information_requested?
+    assessment.further_information_requests.exists?
+  end
+
+  delegate :application_form, to: :assessment
+
+  def update_application_form
+    if application_form.awarded?
+      application_form.update!(awarded_at: nil)
+    elsif application_form.declined?
+      application_form.update!(declined_at: nil)
+    end
+
+    ApplicationFormStatusUpdater.call(application_form:, user:)
+  end
+
+  class RecommendationNotAwardOrDecline < StandardError
+  end
+end

--- a/lib/tasks/assessments.rake
+++ b/lib/tasks/assessments.rake
@@ -1,0 +1,15 @@
+namespace :assessments do
+  desc "Rollback an assessment from an award or decline recommendation."
+  task :rollback, %i[reference staff_email] => :environment do |_task, args|
+    assessment =
+      Assessment.joins(:application_form).find_by!(
+        application_forms: {
+          reference: args[:reference],
+        },
+      )
+
+    user = Staff.find_by!(email: args[:staff_email])
+
+    RollbackAssessment.call(assessment:, user:)
+  end
+end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -271,38 +271,16 @@ RSpec.describe ApplicationForm, type: :model do
       end
     end
 
-    context "when awarded" do
+    context "when awarded and declined" do
       before do
         application_form.assign_attributes(
-          status: "awarded",
+          awarded_at: Time.zone.now,
+          declined_at: Time.zone.now,
           submitted_at: Time.zone.now,
         )
       end
 
       it { is_expected.to_not be_valid }
-
-      context "with awarded_at" do
-        before { application_form.awarded_at = Time.zone.now }
-
-        it { is_expected.to be_valid }
-      end
-    end
-
-    context "when declined" do
-      before do
-        application_form.assign_attributes(
-          status: "declined",
-          submitted_at: Time.zone.now,
-        )
-      end
-
-      it { is_expected.to_not be_valid }
-
-      context "with declined_at" do
-        before { application_form.declined_at = Time.zone.now }
-
-        it { is_expected.to be_valid }
-      end
     end
   end
 

--- a/spec/services/rollback_assessment_spec.rb
+++ b/spec/services/rollback_assessment_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RollbackAssessment do
+  let(:user) { create(:staff) }
+
+  subject(:call) { described_class.call(assessment:, user:) }
+
+  context "with an award assessment" do
+    let(:application_form) { create(:application_form, :awarded) }
+    let(:assessment) { create(:assessment, :award, application_form:) }
+
+    context "having requested verification" do
+      before { create(:reference_request, assessment:) }
+
+      it "sets the assessment to unknown" do
+        expect { call }.to change(assessment, :verify?).to(true)
+      end
+
+      it "reverts application form status" do
+        expect { call }.to change(application_form, :status).to("waiting_on")
+      end
+
+      it "records a timeline event" do
+        expect { call }.to have_recorded_timeline_event(
+          :state_changed,
+          creator: user,
+        )
+      end
+    end
+
+    context "having requested further information" do
+      before { create(:further_information_request, assessment:) }
+
+      it "sets the assessment to unknown" do
+        expect { call }.to change(assessment, :request_further_information?).to(
+          true,
+        )
+      end
+
+      it "reverts application form status" do
+        expect { call }.to change(application_form, :status).to("waiting_on")
+      end
+
+      it "records a timeline event" do
+        expect { call }.to have_recorded_timeline_event(
+          :state_changed,
+          creator: user,
+        )
+      end
+    end
+
+    context "having not requested anything" do
+      it "sets the assessment to unknown" do
+        expect { call }.to change(assessment, :unknown?).to(true)
+      end
+
+      it "reverts application form status" do
+        expect { call }.to change(application_form, :status).to("submitted")
+      end
+
+      it "records a timeline event" do
+        expect { call }.to have_recorded_timeline_event(
+          :state_changed,
+          creator: user,
+        )
+      end
+    end
+  end
+
+  context "with a decline assessment" do
+    let(:application_form) { create(:application_form, :declined) }
+    let(:assessment) { create(:assessment, :decline, application_form:) }
+
+    context "having requested verification" do
+      before { create(:reference_request, assessment:) }
+
+      it "sets the assessment to unknown" do
+        expect { call }.to change(assessment, :verify?).to(true)
+      end
+
+      it "reverts application form status" do
+        expect { call }.to change(application_form, :status).to("waiting_on")
+      end
+
+      it "records a timeline event" do
+        expect { call }.to have_recorded_timeline_event(
+          :state_changed,
+          creator: user,
+        )
+      end
+    end
+
+    context "having requested further information" do
+      before { create(:further_information_request, assessment:) }
+
+      it "sets the assessment to unknown" do
+        expect { call }.to change(assessment, :request_further_information?).to(
+          true,
+        )
+      end
+
+      it "reverts application form status" do
+        expect { call }.to change(application_form, :status).to("waiting_on")
+      end
+
+      it "records a timeline event" do
+        expect { call }.to have_recorded_timeline_event(
+          :state_changed,
+          creator: user,
+        )
+      end
+    end
+
+    context "having not requested anything" do
+      it "sets the assessment to unknown" do
+        expect { call }.to change(assessment, :unknown?).to(true)
+      end
+
+      it "reverts application form status" do
+        expect { call }.to change(application_form, :status).to("submitted")
+      end
+
+      it "records a timeline event" do
+        expect { call }.to have_recorded_timeline_event(
+          :state_changed,
+          creator: user,
+        )
+      end
+    end
+  end
+
+  context "with a verify assessment" do
+    let(:assessment) { create(:assessment, :verify) }
+
+    it "raises an error" do
+      expect { call }.to raise_error(
+        RollbackAssessment::RecommendationNotAwardOrDecline,
+      )
+    end
+  end
+
+  context "with a request_further_information assessment" do
+    let(:assessment) { create(:assessment, :request_further_information) }
+
+    it "raises an error" do
+      expect { call }.to raise_error(
+        RollbackAssessment::RecommendationNotAwardOrDecline,
+      )
+    end
+  end
+
+  context "with an unknown assessment" do
+    let(:assessment) { create(:assessment, :unknown) }
+
+    it "raises an error" do
+      expect { call }.to raise_error(
+        RollbackAssessment::RecommendationNotAwardOrDecline,
+      )
+    end
+  end
+end


### PR DESCRIPTION
This adds the ability to rollback an assessment from a decline or an award recommendation, with some simple logic to revert to the correct state (either unknown, verify or request further information). This is a request we sometimes get, and formalising the logic should make it quicker, and pave the way to allowing assessors to do it themselves in the future.