### PR TITLE
Allow configuring Azure tenant ID

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -374,7 +374,8 @@ Devise.setup do |config|
 
   config.omniauth :azure_activedirectory_v2,
                   client_id: ENV["MICROSOFT_OAUTH_CLIENT_ID"],
-                  client_secret: ENV["MICROSOFT_OAUTH_CLIENT_SECRET"]
+                  client_secret: ENV["MICROSOFT_OAUTH_CLIENT_SECRET"],
+                  tenant_id: ENV["MICROSOFT_OAUTH_TENANT_ID"]
 end
 
 # As we only use magic link authentication for teachers, we don't need to unnecessarily


### PR DESCRIPTION
This fixes an issue where we're unable to sign in because we're using the `common` tenant when actually we should be using the specific tenant ID of the application.

[Trello Card](https://trello.com/c/jT1WHmVj/2048-turn-on-sign-in-with-active-directory)