### PR TITLE
Check twice for duplicates in DQT

### DIFF
--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -52,6 +52,11 @@ class SubmitApplicationForm
     FindApplicantInDQTJob.perform_later(
       application_form_id: application_form.id,
     )
+
+    # Sometimes DQT doesn't find a result the first time
+    FindApplicantInDQTJob.set(wait: 5.minutes).perform_later(
+      application_form_id: application_form.id,
+    )
   end
 
   private

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe SubmitApplicationForm do
     it "calls a background job to find matching DQT records" do
       expect { call }.to have_enqueued_job(FindApplicantInDQTJob).with(
         application_form_id: application_form.id,
-      )
+      ).twice
     end
   end
 end


### PR DESCRIPTION
Sometimes DQT won't find a duplicate the first time we do a search, but it seems to then be able to find the duplicate the next time (perhaps related to caching). While this is figured out, we can check twice for duplicates in DQT, 5 minutes after the first check.

[Trello Card](https://trello.com/c/v2FJ8kfJ/2030-dqt-duplicate-check-not-finding-duplicates)