### PR TITLE
Don't expire old tokens on sign in

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -370,7 +370,7 @@ Devise.setup do |config|
   # When using the :trackable module, set to true to consider magic link tokens
   # generated before the user's current sign in time to be expired. In other words,
   # each time you sign in, all existing magic links will be considered invalid.
-  config.passwordless_expire_old_tokens_on_sign_in = true
+  # config.passwordless_expire_old_tokens_on_sign_in = true
 end
 
 # As we only use magic link authentication for teachers, we don't need to unnecessarily


### PR DESCRIPTION
This is to better handle Outlook's "safe links" feature where it navigates to the page before the user does, and so in certain situations we end up treating the user as already signed in when they come to do it.

A better fix might be to look at the user-agent and not record the sign in if it's coming from Outlook, but I want to see if this change fixes the immediate problem.

[Trello Card](https://trello.com/c/DnyC5BTd/1978-invalid-or-expired-login-link-using-outlook)