### PR TITLE
Fix when we ask applicants to request their written statement

### DIFF
--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -120,11 +120,12 @@ class TeacherInterface::ApplicationFormShowViewObject
   end
 
   def request_professional_standing_certificate?
-    professional_standing_request&.requested? &&
+    teaching_authority_provides_written_statement &&
+      professional_standing_request&.requested? &&
       (
-        assessment&.all_preliminary_sections_passed? ||
-          application_form&.teaching_authority_provides_written_statement
-      )
+        !requires_preliminary_check ||
+          assessment&.all_preliminary_sections_passed?
+      ) || false
   end
 
   delegate :region, to: :application_form
@@ -134,6 +135,8 @@ class TeacherInterface::ApplicationFormShowViewObject
   delegate :needs_work_history,
            :needs_written_statement,
            :needs_registration_number,
+           :teaching_authority_provides_written_statement,
+           :requires_preliminary_check,
            to: :application_form,
            allow_nil: true
 

--- a/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
@@ -344,37 +344,36 @@ RSpec.describe TeacherInterface::ApplicationFormShowViewObject do
       view_object.request_professional_standing_certificate?
     end
 
-    context "when assessment preliminary checks are complete" do
-      before do
-        create(:application_form, assessment:, teacher: current_teacher)
-        create(:professional_standing_request, assessment:)
-        create(:assessment_section, :preliminary, :passed, assessment:)
-      end
+    it { is_expected.to be false }
 
-      it { is_expected.to be true }
-    end
-
-    context "when application form written statement comes from teaching authority" do
-      before do
+    context "when the teaching authority provides the written statement" do
+      let(:application_form) do
         create(
           :application_form,
           assessment:,
           teacher: current_teacher,
           teaching_authority_provides_written_statement: true,
         )
-        create(:professional_standing_request, assessment:)
       end
 
-      it { is_expected.to be true }
-    end
-
-    context "when the application is not waiting on anything" do
-      before do
-        create(:application_form, assessment:, teacher: current_teacher)
-        create(:professional_standing_request, :received, assessment:)
-      end
+      before { create(:professional_standing_request, assessment:) }
 
       it { is_expected.to be false }
+
+      context "when there are preliminary checks and they are complete" do
+        before do
+          application_form.update!(requires_preliminary_check: true)
+          create(:assessment_section, :preliminary, :passed, assessment:)
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context "when there are no preliminary checks" do
+        before { application_form.update!(requires_preliminary_check: false) }
+
+        it { is_expected.to be true }
+      end
     end
   end
 end


### PR DESCRIPTION
This ensures that we only show the page telling the applicant to request their written statement from their teaching authority once they have passed their preliminary checks, which is especially helpful in the case where it costs money to get the written statement.

[Trello Card](https://trello.com/c/A4adzrrY/2084-update-lops-messaging-for-nigerian-applicants-at-the-point-of-application-submission)