### PR TITLE
Remove third application form reminder

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -237,13 +237,8 @@ class ApplicationForm < ApplicationRecord
   end
 
   def should_send_reminder_email?(days_until_expired, number_of_reminders_sent)
-    return true if days_until_expired <= 14 && number_of_reminders_sent.zero?
-
-    return true if days_until_expired <= 7 && number_of_reminders_sent == 1
-
-    return true if days_until_expired <= 2 && number_of_reminders_sent == 2
-
-    false
+    (days_until_expired <= 14 && number_of_reminders_sent.zero?) ||
+      (days_until_expired <= 7 && number_of_reminders_sent == 1)
   end
 
   def send_reminder_email(number_of_reminders_sent)

--- a/app/views/teacher_mailer/application_not_submitted.text.erb
+++ b/app/views/teacher_mailer/application_not_submitted.text.erb
@@ -9,8 +9,6 @@ We need to let you know that if you do not complete and submit your application 
 We contacted you a week ago about your draft application for qualified teacher status (QTS).
 
 If you do not complete and submit your application by <%= @application_form.expired_at.to_date.to_fs(:long_ordinal_uk) %> we’ll delete the application.
-<% when 2 %>
-Your draft application for qualified teacher status (QTS) will be deleted in 2 days on <%= @application_form.expired_at.to_date.to_fs(:long_ordinal_uk) %> if you do not complete and submit it before then.
 <% end %>
 
 # What happens if your application is deleted?

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -14,7 +14,6 @@ en:
         subject:
           0: Your draft QTS application will be deleted in 2 weeks
           1: Your draft QTS application will be deleted in 1 week
-          2: Your draft QTS application will be deleted in 2 days
       application_received:
         subject: We’ve received your application for qualified teacher status (QTS)
       further_information_received:

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -121,16 +121,6 @@ RSpec.describe TeacherMailer, type: :mailer do
           )
         end
       end
-
-      context "with two days to go" do
-        let(:number_of_reminders_sent) { 2 }
-
-        it do
-          is_expected.to eq(
-            "Your draft QTS application will be deleted in 2 days",
-          )
-        end
-      end
     end
 
     describe "#to" do
@@ -173,17 +163,6 @@ RSpec.describe TeacherMailer, type: :mailer do
         it do
           is_expected.to include(
             "If you do not complete and submit your application by 1 July 2020 we’ll delete the application.",
-          )
-        end
-      end
-
-      context "with two days to go" do
-        let(:number_of_reminders_sent) { 2 }
-
-        it do
-          is_expected.to include(
-            "Your draft application for qualified teacher status (QTS) will be " \
-              "deleted in 2 days on 1 July 2020 if you do not complete and submit it before then.",
           )
         end
       end

--- a/spec/services/send_reminder_email_spec.rb
+++ b/spec/services/send_reminder_email_spec.rb
@@ -133,12 +133,6 @@ RSpec.describe SendReminderEmail do
         include_examples "second reminder email",
                          "sends an application not submitted email"
       end
-
-      context "with less than one day remaining" do
-        let(:application_created_at) { (6.months - 1.day).ago }
-        include_examples "third reminder email",
-                         "sends an application not submitted email"
-      end
     end
 
     context "with a submitted application form" do


### PR DESCRIPTION
We'd like to reduce the number of reminders we're sending applicants about unfinished applications as there is a concern that this will substantially increase the size of the backlog.

[Trello Card](https://trello.com/c/DqyQTmGm/2085-reduce-the-number-of-reminders-sent-out-for-draft-applications)