### PR TITLE
Avoid chances of double verification

### DIFF
--- a/app/services/verify_assessment.rb
+++ b/app/services/verify_assessment.rb
@@ -18,6 +18,8 @@ class VerifyAssessment
   end
 
   def call
+    raise AlreadyVerified if assessment.verify?
+
     reference_requests =
       ActiveRecord::Base.transaction do
         assessment.verify!
@@ -34,6 +36,9 @@ class VerifyAssessment
     send_reference_request_emails(reference_requests)
 
     reference_requests
+  end
+
+  class AlreadyVerified < StandardError
   end
 
   private

--- a/spec/services/verify_assessment_spec.rb
+++ b/spec/services/verify_assessment_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe VerifyAssessment do
     )
   end
 
+  describe "when already verified" do
+    let(:assessment) { create(:assessment, :verify, application_form:) }
+
+    it "raises an error" do
+      expect { call }.to raise_error(VerifyAssessment::AlreadyVerified)
+    end
+  end
+
   describe "creating professional standing request" do
     subject(:professional_standing_request) do
       ProfessionalStandingRequest.find_by(assessment:)


### PR DESCRIPTION
There's been a case where an application went through the verification flow twice. It's not entirely clear how this happened, but this conditional should prevent it from happening.