### PR TITLE
Make "Approved providers" link open in a new tab

### DIFF
--- a/app/views/assessor_interface/assessment_sections/_english_language_provider_details.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_english_language_provider_details.html.erb
@@ -5,7 +5,7 @@
     </p>
 
     <% if provider.check_url.present? %>
-      <p class="govuk-body">Check the applicant's <%= provider.reference_name %> at:</p>
+      <p class="govuk-body">Check the applicant’s <%= provider.reference_name %> at:</p>
       <p class="govuk-body"><%= govuk_link_to provider.check_url, provider.check_url, target: "_blank", rel: "noreferrer noopener" %></p>
     <% end %>
   <% else %>
@@ -14,7 +14,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= govuk_link_to "Approved providers", "https://register.ofqual.gov.uk/Search?category=Qualifications&query=ESOl" %>
+      <%= govuk_link_to "Approved providers", "https://register.ofqual.gov.uk/Search?category=Qualifications&query=ESOl", target: "_blank", rel: "noreferrer noopener" %>
     </p>
   <% end %>
 <% end %>


### PR DESCRIPTION
This matches the behaviour of what happens with a specific provider and helpers the assessors when using this page.

[Trello Card](https://trello.com/c/mkShcUDu/2023-ukraine-approved-provider-list-doesnt-open-in-a-new-tab)