### PR TITLE
Remove teaching_authority_checks_sanctions

### DIFF
--- a/app/controllers/support_interface/countries_controller.rb
+++ b/app/controllers/support_interface/countries_controller.rb
@@ -77,7 +77,6 @@ class SupportInterface::CountriesController < SupportInterface::BaseController
       :teaching_authority_other,
       :teaching_authority_sanction_information,
       :teaching_authority_status_information,
-      :teaching_authority_checks_sanctions,
       :teaching_authority_online_checker_url,
     )
   end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -10,7 +10,6 @@
 #  requires_preliminary_check              :boolean          default(FALSE), not null
 #  teaching_authority_address              :text             default(""), not null
 #  teaching_authority_certificate          :text             default(""), not null
-#  teaching_authority_checks_sanctions     :boolean          default(TRUE), not null
 #  teaching_authority_emails               :text             default([]), not null, is an Array
 #  teaching_authority_name                 :text             default(""), not null
 #  teaching_authority_online_checker_url   :string           default(""), not null

--- a/app/views/support_interface/countries/confirm_edit.html.erb
+++ b/app/views/support_interface/countries/confirm_edit.html.erb
@@ -79,6 +79,5 @@
   <%= f.hidden_field :teaching_authority_status_information, value: @country.teaching_authority_status_information%>
   <%= f.hidden_field :teaching_authority_other, value: @country.teaching_authority_other %>
   <%= f.hidden_field :teaching_authority_online_checker_url, value: @country.teaching_authority_online_checker_url %>
-  <%= f.hidden_field :teaching_authority_checks_sanctions, value: @country.teaching_authority_checks_sanctions %>
   <%= f.govuk_submit "Confirm save", prevent_double_click: false %>
 <% end %>

--- a/app/views/support_interface/countries/edit.html.erb
+++ b/app/views/support_interface/countries/edit.html.erb
@@ -12,8 +12,6 @@
   <%= render "shared/qualifications_information_form_fields", f: %>
   <%= render "shared/preliminary_check_form_fields", f: %>
 
-  <%= f.govuk_check_box :teaching_authority_checks_sanctions, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Teaching authority checks sanctions" } %>
-
   <%= f.govuk_text_area :all_regions,
                         value: @all_regions,
                         label: { text: "Regions" },

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -127,7 +127,6 @@
     - teaching_authority_certificate
     - teaching_authority_other
     - teaching_authority_name
-    - teaching_authority_checks_sanctions
     - teaching_authority_online_checker_url
     - teaching_authority_status_information
     - teaching_authority_sanction_information

--- a/db/migrate/20230713104829_remove_teaching_authority_checks_sanctions_from_countries.rb
+++ b/db/migrate/20230713104829_remove_teaching_authority_checks_sanctions_from_countries.rb
@@ -1,0 +1,11 @@
+class RemoveTeachingAuthorityChecksSanctionsFromCountries < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    remove_column :countries,
+                  :teaching_authority_checks_sanctions,
+                  :boolean,
+                  null: false,
+                  default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_11_092318) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_13_104829) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -161,7 +161,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_11_092318) do
     t.text "teaching_authority_certificate", default: "", null: false
     t.text "teaching_authority_other", default: "", null: false
     t.text "teaching_authority_name", default: "", null: false
-    t.boolean "teaching_authority_checks_sanctions", default: true, null: false
     t.string "teaching_authority_online_checker_url", default: "", null: false
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -10,7 +10,6 @@
 #  requires_preliminary_check              :boolean          default(FALSE), not null
 #  teaching_authority_address              :text             default(""), not null
 #  teaching_authority_certificate          :text             default(""), not null
-#  teaching_authority_checks_sanctions     :boolean          default(TRUE), not null
 #  teaching_authority_emails               :text             default([]), not null, is an Array
 #  teaching_authority_name                 :text             default(""), not null
 #  teaching_authority_online_checker_url   :string           default(""), not null
@@ -28,8 +27,6 @@
 FactoryBot.define do
   factory :country do
     sequence :code, Country::CODES.cycle
-
-    teaching_authority_checks_sanctions { true }
 
     trait :requires_secondary_education_teaching_qualification do
       sequence :code,

--- a/spec/helpers/proof_of_recognition_helper_spec.rb
+++ b/spec/helpers/proof_of_recognition_helper_spec.rb
@@ -13,18 +13,12 @@ RSpec.describe ProofOfRecognitionHelper do
       application_form_skip_work_history?: application_form_skip_work_history,
       teaching_authority_name: "teaching authority",
       teaching_authority_certificate: "letter",
-      country:
-        double(
-          teaching_authority_checks_sanctions?:
-            teaching_authority_checks_sanctions,
-        ),
     )
   end
   let(:status) { false }
   let(:sanction) { false }
   let(:teaching_authority_provides_written_statement) { false }
   let(:application_form_skip_work_history) { false }
-  let(:teaching_authority_checks_sanctions) { true }
 
   describe "proof_of_recognition_requirements_for" do
     subject { proof_of_recognition_requirements_for(region:) }
@@ -93,9 +87,8 @@ RSpec.describe ProofOfRecognitionHelper do
       end
     end
 
-    context "with a country where authority doesn't check sanctions and the region skips work history" do
+    context "with a country where the region skips work history" do
       let(:sanction) { true }
-      let(:teaching_authority_checks_sanctions) { false }
       let(:application_form_skip_work_history) { true }
 
       it do

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -10,7 +10,6 @@
 #  requires_preliminary_check              :boolean          default(FALSE), not null
 #  teaching_authority_address              :text             default(""), not null
 #  teaching_authority_certificate          :text             default(""), not null
-#  teaching_authority_checks_sanctions     :boolean          default(TRUE), not null
 #  teaching_authority_emails               :text             default([]), not null, is an Array
 #  teaching_authority_name                 :text             default(""), not null
 #  teaching_authority_online_checker_url   :string           default(""), not null

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_status_information
     when_i_fill_teaching_authority_certificate
     when_i_fill_teaching_authority_online_checker_url
-    when_i_fill_teaching_authority_checks_sanctions
     when_i_fill_qualifications_information
     when_i_check_requires_preliminary_check
     when_i_fill_regions
@@ -197,10 +196,6 @@ RSpec.describe "Countries support", type: :system do
   rescue Capybara::ElementNotFound
     fill_in "country-teaching-authority-online-checker-url-field",
             with: "https://www.example.com/checks"
-  end
-
-  def when_i_fill_teaching_authority_checks_sanctions
-    check "country-teaching-authority-checks-sanctions-1-field", visible: false
   end
 
   def when_i_fill_teaching_authority_sanction_information


### PR DESCRIPTION
This removes the field from countries and the support console as it's not being used for anything and is confusing.