### PR TITLE
Improve failure reasons timeline events

### DIFF
--- a/app/components/timeline_entry/_failure_reasons.html.erb
+++ b/app/components/timeline_entry/_failure_reasons.html.erb
@@ -1,0 +1,9 @@
+<% failure_reasons.each do |failure_reason| %>
+  <li>
+    <p class="govuk-body">
+      <%= t(failure_reason.key, scope: %i[assessor_interface assessment_sections failure_reasons as_statement]) %>
+    </p>
+
+    <%= simple_format failure_reason.assessor_feedback %>
+  </li>
+<% end %>

--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -30,15 +30,15 @@
           <%= govuk_tag(text: "Not passed", colour: "red") %>
         <% end %>
       </p>
-      <% if (failure_reason = description_vars[:failure_reasons].first).present? %>
+
+      <% if (visible_failure_reasons = description_vars[:visible_failure_reasons]).present? %>
         <%= govuk_inset_text do %>
           <ul class="govuk-list--bullet">
-            <%= render "shared/assessor_failure_reason_list_item", failure_reason: %>
-            <% if description_vars[:failure_reasons].size > 1 %>
+            <%= render "timeline_entry/failure_reasons", failure_reasons: visible_failure_reasons %>
+
+            <% if (hidden_failure_reasons = description_vars[:hidden_failure_reasons]).present? %>
               <%= govuk_details(summary_text: "View additional reasons") do %>
-                <% description_vars[:failure_reasons].drop(1).each do |failure_reason| %>
-                    <%= render "shared/assessor_failure_reason_list_item", failure_reason: %>
-                <% end %>
+                <%= render "timeline_entry/failure_reasons", failure_reasons: hidden_failure_reasons %>
               <% end %>
             <% end %>
           </ul>

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -72,10 +72,31 @@ module TimelineEntry
 
     def assessment_section_recorded_vars
       section = timeline_event.assessment_section
+      selected_failure_reasons = section.selected_failure_reasons
+
+      visible_failure_reasons =
+        (
+          if selected_failure_reasons.count <= 2
+            selected_failure_reasons
+          else
+            selected_failure_reasons.take(1)
+          end
+        )
+
+      hidden_failure_reasons =
+        (
+          if selected_failure_reasons.count <= 2
+            []
+          else
+            selected_failure_reasons.drop(1)
+          end
+        )
+
       {
         section_name: section.key.titleize,
         passed: section.passed,
-        failure_reasons: section.selected_failure_reasons,
+        visible_failure_reasons:,
+        hidden_failure_reasons:,
       }
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,8 @@ class ApplicationController < ActionController::Base
   include DfE::Analytics::Requests
   include Pundit::Authorization
 
-  default_form_builder(GOVUKDesignSystemFormBuilder::FormBuilder)
+  default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+  append_view_path Rails.root.join("app/components")
 
   before_action :authenticate,
                 unless: -> { FeatureFlags::FeatureFlag.active?(:service_open) }

--- a/app/views/shared/_assessor_failure_reason_list_item.erb
+++ b/app/views/shared/_assessor_failure_reason_list_item.erb
@@ -1,7 +1,0 @@
-<li>
-  <p class="govuk-body">
-    <%= t(failure_reason.key, scope: %i[assessor_interface assessment_sections failure_reasons as_statement]) %>
-  </p>
-
-  <%= simple_format failure_reason.assessor_feedback %>
-</li>


### PR DESCRIPTION
This improves the failure reasons timeline events by only hidding additional failure reasons if there are more than two, as the link to "View additional responses" takes up the space of a second entry.

[Trello Card](https://trello.com/c/fZllSVmc/2070-show-two-failure-reasons-minimum-in-timeline)