### PR TITLE
Use status tag component in timeline events

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -23,12 +23,7 @@
     <% elsif timeline_event.assessment_section_recorded? %>
       <p class="govuk-body">
         <%= description_vars[:section_name] %>:
-
-        <% if description_vars[:passed] %>
-          <%= govuk_tag(text: "Passed", colour: "green") %>
-        <% else %>
-          <%= govuk_tag(text: "Not passed", colour: "red") %>
-        <% end %>
+        <%= render StatusTag::Component.new(status: description_vars[:passed] ? "accepted" : "rejected") %>
       </p>
 
       <% if (visible_failure_reasons = description_vars[:visible_failure_reasons]).present? %>

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
 
     it "describes the event" do
       expect(component.text).to include("Personal Information:")
-      expect(component.text).to include("Not passed")
+      expect(component.text).to include("Rejected")
       expect(component.text).to include(expected_failure_reason_text)
       expect(component.text).to include(failure_reason.assessor_feedback)
     end


### PR DESCRIPTION
This fixes the issue where the wording is inconsistent with the accepted/rejected wording we use elsewhere.