### PR TITLE
Content changes for ineligable country kick out page

### DIFF
--- a/app/views/eligibility_interface/finish/ineligible.html.erb
+++ b/app/views/eligibility_interface/finish/ineligible.html.erb
@@ -13,16 +13,7 @@
     <p class="govuk-body">If you are recognised as a teacher in <%= CountryName.from_eligibility_check(@eligibility_check, with_definite_article: true) %> you are not currently eligible to use this service.</p>
 
     <p class="govuk-body">
-      However, the regulations are changing, which means you’ll be eligible to use this service
-      <% if CountryCode.eligible_in_february_2023?(@eligibility_check.country_code) %>
-        from 1 February 2023.
-      <% else %>
-        by the end of 2023.
-      <% end %>
-    </p>
-
-    <p class="govuk-body">
-      <%= govuk_link_to "Learn more about the qualifications and experience you’ll need to apply for QTS", "https://www.gov.uk/government/publications/awarding-qualified-teacher-status-to-overseas-teachers/a-fairer-approach-to-awarding-qts-to-overseas-teachers" %>
+      We will update this page should there be any <%= govuk_link_to "changes to eligibility for QTS", "https://www.gov.uk/government/publications/awarding-qualified-teacher-status-to-overseas-teachers/a-fairer-approach-to-awarding-qts-to-overseas-teachers--2#changes-to-eligibility-for-qts" %>.
     </p>
   <% end %>
 <% else %>

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -88,12 +88,6 @@ RSpec.describe "Eligibility check", type: :system do
     when_i_press_back
     when_i_select_nigeria
     then_i_see_the(:ineligible_page)
-    and_i_see_the_ineligible_february_2023_text
-
-    when_i_press_back
-    when_i_select_laos
-    then_i_see_the(:ineligible_page)
-    and_i_see_the_ineligible_end_of_year_2023_text
   end
 
   it "trying to skip steps" do
@@ -474,16 +468,6 @@ RSpec.describe "Eligibility check", type: :system do
     expect(ineligible_page.body).to have_content(
       "This service is for qualified teachers who trained to teach outside of England",
     )
-  end
-
-  def and_i_see_the_ineligible_february_2023_text
-    expect(ineligible_page.body).to have_content("the regulations are changing")
-    expect(ineligible_page.body).to have_content("from 1 February 2023.")
-  end
-
-  def and_i_see_the_ineligible_end_of_year_2023_text
-    expect(ineligible_page.body).to have_content("the regulations are changing")
-    expect(ineligible_page.body).to have_content("by the end of 2023.")
   end
 
   def and_i_see_the_ineligible_misconduct_text


### PR DESCRIPTION
If a user picks a country that is not eligible for QTS application, they will see the [ineligible country](https://test.apply-for-qts-in-england.education.gov.uk/eligibility/ineligible) message page. This makes reference to all countries being online by the end of 2023. This now seems unlikely so we need to change the content on this page.

Second sentence changes from:

However, the regulations are changing, which means you’ll be eligible to use this service by the end of 2023.

To:

We will update this page should there be any [changes to eligibility for QTS](https://mcas-proxyweb.mcas.ms/certificate-checker?login=false&originalUrl=https%3A%2F%2Fwww.gov.uk.mcas.ms%2Fgovernment%2Fpublications%2Fawarding-qualified-teacher-status-to-overseas-teachers%2Fa-fairer-approach-to-awarding-qts-to-overseas-teachers--2%3FMcasTsid%3D20893%23changes-to-eligibility-for-qts&McasCSRF=195ae4277ce6704b05b2aecb7c23ff460d04edab0f6a8c8704ea71a3e0a54fe1).

Note:

The link should go to the ‘Changes to eligibility for QTS’ section of this page https://www.gov.uk/government/publications/awarding-qualified-teacher-status-to-overseas-teachers/a-fairer-approach-to-awarding-qts-to-overseas-teachers--2#changes-to-eligibility-for-qts

Remove: Remove the current link to ‘Learn more about the qualifications and experience you’ll need to reply for QTS'.