### PR TITLE
Improve induction question for Scotland

### DIFF
--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -69,7 +69,11 @@ module AssessorInterface
       elsif assessment_section.professional_standing? &&
             application_form.created_under_new_regulations? &&
             !application_form.needs_work_history
-        InductionRequiredForm
+        if CountryCode.scotland?(application_form.country.code)
+          ScotlandFullRegistrationForm
+        else
+          InductionRequiredForm
+        end
       elsif application_form.english_language_exempt? &&
             assessment_section.personal_information?
         PersonalInformationForm

--- a/app/forms/assessor_interface/scotland_full_registration_form.rb
+++ b/app/forms/assessor_interface/scotland_full_registration_form.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class AssessorInterface::ScotlandFullRegistrationForm < AssessorInterface::InductionRequiredForm
+  attribute :scotland_full_registration, :boolean
+
+  validates :scotland_full_registration, inclusion: [true, false], if: :passed
+
+  def save
+    return false unless valid?
+
+    ActiveRecord::Base.transaction do
+      assessment.update!(scotland_full_registration:)
+      super
+    end
+
+    true
+  end
+
+  class << self
+    def initial_attributes(assessment_section)
+      assessment = assessment_section.assessment
+      super.merge(
+        scotland_full_registration: assessment.scotland_full_registration,
+      )
+    end
+
+    def permittable_parameters
+      args, kwargs = super
+      args += %i[scotland_full_registration]
+      [args, kwargs]
+    end
+  end
+
+  delegate :assessment, to: :assessment_section
+end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -11,6 +11,7 @@
 #  recommendation_assessor_note              :text             default(""), not null
 #  recommended_at                            :datetime
 #  references_verified                       :boolean
+#  scotland_full_registration                :boolean
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null

--- a/app/views/assessor_interface/assessment_sections/_form.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_form.html.erb
@@ -33,6 +33,10 @@
     <%= render "shared/age_range_subjects_form_fields", f: %>
   <% end %>
 
+  <% if form.is_a?(AssessorInterface::ScotlandFullRegistrationForm) %>
+    <%= f.govuk_collection_radio_buttons :scotland_full_registration, %i[true false], :itself %>
+  <% end %>
+
   <% if form.is_a?(AssessorInterface::InductionRequiredForm) %>
     <%= f.govuk_collection_radio_buttons :induction_required,
                                          %i[false true],

--- a/app/views/assessor_interface/assessment_sections/_form.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_form.html.erb
@@ -38,10 +38,12 @@
   <% end %>
 
   <% if form.is_a?(AssessorInterface::InductionRequiredForm) %>
-    <%= f.govuk_collection_radio_buttons :induction_required,
-                                         %i[false true],
-                                         :itself,
-                                         legend: { text: t(view_object.country.code, scope: %i[assessor_interface assessment_sections induction_required]) } %>
+    <%= f.govuk_radio_buttons_fieldset :induction_required, legend: { text: t(view_object.country.code, scope: %i[assessor_interface assessment_sections induction_required]) } do %>
+      <%= f.govuk_radio_button :induction_required, :false, link_errors: true %>
+      <%= f.govuk_radio_button :induction_required, :true do %>
+        <p class="govuk-hint">We can still award QTS, but applicant must complete a statutory induction period.</p>
+      <% end %>
+    <% end %>
   <% end %>
 
   <% if view_object.preliminary? %>

--- a/app/views/assessor_interface/assessment_sections/_form.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_form.html.erb
@@ -35,13 +35,9 @@
 
   <% if form.is_a?(AssessorInterface::InductionRequiredForm) %>
     <%= f.govuk_collection_radio_buttons :induction_required,
-                                         [
-                                           OpenStruct.new(value: :false, label: t(view_object.country.code, scope: %i[assessor_interface assessment_sections induction_required false])),
-                                           OpenStruct.new(value: :true, label: t(view_object.country.code, scope: %i[assessor_interface assessment_sections induction_required true]))
-                                         ],
-                                         :value,
-                                         :label,
-                                         legend: { text: t(view_object.country.code, scope: %i[assessor_interface assessment_sections induction_required legend]) } %>
+                                         %i[false true],
+                                         :itself,
+                                         legend: { text: t(view_object.country.code, scope: %i[assessor_interface assessment_sections induction_required]) } %>
   <% end %>
 
   <% if view_object.preliminary? %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -95,25 +95,26 @@
     - created_at
     - updated_at
   :assessments:
-    - id
-    - application_form_id
-    - recommendation
-    - created_at
-    - updated_at
-    - started_at
-    - age_range_min
     - age_range_max
+    - age_range_min
     - age_range_note
+    - application_form_id
+    - created_at
+    - id
+    - induction_required
+    - recommendation
+    - recommendation_assessor_note
+    - recommended_at
+    - references_verified
+    - scotland_full_registration
+    - started_at
     - subjects
     - subjects_note
-    - recommended_at
-    - recommendation_assessor_note
-    - induction_required
+    - updated_at
     - working_days_since_started
+    - working_days_started_to_recommendation
     - working_days_submission_to_recommendation
     - working_days_submission_to_started
-    - working_days_started_to_recommendation
-    - references_verified
   :countries:
     - id
     - code

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -216,15 +216,8 @@ en:
             teaching_qualification_subjects_criteria: Maths, Science, Biology, Chemistry, Physics, French, German, Italian, Japanese, Latin, Mandarin, Russian, Spanish.
 
       induction_required:
-        legend:
-          GB-SCT: What level of registration does the applicant have?
-          GB-NIR: Has applicant completed Induction?
-        false:
-          GB-SCT: Full registration
-          GB-NIR: "Yes"
-        true:
-          GB-SCT: Provisional registration
-          GB-NIR: "No"
+        GB-SCT: Has the applicant completed an induction period?
+        GB-NIR: Has applicant completed Induction?
 
       english_language_proficiency:
         passed:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -405,6 +405,10 @@ en:
           attributes:
             work_history_ids:
               blank: References account for less than 9 months
+        assessor_interface/scotland_full_registration_form:
+          attributes:
+            scotland_full_registration:
+              inclusion: Select whether the teacher has or is eligible for full registration
         assessor_interface/verify_professional_standing_form:
           attributes:
             verify_professional_standing:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -78,6 +78,9 @@ en:
           text: Note to the applicant
           document: Note to the applicant
           decline: Note to the applicant (optional)
+        induction_required_options:
+          true: "No"
+          false: "Yes"
       assessor_interface_confirm_age_range_subjects_form:
         age_range_min: From
         age_range_max: To

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -67,13 +67,9 @@ en:
           true: "Yes"
           false: "No"
       assessor_interface_assessment_section_form:
-        age_range_min: From
         age_range_max: To
+        age_range_min: From
         age_range_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> If you''ve entered a new range please explain why (optional)'
-        subject_1: Subject 1
-        subject_2: Subject 2 (optional)
-        subject_3: Subject 3 (optional)
-        subjects_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> If you''ve edited the subjects please explain why (optional)'
         failure_reason_notes:
           text: Note to the applicant
           document: Note to the applicant
@@ -81,6 +77,13 @@ en:
         induction_required_options:
           true: "No"
           false: "Yes"
+        scotland_full_registration_options:
+          true: "Yes"
+          false: "No"
+        subject_1: Subject 1
+        subject_2: Subject 2 (optional)
+        subject_3: Subject 3 (optional)
+        subjects_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> If you''ve edited the subjects please explain why (optional)'
       assessor_interface_confirm_age_range_subjects_form:
         age_range_min: From
         age_range_max: To
@@ -263,6 +266,7 @@ en:
         recommendation: QTS review completed
       assessor_interface_assessment_section_form:
         selected_failure_reasons: What are the reasons for your recommendation?
+        scotland_full_registration: Does the applicant have or are they eligible for full registration?
       assessor_interface_filter_form:
         assessor_ids: Assessor name
         states: Status of application

--- a/db/migrate/20230725100654_add_scotland_full_registration_to_assessments.rb
+++ b/db/migrate/20230725100654_add_scotland_full_registration_to_assessments.rb
@@ -1,0 +1,5 @@
+class AddScotlandFullRegistrationToAssessments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :assessments, :scotland_full_registration, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_19_161900) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_25_100654) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -148,6 +148,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_19_161900) do
     t.boolean "induction_required"
     t.text "recommendation_assessor_note", default: "", null: false
     t.boolean "references_verified"
+    t.boolean "scotland_full_registration"
     t.index ["application_form_id"], name: "index_assessments_on_application_form_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,7 +28,7 @@ COUNTRIES = {
     regions: [
       {
         status_check: "online",
-        sanction_check: "written",
+        sanction_check: "online",
         application_form_skip_work_history: true,
       },
     ],

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -11,6 +11,7 @@
 #  recommendation_assessor_note              :text             default(""), not null
 #  recommended_at                            :datetime
 #  references_verified                       :boolean
+#  scotland_full_registration                :boolean
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null

--- a/spec/forms/assessor_interface/scotland_full_registration_form_spec.rb
+++ b/spec/forms/assessor_interface/scotland_full_registration_form_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AssessorInterface::InductionRequiredForm, type: :model do
+RSpec.describe AssessorInterface::ScotlandFullRegistrationForm, type: :model do
   let(:assessment_section) do
     create(:assessment_section, :professional_standing)
   end
@@ -23,13 +23,17 @@ RSpec.describe AssessorInterface::InductionRequiredForm, type: :model do
     it { is_expected.to allow_values(true, false).for(:passed) }
 
     it do
-      is_expected.to allow_values(nil, true, false).for(:induction_required)
+      is_expected.to allow_values(nil, true, false).for(
+        :scotland_full_registration,
+      )
     end
 
     context "when passed" do
       let(:attributes) { { passed: "true" } }
 
-      it { is_expected.to_not allow_values(nil).for(:induction_required) }
+      it do
+        is_expected.to_not allow_values(nil).for(:scotland_full_registration)
+      end
     end
   end
 
@@ -43,12 +47,20 @@ RSpec.describe AssessorInterface::InductionRequiredForm, type: :model do
     end
 
     describe "with valid attributes" do
-      let(:attributes) { { passed: true, induction_required: true } }
+      let(:attributes) do
+        {
+          passed: true,
+          induction_required: true,
+          scotland_full_registration: true,
+        }
+      end
 
       it { is_expected.to be true }
 
       it "sets the attributes" do
-        expect { save }.to change(assessment, :induction_required).to(true)
+        expect { save }.to change(assessment, :scotland_full_registration).to(
+          true,
+        )
       end
     end
   end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -13,6 +13,7 @@
 #  recommendation_assessor_note              :text             default(""), not null
 #  recommended_at                            :datetime
 #  references_verified                       :boolean
+#  scotland_full_registration                :boolean
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null

--- a/spec/support/autoload/page_objects/assessor_interface/check_professional_standing.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_professional_standing.rb
@@ -11,6 +11,15 @@ module PageObjects
 
       sections :cards, ProfessionalStandingCard, ".govuk-summary-card"
 
+      section :scotland_full_registration_form, "form" do
+        element :yes_radio_item,
+                "#assessor-interface-assessment-section-form-scotland-full-registration-true-field",
+                visible: false
+        element :no_radio_item,
+                "#assessor-interface-assessment-section-form-scotland-full-registration-false-field",
+                visible: false
+      end
+
       section :induction_required_form, "form" do
         element :no_radio_item,
                 "#assessor-interface-assessment-section-form-induction-required-false-field",

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     then_i_see_the_professional_standing
 
     when_i_choose_full_registration
+    and_i_choose_induction_not_required
     and_i_choose_check_professional_standing_yes
     then_i_see_the(:assessor_application_page, application_id:)
     and_i_see_check_professional_standing_completed
@@ -355,6 +356,13 @@ RSpec.describe "Assessor check submitted details", type: :system do
                :when_i_choose_check_professional_standing_yes
 
   def when_i_choose_full_registration
+    check_professional_standing_page
+      .scotland_full_registration_form
+      .yes_radio_item
+      .choose
+  end
+
+  def and_i_choose_induction_not_required
     check_professional_standing_page
       .induction_required_form
       .no_radio_item


### PR DESCRIPTION
This improves the induction required form for Scotland by asking two questions, the first captures whether the applicant has a full or provisional registration, and the second asks whether they have already completed induction.

[Trello Card](https://trello.com/c/3EIvJtOl/2106-scotland-and-ni-induction-changes)

## Screenshots

![Screenshot 2023-07-25 at 11 32 44](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/4ce94dfe-4590-4d7c-84c0-5d741d5760bd)
![Screenshot 2023-07-25 at 11 37 34](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/e194cc52-9ac3-4dd9-8c7c-6fa26da86ba4)
