### PR TITLE
Backfill preliminary checks

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -8,15 +8,15 @@ class AssessmentFactory
   end
 
   def call
-    sections = [
-      personal_information_section,
-      qualifications_section,
-      preliminary_qualifications_section,
-      age_range_subjects_section,
-      english_language_proficiency_section,
-      work_history_section,
-      professional_standing_section,
-    ].compact
+    sections =
+      [
+        personal_information_section,
+        qualifications_section,
+        age_range_subjects_section,
+        english_language_proficiency_section,
+        work_history_section,
+        professional_standing_section,
+      ].compact + PreliminaryAssessmentSectionsFactory.call(application_form:)
 
     Assessment.create!(
       application_form:,
@@ -144,37 +144,6 @@ class AssessmentFactory
     ].compact
 
     AssessmentSection.new(key: "qualifications", checks:, failure_reasons:)
-  end
-
-  def preliminary_qualifications_section
-    return nil unless application_form.requires_preliminary_check
-
-    checks =
-      if application_form.secondary_education_teaching_qualification_required?
-        %w[
-          qualifications_meet_level_6_or_equivalent
-          teaching_qualification_subjects_criteria
-        ]
-      else
-        []
-      end
-
-    failure_reasons =
-      if application_form.secondary_education_teaching_qualification_required?
-        [
-          FailureReasons::TEACHING_QUALIFICATIONS_NOT_AT_REQUIRED_LEVEL,
-          FailureReasons::TEACHING_QUALIFICATION_SUBJECTS_CRITERIA,
-        ]
-      else
-        [FailureReasons::TEACHING_QUALIFICATIONS_NOT_AT_REQUIRED_LEVEL]
-      end
-
-    AssessmentSection.new(
-      preliminary: true,
-      key: "qualifications",
-      checks:,
-      failure_reasons:,
-    )
   end
 
   def age_range_subjects_section

--- a/app/lib/preliminary_assessment_sections_factory.rb
+++ b/app/lib/preliminary_assessment_sections_factory.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class PreliminaryAssessmentSectionsFactory
+  include ServicePattern
+
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+  def call
+    application_form.requires_preliminary_check ? [qualifications] : []
+  end
+
+  private
+
+  attr_reader :application_form
+
+  def qualifications
+    AssessmentSection.new(
+      preliminary: true,
+      key: "qualifications",
+      checks: qualifications_checks,
+      failure_reasons: qualifications_failure_reasons,
+    )
+  end
+
+  def qualifications_checks
+    if application_form.secondary_education_teaching_qualification_required?
+      %w[
+        qualifications_meet_level_6_or_equivalent
+        teaching_qualification_subjects_criteria
+      ]
+    else
+      []
+    end
+  end
+
+  def qualifications_failure_reasons
+    [
+      FailureReasons::TEACHING_QUALIFICATIONS_NOT_AT_REQUIRED_LEVEL,
+      if application_form.secondary_education_teaching_qualification_required?
+        FailureReasons::TEACHING_QUALIFICATION_SUBJECTS_CRITERIA
+      end,
+    ].compact
+  end
+end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -57,6 +57,13 @@ class Region < ApplicationRecord
 
   validates :teaching_authority_online_checker_url, url: { allow_blank: true }
 
+  scope :requires_preliminary_check,
+        -> {
+          joins(:country).where(requires_preliminary_check: true).or(
+            where(country: { requires_preliminary_check: true }),
+          )
+        }
+
   def checks_available?
     !sanction_check_none? && !status_check_none?
   end

--- a/app/services/backfill_preliminary_checks.rb
+++ b/app/services/backfill_preliminary_checks.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class BackfillPreliminaryChecks
+  include ServicePattern
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def call
+    applications_forms.find_each do |application_form|
+      assessment = application_form.assessment
+
+      application_form.update!(requires_preliminary_check: true)
+
+      unless assessment.sections.preliminary.exists?
+        assessment.sections +=
+          PreliminaryAssessmentSectionsFactory.call(application_form:)
+        assessment.save!
+      end
+
+      ApplicationFormStatusUpdater.call(application_form:, user:)
+    end
+
+    applications_forms.count
+  end
+
+  private
+
+  attr_reader :user
+
+  def regions
+    @regions ||= Region.requires_preliminary_check
+  end
+
+  def applications_forms
+    @applications_forms ||=
+      ApplicationForm
+        .includes(assessment: :sections)
+        .submitted
+        .where(
+          region: regions,
+          assessor: nil,
+          requires_preliminary_check: false,
+        )
+  end
+end

--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -16,6 +16,14 @@ namespace :application_forms do
     puts "There are #{ApplicationForm.count} applications overall."
   end
 
+  desc "Backfill preliminary checks on applications after enabling them."
+  task :backfill_preliminary_checks,
+       %i[staff_email] => :environment do |_task, args|
+    user = Staff.find_by!(email: args[:staff_email])
+    count = BackfillPreliminaryChecks.call(user:)
+    puts "Updated #{count} applications."
+  end
+
   desc "Change the contact email address of work history associated with an application."
   task :update_work_history_contact_email,
        %i[reference staff_email old_email_address new_email_address] =>

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -108,6 +108,10 @@ FactoryBot.define do
       region.teaching_authority_provides_written_statement
     end
 
+    trait :requires_preliminary_check do
+      requires_preliminary_check { true }
+    end
+
     trait :completed do
       personal_information_status { "completed" }
       identification_document_status { "completed" }

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -49,6 +49,10 @@ FactoryBot.define do
       reduced_evidence_accepted { true }
     end
 
+    trait :requires_preliminary_check do
+      requires_preliminary_check { true }
+    end
+
     trait :written_statement_optional do
       written_statement_optional { true }
     end

--- a/spec/lib/preliminary_assessment_sections_factory_spec.rb
+++ b/spec/lib/preliminary_assessment_sections_factory_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PreliminaryAssessmentSectionsFactory do
+  let(:application_form) { create(:application_form) }
+
+  describe "#call" do
+    subject(:assessment_sections) { described_class.call(application_form:) }
+
+    it { is_expected.to be_empty }
+
+    context "when application form requires a preliminary check" do
+      let(:application_form) do
+        create(
+          :application_form,
+          :requires_preliminary_check,
+          region: create(:region, :in_country, country_code: "FR"),
+        )
+      end
+
+      it { is_expected.to_not be_empty }
+
+      let(:section) { assessment_sections.first }
+
+      it "has the right checks and failure reasons" do
+        expect(section.checks).to be_empty
+        expect(section.failure_reasons).to eq(
+          %w[teaching_qualifications_not_at_required_level],
+        )
+      end
+
+      context "with an application form with subject criteria" do
+        let(:application_form) do
+          create(
+            :application_form,
+            :requires_preliminary_check,
+            region: create(:region, :in_country, country_code: "SG"),
+          )
+        end
+
+        it "has the right checks and failure reasons" do
+          expect(section.checks).to eq(
+            %w[
+              qualifications_meet_level_6_or_equivalent
+              teaching_qualification_subjects_criteria
+            ],
+          )
+          expect(section.failure_reasons).to eq(
+            %w[
+              teaching_qualifications_not_at_required_level
+              teaching_qualification_subjects_criteria
+            ],
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -70,6 +70,29 @@ RSpec.describe Region, type: :model do
     end
   end
 
+  describe "scopes" do
+    describe "#requires_preliminary_check" do
+      subject(:requires_preliminary_check) do
+        described_class.requires_preliminary_check
+      end
+
+      let!(:normal_region) { create(:region) }
+      let!(:preliminary_region) do
+        create(:region, requires_preliminary_check: true)
+      end
+      let!(:preliminary_country_region) do
+        create(
+          :region,
+          country: create(:country, requires_preliminary_check: true),
+        )
+      end
+
+      it { is_expected.to_not include(normal_region) }
+      it { is_expected.to include(preliminary_region) }
+      it { is_expected.to include(preliminary_country_region) }
+    end
+  end
+
   describe "#teaching_authority_emails_string" do
     subject(:teaching_authority_emails_string) do
       region.teaching_authority_emails_string

--- a/spec/services/backfill_preliminary_checks_spec.rb
+++ b/spec/services/backfill_preliminary_checks_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BackfillPreliminaryChecks do
+  let(:user) { create(:staff, :confirmed) }
+
+  subject(:call) { described_class.call(user:) }
+
+  context "with no application forms" do
+    it "does nothing" do
+      expect { call }.to_not raise_error
+    end
+  end
+
+  context "with application forms" do
+    let!(:submitted_application_form) do
+      create(:application_form, :submitted, :with_assessment, region:)
+    end
+    let!(:preliminary_check_application_form) do
+      create(:application_form, :preliminary_check, :with_assessment, region:)
+    end
+    let!(:awarded_check_application_form) do
+      create(:application_form, :awarded, :with_assessment, region:)
+    end
+
+    context "with a normal region" do
+      let(:region) { create(:region) }
+
+      it "doesn't backfill the submitted application form" do
+        expect { call }.to_not(
+          change { submitted_application_form.reload.status },
+        )
+      end
+
+      it "doesn't backfill the preliminary checked application form" do
+        expect { call }.to_not(
+          change { preliminary_check_application_form.reload.status },
+        )
+      end
+
+      it "doesn't backfill the awarded application form" do
+        expect { call }.to_not(
+          change { awarded_check_application_form.reload.status },
+        )
+      end
+    end
+
+    context "with a preliminary checked region" do
+      let(:region) { create(:region, :requires_preliminary_check) }
+
+      it "backfills the submitted application form" do
+        call
+
+        submitted_application_form.reload
+
+        expect(submitted_application_form.status).to eq("preliminary_check")
+        expect(submitted_application_form.requires_preliminary_check).to be true
+        expect(
+          submitted_application_form.assessment.sections.preliminary,
+        ).to_not be_empty
+      end
+
+      it "doesn't backfill the preliminary checked application form" do
+        expect { call }.to_not(
+          change { preliminary_check_application_form.reload.status },
+        )
+      end
+
+      it "doesn't backfill the awarded application form" do
+        expect { call }.to_not(
+          change { awarded_check_application_form.reload.status },
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a task for backfilling preliminary checks, which means enabling preliminary checks on existing submitted applications which would have not have previously gone through preliminary checks as it would not have been enabled for the region or country.

[Trello Card](https://trello.com/c/ocLDSwCI/2060-turn-on-retroactive-and-future-preliminary-check-for-south-africa-and-jamaica)