### PR TITLE
Set cookie same site protection to nil

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+Rails.application.config.action_dispatch.cookies_same_site_protection = nil
+
 Rails.application.config.session_store :active_record_store,
                                        key: "_session_id",
                                        secure: Rails.env.production?,


### PR DESCRIPTION
This is an attempt to fix an issue we're seeing where signing in with Omniauth isn't working in Safari. Setting this value to `nil` (which means the `SameSite` attribute is left unset) should in theory be the same as setting to to `lax` (which means the `SameSet` attribute is set to `Lax`), however it seems like Safari treats these differently:

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#lax

https://github.com/omniauth/omniauth-oauth2/issues/155#issuecomment-1163426605

[Trello Card](https://trello.com/c/jT1WHmVj/2048-turn-on-sign-in-with-active-directory)