### PR TITLE
Fix flaky update assessment section test

### DIFF
--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe UpdateAssessmentSection do
-  let(:user) { build(:staff, id: 1) }
+  let(:user) { create(:staff) }
   let(:application_form) { create(:application_form, :submitted) }
   let(:assessment) { create(:assessment, application_form:) }
   let(:assessment_section) do


### PR DESCRIPTION
This fixes the flaky test by not hard coding the ID of the staff user, so we don't end up with two staff users with the same ID.

https://github.com/DFE-Digital/apply-for-qualified-teacher-status/actions/runs/5334743623/jobs/9666943566?pr=1500 is an example of this test failing.