### PR TITLE
[1975] Add task to update status of waiting on application forms

### DIFF
--- a/app/services/expire_requestable.rb
+++ b/app/services/expire_requestable.rb
@@ -15,6 +15,7 @@ class ExpireRequestable
       requestable.expired!
       requestable.after_expired(user:)
       create_timeline_event
+      ApplicationFormStatusUpdater.call(user:, application_form:)
     end
 
     requestable

--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -61,4 +61,17 @@ namespace :application_forms do
       puts "#{application_form.reference}: #{application_form.status}"
     end
   end
+
+  desc "Update status of application forms in waiting on to overdue"
+  task update_waiting_on_applications: :environment do
+    user = "Expirer"
+    assessment_ids = ReferenceRequest.expired.select(:assessment_id)
+    ApplicationForm
+      .waiting_on
+      .joins(:assessment)
+      .where(assessment: { id: assessment_ids })
+      .each do |application_form|
+        ApplicationFormStatusUpdater.call(application_form:, user:)
+      end
+  end
 end

--- a/spec/services/expire_requestable_spec.rb
+++ b/spec/services/expire_requestable_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe ExpireRequestable do
           creator: user,
         )
       end
+
+      it "calls the status updater" do
+        expect(ApplicationFormStatusUpdater).to receive(:call).with(
+          application_form: requestable.application_form,
+          user:,
+        ).at_least(:once)
+        subject
+      end
     end
 
     shared_examples_for "not expiring a requestable" do


### PR DESCRIPTION
Expected:
When a work reference becomes overdue
The 'verify reference requests' has a status of overdue;

And the application’s status is moved to overdue

Actual:

The application status is showing as waiting on (see attachment for screenshots).

It's done when

The application status is overdue, when the work reference and verify reference requests are in a status of overdue

Any applications that have overdue work references (and not actioned) have a status of overdue.

In this PR there is a fix to ensure when we update a timeline event that status will be updated. There is also a rake task to backfill any application forms that have incorrect statuses.