### PR TITLE
Remove rake task that is no longer needed

### DIFF
--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -61,17 +61,4 @@ namespace :application_forms do
       puts "#{application_form.reference}: #{application_form.status}"
     end
   end
-
-  desc "Update status of application forms in waiting on to overdue"
-  task update_waiting_on_applications: :environment do
-    user = "Expirer"
-    assessment_ids = ReferenceRequest.expired.select(:assessment_id)
-    ApplicationForm
-      .waiting_on
-      .joins(:assessment)
-      .where(assessment: { id: assessment_ids })
-      .each do |application_form|
-        ApplicationFormStatusUpdater.call(application_form:, user:)
-      end
-  end
 end


### PR DESCRIPTION
This rake task was added as part of a previous ticket to backfill any applications that have overdue work references (and not actioned). It was to move them to a status of overdue. This task has been run and is no longer needed; so it should be removed.