### PR TITLE
Improve preliminary check status

### DIFF
--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -375,10 +375,28 @@ RSpec.describe ApplicationFormStatusUpdater do
 
         include_examples "changes status", "preliminary_check"
 
-        context "once preliminary check is complete" do
+        context "when the preliminary check has passed" do
           before { preliminary_assessment_section.update!(passed: true) }
 
           include_examples "changes status", "waiting_on"
+        end
+
+        context "when the preliminary check has failed" do
+          before do
+            create(
+              :selected_failure_reason,
+              assessment_section: preliminary_assessment_section,
+            )
+            preliminary_assessment_section.reload.update!(passed: false)
+          end
+
+          include_examples "changes status", "preliminary_check"
+
+          context "and the application form is declined" do
+            before { application_form.update!(declined_at: Time.zone.now) }
+
+            include_examples "changes status", "declined"
+          end
         end
       end
     end


### PR DESCRIPTION
This ensures that the status is always set correctly, and improves the readability of the code. It's necessary if an assessors reviews the preliminary assessment section but then chooses not to decline immediately, this will currently result in the status changing to "assessment in progress" but I think we should leave it as "preliminary check".