### PR TITLE
Add UpdateWorkHistoryContact service

### DIFF
--- a/app/services/update_work_history_contact.rb
+++ b/app/services/update_work_history_contact.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+class UpdateWorkHistoryContact
+  include ServicePattern
+
+  def initialize(work_history:, user:, name: nil, job: nil, email: nil)
+    @work_history = work_history
+    @user = user
+    @name = name
+    @job = job
+    @email = email
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      change_value("contact_name", name) if name.present?
+
+      change_value("contact_job", job) if job.present?
+
+      if email.present?
+        change_value("contact_email", email)
+        work_history.update!(
+          canonical_contact_email: EmailAddress.canonical(email),
+        )
+      end
+    end
+
+    if email.present? && (reference_request = work_history.reference_request)
+      RefereeMailer.with(reference_request:).reference_requested.deliver_later
+    end
+  end
+
+  private
+
+  attr_reader :work_history, :user, :name, :job, :email
+
+  delegate :application_form, to: :work_history
+
+  def change_value(column_name, new_value)
+    old_value = work_history.send(column_name)
+    work_history.update!(column_name => new_value)
+    create_timeline_event(column_name, old_value, new_value)
+  end
+
+  def create_timeline_event(column_name, old_value, new_value)
+    TimelineEvent.create!(
+      event_type: "information_changed",
+      application_form:,
+      creator: user,
+      work_history:,
+      column_name:,
+      old_value:,
+      new_value:,
+    )
+  end
+end

--- a/app/services/update_work_history_contact_email.rb
+++ b/app/services/update_work_history_contact_email.rb
@@ -17,16 +17,11 @@ class UpdateWorkHistoryContactEmail
 
   def call
     work_histories.each do |work_history|
-      work_history.update!(
-        contact_email: new_email_address,
-        canonical_contact_email: EmailAddress.canonical(new_email_address),
+      UpdateWorkHistoryContact.call(
+        work_history:,
+        user:,
+        email: new_email_address,
       )
-
-      if (reference_request = work_history.reference_request)
-        RefereeMailer.with(reference_request:).reference_requested.deliver_later
-      end
-
-      create_timeline_event(work_history)
     end
   end
 
@@ -38,18 +33,6 @@ class UpdateWorkHistoryContactEmail
     application_form.work_histories.where(
       "LOWER(contact_email) = ?",
       old_email_address.downcase,
-    )
-  end
-
-  def create_timeline_event(work_history)
-    TimelineEvent.create!(
-      event_type: "information_changed",
-      application_form:,
-      creator: user,
-      work_history:,
-      column_name: "contact_email",
-      old_value: old_email_address,
-      new_value: new_email_address,
     )
   end
 end

--- a/spec/services/update_work_history_contact_spec.rb
+++ b/spec/services/update_work_history_contact_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UpdateWorkHistoryContact do
+  let(:work_history) { create(:work_history, :completed) }
+  let(:user) { create(:staff, :confirmed) }
+  let(:new_name) { "New name" }
+  let(:new_job) { "New job" }
+  let(:new_email) { "new@example.com" }
+
+  subject(:call) do
+    described_class.call(
+      work_history:,
+      user:,
+      name: new_name,
+      job: new_job,
+      email: new_email,
+    )
+  end
+
+  it "changes the contact name" do
+    expect { call }.to change(work_history, :contact_name).to(new_name)
+  end
+
+  it "changes the contact job" do
+    expect { call }.to change(work_history, :contact_job).to(new_job)
+  end
+
+  it "changes the contact email" do
+    expect { call }.to change(work_history, :contact_email).to(new_email)
+  end
+
+  it "changes the canonical contact email" do
+    expect { call }.to change(work_history, :canonical_contact_email).to(
+      new_email,
+    )
+  end
+
+  it "doesn't send any emails" do
+    expect { call }.to_not have_enqueued_mail(
+      RefereeMailer,
+      :reference_requested,
+    )
+  end
+
+  it "records timeline events" do
+    expect { call }.to have_recorded_timeline_event(
+      :information_changed,
+      creator: user,
+      work_history:,
+    )
+  end
+
+  describe "when references already sent out" do
+    before { create(:reference_request, work_history:) }
+
+    it "sends an email" do
+      expect { call }.to have_enqueued_mail(RefereeMailer, :reference_requested)
+    end
+  end
+end


### PR DESCRIPTION
This adds a service allowing assessors to change the contact details of an item of work history. It also sends an email to referees if necessary, and records timeline events about the changed information.

[Trello Card](https://trello.com/c/1os91x1f/2072-update-service-for-changing-referee-information)