### PR TITLE
Refactor task lists

### DIFF
--- a/app/components/task_list/component.html.erb
+++ b/app/components/task_list/component.html.erb
@@ -1,0 +1,31 @@
+<ol class="app-task-list">
+  <% sections.each do |section| %>
+    <li>
+      <h2 class="app-task-list__section">
+        <% if sections.count > 1 %>
+          <span class="app-task-list__section-number"><%= section[:number] %>. </span>
+        <% end %>
+
+        <%= section[:title] %>
+      </h2>
+
+      <ul class="app-task-list__items">
+        <% section[:items].each do |item| %>
+          <li class="app-task-list__item">
+            <% status_key = "#{section[:number]}-#{section[:key]}-#{item[:key]}" %>
+
+            <span class="app-task-list__task-name" aria-describedby="<%= status_key %>-status">
+              <% if (link = item[:link]).present? %>
+                <%= govuk_link_to item[:name], link %>
+              <% else %>
+                <%= item[:name] %>
+              <% end %>
+            </span>
+
+            <%= render(StatusTag::Component.new(key: status_key, status: item[:status], class_context: "app-task-list")) %>
+          </li>
+        <% end %>
+      </ul>
+    </li>
+  <% end %>
+</ol>

--- a/app/components/task_list/component.rb
+++ b/app/components/task_list/component.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module TaskList
+  class Component < ViewComponent::Base
+    ##
+    # Renders a task list from the following data structure:
+    #
+    # sections: [
+    #   {
+    #     title: "Title",
+    #     items: [
+    #       {
+    #         name: "Do this thing",
+    #         link: "/do-this-thing",
+    #         status: "not_started"
+    #       }
+    #     ]
+    #   }
+    # ]
+
+    def initialize(sections)
+      super
+      @sections = sections
+    end
+
+    def sections
+      @sections
+        .filter { |section| section[:items].present? }
+        .each_with_index
+        .map do |section, index|
+          section.merge(
+            number: index + 1,
+            key: section[:title].parameterize,
+            items:
+              section[:items].map do |item|
+                item.merge(key: item[:name].parameterize)
+              end,
+          )
+        end
+    end
+  end
+end

--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -16,11 +16,12 @@ module AssessorInterface
 
     def update
       unless assessment_section_view_object.render_form?
-        redirect_to assessor_interface_application_form_assessment_assessment_section_path(
-                      assessment_section_view_object.application_form,
-                      assessment_section_view_object.assessment,
-                      assessment_section_view_object.assessment_section.key,
-                    )
+        redirect_to [
+                      :assessor_interface,
+                      application_form,
+                      assessment,
+                      assessment_section,
+                    ]
         return
       end
 
@@ -33,10 +34,7 @@ module AssessorInterface
         )
 
       if @assessment_section_form.save
-        redirect_to [
-                      :assessor_interface,
-                      assessment_section_view_object.application_form,
-                    ]
+        redirect_to [:assessor_interface, application_form]
       else
         render :show, status: :unprocessable_entity
       end
@@ -78,6 +76,7 @@ module AssessorInterface
     end
 
     delegate :assessment_section,
+             :assessment,
              :application_form,
              to: :assessment_section_view_object
   end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -90,7 +90,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
         url_helpers.assessor_interface_application_form_assessment_assessment_section_path(
           application_form,
           assessment,
-          item,
+          assessment.sections.find { |s| s.key == item.to_s }.id,
         )
       end
     when :further_information_requests

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -13,220 +13,13 @@ class AssessorInterface::ApplicationFormsShowViewObject
         .find(params[:id])
   end
 
-  def assessment_tasks
-    pre_assessment_tasks = [
-      (:preliminary_check if application_form.requires_preliminary_check),
-      (
-        if teaching_authority_provides_written_statement &&
-             professional_standing_request.present?
-          :await_professional_standing_request
-        end
-      ),
-    ].compact
-
-    assessment_section_keys = assessment.sections.map(&:key).map(&:to_sym)
-
-    initial_assessment =
-      %i[
-        personal_information
-        qualifications
-        age_range_subjects
-        english_language_proficiency
-        work_history
-        professional_standing
-      ].select { |key| assessment_section_keys.include?(key) } +
-        %i[initial_assessment_recommendation]
-
-    further_information =
-      further_information_requests.map { :review_requested_information }
-
-    verify_professional_standing =
-      !teaching_authority_provides_written_statement &&
-        professional_standing_request.present?
-
-    verification_requests = [
-      (:qualification_requests if qualification_requests.present?),
-      (:reference_requests if reference_requests.present?),
-      (:locate_professional_standing_request if verify_professional_standing),
-      (:review_professional_standing_request if verify_professional_standing),
-    ].compact
-
-    if verification_requests.present?
-      verification_requests << :assessment_recommendation
-    end
-
-    {
-      pre_assessment_tasks:,
-      initial_assessment:,
-      further_information_requests: further_information,
-      verification_requests:,
-    }.compact_blank
-  end
-
-  def assessment_task_path(section, item, index)
-    case section
-    when :pre_assessment_tasks
-      if item == :preliminary_check
-        url_helpers.assessor_interface_application_form_assessment_preliminary_check_path(
-          application_form,
-          assessment,
-        )
-      elsif assessment.preliminary_check_complete != false
-        url_helpers.location_assessor_interface_application_form_assessment_professional_standing_request_path(
-          application_form,
-          assessment,
-        )
-      end
-    when :initial_assessment
-      if item == :initial_assessment_recommendation
-        return nil if initial_assessment_recommendation_complete?
-        return nil unless assessment.recommendable?
-
-        url_helpers.edit_assessor_interface_application_form_assessment_path(
-          application_form,
-          assessment,
-        )
-      else
-        url_helpers.assessor_interface_application_form_assessment_assessment_section_path(
-          application_form,
-          assessment,
-          assessment.sections.find { |s| s.key == item.to_s }.id,
-        )
-      end
-    when :further_information_requests
-      further_information_request = further_information_requests[index]
-
-      if further_information_request.received?
-        url_helpers.edit_assessor_interface_application_form_assessment_further_information_request_path(
-          application_form,
-          assessment,
-          further_information_request,
-        )
-      end
-    when :verification_requests
-      return nil unless preassessment_professional_standing_request_completed?
-
-      case item
-      when :assessment_recommendation
-        return nil unless assessment.recommendable?
-
-        url_helpers.edit_assessor_interface_application_form_assessment_path(
-          application_form,
-          assessment,
-        )
-      when :locate_professional_standing_request
-        url_helpers.location_assessor_interface_application_form_assessment_professional_standing_request_path(
-          application_form,
-          assessment,
-        )
-      when :review_professional_standing_request
-        if professional_standing_request.received? ||
-             professional_standing_request.ready_for_review
-          url_helpers.review_assessor_interface_application_form_assessment_professional_standing_request_path(
-            application_form,
-            assessment,
-          )
-        end
-      when :qualification_requests
-        url_helpers.assessor_interface_application_form_assessment_qualification_requests_path(
-          application_form,
-          assessment,
-        )
-      when :reference_requests
-        url_helpers.assessor_interface_application_form_assessment_reference_requests_path(
-          application_form,
-          assessment,
-        )
-      end
-    end
-  end
-
-  def assessment_task_status(section, item, index)
-    case section
-    when :pre_assessment_tasks
-      if item == :await_professional_standing_request
-        return :cannot_start if cannot_start_professional_standing_request?
-        if preassessment_professional_standing_request_completed?
-          :completed
-        else
-          :waiting_on
-        end
-      else
-        assessment.preliminary_check_complete.nil? ? :not_started : :completed
-      end
-    when :initial_assessment
-      if item == :initial_assessment_recommendation
-        return :completed if initial_assessment_recommendation_complete?
-        return :cannot_start unless assessment.recommendable?
-        return :in_progress if request_further_information_unfinished?
-        :not_started
-      else
-        unless preassessment_professional_standing_request_completed?
-          return :cannot_start
-        end
-        assessment.sections.find { |s| s.key == item.to_s }.status
-      end
-    when :further_information_requests
-      unless preassessment_professional_standing_request_completed?
-        return :cannot_start
-      end
-      further_information_request = further_information_requests[index]
-      return :cannot_start if further_information_request.requested?
-      return :not_started if further_information_request.passed.nil?
-      return :in_progress if assessment.request_further_information?
-      :completed
-    when :verification_requests
-      case item
-      when :assessment_recommendation
-        return :completed if assessment.completed?
-        return :cannot_start unless assessment.recommendable?
-        :not_started
-      when :locate_professional_standing_request
-        if professional_standing_request.ready_for_review ||
-             professional_standing_request.received?
-          :completed
-        elsif professional_standing_request.expired?
-          :overdue
-        else
-          :waiting_on
-        end
-      when :review_professional_standing_request
-        if professional_standing_request.reviewed?
-          :completed
-        elsif professional_standing_request.received? ||
-              professional_standing_request.ready_for_review
-          :received
-        else
-          :cannot_start
-        end
-      when :reference_requests
-        return :completed if assessment.references_verified
-
-        unreviewed_requests = reference_requests.reject(&:reviewed?)
-
-        if unreviewed_requests.empty?
-          :in_progress
-        elsif unreviewed_requests.any?(&:expired?)
-          :overdue
-        elsif unreviewed_requests.any?(&:received?)
-          :received
-        else
-          :waiting_on
-        end
-      when :qualification_requests
-        unreviewed_requests = qualification_requests.reject(&:reviewed?)
-
-        if unreviewed_requests.empty?
-          :completed
-        elsif unreviewed_requests.any?(&:expired?)
-          :overdue
-        elsif unreviewed_requests.any?(&:received?)
-          :received
-        else
-          :waiting_on
-        end
-      end
-    end
+  def task_list_sections
+    [
+      pre_assessment_task_list_section,
+      initial_assessment_task_list_section,
+      further_information_task_list_section,
+      verification_task_list_section,
+    ]
   end
 
   def status
@@ -265,6 +58,354 @@ class AssessorInterface::ApplicationFormsShowViewObject
   delegate :professional_standing_request, to: :assessment
   delegate :canonical_email, to: :teacher
 
+  def pre_assessment_task_list_section
+    {
+      title:
+        I18n.t(
+          "assessor_interface.application_forms.show.assessment_tasks.sections.pre_assessment_tasks",
+        ),
+      items: [
+        preliminary_check_task_list_item,
+        await_professional_standing_task_list_item,
+      ].compact,
+    }
+  end
+
+  def preliminary_check_task_list_item
+    return unless application_form.requires_preliminary_check
+
+    {
+      name:
+        I18n.t(
+          "assessor_interface.application_forms.show.assessment_tasks.items.preliminary_check",
+        ),
+      link: [
+        :assessor_interface,
+        application_form,
+        assessment,
+        :preliminary_check,
+      ],
+      status:
+        (
+          if assessment.preliminary_check_complete.nil?
+            :not_started
+          else
+            :completed
+          end
+        ),
+    }
+  end
+
+  def await_professional_standing_task_list_item
+    unless teaching_authority_provides_written_statement &&
+             professional_standing_request.present?
+      return
+    end
+
+    {
+      name:
+        I18n.t(
+          "assessor_interface.application_forms.show.assessment_tasks.items.await_professional_standing_request",
+        ),
+      link:
+        if assessment.preliminary_check_complete != false
+          [
+            :location,
+            :assessor_interface,
+            application_form,
+            assessment,
+            :professional_standing_request,
+          ]
+        end,
+      status:
+        if cannot_start_professional_standing_request?
+          :cannot_start
+        elsif preassessment_professional_standing_request_completed?
+          :completed
+        else
+          :waiting_on
+        end,
+    }
+  end
+
+  def initial_assessment_task_list_section
+    assessment_sections =
+      %i[
+        personal_information
+        qualifications
+        age_range_subjects
+        english_language_proficiency
+        work_history
+        professional_standing
+      ].filter_map { |key| assessment.sections.find { |s| s.key == key.to_s } }
+
+    assessment_section_items =
+      assessment_sections.map do |assessment_section|
+        assessment_section_task_list_item(assessment_section)
+      end
+
+    {
+      title:
+        I18n.t(
+          "assessor_interface.application_forms.show.assessment_tasks.sections.initial_assessment",
+        ),
+      items: [
+        *assessment_section_items,
+        initial_assessment_recommendation_task_list_item,
+      ],
+    }
+  end
+
+  def assessment_section_task_list_item(assessment_section)
+    {
+      name:
+        I18n.t(
+          assessment_section.key,
+          scope: %i[
+            assessor_interface
+            application_forms
+            show
+            assessment_tasks
+            items
+          ],
+        ),
+      link: [
+        :assessor_interface,
+        application_form,
+        assessment,
+        assessment_section,
+      ],
+      status:
+        (
+          if !preassessment_professional_standing_request_completed?
+            :cannot_start
+          else
+            assessment_section.status
+          end
+        ),
+    }
+  end
+
+  def initial_assessment_recommendation_task_list_item
+    {
+      name:
+        I18n.t(
+          "assessor_interface.application_forms.show.assessment_tasks.items.initial_assessment_recommendation",
+        ),
+      link:
+        if !initial_assessment_recommendation_complete? &&
+             assessment.recommendable?
+          [:edit, :assessor_interface, application_form, assessment]
+        end,
+      status:
+        if initial_assessment_recommendation_complete?
+          :completed
+        elsif !assessment.recommendable?
+          :cannot_start
+        elsif request_further_information_unfinished?
+          :in_progress
+        else
+          :not_started
+        end,
+    }
+  end
+
+  def further_information_task_list_section
+    {
+      title:
+        I18n.t(
+          "assessor_interface.application_forms.show.assessment_tasks.sections.further_information_requests",
+        ),
+      items:
+        further_information_requests.map do |further_information_request|
+          further_information_request_task_list_item(
+            further_information_request,
+          )
+        end,
+    }
+  end
+
+  def further_information_request_task_list_item(further_information_request)
+    {
+      name:
+        I18n.t(
+          "assessor_interface.application_forms.show.assessment_tasks.items.review_requested_information",
+        ),
+      link:
+        if further_information_request.received?
+          [
+            :edit,
+            :assessor_interface,
+            application_form,
+            assessment,
+            further_information_request,
+          ]
+        end,
+      status:
+        if !preassessment_professional_standing_request_completed? ||
+             further_information_request.requested?
+          :cannot_start
+        elsif further_information_request.passed.nil?
+          :not_started
+        elsif assessment.request_further_information?
+          :in_progress
+        else
+          :completed
+        end,
+    }
+  end
+
+  def verification_task_list_section
+    items = [
+      qualification_requests_task_list_item,
+      reference_requests_task_list_item,
+      locate_professional_standing_request_task_list_item,
+      review_professional_standing_request_task_list_item,
+    ].compact
+
+    items << assessment_recommendation_task_list_item if items.present?
+
+    {
+      title:
+        I18n.t(
+          "assessor_interface.application_forms.show.assessment_tasks.sections.verification_requests",
+        ),
+      items:,
+    }
+  end
+
+  def qualification_requests_task_list_item
+    qualification_requests =
+      assessment.qualification_requests.order(:created_at).to_a
+    return if qualification_requests.empty?
+
+    {
+      name:
+        I18n.t(
+          "assessor_interface.application_forms.show.assessment_tasks.items.qualification_requests",
+        ),
+      link: [
+        :assessor_interface,
+        application_form,
+        assessment,
+        :qualification_requests,
+      ],
+      status: requestables_task_item_status(qualification_requests),
+    }
+  end
+
+  def reference_requests_task_list_item
+    reference_requests = assessment.reference_requests.order(:created_at).to_a
+
+    return if reference_requests.empty?
+
+    {
+      name:
+        I18n.t(
+          "assessor_interface.application_forms.show.assessment_tasks.items.reference_requests",
+        ),
+      link: [
+        :assessor_interface,
+        application_form,
+        assessment,
+        :reference_requests,
+      ],
+      status:
+        (
+          if assessment.references_verified
+            :completed
+          else
+            requestables_task_item_status(reference_requests)
+          end
+        ),
+    }
+  end
+
+  def assessment_recommendation_task_list_item
+    {
+      name:
+        I18n.t(
+          "assessor_interface.application_forms.show.assessment_tasks.items.assessment_recommendation",
+        ),
+      link:
+        if assessment.recommendable?
+          [:edit, :assessor_interface, application_form, assessment]
+        end,
+      status:
+        if assessment.completed?
+          :completed
+        elsif !assessment.recommendable?
+          :cannot_start
+        else
+          :not_started
+        end,
+    }
+  end
+
+  def locate_professional_standing_request_task_list_item
+    unless !teaching_authority_provides_written_statement &&
+             professional_standing_request.present?
+      return
+    end
+
+    {
+      name:
+        I18n.t(
+          "assessor_interface.application_forms.show.assessment_tasks.items.locate_professional_standing_request",
+        ),
+      link: [
+        :location,
+        :assessor_interface,
+        application_form,
+        assessment,
+        :professional_standing_request,
+      ],
+      status:
+        if professional_standing_request.ready_for_review ||
+             professional_standing_request.received?
+          :completed
+        elsif professional_standing_request.expired?
+          :overdue
+        else
+          :waiting_on
+        end,
+    }
+  end
+
+  def review_professional_standing_request_task_list_item
+    unless !teaching_authority_provides_written_statement &&
+             professional_standing_request.present?
+      return
+    end
+
+    {
+      name:
+        I18n.t(
+          "assessor_interface.application_forms.show.assessment_tasks.items.review_professional_standing_request",
+        ),
+      link:
+        if professional_standing_request.received? ||
+             professional_standing_request.ready_for_review
+          [
+            :review,
+            :assessor_interface,
+            application_form,
+            assessment,
+            :professional_standing_request,
+          ]
+        end,
+      status:
+        if professional_standing_request.reviewed?
+          :completed
+        elsif professional_standing_request.received? ||
+              professional_standing_request.ready_for_review
+          :received
+        else
+          :cannot_start
+        end,
+    }
+  end
+
   def preassessment_professional_standing_request_completed?
     if teaching_authority_provides_written_statement
       professional_standing_request.received?
@@ -287,22 +428,22 @@ class AssessorInterface::ApplicationFormsShowViewObject
       !assessment.preliminary_check_complete
   end
 
+  def requestables_task_item_status(requestables)
+    unreviewed_requests = requestables.reject(&:reviewed?)
+
+    if unreviewed_requests.empty?
+      :completed
+    elsif unreviewed_requests.any?(&:expired?)
+      :overdue
+    elsif unreviewed_requests.any?(&:received?)
+      :received
+    else
+      :waiting_on
+    end
+  end
+
   def further_information_requests
     @further_information_requests ||=
       assessment.further_information_requests.order(:created_at).to_a
-  end
-
-  def qualification_requests
-    @qualification_requests ||=
-      assessment.qualification_requests.order(:created_at).to_a
-  end
-
-  def reference_requests
-    @reference_requests ||=
-      assessment.reference_requests.order(:created_at).to_a
-  end
-
-  def url_helpers
-    Rails.application.routes.url_helpers
   end
 end

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -8,15 +8,19 @@ module AssessorInterface
 
     def assessment_section
       @assessment_section ||=
-        AssessmentSection
-          .includes(assessment: { application_form: { region: :country } })
-          .where(
-            assessment_id: params[:assessment_id],
-            assessment: {
-              application_form_id: params[:application_form_id],
+        AssessmentSection.includes(
+          assessment: {
+            application_form: {
+              region: :country,
             },
-          )
-          .find_by!(key: params[:key])
+          },
+        ).find_by!(
+          id: params[:id],
+          assessment_id: params[:assessment_id],
+          assessment: {
+            application_form_id: params[:application_form_id],
+          },
+        )
     end
 
     delegate :assessment, to: :assessment_section

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -16,24 +16,26 @@ module TeacherInterface
           .find(params[:id])
     end
 
-    def task_items
-      further_information_request
-        .items
-        .order(:created_at)
-        .map do |item|
-          {
-            key: item.id,
-            text: item_text(item),
-            href: [
-              :edit,
-              :teacher_interface,
-              :application_form,
-              further_information_request,
-              item,
-            ],
-            status: item.state,
-          }
-        end
+    def task_list_sections
+      items =
+        further_information_request
+          .items
+          .order(:created_at)
+          .map do |item|
+            {
+              name: item_name(item),
+              link: [
+                :edit,
+                :teacher_interface,
+                :application_form,
+                further_information_request,
+                item,
+              ],
+              status: item.state,
+            }
+          end
+
+      [{ title: "Further information requested", items: }]
     end
 
     def can_check_answers?
@@ -48,7 +50,7 @@ module TeacherInterface
         .order(:created_at)
         .each_with_object({}) do |item, memo|
           memo[item.id] = {
-            title: item_text(item),
+            title: item_name(item),
             value: item.text? ? item.response : item.document,
             href: [
               :edit,
@@ -69,7 +71,7 @@ module TeacherInterface
       @application_form ||= current_teacher.application_form
     end
 
-    def item_text(item)
+    def item_name(item)
       case item.information_type
       when "text"
         I18n.t(

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -22,33 +22,4 @@
 
 <h2 class="govuk-heading-l govuk-!-margin-top-9">Assessment</h2>
 
-<ol class="app-task-list">
-  <% @view_object.assessment_tasks.each_with_index do |(section, items), index| %>
-    <li>
-      <h2 class="app-task-list__section">
-        <span class="app-task-list__section-number"><%= index + 1 %>. </span>
-        <%= t(".assessment_tasks.sections.#{section}") %>
-      </h2>
-
-      <ul class="app-task-list__items">
-        <% items.each_with_index do |item, index| %>
-          <li class="app-task-list__item">
-            <span class="app-task-list__task-name" aria-describedby="<%= item %>-<%= index %>-status">
-              <% if (href = @view_object.assessment_task_path(section, item, index)) %>
-                <%= link_to t(".assessment_tasks.items.#{item}"), href %>
-              <% else %>
-                <%= t(".assessment_tasks.items.#{item}") %>
-              <% end %>
-            </span>
-
-            <%= render(StatusTag::Component.new(
-              key: "#{item}-#{index}",
-              status: @view_object.assessment_task_status(section, item, index),
-              class_context: "app-task-list",
-            )) %>
-          </li>
-        <% end %>
-      </ul>
-    </li>
-  <% end %>
-</ol>
+<%= render(TaskList::Component.new(@view_object.task_list_sections)) %>

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -22,11 +22,7 @@
            highlighted_work_history_contact_emails: @assessment_section_view_object.highlighted_work_history_contact_emails %>
 
 <% if @assessment_section_view_object.render_form? %>
-  <%= form_with model: @assessment_section_form,
-    url: assessor_interface_application_form_assessment_assessment_section_path(
-      @assessment_section_view_object.application_form, @assessment_section_view_object.assessment, section_key
-    ), method: :put do |f| %>
-
+  <%= form_with model: @assessment_section_form, url: [:assessor_interface, @assessment_section_view_object.application_form, @assessment_section_view_object.assessment, @assessment_section_view_object.assessment_section], method: :put do |f| %>
     <%= f.govuk_error_summary %>
 
     <% if @assessment_section_view_object.show_english_language_exemption_checkbox? %>

--- a/app/views/assessor_interface/qualification_requests/index.html.erb
+++ b/app/views/assessor_interface/qualification_requests/index.html.erb
@@ -7,30 +7,20 @@
   </div>
 
   <div class="govuk-grid-column-full-from-desktop">
-    <ol class="app-task-list">
-      <li>
-        <h2 class="app-task-list__section">Qualifications</h2>
-
-        <ul class="app-task-list__items govuk-!-padding-left-0">
-          <% @qualification_requests.each_with_index do |qualification_request| %>
-            <li class="app-task-list__item">
-              <span class="app-task-list__task-name">
-                <%= govuk_link_to(
-                  qualification_title(qualification_request.qualification),
-                  [:edit, :assessor_interface, @application_form, @assessment, qualification_request]
-                ) %>
-              </span>
-
-              <%= render StatusTag::Component.new(
-                key: "qualification-request-#{qualification_request.id}",
-                status: qualification_request.status,
-                class_context: "app-task-list",
-              ) %>
-            </li>
-          <% end %>
-        </ul>
-      </li>
-    </ol>
+    <%= render TaskList::Component.new(
+      [
+        {
+          title: "Qualifications",
+          items: @qualification_requests.map do |qualification_request|
+            {
+              name: qualification_title(qualification_request.qualification),
+              link: [:edit, :assessor_interface, @application_form, @assessment, qualification_request],
+              status: qualification_request.status
+            }
+          end
+        }
+      ]
+    ) %>
   </div>
 
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/assessor_interface/reference_requests/index.html.erb
+++ b/app/views/assessor_interface/reference_requests/index.html.erb
@@ -13,31 +13,20 @@
     </div>
 
     <div class="govuk-grid-column-full-from-desktop">
-      <ol class="app-task-list">
-        <li>
-          <h2 class="app-task-list__section">
-            Work references
-          </h2>
-          <ul class="app-task-list__items govuk-!-padding-left-0">
-            <% @reference_requests.each_with_index do |reference_request, idx| %>
-              <li class="app-task-list__item">
-                <span class="app-task-list__task-name">
-                  <%= govuk_link_to(
-                    work_history_name_and_duration(reference_request.work_history, most_recent: idx.zero?),
-                    [:edit, :assessor_interface, @application_form, @assessment, reference_request]
-                  ) %>
-                </span>
-
-                <%= render StatusTag::Component.new(
-                  key: "reference-request-#{reference_request.id}",
-                  status: reference_request.status,
-                  class_context: "app-task-list",
-                  ) %>
-              </li>
-            <% end %>
-          </ul>
-        </li>
-      </ol>
+      <%= render TaskList::Component.new(
+        [
+          {
+            title: "Work references",
+            items: @reference_requests.each_with_index.map do |reference_request, index|
+              {
+                name: work_history_name_and_duration(reference_request.work_history, most_recent: index.zero?),
+                link: [:edit, :assessor_interface, @application_form, @assessment, reference_request],
+                status: reference_request.status
+              }
+            end
+          }
+        ]
+      ) %>
     </div>
 
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/teacher_interface/application_forms/show/_draft.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_draft.html.erb
@@ -7,7 +7,7 @@
 </h2>
 
 <p class="govuk-body govuk-!-margin-bottom-7">
-  You have completed <%= view_object.completed_task_sections.count %> of <%= view_object.tasks.count %> sections.
+  You have completed <%= view_object.completed_task_list_sections.count %> of <%= view_object.task_list_sections.count %> sections.
 </p>
 
 <% if view_object.application_form.created_under_new_regulations? %>
@@ -19,38 +19,12 @@
   <% end %>
 <% end %>
 
-<ol class="app-task-list">
-  <% view_object.tasks.each_with_index do |(section, items), index| %>
-    <li>
-      <h2 class="app-task-list__section">
-        <span class="app-task-list__section-number"><%= index + 1 %>. </span>
-        <%= I18n.t("application_form.tasks.sections.#{section}") %>
-      </h2>
-
-      <ul class="app-task-list__items">
-        <% items.each do |item| %>
-          <li class="app-task-list__item">
-            <span class="app-task-list__task-name">
-              <%= link_to view_object.text_for_task_item(item),
-                          view_object.path_for_task_item(item),
-                          aria: { describedby: "#{item}-status" } %>
-            </span>
-
-            <%= render(StatusTag::Component.new(
-              key: item,
-              status: view_object.task_statuses.dig(section, item),
-              class_context: "app-task-list"
-            )) %>
-          </li>
-        <% end %>
-      </ul>
-    </li>
-  <% end %>
-</ol>
+<%= render TaskList::Component.new(view_object.task_list_sections) %>
 
 <div class="govuk-button-group">
-  <%- if view_object.can_submit? -%>
+  <% if view_object.can_submit? %>
     <%= govuk_button_link_to t("teacher_interface.application_forms.show.draft.check"), edit_teacher_interface_application_form_path %>
-  <%- end -%>
+  <% end %>
+
   <%= govuk_button_link_to t("teacher_interface.application_forms.show.draft.save"), destroy_teacher_session_path, secondary: true %>
 </div>

--- a/app/views/teacher_interface/further_information_requests/show.html.erb
+++ b/app/views/teacher_interface/further_information_requests/show.html.erb
@@ -3,27 +3,7 @@
 
 <h1 class="govuk-heading-l">Apply for qualified teacher status (QTS)</h1>
 
-<ol class="app-task-list">
-  <li>
-    <h2 class="app-task-list__section">
-      Further information requested
-    </h2>
-
-    <ul class="app-task-list__items">
-      <% @view_object.task_items.each do |item| %>
-        <li class="app-task-list__item">
-          <span class="app-task-list__task-name">
-            <%= link_to item[:text], item[:href], aria: { describedby: "#{item[:key]}-status" } %>
-          </span>
-
-          <%= render(StatusTag::Component.new(
-            **item.slice(:key, :status).merge(class_context: "app-task-list")
-          )) %>
-        </li>
-      <% end %>
-    </ul>
-  </li>
-</ol>
+<%= render TaskList::Component.new(@view_object.task_list_sections) %>
 
 <% if @view_object.can_check_answers? %>
   <p class="govuk-body"> Once you’ve checked your response on the next screen, you’ll be able to submit it. </p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,10 +31,7 @@ Rails.application.routes.draw do
       resources :timeline_events, only: :index
 
       resources :assessments, only: %i[edit update] do
-        resources :assessment_sections,
-                  path: "/sections",
-                  param: :key,
-                  only: %i[show update]
+        resources :assessment_sections, path: "/sections", only: %i[show update]
 
         resource :assessment_recommendation_award,
                  controller: "assessment_recommendation_award",

--- a/spec/components/task_list_spec.rb
+++ b/spec/components/task_list_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TaskList::Component, type: :component do
+  subject(:component) { render_inline(described_class.new(sections)) }
+
+  let(:sections) do
+    [
+      {
+        title: "Section A",
+        items: [{ name: "Item A", href: "/item-a", status: "not_started" }],
+      },
+      { title: "Section B", items: [{ name: "Item B", status: "completed" }] },
+    ]
+  end
+
+  it "numbers the section titles" do
+    expect(component.text.squish).to include("1. Section A")
+    expect(component.text.squish).to include("2. Section B")
+  end
+
+  it "shows the item statuses" do
+    expect(component.text.squish).to include("Item A Not started")
+    expect(component.text.squish).to include("Item B Completed")
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/check_english_language_proficiency.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_english_language_proficiency.rb
@@ -5,8 +5,7 @@ module PageObjects
     end
 
     class CheckEnglishLanguageProficiency < AssessmentSection
-      set_url "/assessor/applications/{application_id}/assessments/ \
-        {assessment_id}/sections/english_language_proficiency"
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/{section_id}"
 
       sections :cards, EnglishLanguageProficiencyCard, ".govuk-summary-card"
 

--- a/spec/support/autoload/page_objects/assessor_interface/check_personal_information.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_personal_information.rb
@@ -9,7 +9,7 @@ module PageObjects
     end
 
     class CheckPersonalInformation < AssessmentSection
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/personal_information"
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/{section_id}"
 
       sections :cards, PersonalInformationCard, ".govuk-summary-card"
 

--- a/spec/support/autoload/page_objects/assessor_interface/check_professional_standing.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_professional_standing.rb
@@ -7,7 +7,7 @@ module PageObjects
     end
 
     class CheckProfessionalStanding < AssessmentSection
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/professional_standing"
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/{section_id}"
 
       sections :cards, ProfessionalStandingCard, ".govuk-summary-card"
 

--- a/spec/support/autoload/page_objects/assessor_interface/check_qualifications.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_qualifications.rb
@@ -7,7 +7,7 @@ module PageObjects
     end
 
     class CheckQualifications < AssessmentSection
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/qualifications"
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/{section_id}"
 
       sections :cards, QualificationCard, ".govuk-summary-card"
 

--- a/spec/support/autoload/page_objects/assessor_interface/check_work_history.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_work_history.rb
@@ -7,7 +7,7 @@ module PageObjects
     end
 
     class CheckWorkHistory < AssessmentSection
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/work_history"
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/{section_id}"
 
       sections :cards, WorkHistoryCard, ".govuk-summary-card"
 

--- a/spec/support/autoload/page_objects/assessor_interface/verify_age_range_subjects_page.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/verify_age_range_subjects_page.rb
@@ -7,7 +7,7 @@ module PageObjects
     end
 
     class VerifyAgeRangeSubjectsPage < AssessmentSection
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/age_range_subjects"
+      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/{section_id}"
 
       sections :cards, AgeRangeSubjectCard, ".govuk-summary-card"
 

--- a/spec/support/matchers/task_list.rb
+++ b/spec/support/matchers/task_list.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rspec/expectations"
+
+RSpec::Matchers.define :include_task_list_section do |title|
+  match do |task_list_sections|
+    rendered_sections =
+      task_list_sections.filter { |section| section[:items].present? }
+    expect(rendered_sections).to include(hash_including(title:))
+  end
+
+  match_when_negated do |task_list_sections|
+    rendered_sections =
+      task_list_sections.filter { |section| section[:items].present? }
+    expect(rendered_sections).to_not include(hash_including(title:))
+  end
+end
+
+RSpec::Matchers.define :include_task_list_item do |section_title, name, **attributes|
+  match do |task_list_sections|
+    all_items =
+      task_list_sections.flat_map do |section|
+        section[:items].map do |item|
+          item.merge(section_title: section[:title])
+        end
+      end
+    expect(all_items).to include(
+      hash_including(section_title:, name:, **attributes),
+    )
+  end
+
+  match_when_negated do |task_list_sections|
+    all_items =
+      task_list_sections.flat_map do |section|
+        section[:items].map do |item|
+          item.merge(section_title: section[:title])
+        end
+      end
+    expect(all_items).to_not include(
+      hash_including(section_title:, name:, **attributes),
+    )
+  end
+end

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
       :check_personal_information_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("personal_information"),
     )
     then_i_see_the_personal_information
 
@@ -25,6 +26,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
       :check_personal_information_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("personal_information"),
     )
     then_i_see_the_personal_information
 
@@ -38,6 +40,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
       :check_qualifications_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("qualifications"),
     )
     then_i_see_the_qualifications
 
@@ -51,6 +54,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
       :check_qualifications_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("qualifications"),
     )
     then_i_see_the_qualifications
 
@@ -64,6 +68,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
       :verify_age_range_subjects_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("age_range_subjects"),
     )
     then_i_see_the_age_range_and_subjects
 
@@ -79,6 +84,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
       :verify_age_range_subjects_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("age_range_subjects"),
     )
     then_i_see_the_age_range_and_subjects
 
@@ -90,7 +96,12 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   it "allows passing the work history" do
-    when_i_visit_the(:check_work_history_page, application_id:, assessment_id:)
+    when_i_visit_the(
+      :check_work_history_page,
+      application_id:,
+      assessment_id:,
+      section_id: section_id("work_history"),
+    )
     then_i_see_the_work_history
 
     when_i_choose_check_work_history_yes
@@ -99,7 +110,12 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   it "allows failing the work history" do
-    when_i_visit_the(:check_work_history_page, application_id:, assessment_id:)
+    when_i_visit_the(
+      :check_work_history_page,
+      application_id:,
+      assessment_id:,
+      section_id: section_id("work_history"),
+    )
     then_i_see_the_work_history
 
     when_i_choose_check_work_history_no
@@ -112,6 +128,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
       :check_professional_standing_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("professional_standing"),
     )
     then_i_see_the_professional_standing
 
@@ -125,6 +142,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
       :check_professional_standing_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("professional_standing"),
     )
     then_i_see_the_professional_standing
 
@@ -140,6 +158,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
       :check_professional_standing_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("professional_standing"),
     )
     then_i_see_the_professional_standing
 
@@ -415,5 +434,9 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def assessment_id
     application_form.assessment.id
+  end
+
+  def section_id(key)
+    application_form.assessment.sections.find_by(key:).id
   end
 end

--- a/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
+++ b/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
       :check_english_language_proficiency_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("english_language_proficiency"),
     )
     then_i_am_asked_to_confirm_english_language_proficiency_in_the_personal_information_section
 
@@ -21,6 +22,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
       :check_personal_information_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("personal_information"),
     )
     then_i_can_see_failure_reasons_if_i_do_not_wish_to_confirm(
       check_personal_information_page,
@@ -45,6 +47,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
       :check_english_language_proficiency_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("english_language_proficiency"),
     )
     then_i_am_asked_to_confirm_english_language_proficiency_in_the_qualifications_section
 
@@ -52,6 +55,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
       :check_qualifications_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("qualifications"),
     )
     then_i_can_see_failure_reasons_if_i_do_not_wish_to_confirm(
       check_qualifications_page,
@@ -72,6 +76,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
       :check_english_language_proficiency_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("english_language_proficiency"),
     )
     then_i_am_asked_to_confirm_english_language_proficiency_by_provider
     and_i_can_see_provider_failure_reasons_if_i_do_not_wish_to_confirm
@@ -90,6 +95,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
       :check_english_language_proficiency_page,
       application_id:,
       assessment_id:,
+      section_id: section_id("english_language_proficiency"),
     )
     then_i_am_asked_to_confirm_english_language_proficiency_by_moi
     and_i_can_see_moi_failure_reasons_if_i_do_not_wish_to_confirm
@@ -306,5 +312,9 @@ RSpec.describe "Assessor confirms English language section", type: :system do
 
   def assessment_id
     application_form.assessment.id
+  end
+
+  def section_id(key)
+    application_form.assessment.sections.find_by(key:).id
   end
 end

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -192,9 +192,13 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       context "and personal information" do
         let(:item) { :personal_information }
 
+        let!(:assessment_section) do
+          create(:assessment_section, :personal_information, assessment:)
+        end
+
         it do
           is_expected.to eq(
-            "/assessor/applications/#{application_form.id}/assessments/#{assessment.id}/sections/personal_information",
+            "/assessor/applications/#{application_form.id}/assessments/#{assessment.id}/sections/#{assessment_section.id}",
           )
         end
       end

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
 
   let(:params) do
     {
-      key: assessment_section.key,
+      id: assessment_section.id,
       assessment_id: assessment.id,
       application_form_id: application_form.id,
     }
@@ -186,20 +186,11 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
   end
 
   describe "#show_english_language_provider_details?" do
-    let(:params) do
-      {
-        key:,
-        assessment_id: assessment.id,
-        application_form_id: application_form.id,
-      }
-    end
-
     subject(:show_english_language_provider_details?) do
       view_object.show_english_language_provider_details?
     end
 
     context "when the application EL proof method is 'provider'" do
-      let(:key) { "english_language_proficiency" }
       let(:application_form) do
         create(:application_form, :with_english_language_provider)
       end
@@ -211,7 +202,6 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
     end
 
     context "when the application EL proof method is not 'provider'" do
-      let(:key) { "english_language_proficiency" }
       let(:application_form) do
         create(:application_form, :with_english_language_medium_of_instruction)
       end
@@ -223,7 +213,6 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
     end
 
     context "when the section is not 'english_language_proficiency'" do
-      let(:key) { "personal_information" }
       let(:assessment_section) do
         create(:assessment_section, :personal_information, assessment:)
       end
@@ -233,22 +222,12 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
   end
 
   describe "#show_english_language_exemption_checkbox?" do
-    let(:params) do
-      {
-        key:,
-        assessment_id: assessment.id,
-        application_form_id: application_form.id,
-      }
-    end
-
     subject(:show_english_language_exemption_checkbox?) do
       view_object.show_english_language_exemption_checkbox?
     end
 
-    before { create(:assessment_section, :qualifications, assessment:) }
-
     context "when the section is personal information" do
-      let(:key) { "personal_information" }
+      before { create(:assessment_section, :qualifications, assessment:) }
 
       context "with exemption by citizenship" do
         let(:application_form) do
@@ -274,7 +253,9 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
     end
 
     context "when the section is qualifications" do
-      let(:key) { "qualifications" }
+      let(:assessment_section) do
+        create(:assessment_section, :qualifications, assessment:)
+      end
 
       context "with exemption by citizenship" do
         let(:application_form) do

--- a/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
@@ -52,218 +52,120 @@ RSpec.describe TeacherInterface::ApplicationFormShowViewObject do
     end
   end
 
-  describe "#tasks" do
-    subject(:tasks) { view_object.tasks }
+  describe "#task_list_sections" do
+    subject(:task_list_sections) { view_object.task_list_sections }
+
+    let(:needs_work_history) { false }
+    let(:needs_written_statement) { false }
+    let(:needs_registration_number) { false }
+
+    before do
+      create(
+        :application_form,
+        teacher: current_teacher,
+        needs_work_history:,
+        needs_written_statement:,
+        needs_registration_number:,
+      )
+    end
+
+    it do
+      is_expected.to include_task_list_item(
+        "About you",
+        "Enter your personal information",
+      )
+    end
+    it do
+      is_expected.to include_task_list_item(
+        "About you",
+        "Upload your identity document",
+      )
+    end
+
+    it do
+      is_expected.to include_task_list_item(
+        "Your English language proficiency",
+        "Verify your English language proficiency",
+      )
+    end
+
+    it do
+      is_expected.to include_task_list_item(
+        "Your qualifications",
+        "Add your teaching qualifications",
+      )
+    end
+    it do
+      is_expected.to include_task_list_item(
+        "Your qualifications",
+        "Enter the age range you can teach",
+      )
+    end
+    it do
+      is_expected.to include_task_list_item(
+        "Your qualifications",
+        "Enter the subjects you can teach",
+      )
+    end
+
+    it do
+      is_expected.to_not include_task_list_item(
+        "Your work history",
+        "Add your work history",
+      )
+    end
+
+    it do
+      is_expected.to_not include_task_list_item(
+        "Proof that you’re recognised as a teacher",
+        "Upload your written statement",
+      )
+    end
+    it do
+      is_expected.to_not include_task_list_item(
+        "Proof that you’re recognised as a teacher",
+        "Enter your registration number",
+      )
+    end
 
     context "with needs work history" do
-      before do
-        create(
-          :application_form,
-          teacher: current_teacher,
-          needs_work_history: true,
-          needs_written_statement: false,
-          needs_registration_number: false,
-        )
-      end
+      let(:needs_work_history) { true }
 
       it do
-        is_expected.to eq(
-          {
-            about_you: %i[personal_information identification_document],
-            english_language: %i[english_language],
-            qualifications: %i[qualifications age_range subjects],
-            work_history: %i[work_history],
-          },
+        is_expected.to include_task_list_item(
+          "Your work history",
+          "Add your work history",
         )
       end
     end
 
     context "with needs written statement" do
-      before do
-        create(
-          :application_form,
-          teacher: current_teacher,
-          needs_work_history: false,
-          needs_written_statement: true,
-          needs_registration_number: false,
-        )
-      end
+      let(:needs_written_statement) { true }
 
       it do
-        is_expected.to eq(
-          {
-            about_you: %i[personal_information identification_document],
-            english_language: %i[english_language],
-            qualifications: %i[qualifications age_range subjects],
-            proof_of_recognition: %i[written_statement],
-          },
+        is_expected.to include_task_list_item(
+          "Proof that you’re recognised as a teacher",
+          "Upload your written statement",
         )
       end
     end
 
-    context "with needs registration number" do
-      before do
-        create(
-          :application_form,
-          teacher: current_teacher,
-          needs_work_history: false,
-          needs_written_statement: false,
-          needs_registration_number: true,
-        )
-      end
+    context "with needs written statement" do
+      let(:needs_registration_number) { true }
 
       it do
-        is_expected.to eq(
-          {
-            about_you: %i[personal_information identification_document],
-            english_language: %i[english_language],
-            qualifications: %i[qualifications age_range subjects],
-            proof_of_recognition: %i[registration_number],
-          },
+        is_expected.to include_task_list_item(
+          "Proof that you’re recognised as a teacher",
+          "Enter your registration number",
         )
       end
     end
   end
 
-  describe "#task_statuses" do
-    subject(:task_statuses) { view_object.task_statuses }
-
-    context "with no extra requirements" do
-      before do
-        create(
-          :application_form,
-          teacher: current_teacher,
-          needs_work_history: false,
-          needs_written_statement: false,
-          needs_registration_number: false,
-        )
-      end
-
-      it do
-        is_expected.to eq(
-          {
-            about_you: {
-              personal_information: "not_started",
-              identification_document: "not_started",
-            },
-            english_language: {
-              english_language: "not_started",
-            },
-            qualifications: {
-              qualifications: "not_started",
-              age_range: "not_started",
-              subjects: "not_started",
-            },
-          },
-        )
-      end
+  describe "#completed_task_list_sections" do
+    subject(:completed_task_list_sections) do
+      view_object.completed_task_list_sections
     end
-
-    context "with work history" do
-      before do
-        create(
-          :application_form,
-          teacher: current_teacher,
-          needs_work_history: true,
-          needs_written_statement: false,
-          needs_registration_number: false,
-        )
-      end
-
-      it do
-        is_expected.to eq(
-          {
-            about_you: {
-              personal_information: "not_started",
-              identification_document: "not_started",
-            },
-            english_language: {
-              english_language: "not_started",
-            },
-            qualifications: {
-              qualifications: "not_started",
-              age_range: "not_started",
-              subjects: "not_started",
-            },
-            work_history: {
-              work_history: "not_started",
-            },
-          },
-        )
-      end
-    end
-
-    context "with written statement" do
-      before do
-        create(
-          :application_form,
-          teacher: current_teacher,
-          needs_work_history: false,
-          needs_written_statement: true,
-          needs_registration_number: false,
-        )
-      end
-
-      it do
-        is_expected.to eq(
-          {
-            about_you: {
-              personal_information: "not_started",
-              identification_document: "not_started",
-            },
-            english_language: {
-              english_language: "not_started",
-            },
-            qualifications: {
-              qualifications: "not_started",
-              age_range: "not_started",
-              subjects: "not_started",
-            },
-            proof_of_recognition: {
-              written_statement: "not_started",
-            },
-          },
-        )
-      end
-    end
-
-    context "with registration number" do
-      before do
-        create(
-          :application_form,
-          teacher: current_teacher,
-          needs_work_history: false,
-          needs_written_statement: false,
-          needs_registration_number: true,
-        )
-      end
-
-      it do
-        is_expected.to eq(
-          {
-            about_you: {
-              personal_information: "not_started",
-              identification_document: "not_started",
-            },
-            english_language: {
-              english_language: "not_started",
-            },
-            qualifications: {
-              qualifications: "not_started",
-              age_range: "not_started",
-              subjects: "not_started",
-            },
-            proof_of_recognition: {
-              registration_number: "not_started",
-            },
-          },
-        )
-      end
-    end
-  end
-
-  describe "#completed_task_sections" do
-    subject(:completed_task_sections) { view_object.completed_task_sections }
 
     let!(:application_form) do
       create(:application_form, teacher: current_teacher)
@@ -281,7 +183,7 @@ RSpec.describe TeacherInterface::ApplicationFormShowViewObject do
         )
       end
 
-      it { is_expected.to match_array(:about_you) }
+      it { is_expected.to_not be_empty }
     end
   end
 

--- a/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
     }
   end
 
-  describe "#task_items" do
+  describe "#task_list_sections" do
+    subject(:task_list_sections) { view_object.task_list_sections }
+
     let!(:text_item) do
       create(
         :further_information_request_item,
@@ -34,6 +36,7 @@ RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
         further_information_request:,
       )
     end
+
     let!(:document_item) do
       create(
         :further_information_request_item,
@@ -42,36 +45,33 @@ RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
       )
     end
 
-    subject(:task_items) { view_object.task_items }
+    it do
+      is_expected.to include_task_list_item(
+        "Further information requested",
+        "Tell us more about the subjects you can teach",
+        link: [
+          :edit,
+          :teacher_interface,
+          :application_form,
+          further_information_request,
+          text_item,
+        ],
+        status: :not_started,
+      )
+    end
 
     it do
-      is_expected.to eq(
-        [
-          {
-            key: text_item.id,
-            text: "Tell us more about the subjects you can teach",
-            href: [
-              :edit,
-              :teacher_interface,
-              :application_form,
-              further_information_request,
-              text_item,
-            ],
-            status: :not_started,
-          },
-          {
-            key: document_item.id,
-            text: "Upload your identity document",
-            href: [
-              :edit,
-              :teacher_interface,
-              :application_form,
-              further_information_request,
-              document_item,
-            ],
-            status: :not_started,
-          },
+      is_expected.to include_task_list_item(
+        "Further information requested",
+        "Upload your identity document",
+        link: [
+          :edit,
+          :teacher_interface,
+          :application_form,
+          further_information_request,
+          document_item,
         ],
+        status: :not_started,
       )
     end
   end


### PR DESCRIPTION
This refactors how we render task lists to move them in to a common component with a specific structure, which then allows us to be clearer in the view objects.

This is necessary as a precursor to some upcoming work related to preliminary checks and consent which means the task list for assessors will be more dynamic.