### PR TITLE
Improve performance of personas page

### DIFF
--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -124,7 +124,7 @@
               bucket = region_bucket_for_persona(persona)
               govuk_tag(text: bucket) if bucket
             end
-            row.with_cell { CountryName.from_country(persona[:teacher].application_form.country) }
+            row.with_cell { CountryName.from_country(persona[:application_form].country) }
 
             row.with_cell { persona_check_tag(persona[:status_check]) }
             row.with_cell { persona_check_tag(persona[:sanction_check]) }


### PR DESCRIPTION
This improves the load time of the personas page by avoiding a query to the application form for each teacher.