### PR TITLE
Allow backfilling waiting on preliminary checks

### DIFF
--- a/app/services/backfill_preliminary_checks.rb
+++ b/app/services/backfill_preliminary_checks.rb
@@ -37,11 +37,18 @@ class BackfillPreliminaryChecks
     @applications_forms ||=
       ApplicationForm
         .includes(assessment: :sections)
-        .submitted
         .where(
           region: regions,
           assessor: nil,
           requires_preliminary_check: false,
+        )
+        .merge(
+          ApplicationForm.submitted.or(
+            ApplicationForm.waiting_on.where(
+              teaching_authority_provides_written_statement: true,
+              waiting_on_professional_standing: true,
+            ),
+          ),
         )
   end
 end


### PR DESCRIPTION
If an application is in the waiting on status because the teaching authority provides the written statement, we were previously ignoring it as it wouldn't be in the "submitted" state.

However, this is incorrect, as some applications will have two pre-assessment tasks, one waiting on the profession standing, and one to complete the preliminary check.