### PR TITLE
Fix typo in monitoring configuration

### DIFF
--- a/terraform/aks/monitoring.tf
+++ b/terraform/aks/monitoring.tf
@@ -1,5 +1,5 @@
 locals {
-  external_url = var.external_hostname != null ? "https://#{var.external_hostname}" : null
+  external_url = var.external_hostname != null ? "https://${var.external_hostname}" : null
 }
 
 module "statuscake" {


### PR DESCRIPTION
The interpolation should use the `$` rather than `#`.