### PR TITLE
Add a warning about deleted uploads

### DIFF
--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -129,7 +129,16 @@ module CheckYourAnswersSummary
       uploads =
         scope.order(:created_at).select { |upload| upload.attachment.present? }
 
-      format_array(uploads, field)
+      html = format_array(uploads, field)
+
+      malware_scan_active =
+        FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
+
+      if malware_scan_active && scope.scan_result_suspect.exists?
+        "#{html}<br /><br /><em>One or more upload has been deleted by the virus scanner.</em>"
+      else
+        html
+      end
     end
 
     def format_array(list, field)

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -275,6 +275,25 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       )
     end
 
+    context "with a suspect malware scan" do
+      before do
+        FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result)
+        create(
+          :upload,
+          malware_scan_result: "suspect",
+          document: model.document,
+        )
+      end
+
+      after { FeatureFlags::FeatureFlag.deactivate(:fetch_malware_scan_result) }
+
+      it "includes a warning" do
+        expect(row.at_css(".govuk-summary-list__value").text).to include(
+          "One or more upload has been deleted by the virus scanner",
+        )
+      end
+    end
+
     it "renders the change link" do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 


### PR DESCRIPTION
Sometimes an upload gets deleted as it's suspected malware, but we don't explain this to assessors, so it looks as though the applicant didn't upload a document in the first place.

This adds a warning message explaining why it looks like there are no documents uploaded.

[Trello Card](https://trello.com/c/Gap38WDq/2115-investigation-into-returned-fi-file-upload-with-no-file-uploaded)