### PR TITLE
Improve Azure error messages

### DIFF
--- a/app/controllers/staff/omniauth_callbacks_controller.rb
+++ b/app/controllers/staff/omniauth_callbacks_controller.rb
@@ -14,13 +14,13 @@ class Staff::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
-  def failure
-    redirect_to new_staff_session_url, alert: t(".failure")
-  end
-
   protected
 
   def after_sign_in_path_for(resource)
     stored_location_for(resource) || assessor_interface_root_path
+  end
+
+  def after_omniauth_failure_path_for(_scope)
+    new_staff_session_url
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,8 +41,7 @@ en:
 
   staff:
     omniauth_callbacks:
-      azure_activedirectory_v2:
-        failure: "There was a problem signing you in. Please try again."
+      failure: There was a problem signing you in. Please try again.
 
   activerecord:
     attributes:


### PR DESCRIPTION
This lets us use the failure method of the super class which includes an improved error message with a reason for the failure. At the moment we get a message saying the locale string cannot be found.

## Screenshot

![Screenshot 2023-07-25 at 10 11 11](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/0177cd0a-e9bf-4601-9679-ec79d04a1b0d)
