### PR TITLE
Fix reference to application forms

### DIFF
--- a/app/views/assessor_interface/application_forms/_linked_application_forms.html.erb
+++ b/app/views/assessor_interface/application_forms/_linked_application_forms.html.erb
@@ -18,6 +18,6 @@
       <strong class="govuk-!-font-weight-bold"><%= teacher.email %></strong> appears as a <strong class="govuk-!-font-weight-bold">reference</strong> in these applications:
     </p>
 
-    <%= render "shared/linked_application_forms_list", application_forms: %>
+    <%= render "shared/linked_application_forms_list", application_forms: other_application_forms_where_email_used_as_reference %>
   <% end %>
 <% end %>


### PR DESCRIPTION
This updates the call to render the shared view for showing a list of linked applications to fix the argument which currently doesn't exist.

[Sentry Issue](https://dfe-teacher-services.sentry.io/issues/4252506165/)