### PR TITLE
Add a workflow for syncing PaaS storage to AKS

### DIFF
--- a/.github/workflows/migrate-storage.yaml
+++ b/.github/workflows/migrate-storage.yaml
@@ -1,0 +1,103 @@
+name: Migrate storage to AKS
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: GitHub environment to backup and restore
+        type: choice
+        default: preproduction
+        options:
+          - preproduction
+          - production
+
+jobs:
+  azure-storage:
+    name: Get Azure Storage details
+    runs-on: ubuntu-latest
+
+    environment:
+      name: ${{ github.event.inputs.environment }}_aks
+
+    outputs:
+      account-name: ${{ steps.azure-storage.outputs.account-name }}
+      access-key: ${{ steps.encrypted-access-key.outputs.out }}
+      container: ${{ steps.azure-storage.outputs.container }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: ./.github/actions/set-kubernetes-credentials
+        with:
+          environment: ${{ github.event.inputs.environment }}
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Get Azure Storage details
+        id: azure-storage
+        working-directory: terraform/aks
+        run: |
+          ACCOUNT_NAME=$(terraform output -raw azure_storage_account_name)
+          echo "account-name=$ACCOUNT_NAME" >> $GITHUB_OUTPUT
+
+          ACCESS_KEY=$(terraform output -raw azure_storage_access_key)
+          echo "::add-mask::$ACCESS_KEY"
+          echo "access-key=$ACCESS_KEY" >> $GITHUB_OUTPUT
+
+          CONTAINER=$(terraform output -raw azure_storage_container)
+          echo "container=$CONTAINER" >> $GITHUB_OUTPUT
+
+      - uses: cloudposse/github-action-secret-outputs@main
+        id: encrypted-access-key
+        with:
+          secret: ${{ secrets.ENCRYPTION_KEY }}
+          op: encode
+          in: ${{ steps.azure-storage.outputs.access-key }}
+
+  migrate-stored-blob-data:
+    name: Migrate stored blob data
+    needs: [azure-storage]
+    runs-on: ubuntu-latest
+
+    environment:
+      name: ${{ (github.event.inputs.environment == 'preproduction' && 'preprod') || github.event.inputs.environment }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: Azure/login@v1
+        with:
+          creds: ${{ secrets.azure_credentials }}
+
+      - name: Set environment variables Production
+        shell: bash
+        run: |
+          tf_vars_file=terraform/paas/workspace_variables/${{ (github.event.inputs.environment == 'preproduction' && 'preprod') || github.event.inputs.environment }}.tfvars.json
+          echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
+          echo "PAAS_SPACE=$(jq -r '.paas_space' ${tf_vars_file})" >> $GITHUB_ENV
+
+      - uses: Azure/get-keyvault-secrets@v1
+        id: get_secrets
+        with:
+          keyvault: ${{ env.KEY_VAULT_NAME }}
+          secrets: "PAAS-USER,PAAS-PASSWORD"
+
+      - name: Setup cf cli
+        uses: DFE-Digital/github-actions/setup-cf-cli@master
+        with:
+          CF_USERNAME: ${{ steps.get_secrets.outputs.PAAS-USER }}
+          CF_PASSWORD: ${{ steps.get_secrets.outputs.PAAS-PASSWORD }}
+          CF_SPACE_NAME: ${{ env.PAAS_SPACE }}
+
+      - uses: cloudposse/github-action-secret-outputs@main
+        id: decrypted-access-key
+        with:
+          secret: ${{ secrets.ENCRYPTION_KEY }}
+          op: decode
+          in: ${{ needs.azure-storage.outputs.access-key }}
+
+      - name: Migrate stored blob data
+        run: |
+          cf ssh apply-for-qts-in-england-${{ (github.event.inputs.environment == 'preproduction' && 'preprod') || github.event.inputs.environment || 'preprod' }} \
+            -c "AZURE_STORAGE_ACCOUNT_NAME_AKS=${{ needs.azure-storage.outputs.account-name }} AZURE_STORAGE_ACCESS_KEY_AKS=${{ steps.decrypted-access-key.outputs.out }} AZURE_STORAGE_CONTAINER_AKS=${{ needs.azure-storage.outputs.container }} cd /app && /usr/local/bin/bundle exec rails migrate_stored_blob_data"

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -4,6 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  malware_scan_result :string           default("pending"), not null
+#  migrated_to_aks     :boolean          default(FALSE), not null
 #  translation         :boolean          not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/app/services/migrate_stored_blob_data.rb
+++ b/app/services/migrate_stored_blob_data.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class MigrateStoredBlobData
+  include ServicePattern
+
+  # Only later versions of the Azure Storage REST API support tags operations.
+  Kernel.silence_warnings do
+    Azure::Storage::Blob::Default::STG_VERSION = "2022-11-02"
+  end
+
+  BLOB_CONTAINER_NAME = ENV["AZURE_STORAGE_CONTAINER_AKS"] || "uploads"
+
+  def initialize(upload:)
+    @upload = upload
+  end
+
+  def call
+    return if upload.migrated_to_aks || upload.attachment&.key.blank?
+
+    response = blob_service.call(:put, put_blob_url, attachment_data, headers)
+
+    upload.update!(migrated_to_aks: true) if response.success?
+  rescue ActiveStorage::FileNotFoundError
+    upload.update!(migrated_to_aks: false)
+  end
+
+  private
+
+  attr_reader :upload
+
+  def blob_service
+    @blob_service ||=
+      Azure::Storage::Blob::BlobService.new(
+        storage_account_name: ENV["AZURE_STORAGE_ACCOUNT_NAME_AKS"],
+        storage_access_key: ENV["AZURE_STORAGE_ACCESS_KEY_AKS"],
+      )
+  end
+
+  def headers
+    {
+      "x-ms-blob-type" => "BlockBlob",
+      "x-ms-version" => "2022-11-02",
+      "Content-Length" => attachment_data.size,
+    }
+  end
+
+  def attachment_data
+    @attachment_data ||= upload.attachment.download
+  end
+
+  def put_blob_url
+    blob_service.generate_uri(
+      File.join(BLOB_CONTAINER_NAME, upload.attachment.key),
+    )
+  end
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -387,6 +387,7 @@
     - created_at
     - updated_at
     - malware_scan_result
+    - migrated_to_aks
   :work_histories:
     - application_form_id
     - canonical_contact_email

--- a/db/migrate/20230627152008_add_migrated_to_aks_to_uploads.rb
+++ b/db/migrate/20230627152008_add_migrated_to_aks_to_uploads.rb
@@ -1,0 +1,5 @@
+class AddMigratedToAksToUploads < ActiveRecord::Migration[7.0]
+  def change
+    add_column :uploads, :migrated_to_aks, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_27_071158) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_27_152008) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -493,6 +493,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_27_071158) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "malware_scan_result", default: "pending", null: false
+    t.boolean "migrated_to_aks", default: false, null: false
     t.index ["document_id"], name: "index_uploads_on_document_id"
   end
 

--- a/lib/tasks/migrate_stored_blob_data.rake
+++ b/lib/tasks/migrate_stored_blob_data.rake
@@ -1,0 +1,12 @@
+desc "Migrate stored blob data from PaaS to AKS"
+task migrate_stored_blob_data: :environment do
+  uploads = Upload.where(migrated_to_aks: false).order(:created_at)
+
+  count = uploads.count
+
+  uploads.each_with_index do |upload, index|
+    MigrateStoredBlobData.call(upload:)
+    puts "Migrated #{index + 1}/#{count} uploads"
+    sleep(2) # Avoid rate limiting
+  end
+end

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -4,6 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  malware_scan_result :string           default("pending"), not null
+#  migrated_to_aks     :boolean          default(FALSE), not null
 #  translation         :boolean          not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -4,6 +4,7 @@
 #
 #  id                  :bigint           not null, primary key
 #  malware_scan_result :string           default("pending"), not null
+#  migrated_to_aks     :boolean          default(FALSE), not null
 #  translation         :boolean          not null
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/spec/services/migrate_stored_blob_data_spec.rb
+++ b/spec/services/migrate_stored_blob_data_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MigrateStoredBlobData do
+  describe "#call" do
+    subject(:call) { described_class.call(upload:) }
+
+    let(:upload) { create(:upload) }
+    let(:response_success) { true }
+    let(:put_blob_url) { "http://example.com/uploads/#{upload.attachment.key}" }
+    let(:stubbed_blob_service) do
+      instance_double(
+        Azure::Storage::Blob::BlobService,
+        generate_uri: put_blob_url,
+      )
+    end
+    let(:stubbed_response) do
+      instance_double(
+        Azure::Core::Http::HttpResponse,
+        success?: response_success,
+      )
+    end
+
+    before do
+      allow(Azure::Storage::Blob::BlobService).to receive(:new).and_return(
+        stubbed_blob_service,
+      )
+      allow(stubbed_blob_service).to receive(:call).and_return(stubbed_response)
+    end
+
+    it "calls the Azure Storage REST API to PUT blob data from the upload attachment" do
+      expect(stubbed_blob_service).to receive(:call).with(
+        :put,
+        put_blob_url,
+        upload.attachment.download,
+        anything,
+      )
+      call
+    end
+
+    it "marks the file as migrated" do
+      expect { call }.to change(upload, :migrated_to_aks).to(true)
+    end
+
+    context "when the upload attachment is missing" do
+      let(:attachment) { instance_double(ActiveStorage::Blob) }
+      before do
+        allow(upload).to receive(:attachment).and_return(attachment)
+        allow(attachment).to receive(:key).and_raise(
+          ActiveStorage::FileNotFoundError,
+        )
+      end
+
+      it "doesn't mark the file as migrated" do
+        expect { call }.to_not change(upload, :migrated_to_aks)
+      end
+    end
+
+    context "when the upload attachment key is nil" do
+      let(:attachment) { instance_double(ActiveStorage::Blob, key: nil) }
+      before { allow(upload).to receive(:attachment).and_return(attachment) }
+
+      it "doesn't mark the file as migrated" do
+        expect { call }.to_not change(upload, :migrated_to_aks)
+      end
+    end
+  end
+end

--- a/terraform/aks/outputs.tf
+++ b/terraform/aks/outputs.tf
@@ -17,3 +17,16 @@ output "kubernetes_cluster_name" {
 output "kubernetes_cluster_resource_group_name" {
   value = module.cluster_data.configuration_map.resource_group_name
 }
+
+output "azure_storage_account_name" {
+  value = azurerm_storage_account.uploads.name
+}
+
+output "azure_storage_access_key" {
+  value     = azurerm_storage_account.uploads.primary_access_key
+  sensitive = true
+}
+
+output "azure_storage_container" {
+  value = azurerm_storage_container.uploads.name
+}


### PR DESCRIPTION
This adds the ability to copy storage data from the PaaS to AKS, and records which files have been migrated allowing us to run this incrementally.

To be able to access the secrets from one environment to the other I've had to encrypt the secrets in the workflow between sending them between jobs which means I've set a matching `ENCRYPTION_KEY` secret in each preproduction and production environment.

[Trello Card](https://trello.com/c/dD3ULUfN/1997-sync-uploaded-files-from-paas-to-aks)