### PR TITLE
Don't migrate uploads with errors

### DIFF
--- a/lib/tasks/migrate_stored_blob_data.rake
+++ b/lib/tasks/migrate_stored_blob_data.rake
@@ -1,12 +1,16 @@
 desc "Migrate stored blob data from PaaS to AKS"
 task migrate_stored_blob_data: :environment do
-  uploads = Upload.where(migrated_to_aks: false).order(:created_at)
+  uploads =
+    Upload
+      .where(migrated_to_aks: false)
+      .not_scan_result_error
+      .order(:created_at)
 
   count = uploads.count
 
   uploads.each_with_index do |upload, index|
     MigrateStoredBlobData.call(upload:)
     puts "Migrated #{index + 1}/#{count} uploads"
-    sleep(2) # Avoid rate limiting
+    sleep(1.5) # Avoid rate limiting
   end
 end


### PR DESCRIPTION
Errors means that the file isn't in Azure anyway so there's nothing to migrate across, and saves us a little time in the process.