### PR TITLE
Remove PaaS event triggers after migrating

### DIFF
--- a/.github/workflows/migrate-database.yaml
+++ b/.github/workflows/migrate-database.yaml
@@ -102,6 +102,13 @@ jobs:
       - name: Restore database
         run: bin/konduit.sh -i backup.sql.gz -c apply-for-qts-${{ github.event.inputs.environment }}-web -- psql
 
+      - name: Remove PaaS event triggers
+        shell: bash
+        run: |
+          bin/konduit.sh apply-for-qts-${{ github.event.inputs.environment }}-web -- psql -c 'drop event trigger forbid_ddl_reader'
+          bin/konduit.sh apply-for-qts-${{ github.event.inputs.environment }}-web -- psql -c 'drop event trigger make_readable'
+          bin/konduit.sh apply-for-qts-${{ github.event.inputs.environment }}-web -- psql -c 'drop event trigger reassign_owned'
+
       - uses: geekyeggo/delete-artifact@v2
         with:
           name: backup


### PR DESCRIPTION
After migrating the database from AKS to PaaS we need to remove some PaaS specific event triggers from the database. I've based this on the version in Register Trainee Teachers:

https://github.com/DFE-Digital/register-trainee-teachers/blob/main/.github/actions/backup_and_restore/action.yml