### PR TITLE
Don't send reminder emails for old applications

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -237,6 +237,8 @@ class ApplicationForm < ApplicationRecord
   end
 
   def should_send_reminder_email?(days_until_expired, number_of_reminders_sent)
+    return false if teacher.application_form != self
+
     (days_until_expired <= 14 && number_of_reminders_sent.zero?) ||
       (days_until_expired <= 7 && number_of_reminders_sent == 1)
   end


### PR DESCRIPTION
If a teacher has two draft application forms (which shouldn't happen, but is possible in rare circumstances such as resubmitting forms), then currently we send them two emails about an application being deleted. However, teachers can only access their most recent application form, so we don't need to send an email about a previous one as it's not accessible anyway.

This will also fix an issue in Sentry where we were sending emails for the wrong application form as we send from the perspective of a teacher (which only has access to the most recent application form):

https://dfe-teacher-services.sentry.io/issues/4322438918/