### PR TITLE
Handle no teaching qualification yet

### DIFF
--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -113,7 +113,7 @@ module ApplicationFormHelper
     application_form
   )
     earliest_certificate_date =
-      application_form.teaching_qualification.certificate_date
+      application_form.teaching_qualification&.certificate_date
     earliest_work_history_date =
       application_form.work_histories.pluck(:start_date).compact.min
 


### PR DESCRIPTION
This updates the helper which displays the banner to handle the case when the user hasn't submitted any qualifications yet.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/4252292449/?referrer=slack)