### PR TITLE
Add "information changed" timeline event

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -52,6 +52,12 @@
           <%= simple_format failure_assessor_note %>
         <% end %>
       <% end %>
+    <% elsif timeline_event.information_changed? %>
+      <p class="govuk-body">
+        <%= t(description_vars[:column_name], scope: %i[components timeline_entry columns]) %>
+        has changed from <strong class="govuk-!-font-weight-bold"><%= description_vars[:old_value] %></strong>
+        to <strong class="govuk-!-font-weight-bold"><%= description_vars[:new_value] %></strong>.
+      </p>
     <% else %>
       <p class="govuk-body"><%= simple_format description.html_safe %></p>
     <% end %>

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -130,5 +130,13 @@ module TimelineEntry
         {}
       end
     end
+
+    def information_changed_vars
+      {
+        column_name: timeline_event.column_name,
+        old_value: timeline_event.old_value,
+        new_value: timeline_event.new_value,
+      }
+    end
   end
 end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -62,17 +62,18 @@ class TimelineEvent < ApplicationRecord
             unless: -> { creator_id.present? && creator_type.present? }
 
   enum event_type: {
+         age_range_subjects_verified: "age_range_subjects_verified",
+         assessment_section_recorded: "assessment_section_recorded",
          assessor_assigned: "assessor_assigned",
+         email_sent: "email_sent",
+         information_changed: "information_changed",
+         note_created: "note_created",
+         requestable_assessed: "requestable_assessed",
+         requestable_expired: "requestable_expired",
+         requestable_received: "requestable_received",
+         requestable_requested: "requestable_requested",
          reviewer_assigned: "reviewer_assigned",
          state_changed: "state_changed",
-         assessment_section_recorded: "assessment_section_recorded",
-         note_created: "note_created",
-         email_sent: "email_sent",
-         age_range_subjects_verified: "age_range_subjects_verified",
-         requestable_requested: "requestable_requested",
-         requestable_received: "requestable_received",
-         requestable_expired: "requestable_expired",
-         requestable_assessed: "requestable_assessed",
        }
   validates :event_type, inclusion: { in: event_types.values }
 
@@ -144,6 +145,20 @@ class TimelineEvent < ApplicationRecord
             :requestable_type,
             absence: true,
             unless: :requestable_event_type?
+
+  belongs_to :work_history, optional: true
+  validates :work_history_id,
+            :column_name,
+            :old_value,
+            :new_value,
+            presence: true,
+            if: :information_changed?
+  validates :work_history_id,
+            :column_name,
+            :old_value,
+            :new_value,
+            absence: true,
+            unless: :information_changed?
 
   def requestable_event_type?
     requestable_requested? || requestable_received? || requestable_expired? ||

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -8,6 +8,7 @@
 #  age_range_max         :integer
 #  age_range_min         :integer
 #  age_range_note        :text             default(""), not null
+#  column_name           :string           default(""), not null
 #  creator_name          :string           default(""), not null
 #  creator_type          :string
 #  event_type            :string           not null
@@ -15,7 +16,9 @@
 #  mailer_class_name     :string           default(""), not null
 #  message_subject       :string           default(""), not null
 #  new_state             :string           default(""), not null
+#  new_value             :text             default(""), not null
 #  old_state             :string           default(""), not null
+#  old_value             :text             default(""), not null
 #  requestable_type      :string
 #  subjects              :text             default([]), not null, is an Array
 #  subjects_note         :text             default(""), not null
@@ -28,6 +31,7 @@
 #  creator_id            :integer
 #  note_id               :bigint
 #  requestable_id        :bigint
+#  work_history_id       :bigint
 #
 # Indexes
 #
@@ -37,6 +41,7 @@
 #  index_timeline_events_on_assignee_id            (assignee_id)
 #  index_timeline_events_on_note_id                (note_id)
 #  index_timeline_events_on_requestable            (requestable_type,requestable_id)
+#  index_timeline_events_on_work_history_id        (work_history_id)
 #
 # Foreign Keys
 #
@@ -45,6 +50,7 @@
 #  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #  fk_rails_...  (assignee_id => staff.id)
 #  fk_rails_...  (note_id => notes.id)
+#  fk_rails_...  (work_history_id => work_histories.id)
 #
 class TimelineEvent < ApplicationRecord
   belongs_to :application_form

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -358,30 +358,34 @@
     - updated_at
     - uuid
   :timeline_events:
-    - id
-    - event_type
-    - application_form_id
-    - creator_id
-    - creator_type
-    - creator_name
-    - created_at
-    - updated_at
-    - assignee_id
-    - old_state
-    - new_state
-    - assessment_section_id
-    - note_id
-    - mailer_class_name
-    - mailer_action_name
-    - message_subject
-    - assessment_id
-    - requestable_type
-    - requestable_id
-    - age_range_min
     - age_range_max
+    - age_range_min
     - age_range_note
+    - application_form_id
+    - assessment_id
+    - assessment_section_id
+    - assignee_id
+    - column_name
+    - created_at
+    - creator_id
+    - creator_name
+    - creator_type
+    - event_type
+    - id
+    - mailer_action_name
+    - mailer_class_name
+    - message_subject
+    - new_state
+    - new_value
+    - note_id
+    - old_state
+    - old_value
+    - requestable_id
+    - requestable_type
     - subjects
     - subjects_note
+    - updated_at
+    - work_history_id
   :uploads:
     - id
     - document_id

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -54,6 +54,8 @@
     - unconfirmed_email
   :timeline_events:
     - age_range_note
+    - new_value
+    - old_value
     - subjects_note
   :work_histories:
     - canonical_contact_email

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -66,6 +66,7 @@ en:
           ProfessionalStandingRequest: Professional standing assessed
           QualificationRequest: Qualification assessed
           ReferenceRequest: Reference assessed
+        information_changed: Information changed after submission
       description:
         assessor_assigned: "%{assignee_name} is assigned as the assessor."
         reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
@@ -92,3 +93,5 @@ en:
           ProfessionalStandingRequest: The professional standing request has been assessed.
           QualificationRequest: A qualification has been assessed.
           ReferenceRequest: A reference has been assessed.
+      columns:
+        contact_email: Reference contact email

--- a/db/migrate/20230711092318_add_information_changed_to_timeline_events.rb
+++ b/db/migrate/20230711092318_add_information_changed_to_timeline_events.rb
@@ -1,0 +1,10 @@
+class AddInformationChangedToTimelineEvents < ActiveRecord::Migration[7.0]
+  def change
+    change_table :timeline_events, bulk: true do |t|
+      t.references :work_history, foreign_key: true
+      t.string :column_name, null: false, default: ""
+      t.text :old_value, null: false, default: ""
+      t.text :new_value, null: false, default: ""
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_07_092452) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_11_092318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -426,8 +426,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_07_092452) do
     t.text "name", default: "", null: false
     t.boolean "award_decline_permission", default: false
     t.boolean "support_console_permission", default: false, null: false
-    t.boolean "manage_applications_permission", default: false, null: false
     t.string "azure_ad_uid"
+    t.boolean "manage_applications_permission", default: false, null: false
     t.index "lower((email)::text)", name: "index_staff_on_lower_email", unique: true
     t.index ["confirmation_token"], name: "index_staff_on_confirmation_token", unique: true
     t.index ["invitation_token"], name: "index_staff_on_invitation_token", unique: true
@@ -481,12 +481,17 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_07_092452) do
     t.text "age_range_note", default: "", null: false
     t.text "subjects", default: [], null: false, array: true
     t.text "subjects_note", default: "", null: false
+    t.bigint "work_history_id"
+    t.string "column_name", default: "", null: false
+    t.text "old_value", default: "", null: false
+    t.text "new_value", default: "", null: false
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
     t.index ["assessment_id"], name: "index_timeline_events_on_assessment_id"
     t.index ["assessment_section_id"], name: "index_timeline_events_on_assessment_section_id"
     t.index ["assignee_id"], name: "index_timeline_events_on_assignee_id"
     t.index ["note_id"], name: "index_timeline_events_on_note_id"
     t.index ["requestable_type", "requestable_id"], name: "index_timeline_events_on_requestable"
+    t.index ["work_history_id"], name: "index_timeline_events_on_work_history_id"
   end
 
   create_table "uploads", force: :cascade do |t|
@@ -547,6 +552,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_07_092452) do
   add_foreign_key "timeline_events", "assessments"
   add_foreign_key "timeline_events", "notes"
   add_foreign_key "timeline_events", "staff", column: "assignee_id"
+  add_foreign_key "timeline_events", "work_histories"
   add_foreign_key "uploads", "documents"
   add_foreign_key "work_histories", "application_forms"
 end

--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -18,12 +18,14 @@ namespace :application_forms do
 
   desc "Change the contact email address of work history associated with an application."
   task :update_work_history_contact_email,
-       %i[reference old_email_address new_email_address] =>
+       %i[reference staff_email old_email_address new_email_address] =>
          :environment do |_task, args|
     application_form = ApplicationForm.find_by!(reference: args[:reference])
+    user = Staff.find_by!(email: args[:staff_email])
 
     UpdateWorkHistoryContactEmail.call(
       application_form:,
+      user:,
       old_email_address: args[:old_email_address],
       new_email_address: args[:new_email_address],
     )

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -488,4 +488,20 @@ RSpec.describe TimelineEntry::Component, type: :component do
       expect(component.text).to include(creator.name)
     end
   end
+
+  context "information changed" do
+    let(:timeline_event) { create(:timeline_event, :information_changed) }
+    let(:old_value) { timeline_event.old_value }
+    let(:new_value) { timeline_event.new_value }
+
+    it "describes the event" do
+      expect(component.text.squish).to include(
+        "Reference contact email has changed from #{old_value} to #{new_value}.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
 end

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -97,5 +97,13 @@ FactoryBot.define do
       mailer_action_name { "application_received" }
       message_subject { "Application received" }
     end
+
+    trait :information_changed do
+      event_type { "information_changed" }
+      association :work_history
+      column_name { "contact_email" }
+      old_value { Faker::Internet.email }
+      new_value { Faker::Internet.email }
+    end
   end
 end

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -6,6 +6,7 @@
 #  age_range_max         :integer
 #  age_range_min         :integer
 #  age_range_note        :text             default(""), not null
+#  column_name           :string           default(""), not null
 #  creator_name          :string           default(""), not null
 #  creator_type          :string
 #  event_type            :string           not null
@@ -13,7 +14,9 @@
 #  mailer_class_name     :string           default(""), not null
 #  message_subject       :string           default(""), not null
 #  new_state             :string           default(""), not null
+#  new_value             :text             default(""), not null
 #  old_state             :string           default(""), not null
+#  old_value             :text             default(""), not null
 #  requestable_type      :string
 #  subjects              :text             default([]), not null, is an Array
 #  subjects_note         :text             default(""), not null
@@ -26,6 +29,7 @@
 #  creator_id            :integer
 #  note_id               :bigint
 #  requestable_id        :bigint
+#  work_history_id       :bigint
 #
 # Indexes
 #
@@ -35,6 +39,7 @@
 #  index_timeline_events_on_assignee_id            (assignee_id)
 #  index_timeline_events_on_note_id                (note_id)
 #  index_timeline_events_on_requestable            (requestable_type,requestable_id)
+#  index_timeline_events_on_work_history_id        (work_history_id)
 #
 # Foreign Keys
 #
@@ -43,6 +48,7 @@
 #  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #  fk_rails_...  (assignee_id => staff.id)
 #  fk_rails_...  (note_id => notes.id)
+#  fk_rails_...  (work_history_id => work_histories.id)
 #
 FactoryBot.define do
   factory :timeline_event do

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -6,6 +6,7 @@
 #  age_range_max         :integer
 #  age_range_min         :integer
 #  age_range_note        :text             default(""), not null
+#  column_name           :string           default(""), not null
 #  creator_name          :string           default(""), not null
 #  creator_type          :string
 #  event_type            :string           not null
@@ -13,7 +14,9 @@
 #  mailer_class_name     :string           default(""), not null
 #  message_subject       :string           default(""), not null
 #  new_state             :string           default(""), not null
+#  new_value             :text             default(""), not null
 #  old_state             :string           default(""), not null
+#  old_value             :text             default(""), not null
 #  requestable_type      :string
 #  subjects              :text             default([]), not null, is an Array
 #  subjects_note         :text             default(""), not null
@@ -26,6 +29,7 @@
 #  creator_id            :integer
 #  note_id               :bigint
 #  requestable_id        :bigint
+#  work_history_id       :bigint
 #
 # Indexes
 #
@@ -35,6 +39,7 @@
 #  index_timeline_events_on_assignee_id            (assignee_id)
 #  index_timeline_events_on_note_id                (note_id)
 #  index_timeline_events_on_requestable            (requestable_type,requestable_id)
+#  index_timeline_events_on_work_history_id        (work_history_id)
 #
 # Foreign Keys
 #
@@ -43,6 +48,7 @@
 #  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #  fk_rails_...  (assignee_id => staff.id)
 #  fk_rails_...  (note_id => notes.id)
+#  fk_rails_...  (work_history_id => work_histories.id)
 #
 require "rails_helper"
 

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -79,17 +79,18 @@ RSpec.describe TimelineEvent do
 
     it do
       is_expected.to define_enum_for(:event_type).with_values(
+        age_range_subjects_verified: "age_range_subjects_verified",
+        assessment_section_recorded: "assessment_section_recorded",
         assessor_assigned: "assessor_assigned",
+        email_sent: "email_sent",
+        information_changed: "information_changed",
+        note_created: "note_created",
+        requestable_assessed: "requestable_assessed",
+        requestable_expired: "requestable_expired",
+        requestable_received: "requestable_received",
+        requestable_requested: "requestable_requested",
         reviewer_assigned: "reviewer_assigned",
         state_changed: "state_changed",
-        assessment_section_recorded: "assessment_section_recorded",
-        note_created: "note_created",
-        email_sent: "email_sent",
-        age_range_subjects_verified: "age_range_subjects_verified",
-        requestable_requested: "requestable_requested",
-        requestable_received: "requestable_received",
-        requestable_expired: "requestable_expired",
-        requestable_assessed: "requestable_assessed",
       ).backed_by_column_of_type(:string)
     end
 
@@ -110,6 +111,10 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_absence_of(:old_value) }
+      it { is_expected.to validate_absence_of(:new_value) }
     end
 
     context "with an reviewer assigned event type" do
@@ -129,6 +134,10 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_absence_of(:old_value) }
+      it { is_expected.to validate_absence_of(:new_value) }
     end
 
     context "with a state changed event type" do
@@ -148,6 +157,10 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_absence_of(:old_value) }
+      it { is_expected.to validate_absence_of(:new_value) }
     end
 
     context "with an assessment section recorded event type" do
@@ -167,6 +180,10 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_absence_of(:old_value) }
+      it { is_expected.to validate_absence_of(:new_value) }
     end
 
     context "with a note created event type" do
@@ -186,6 +203,10 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_absence_of(:old_value) }
+      it { is_expected.to validate_absence_of(:new_value) }
     end
 
     context "with an email sent event type" do
@@ -205,6 +226,10 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_absence_of(:old_value) }
+      it { is_expected.to validate_absence_of(:new_value) }
     end
 
     context "with an age range subjects verified event type" do
@@ -224,6 +249,10 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_presence_of(:subjects) }
       it { is_expected.to validate_absence_of(:requestable_id) }
       it { is_expected.to validate_absence_of(:requestable_type) }
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_absence_of(:old_value) }
+      it { is_expected.to validate_absence_of(:new_value) }
     end
 
     context "with a requestable requested event type" do
@@ -253,6 +282,10 @@ RSpec.describe TimelineEvent do
           ],
         )
       end
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_absence_of(:old_value) }
+      it { is_expected.to validate_absence_of(:new_value) }
     end
 
     context "with a requestable received event type" do
@@ -282,6 +315,10 @@ RSpec.describe TimelineEvent do
           ],
         )
       end
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_absence_of(:old_value) }
+      it { is_expected.to validate_absence_of(:new_value) }
     end
 
     context "with a requestable expired event type" do
@@ -311,6 +348,10 @@ RSpec.describe TimelineEvent do
           ],
         )
       end
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_absence_of(:old_value) }
+      it { is_expected.to validate_absence_of(:new_value) }
     end
 
     context "with a requestable assessed event type" do
@@ -340,6 +381,10 @@ RSpec.describe TimelineEvent do
           ],
         )
       end
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_absence_of(:old_value) }
+      it { is_expected.to validate_absence_of(:new_value) }
     end
   end
 end

--- a/spec/services/update_work_history_contact_email_spec.rb
+++ b/spec/services/update_work_history_contact_email_spec.rb
@@ -4,12 +4,14 @@ require "rails_helper"
 
 RSpec.describe UpdateWorkHistoryContactEmail do
   let(:application_form) { create(:application_form, :submitted) }
+  let(:user) { create(:staff, :confirmed) }
   let(:old_email_address) { "old@example.com" }
   let(:new_email_address) { "new@example.com" }
 
   subject(:call) do
     described_class.call(
       application_form:,
+      user:,
       old_email_address:,
       new_email_address:,
     )
@@ -42,6 +44,18 @@ RSpec.describe UpdateWorkHistoryContactEmail do
       expect { call }.to_not have_enqueued_mail(
         RefereeMailer,
         :reference_requested,
+      )
+    end
+
+    it "records a timeline event" do
+      expect { call }.to have_recorded_timeline_event(
+        :information_changed,
+        creator: user,
+        application_form:,
+        work_history:,
+        column_name: "contact_email",
+        old_value: old_email_address,
+        new_value: new_email_address,
       )
     end
   end
@@ -84,6 +98,18 @@ RSpec.describe UpdateWorkHistoryContactEmail do
       expect { call }.to_not have_enqueued_mail(
         RefereeMailer,
         :reference_requested,
+      )
+    end
+
+    it "records a timeline event" do
+      expect { call }.to have_recorded_timeline_event(
+        :information_changed,
+        creator: user,
+        application_form:,
+        work_history:,
+        column_name: "contact_email",
+        old_value: old_email_address,
+        new_value: new_email_address,
       )
     end
   end


### PR DESCRIPTION
This adds a new kind of timeline event which tracks when information on an application form has changed after it's been submitted. I've also updated the service class we use to change referee email addresses to record this timeline event.

[Trello Card](https://trello.com/c/ruVwrHeg/2065-add-timeline-events-for-changing-application-information)