### PR TITLE
Fix declaration form validation

### DIFF
--- a/app/views/assessor_interface/assessment_recommendation_award/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_award/edit.html.erb
@@ -25,11 +25,10 @@
   <p class="govuk-body"><%= t(".instruction") %></p>
   <p class="govuk-body">If you need to check something, use the ‘Back’ button.</p>
 
-  <%= f.govuk_check_boxes_fieldset :declaration, small: true do %>
+  <%= f.govuk_check_boxes_fieldset :declaration, multiple: false, small: true do %>
     <%= f.govuk_check_box :declaration,
                           true,
                           false,
-                          multiple: false,
                           link_errors: true,
                           label: { text: t(".declaration") } %>
   <% end %>

--- a/app/views/assessor_interface/assessment_recommendation_decline/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_decline/edit.html.erb
@@ -66,11 +66,10 @@
   <p class="govuk-body"><%= t(".instruction") %></p>
   <p class="govuk-body">If you need to check something, use the ‘Back’ button.</p>
 
-  <%= f.govuk_check_boxes_fieldset :declaration, small: true do %>
+  <%= f.govuk_check_boxes_fieldset :declaration, multiple: false, small: true do %>
     <%= f.govuk_check_box :declaration,
                           true,
                           false,
-                          multiple: false,
                           link_errors: true,
                           label: { text: t(".declaration") } %>
   <% end %>


### PR DESCRIPTION
This fixes the validation for the declaration form by setting the fieldset as not multiple. Currently it's set as multiple which means that the value comes through as an array, which makes it truthy.

[Trello Card](https://trello.com/c/MfbmiTj8/2090-declaration-page-allows-continuing-without-checking-box)

## Screenshots

![Screenshot 2023-07-26 at 15 15 11](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/8ee960e8-c7b4-42fb-b939-e8ad09ac478f)
![Screenshot 2023-07-26 at 15 15 13](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/6b110ee4-cefa-42af-923d-4273b2e8fa65)
