### PR TITLE
Revert "Remove tasks jobs and services for resending blob data"

### DIFF
--- a/app/jobs/resend_stored_blob_data_job.rb
+++ b/app/jobs/resend_stored_blob_data_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class ResendStoredBlobDataJob < ApplicationJob
+  # Resending the blob data will trigger a malware scan.
+  def perform(batch_size: 1000)
+    return unless FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
+
+    Upload
+      .where(malware_scan_result: "pending")
+      .limit(batch_size)
+      .find_each do |upload|
+        sleep(2) # Avoid rate limiting
+        ResendStoredBlobData.call(upload:)
+      end
+  end
+end

--- a/app/services/resend_stored_blob_data.rb
+++ b/app/services/resend_stored_blob_data.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+class ResendStoredBlobData
+  include ServicePattern
+
+  # Only later versions of the Azure Storage REST API support tags operations.
+  Kernel.silence_warnings do
+    Azure::Storage::Blob::Default::STG_VERSION = "2022-11-02"
+  end
+
+  BLOB_CONTAINER_NAME = ENV["AZURE_STORAGE_CONTAINER"] || "uploads"
+
+  def initialize(upload:)
+    @upload = upload
+  end
+
+  def call
+    return unless upload.scan_result_pending? && upload.attachment&.key.present?
+
+    response = blob_service.call(:put, put_blob_url, attachment_data, headers)
+
+    if response.success?
+      FetchMalwareScanResultJob.set(wait: 1.minute).perform_later(
+        upload_id: upload.id,
+      )
+    end
+  rescue ActiveStorage::FileNotFoundError
+    upload.update!(malware_scan_result: "error")
+  end
+
+  private
+
+  attr_reader :upload
+
+  def blob_service
+    @blob_service ||=
+      Azure::Storage::Blob::BlobService.new(
+        storage_account_name: ENV["AZURE_STORAGE_ACCOUNT_NAME"],
+        storage_access_key: ENV["AZURE_STORAGE_ACCESS_KEY"],
+      )
+  end
+
+  def headers
+    {
+      "x-ms-blob-type" => "BlockBlob",
+      "x-ms-version" => "2022-11-02",
+      "Content-Length" => attachment_data.size,
+    }
+  end
+
+  def attachment_data
+    @attachment_data ||= upload.attachment.download
+  end
+
+  def put_blob_url
+    blob_service.generate_uri(
+      File.join(BLOB_CONTAINER_NAME, upload.attachment.key),
+    )
+  end
+end

--- a/lib/tasks/malware_scan.rake
+++ b/lib/tasks/malware_scan.rake
@@ -1,0 +1,12 @@
+namespace :malware_scan do
+  desc "Resend blob data for uploads that have a pending malware scan result"
+  task resend_stored_blob_data: :environment do
+    ResendStoredBlobDataJob.perform_later
+  end
+
+  desc "Print a count of uploads with a pending malware scan result"
+  task count_pending: :environment do
+    upload_count = Upload.where(malware_scan_result: "pending").count
+    puts "#{upload_count} uploads have a pending malware scan result"
+  end
+end

--- a/spec/services/resend_stored_blob_data_spec.rb
+++ b/spec/services/resend_stored_blob_data_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ResendStoredBlobData do
+  describe "#call" do
+    let(:upload) { create(:upload) }
+    let(:response_success) { true }
+    let(:put_blob_url) { "http://example.com/uploads/#{upload.attachment.key}" }
+    let(:stubbed_blob_service) do
+      instance_double(
+        Azure::Storage::Blob::BlobService,
+        generate_uri: put_blob_url,
+      )
+    end
+    let(:stubbed_response) do
+      instance_double(
+        Azure::Core::Http::HttpResponse,
+        success?: response_success,
+      )
+    end
+    subject(:resend_stored_blob_data) { described_class.call(upload:) }
+
+    before do
+      allow(Azure::Storage::Blob::BlobService).to receive(:new).and_return(
+        stubbed_blob_service,
+      )
+      allow(stubbed_blob_service).to receive(:call).and_return(stubbed_response)
+    end
+
+    it "calls the Azure Storage REST API to PUT blob data from the upload attachment" do
+      expect(stubbed_blob_service).to receive(:call).with(
+        :put,
+        put_blob_url,
+        upload.attachment.download,
+        anything,
+      )
+      resend_stored_blob_data
+    end
+
+    it "enqueues a FetchMalwareScanResultJob" do
+      expect(FetchMalwareScanResultJob).to receive(:set).with(
+        wait: 1.minute,
+      ).and_return(FetchMalwareScanResultJob)
+      expect(FetchMalwareScanResultJob).to receive(:perform_later).with(
+        upload_id: upload.id,
+      )
+      resend_stored_blob_data
+    end
+
+    context "when the upload attachment is missing" do
+      let(:attachment) { instance_double(ActiveStorage::Blob) }
+      before do
+        allow(upload).to receive(:attachment).and_return(attachment)
+        allow(attachment).to receive(:key).and_raise(
+          ActiveStorage::FileNotFoundError,
+        )
+      end
+
+      it "updates to the malware scan result field to 'error'" do
+        resend_stored_blob_data
+        expect(upload.reload.malware_scan_result).to eq("error")
+      end
+    end
+
+    context "when the upload attachment key is nil" do
+      let(:attachment) { instance_double(ActiveStorage::Blob, key: nil) }
+      before { allow(upload).to receive(:attachment).and_return(attachment) }
+
+      it "returns without update" do
+        expect { resend_stored_blob_data }.not_to change(
+          upload.reload,
+          :malware_scan_result,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This reverts commit 02148817c58b5fb7dd4aeaeb78ae966da41aa532.

Sometimes it seems like the virus scanner gets stuck and we end up with a number of pending uploads, these tasks will make it possible to resend them so they get scanned again.