### PR TITLE
Revert "Bump prettier from 2.8.8 to 3.0.0"

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,7 +8,6 @@
 *.svg
 *.txt
 *.woff*
-*.min.*
 .bundle
 .gitattributes
 .gitignore

--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
   },
   "devDependencies": {
     "@prettier/plugin-ruby": "^3.2.2",
-    "prettier": "^3.0.0"
-  },
-  "prettier": {
-    "trailingComma": "es5"
+    "prettier": "^2.8.8"
   }
 }

--- a/service_unavailable_page/web/public/internal/index.html
+++ b/service_unavailable_page/web/public/internal/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -310,10 +310,10 @@ preact@^8.3.1:
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.3.tgz#78c2a5562fcecb1fed1d0055fa4ac1e27bde17c1"
   integrity sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==
 
-prettier@>=2.3.0, prettier@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
-  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
+prettier@>=2.3.0, prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 readdirp@~3.6.0:
   version "3.6.0"


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-qualified-teacher-status#1541

It's lead to the linter ignoring all our Ruby files.