### PR TITLE
Don't run production smoke test with credentials

### DIFF
--- a/.github/actions/deploy-environment-to-aks/action.yml
+++ b/.github/actions/deploy-environment-to-aks/action.yml
@@ -14,6 +14,10 @@ inputs:
   pull-request-number:
     description: The pull request number which triggered this deploy. If set, this will automatically seed the database.
     required: false
+  smoke-test-credentials-required:
+    description: Whether to run the smoke test with support credentials
+    required: false
+    default: "true"
 
 outputs:
   url:
@@ -56,6 +60,7 @@ runs:
         kubectl exec -n tra-development deployment/apply-for-qts-review-${{ inputs.pull-request-number }}-web -- sh -c "cd /app && /usr/local/bin/bundle exec rails db:seed example_data:generate review_app:configure"
 
     - id: key-vault-name
+      if: ${{ inputs.smoke-test-credentials-required == 'true' }}
       shell: bash
       run: echo "value=$(make -s ${{ inputs.environment }}_aks print-application-key-vault-name)" >> $GITHUB_OUTPUT
       env:
@@ -63,6 +68,7 @@ runs:
 
     - uses: Azure/get-keyvault-secrets@v1
       id: smoke-test-secrets
+      if: ${{ inputs.smoke-test-credentials-required == 'true' }}
       with:
         keyvault: ${{ steps.key-vault-name.outputs.value }}
         secrets: "SUPPORT-USERNAME,SUPPORT-PASSWORD"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -266,6 +266,7 @@ jobs:
           environment: production
           docker-image: ${{ needs.docker.outputs.docker_image }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          smoke-test-credentials-required: "false"
 
   notify_slack_of_failures:
     name: Notify Slack of failures


### PR DESCRIPTION
The production service should be open so we don't need to run the smoke test against it with credentials.