### PR TITLE
Clarify "Clear selection" button

### DIFF
--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -7,8 +7,11 @@
 
   <%= form_with model: @view_object.filter_form, url: filters_apply_assessor_interface_application_forms_path, method: :post, class: "app-application-forms__filter-form" do |f| %>
     <%= f.govuk_submit t(".filters.apply") do %>
-      <%= govuk_link_to t(".filters.clear"), filters_clear_assessor_interface_application_forms_path %>
-    <%- end -%>
+      <a href="<%= filters_clear_assessor_interface_application_forms_path %>" class="govuk-link">
+        <%= t(".filters.clear") %>
+        <span class="govuk-visually-hidden"><%= t(".filters.of_filter") %></span>
+      </a>
+    <% end %>
 
     <section id="app-applications-filters-assessor" class="app-checkbox-filter app-checkbox-filter--enhanced">
       <div class="app-checkbox-filter__container">

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -7,6 +7,7 @@ en:
           title: Filters
           apply: Apply filters
           clear: Clear selection
+          of_filter: of filters
         results:
           empty: No applications found. Use the filters on the left to try again or refine your search.
 


### PR DESCRIPTION
This clarifies what the button does by adding a visually hidden "of filters" text which will be read out by screen readers and other accessibility tools.

[Trello Card](https://trello.com/c/fJaXoq0L/2071-fix-clear-selection-label)