### PR TITLE
Improve induction question for Northern Ireland

### DIFF
--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -126,18 +126,25 @@ module CheckYourAnswersSummary
           end
         )
 
-      uploads =
-        scope.order(:created_at).select { |upload| upload.attachment.present? }
-
-      html = format_array(uploads, field)
-
-      malware_scan_active =
-        FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
-
-      if malware_scan_active && scope.scan_result_suspect.exists?
-        "#{html}<br /><br /><em>One or more upload has been deleted by the virus scanner.</em>"
+      if document.optional? && !document.available
+        "<em>The applicant has indicated that they haven't done an induction period " \
+          "and don't have this document.</em>".html_safe
       else
-        html
+        uploads =
+          scope
+            .order(:created_at)
+            .select { |upload| upload.attachment.present? }
+
+        html = format_array(uploads, field)
+
+        malware_scan_active =
+          FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
+
+        if malware_scan_active && scope.scan_result_suspect.exists?
+          "#{html}<br /><br /><em>One or more upload has been deleted by the virus scanner.</em>"
+        else
+          html
+        end
       end
     end
 

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -26,13 +26,7 @@ module TeacherInterface
     end
 
     def new
-      @upload_form =
-        UploadForm.new(
-          document:,
-          do_not_have_document:
-            document.optional? && document.completed? &&
-              document.uploads.empty?,
-        )
+      @upload_form = UploadForm.new(document:)
     end
 
     def create
@@ -40,19 +34,15 @@ module TeacherInterface
 
       handle_application_form_section(
         form: @upload_form,
-        if_success_then_redirect: ->(check_path) do
-          if @upload_form.do_not_have_document
-            check_path || DocumentContinueRedirection.call(document:)
-          else
-            history_stack.replace_self(
-              path:
-                edit_teacher_interface_application_form_document_path(document),
-              origin: false,
-              check: false,
-            )
+        if_success_then_redirect: ->(_check_path) do
+          history_stack.replace_self(
+            path:
+              edit_teacher_interface_application_form_document_path(document),
+            origin: false,
+            check: false,
+          )
 
-            [:teacher_interface, :application_form, document]
-          end
+          [:teacher_interface, :application_form, document]
         end,
         if_failure_then_render: :new,
       )
@@ -85,7 +75,6 @@ module TeacherInterface
     def upload_form_params
       params.permit(
         teacher_interface_upload_form: %i[
-          do_not_have_document
           original_attachment
           translated_attachment
           written_in_english

--- a/app/forms/teacher_interface/document_available_form.rb
+++ b/app/forms/teacher_interface/document_available_form.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class TeacherInterface::DocumentAvailableForm < TeacherInterface::BaseForm
+  attr_accessor :document
+  attribute :available, :boolean
+
+  validates :document, presence: true
+  validates :available, inclusion: { in: [true, false] }
+
+  def update_model
+    document.update!(
+      available:,
+      completed: available ? !document.uploads.empty? : true,
+    )
+  end
+
+  delegate :application_form, to: :document
+end

--- a/app/lib/application_form_section_status_updater.rb
+++ b/app/lib/application_form_section_status_updater.rb
@@ -106,10 +106,16 @@ class ApplicationFormSectionStatusUpdater
 
     case english_language_proof_method
     when "medium_of_instruction"
-      status_for_document(english_language_medium_of_instruction_document)
+      status_for_document(
+        english_language_medium_of_instruction_document,
+        not_started: :in_progress,
+      )
     when "provider"
       if english_language_provider_other
-        status_for_document(english_language_proficiency_document)
+        status_for_document(
+          english_language_proficiency_document,
+          not_started: :in_progress,
+        )
       else
         status_for_values(
           english_language_proof_method,
@@ -157,14 +163,11 @@ class ApplicationFormSectionStatusUpdater
   end
 
   def written_statement_status
-    completed =
-      if teaching_authority_provides_written_statement
-        written_statement_confirmation
-      else
-        written_statement_document.completed?
-      end
-
-    completed ? :completed : :not_started
+    if teaching_authority_provides_written_statement
+      written_statement_confirmation ? :completed : :not_started
+    else
+      status_for_document(written_statement_document)
+    end
   end
 
   def status_for_values(*values)
@@ -173,7 +176,13 @@ class ApplicationFormSectionStatusUpdater
     :in_progress
   end
 
-  def status_for_document(document)
-    document.completed? ? :completed : :in_progress
+  def status_for_document(document, not_started: :not_started)
+    if document.completed?
+      :completed
+    elsif !document.available.nil?
+      :in_progress
+    else
+      not_started
+    end
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -5,6 +5,7 @@
 # Table name: documents
 #
 #  id                :bigint           not null, primary key
+#  available         :boolean
 #  completed         :boolean          default(FALSE)
 #  document_type     :string           not null
 #  documentable_type :string

--- a/app/views/teacher_interface/documents/edit_available.html.erb
+++ b/app/views/teacher_interface/documents/edit_available.html.erb
@@ -1,0 +1,25 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}Upload a document" %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
+
+<%= form_with model: @form, url: [:teacher_interface, :application_form, @document], method: :patch do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_collection_radio_buttons :available,
+                                       %i[true false],
+                                       :itself,
+                                       legend: { tag: "h1", size: "l" } %>
+
+  <%= govuk_details(summary_text: "What is an induction period?") do %>
+    <p class="govuk-body">
+      This is the first stage of a teacher’s professional development, where newly qualified teachers (NQTs) are supported to develop their teaching skills and knowledge.
+    </p>
+  <% end %>
+
+  <%= govuk_inset_text do %>
+    <p class="govuk-body">
+      Note that if you cannot show evidence that you’ve already completed an induction period in Northern Ireland, if you’re awarded QTS you’ll need to do a period of statutory induction.
+    </p>
+  <% end %>
+
+  <%= render "shared/save_submit_buttons", f: %>
+<% end %>

--- a/app/views/teacher_interface/documents/edit_uploads.html.erb
+++ b/app/views/teacher_interface/documents/edit_uploads.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{"Error: " if @add_another_upload_form.errors.any?}Check your uploaded files" %>
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}Check your uploaded files" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <h1 class="govuk-heading-l">Check your uploaded files – <%= I18n.t("document.document_type.#{@document.document_type}") %> document</h1>
@@ -19,7 +19,7 @@
   end
 end %>
 
-<%= form_with model: @add_another_upload_form, url: [:teacher_interface, :application_form, @document], method: :patch do |f| %>
+<%= form_with model: @form, url: [:teacher_interface, :application_form, @document], method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_radio_buttons_fieldset :add_another,

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -43,22 +43,24 @@
     <span class="govuk-caption-l">Proof that you’re recognised as a teacher</span>
     <h1 class="govuk-heading-l">Upload your written statement</h1>
 
-    <% if @application_form.region.country.code == "GB-NIR" %>
+    <% if CountryCode.northern_ireland?(@application_form.region.country.code) %>
       <p class="govuk-body">
-        If you’ve already completed an induction period in Northern Ireland, you can provide evidence by uploading a ‘Letter of Successful Completion of Induction’ from the school where you did your induction period.
+        Provide your ‘Letter of Successful Completion of Induction’ to confirm that you've completed an induction period in Northern Ireland.
       </p>
 
-      <p class="govuk-body">
-        It must confirm that you completed your induction in Northern Ireland and show the completion date, as well as your Teacher Reference (TR) number (if you have one). It must also include the name of the school and the signature of the administration department or headteacher/principal.
-      </p>
+      <p class="govuk-body">The letter must include:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>confirmation that you completed the induction in Northern Ireland</li>
+        <li>the date you completed your induction</li>
+        <li>your Teacher Reference (TR) number (if you have one)</li>
+        <li>the name of the school where you completed the induction</li>
+        <li>a signature from the school’s administrative department or headteacher/principal</li>
+      </ul>
 
       <%= govuk_details(summary_text: "How to get this") do %>
         <p class="govuk-body">You can get a Letter of Successful Completion of Induction by contacting the school where you completed your induction period.</p>
       <% end %>
-
-      <p class="govuk-body">
-        If you did not complete an induction period, or you do not have a letter, check the box below and select ‘Continue’.
-      </p>
 
       <%= govuk_inset_text do %>
         <p class="govuk-body">

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -151,12 +151,6 @@
 <%= form_with model: @upload_form, url: [:teacher_interface, :application_form, @document, :uploads] do |f| %>
   <%= f.govuk_error_summary %>
 
-  <% if @document.optional? %>
-    <%= f.govuk_check_boxes_fieldset :do_not_have_document, multiple: false, legend: nil do %>
-      <%= f.govuk_check_box :do_not_have_document, 1, 0, multiple: false, link_errors: true, label: { text: "I do not have #{region_certificate_phrase(@application_form.region)}.".html_safe }%>
-    <% end %>
-  <% end %>
-
   <%= f.govuk_file_field :original_attachment,
                          label: { text: "Select a file to upload", class: "govuk-heading-m" },
                          hint: { text: "You can upload your files in PDF, JPG, PNG, DOCX or DOC format. Each file must be no larger than 50MB." } %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -134,12 +134,13 @@
     - qualifications_information
     - requires_preliminary_check
   :documents:
-    - id
-    - document_type
-    - documentable_type
-    - documentable_id
+    - available
     - completed
     - created_at
+    - document_type
+    - documentable_id
+    - documentable_type
+    - id
     - updated_at
   :dqt_trn_requests:
     - id

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -216,8 +216,8 @@ en:
             teaching_qualification_subjects_criteria: Maths, Science, Biology, Chemistry, Physics, French, German, Italian, Japanese, Latin, Mandarin, Russian, Spanish.
 
       induction_required:
+        GB-NIR: Has applicant provided proof that they’ve completed an induction period?
         GB-SCT: Has the applicant completed an induction period?
-        GB-NIR: Has applicant completed Induction?
 
       english_language_proficiency:
         passed:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -173,6 +173,10 @@ en:
         confirm_options:
           true: "Yes"
           false: "No"
+      teacher_interface_document_available_form:
+        available_options:
+          true: "Yes"
+          false: "No"
       teacher_interface_english_language_exemption_form:
         exempt_options:
           true: "Yes"

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -298,6 +298,8 @@ en:
         add_another: Add another role?
       teacher_interface_alternative_name_form:
         has_alternative_name: Does your name appear differently on your ID documents or qualifications?
+      teacher_interface_document_available_form:
+        available: Have you completed your induction period in Northern Ireland?
       teacher_interface_english_language_proof_method_form:
         proof_method: You need to provide proof of your English language proficiency
       teacher_interface_english_language_provider_form:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -205,6 +205,10 @@ en:
           attributes:
             confirm:
               inclusion: Select whether you want to delete this role
+        teacher_interface/document_available_form:
+          attributes:
+            available:
+              inclusion: Select whether you have this document available
         teacher_interface/english_language_exemption_form:
           attributes:
             exempt:

--- a/db/migrate/20230725111002_add_available_to_documents.rb
+++ b/db/migrate/20230725111002_add_available_to_documents.rb
@@ -1,0 +1,5 @@
+class AddAvailableToDocuments < ActiveRecord::Migration[7.0]
+  def change
+    add_column :documents, :available, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_25_100654) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_25_111002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -179,6 +179,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_25_100654) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "completed", default: false
+    t.boolean "available"
     t.index ["document_type"], name: "index_documents_on_document_type"
     t.index ["documentable_type", "documentable_id"], name: "index_documents_on_documentable"
   end

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -3,6 +3,7 @@
 # Table name: documents
 #
 #  id                :bigint           not null, primary key
+#  available         :boolean
 #  completed         :boolean          default(FALSE)
 #  document_type     :string           not null
 #  documentable_type :string

--- a/spec/forms/teacher_interface/document_available_form_spec.rb
+++ b/spec/forms/teacher_interface/document_available_form_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe TeacherInterface::DocumentAvailableForm, type: :model do
+  let(:document) { create(:document) }
+
+  subject(:form) { described_class.new(document:, available:) }
+
+  describe "validations" do
+    let(:available) { "" }
+
+    it { is_expected.to validate_presence_of(:document) }
+    it { is_expected.to allow_values(true, false).for(:available) }
+  end
+
+  describe "#save" do
+    before { form.save(validate: true) }
+
+    context "when available" do
+      let(:available) { "true" }
+
+      it "saves the document" do
+        expect(document.available).to eq(true)
+        expect(document.completed).to eq(false)
+      end
+    end
+
+    context "when unavailable" do
+      let(:available) { "false" }
+
+      it "saves the document" do
+        expect(document.available).to eq(false)
+        expect(document.completed).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/forms/teacher_interface/upload_form_spec.rb
+++ b/spec/forms/teacher_interface/upload_form_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
   subject(:upload_form) do
     described_class.new(
       document:,
-      do_not_have_document:,
       original_attachment:,
       translated_attachment:,
       written_in_english:,
@@ -14,7 +13,6 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
   end
 
   let(:document) { create(:document, :identification) }
-  let(:do_not_have_document) { nil }
   let(:original_attachment) { nil }
   let(:translated_attachment) { nil }
   let(:written_in_english) { nil }
@@ -36,19 +34,6 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
 
     context "with nil attachments" do
       it { is_expected.to be false }
-
-      context "when document not available" do
-        let(:do_not_have_document) { true }
-
-        it { is_expected.to be false }
-      end
-
-      context "when optional and document not available" do
-        let(:document) { create(:document, :optional_written_statement) }
-        let(:do_not_have_document) { true }
-
-        it { is_expected.to be true }
-      end
     end
 
     context "with an original attachment" do
@@ -141,15 +126,6 @@ RSpec.describe TeacherInterface::UploadForm, type: :model do
         expect(document.uploads.count).to eq(2)
         expect(document.uploads.second.translation).to be(true)
       end
-
-      it "marks the document as complete" do
-        expect(document.completed?).to be true
-      end
-    end
-
-    context "with an optional document" do
-      let(:document) { create(:document, :optional_written_statement) }
-      let(:do_not_have_document) { true }
 
       it "marks the document as complete" do
         expect(document.completed?).to be true

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -3,6 +3,7 @@
 # Table name: documents
 #
 #  id                :bigint           not null, primary key
+#  available         :boolean
 #  completed         :boolean          default(FALSE)
 #  document_type     :string           not null
 #  documentable_type :string

--- a/spec/support/autoload/page_objects/teacher_interface/document_available.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/document_available.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class DocumentAvailable < SitePrism::Page
+      set_url "/teacher/application/documents/{application_id}/edit"
+
+      element :heading, "h1"
+
+      section :form, "form" do
+        element :yes_radio_item,
+                "#teacher-interface-document-available-form-available-true-field",
+                visible: false
+        element :no_radio_item,
+                "#teacher-interface-document-available-form-available-false-field",
+                visible: false
+        element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/upload_document.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/upload_document.rb
@@ -6,10 +6,6 @@ module PageObjects
       element :heading, "h1"
 
       section :form, "form" do
-        element :do_not_have_document,
-                "#teacher-interface-upload-form-do-not-have-document-1-field",
-                visible: false
-
         element :original_attachment,
                 "#teacher-interface-upload-form-original-attachment-field"
         element :translated_attachment,

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -323,6 +323,11 @@ module PageHelpers
       PageObjects::TeacherInterface::DeleteWorkHistory.new
   end
 
+  def teacher_document_available_page
+    @teacher_document_available_page =
+      PageObjects::TeacherInterface::DocumentAvailable.new
+  end
+
   def teacher_edit_qualification_page
     @teacher_edit_qualification_page ||=
       PageObjects::TeacherInterface::EditQualification.new

--- a/spec/system/teacher_interface/written_statement_spec.rb
+++ b/spec/system/teacher_interface/written_statement_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Teacher written statement", type: :system do
     and_i_see_the_upload_written_statement_task
 
     when_i_click_the_upload_written_statement_task
-    then_i_see_the(:teacher_upload_document_page)
+    then_i_see_the(:teacher_document_available_page)
 
     when_i_dont_have_the_document
     then_i_see_the(:teacher_application_page)
@@ -91,8 +91,8 @@ RSpec.describe "Teacher written statement", type: :system do
   end
 
   def when_i_dont_have_the_document
-    teacher_upload_document_page.form.do_not_have_document.check
-    teacher_upload_document_page.form.continue_button.click
+    teacher_document_available_page.form.no_radio_item.choose
+    teacher_document_available_page.form.continue_button.click
   end
 
   def when_i_dont_need_to_upload_another_file
@@ -145,7 +145,8 @@ RSpec.describe "Teacher written statement", type: :system do
       create(
         :application_form,
         teacher:,
-        region: create(:region, :written_checks),
+        region:
+          create(:region, :written_checks, :in_country, country_code: "GB-NIR"),
       )
   end
 end


### PR DESCRIPTION
This improves the induction upload form for Northern Ireland by asking first whether the applicant has induction (and therefore would be able to upload a document). If they can't upload a document then they don't need to go through the upload form and the assessor sees this on their side.

[Trello Card](https://trello.com/c/3EIvJtOl/2106-scotland-and-ni-induction-changes)

## Screenshots

![Screenshot 2023-07-25 at 11 42 32](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/e3f84365-7175-4080-8dfa-68c96ba2f796)
![Screenshot 2023-07-25 at 11 42 36](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/98ebabf4-8e7c-48ce-8770-0a2fb35e36f4)
![Screenshot 2023-07-25 at 14 51 46](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/956ee425-f376-445f-851f-908e7312477f)
![Screenshot 2023-07-25 at 14 51 53](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/a6b615b3-eb4a-4781-9561-4ef6379c02cd)
![Screenshot 2023-07-25 at 15 35 34](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/f8da66e9-afac-46df-8fb8-1578d88ae46e)
