### PR TITLE
Use development qualified teachers API in review

### DIFF
--- a/terraform/application/config/review/variables.tfvars.json
+++ b/terraform/application/config/review/variables.tfvars.json
@@ -2,7 +2,7 @@
   "app_environment": "review",
   "cluster": "test",
   "deploy_azure_backing_services": false,
-  "dqt_api_url": "https://preprod-teacher-qualifications-api.education.gov.uk",
+  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital",
   "enable_monitoring": false,
   "namespace": "tra-development",
   "uploads_storage_environment_tag": "Test"


### PR DESCRIPTION
The review environment is similar to the development environment except the apps are short lived, we should match up the environments so they correspond to the same one that the qualified teachers API is running in.