### PR TITLE
Update application form remindable scope

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -192,7 +192,7 @@ class ApplicationForm < ApplicationRecord
             .or(withdrawn.where("withdrawn_at < ?", 5.years.ago))
         }
 
-  scope :remindable, -> { draft }
+  scope :remindable, -> { draft.where("created_at < ?", 5.months.ago) }
 
   def teaching_qualification
     qualifications.find(&:is_teaching_qualification?)

--- a/spec/jobs/send_reminder_emails_job_spec.rb
+++ b/spec/jobs/send_reminder_emails_job_spec.rb
@@ -7,8 +7,12 @@ RSpec.describe SendReminderEmailsJob do
     describe "#perform" do
       subject(:perform) { described_class.new.perform(class_name) }
 
-      let!(:remindable) { create(factory_name, remindable_trait) }
-      let!(:not_remindable) { create(factory_name, not_remindable_trait) }
+      let!(:remindable) do
+        create(factory_name, remindable_trait, created_at: 6.months.ago)
+      end
+      let!(:not_remindable) do
+        create(factory_name, not_remindable_trait, created_at: 6.months.ago)
+      end
 
       it "enqueues a job for each 'remindable' #{class_name}s" do
         expect { perform }.to have_enqueued_job(SendReminderEmailJob).with(

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -398,6 +398,27 @@ RSpec.describe ApplicationForm, type: :model do
         end
       end
     end
+
+    describe "#remindable" do
+      subject(:remindable) { described_class.remindable }
+
+      context "with a draft application form older than 5 months old" do
+        let(:application_form) do
+          create(:application_form, created_at: (5.months + 1.week).ago)
+        end
+        it { is_expected.to eq([application_form]) }
+      end
+
+      context "with a draft application form newer than 5 months old" do
+        before { create(:application_form, created_at: 4.months.ago) }
+        it { is_expected.to be_empty }
+      end
+
+      context "with a submitted application form" do
+        before { create(:application_form, :submitted) }
+        it { is_expected.to be_empty }
+      end
+    end
   end
 
   it "attaches empty documents" do


### PR DESCRIPTION
We only send reminder emails with 2 weeks before 6 months, so we can reduce the number of application forms we're processing by adding a filter to the remindable scope.