### PR TITLE
Increase written statement expiration to 180 days

### DIFF
--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -29,7 +29,7 @@ class ProfessionalStandingRequest < ApplicationRecord
 
   def expires_after
     if application_form.teaching_authority_provides_written_statement
-      18.weeks # 90 working days
+      36.weeks # 180 working days
     else
       6.weeks # 30 working days
     end

--- a/app/views/shared/eligible_region_content_components/_proof_of_recognition.html.erb
+++ b/app/views/shared/eligible_region_content_components/_proof_of_recognition.html.erb
@@ -70,11 +70,11 @@
 
     <% if teaching_authority_provides_written_statement %>
       <p class="govuk-body">
-        This must be dated within 3 months of you applying for QTS.
+        This must be dated within 6 months of you applying for QTS.
       </p>
 
       <p class="govuk-body">
-        If we do not receive the document within 90 days of the date that you submit your application, we’ll need to close your application.
+        If we do not receive the document within 180 days of the date that you submit your application, we’ll need to close your application.
       </p>
     <% end %>
   <% end %>

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -86,7 +86,7 @@
           <li><%= requirement %></li>
         <%- end -%>
       </ul>
-      <p class="govuk-body">This written confirmation must be dated within 3 months of you applying for QTS.</p>
+      <p class="govuk-body">This written confirmation must be dated within 6 months of you applying for QTS.</p>
 
       <% if @application_form.region.status_check_written? %>
         <% if @application_form.region.teaching_authority_status_information.present?%>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -151,7 +151,7 @@ en:
         written_statement_completion_date: induction letter shows the completion date (if applicable)
         written_statement_induction: induction letter shows the applicant completed induction in the country (if applicable)
         written_statement_present: letter from the country or state’s competent authority provided
-        written_statement_recent: letter from the country or state’s competent authority was issued within the last 3 months
+        written_statement_recent: letter from the country or state’s competent authority was issued within the last 6 months
         written_statement_registration_number: induction letter shows the teacher reference (TR) number (if applicable)
         written_statement_school_name: induction letter shows the name of the school (if applicable)
         written_statement_signature: induction letter shows the signature of the administration department or headteacher/principal (if applicable)
@@ -207,7 +207,7 @@ en:
           work_history_duration: The applicant’s work experience does not meet the minimum duration requirements.
           written_statement_illegible: The letter is illegible or in a format that we cannot accept.
           written_statement_information: The letter is missing information.
-          written_statement_recent: The letter was not issued within the last 3 months.
+          written_statement_recent: The letter was not issued within the last 6 months.
         as_question:
           label:
             teaching_qualifications_not_at_required_level: Does the teaching qualification meet the required academic level? (level 6 or higher)

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -10,7 +10,7 @@ en:
       show:
         declined:
           further_information_request_expired: Your application has been declined as you did not respond to the assessor’s request for further information within the specified time.
-          professional_standing_request_expired: Your application has been declined as we did not receive your %{certificate_name} from %{teaching_authority_name} within the 90-day period.
+          professional_standing_request_expired: Your application has been declined as we did not receive your %{certificate_name} from %{teaching_authority_name} within 180 days.
         draft:
           check: Check your application
           save: Save and sign out

--- a/spec/jobs/expire_requestable_job_spec.rb
+++ b/spec/jobs/expire_requestable_job_spec.rb
@@ -96,14 +96,14 @@ RSpec.describe ExpireRequestableJob do
         create(:professional_standing_request, created_at:, assessment:)
       end
 
-      context "when less than 18 weeks old" do
-        let(:created_at) { (18.weeks - 1.hour).ago }
+      context "when less than 36 weeks old" do
+        let(:created_at) { (36.weeks - 1.hour).ago }
 
         it_behaves_like "not expired requestable"
       end
 
-      context "when it is more than 18 weeks old" do
-        let(:created_at) { (18.weeks + 1.hour).ago }
+      context "when it is more than 36 weeks old" do
+        let(:created_at) { (36.weeks + 1.hour).ago }
 
         it_behaves_like "expired requestable"
       end

--- a/spec/models/professional_standing_request_spec.rb
+++ b/spec/models/professional_standing_request_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe ProfessionalStandingRequest, type: :model do
 
     context "when the teaching authority provides the written statement" do
       let(:teaching_authority_provides_written_statement) { true }
-      it { is_expected.to eq(18.weeks) }
+      it { is_expected.to eq(36.weeks) }
     end
 
     context "when the applicant provides the written statement" do

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
         is_expected.to match(
           /we did not receive your letter that proves you’re recognised as a teacher/,
         )
-        is_expected.to match(/from teaching authority within the 90-day period/)
+        is_expected.to match(/from teaching authority within 180 days/)
       end
     end
 


### PR DESCRIPTION
We'd like to give applicants more time to receive their written statement as we're receiving a high number just after the deadline which is requiring us to rollback many applications.