### PR TITLE
Add AKS migration banner

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -48,6 +48,19 @@
       </div>
     </div>
 
+    <% if FeatureFlags::FeatureFlag.active?(:aks_migration_banner) %>
+      <div class="govuk-width-container govuk-!-margin-top-4">
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-two-thirds">
+            <%= govuk_notification_banner(title_text: "Important") do %>
+              <p>The Apply for QTS in England service will be unavailable from 7pm to 10pm Greenwich Mean Time (GMT) on Wednesday 19 July 2023, due to scheduled maintenance.</p>
+              <p>You may lose any new changes made if you’re using the service when it becomes unavailable.</p>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+
     <div class="govuk-width-container">
       <%= govuk_back_link(href: yield(:back_link_url)) unless yield(:back_link_url).blank? %>
       <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,4 +1,8 @@
 feature_flags:
+  aks_migration_banner:
+    author: Thomas Leese
+    description: Show the AKS migration banner explaining the outage.
+
   fetch_malware_scan_result:
     author: Steve Laing
     description: >

--- a/service_unavailable_page/web/public/internal/index.html
+++ b/service_unavailable_page/web/public/internal/index.html
@@ -104,10 +104,10 @@
             </h1>
 
             <p class="govuk-body">
-              We’re opening up this service to more countries, which will make
-              it temporarily unavailable from 11:59pm GMT on 31 January 2023
-              until 10am GMT on 1 February 2023 (Greenwich Mean Time). We
-              apologise for any inconvenience this may cause.
+              The Apply for QTS in England service is temporarily unavailable
+              due to scheduled maintenance between 7pm till 10pm Greenwich Mean
+              Time (GMT) on Wednesday 19 July 2023. We apologise for any
+              inconvenience this may cause.
             </p>
 
             <p class="govuk-body">


### PR DESCRIPTION
This adds a banner which we can switch on and off using a feature flag suitable for the migration to AKS which is happening in two weeks time.

[Trello Card](https://trello.com/c/3QGcnFhv/2022-migration-from-paas-to-aks-planning)

## Screenshot

![Screenshot 2023-07-06 at 15 59 33](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/936e9cd3-d44f-4cd5-8f68-5f9d8d0f29eb)

