### PR TITLE
Fix HostingEnvironment#host

### DIFF
--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -19,8 +19,12 @@ module HostingEnvironment
     def host
       if production?
         "apply-for-qts-in-england.education.gov.uk"
+      elsif preproduction?
+        "preprod.apply-for-qts-in-england.education.gov.uk"
       elsif review?
         "apply-for-qts-#{value}-web.test.teacherservices.cloud"
+      elsif development?
+        "dev.apply-for-qts-in-england.education.gov.uk"
       else
         "#{name}.apply-for-qts-in-england.education.gov.uk"
       end
@@ -31,11 +35,11 @@ module HostingEnvironment
     end
 
     def preproduction?
-      name.start_with?("preprod")
+      name == "preproduction"
     end
 
     def development?
-      name.start_with?("dev")
+      name == "development"
     end
 
     def review?

--- a/spec/lib/hosting_environment_spec.rb
+++ b/spec/lib/hosting_environment_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe HostingEnvironment do
     end
 
     context "when the environment is preprod" do
-      let(:hosting_environment) { "preprod" }
+      let(:hosting_environment) { "preproduction" }
 
       it do
         is_expected.to eq("preprod.apply-for-qts-in-england.education.gov.uk")
@@ -48,8 +48,8 @@ RSpec.describe HostingEnvironment do
       it { is_expected.to eq("test.apply-for-qts-in-england.education.gov.uk") }
     end
 
-    context "when the environment is dev" do
-      let(:hosting_environment) { "dev" }
+    context "when the environment is development" do
+      let(:hosting_environment) { "development" }
 
       it { is_expected.to eq("dev.apply-for-qts-in-england.education.gov.uk") }
     end


### PR DESCRIPTION
With the new environment names we need to fix how we determine the host of the deployed application. This will fix an issue with links in emails not working.