### PR TITLE
Allow third-party professional standing to be submitted

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -79,22 +79,15 @@ class AssessorInterface::ApplicationFormsShowViewObject
         I18n.t(
           "assessor_interface.application_forms.show.assessment_tasks.items.await_professional_standing_request",
         ),
-      link:
-        if assessment.all_preliminary_sections_passed?
-          [
-            :location,
-            :assessor_interface,
-            application_form,
-            assessment,
-            :professional_standing_request,
-          ]
-        end,
+      link: [
+        :location,
+        :assessor_interface,
+        application_form,
+        assessment,
+        :professional_standing_request,
+      ],
       status:
-        if assessment.all_preliminary_sections_passed?
-          professional_standing_request.received? ? :completed : :waiting_on
-        else
-          :cannot_start
-        end,
+        professional_standing_request.received? ? :completed : :waiting_on,
     }
   end
 

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -129,18 +129,6 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           )
         end
       end
-
-      context "when preliminary checks exist" do
-        before { create(:assessment_section, :preliminary, assessment:) }
-
-        it do
-          is_expected.to include_task_list_item(
-            "Pre-assessment tasks",
-            "Awaiting third-party professional standing",
-            status: :cannot_start,
-          )
-        end
-      end
     end
 
     context "with a preliminary check" do


### PR DESCRIPTION
Currently it's not possible to access this section of the form without first completing the preliminary assessment, but we'd like to open this up as we sometimes receive the professional standing before it's received.