### PR TITLE
Add work history contact further information request flow

### DIFF
--- a/app/controllers/teacher_interface/further_information_request_items_controller.rb
+++ b/app/controllers/teacher_interface/further_information_request_items_controller.rb
@@ -24,7 +24,7 @@ module TeacherInterface
     end
 
     def edit_text
-      @further_information_request_item_text_form =
+      @form =
         FurtherInformationRequestItemTextForm.new(
           response: further_information_request_item.response,
         )
@@ -33,8 +33,12 @@ module TeacherInterface
     def edit_document
     end
 
+    def edit_work_history_contact
+      @form = FurtherInformationRequestItemWorkHistoryContactForm.new
+    end
+
     def update_text
-      @further_information_request_item_text_form =
+      @form =
         FurtherInformationRequestItemTextForm.new(
           further_information_request_item_text_form_params.merge(
             further_information_request_item:,
@@ -42,7 +46,25 @@ module TeacherInterface
         )
 
       handle_application_form_section(
-        form: @further_information_request_item_text_form,
+        form: @form,
+        if_success_then_redirect: [
+          :teacher_interface,
+          :application_form,
+          further_information_request,
+        ],
+      )
+    end
+
+    def update_work_history_contact
+      @form =
+        FurtherInformationRequestItemWorkHistoryContactForm.new(
+          further_information_request_item_work_history_contact_form_params.merge(
+            further_information_request_item:,
+          ),
+        )
+
+      handle_application_form_section(
+        form: @form,
         if_success_then_redirect: [
           :teacher_interface,
           :application_form,
@@ -84,6 +106,12 @@ module TeacherInterface
       params.require(
         :teacher_interface_further_information_request_item_text_form,
       ).permit(:response)
+    end
+
+    def further_information_request_item_work_history_contact_form_params
+      params.require(
+        :teacher_interface_further_information_request_item_work_history_contact_form,
+      ).permit(:contact_name, :contact_job, :contact_email)
     end
 
     def document_path

--- a/app/forms/assessor_interface/assessment_section_form.rb
+++ b/app/forms/assessor_interface/assessment_section_form.rb
@@ -15,15 +15,33 @@ class AssessorInterface::AssessmentSectionForm
   validates :selected_failure_reasons,
             presence: true,
             if: -> { passed == false }
+  validates :work_history,
+            presence: true,
+            if: -> {
+              passed == false &&
+                FailureReasons.chooses_work_history?(
+                  failure_reason: selected_failure_reasons,
+                )
+            }
 
   def selected_failure_reasons
     return {} if passed
 
+    work_histories =
+      assessment_section.assessment.application_form.work_histories
+
     assessment_section
       .failure_reasons
       .each_with_object({}) do |failure_reason, memo|
-        if send("#{failure_reason}_checked")
-          memo[failure_reason] = send("#{failure_reason}_notes")
+        next unless send("#{failure_reason}_checked")
+        memo[failure_reason] = { notes: send("#{failure_reason}_notes") }
+        next unless FailureReasons.chooses_work_history?(failure_reason:)
+        memo[failure_reason][
+          :work_histories
+        ] = work_histories.filter do |work_history|
+          send("#{failure_reason}_work_history_checked").include?(
+            work_history.id.to_s,
+          )
         end
       end
   end
@@ -68,6 +86,14 @@ class AssessorInterface::AssessmentSectionForm
           klass.validates "#{failure_reason}_checked", inclusion: [true, false]
         end
 
+        if FailureReasons.chooses_work_history?(failure_reason:)
+          klass.attribute "#{failure_reason}_work_history_checked"
+
+          klass.validates "#{failure_reason}_work_history_checked",
+                          presence: true,
+                          if: :"#{failure_reason}_checked"
+        end
+
         klass.attribute "#{failure_reason}_notes", :string
 
         if assessment_section.preliminary? ||
@@ -89,12 +115,16 @@ class AssessorInterface::AssessmentSectionForm
         assessment_section
           .selected_failure_reasons
           .each_with_object({}) do |failure_reason, memo|
-            memo[failure_reason.key] = failure_reason.assessor_feedback
+            memo[failure_reason.key] = {
+              assessor_feedback: failure_reason.assessor_feedback,
+              work_history_ids: failure_reason.work_histories.pluck(:id),
+            }
           end
 
       selected_failure_reasons_hash.each do |key, notes|
         attributes["#{key}_checked"] = true
-        attributes["#{key}_notes"] = notes
+        attributes["#{key}_notes"] = notes[:assessor_feedback]
+        attributes["#{key}_work_history_checked"] = notes[:work_history_ids]
       end
 
       if assessment_section.preliminary? && assessment_section.passed?
@@ -112,7 +142,18 @@ class AssessorInterface::AssessmentSectionForm
 
     def permit_parameters(params)
       args, kwargs = permittable_parameters
-      params.permit(:passed, *args, **kwargs)
+      params =
+        params
+          .permit(:passed, *args, **kwargs)
+          .to_h
+          .map do |key, value|
+            if key.end_with?("work_history_checked")
+              [key, value.compact_blank]
+            else
+              [key, value]
+            end
+          end
+      params.to_h
     end
 
     def permittable_parameters

--- a/app/forms/teacher_interface/further_information_request_item_work_history_contact_form.rb
+++ b/app/forms/teacher_interface/further_information_request_item_work_history_contact_form.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class FurtherInformationRequestItemWorkHistoryContactForm < BaseForm
+    attr_accessor :further_information_request_item
+    attribute :contact_name, :string
+    attribute :contact_job, :string
+    attribute :contact_email, :string
+
+    validates :further_information_request_item, presence: true
+    validates :contact_name,
+              :contact_job,
+              :contact_email,
+              presence: true,
+              if: -> { further_information_request_item.work_history_contact? }
+
+    def update_model
+      further_information_request_item.update(
+        contact_name:,
+        contact_job:,
+        contact_email:,
+      )
+    end
+  end
+end

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -68,6 +68,8 @@ class FailureReasons
     WRITTEN_STATEMENT_RECENT = "written_statement_recent",
   ].freeze
 
+  WORK_HISTORY_FAILURE_REASONS = [SCHOOL_DETAILS_CANNOT_BE_VERIFIED].freeze
+
   ALL = (DECLINABLE + FURTHER_INFORMATIONABLE).freeze
 
   DOCUMENT_FAILURE_REASONS = {
@@ -98,5 +100,9 @@ class FailureReasons
 
   def self.further_information_request_document_type(failure_reason:)
     DOCUMENT_FAILURE_REASONS[failure_reason.to_s]
+  end
+
+  def self.chooses_work_history?(failure_reason:)
+    WORK_HISTORY_FAILURE_REASONS.include?(failure_reason.to_s)
   end
 end

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -66,5 +66,19 @@ class FurtherInformationRequest < ApplicationRecord
     DeclineQTS.call(application_form:, user:) unless application_form.withdrawn?
   end
 
+  def after_reviewed(user:)
+    items
+      .select(&:work_history_contact?)
+      .each do |item|
+        UpdateWorkHistoryContact.call(
+          user:,
+          work_history: item.work_history,
+          name: item.contact_name,
+          job: item.contact_job,
+          email: item.contact_email,
+        )
+      end
+  end
+
   delegate :teacher, to: :application_form
 end

--- a/app/models/selected_failure_reason.rb
+++ b/app/models/selected_failure_reason.rb
@@ -24,6 +24,7 @@ class SelectedFailureReason < ApplicationRecord
 
   validates :key, presence: true
   validates :key, inclusion: { in: FailureReasons::ALL }
+  has_and_belongs_to_many :work_histories
 
   scope :declinable, -> { where(key: FailureReasons::DECLINABLE) }
 end

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -35,6 +35,10 @@
 class WorkHistory < ApplicationRecord
   belongs_to :application_form
   has_one :reference_request, required: false
+  has_and_belongs_to_many :selected_failure_reasons
+  has_one :further_information_request_item,
+          required: false,
+          dependent: :destroy
 
   scope :ordered, -> { order(created_at: :asc) }
 

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -22,10 +22,15 @@ class UpdateAssessmentSection
         .destroy_all
 
       selected_failure_reasons.each do |key, assessor_feedback|
-        assessment_section
-          .selected_failure_reasons
-          .find_or_initialize_by(key:)
-          .update(assessor_feedback:)
+        failure_reason =
+          assessment_section.selected_failure_reasons.find_or_initialize_by(
+            key:,
+          )
+        failure_reason.update!(assessor_feedback: assessor_feedback[:notes])
+        next unless assessor_feedback[:work_histories]
+        failure_reason.update!(
+          work_histories: assessor_feedback[:work_histories],
+        )
       end
 
       next false unless assessment_section.update(params)

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -142,6 +142,8 @@ module AssessorInterface
       end
     end
 
+    delegate :work_histories, to: :application_form
+
     private
 
     attr_reader :params
@@ -159,7 +161,6 @@ module AssessorInterface
         else
           "text"
         end
-
       "helpers.#{key_section}.assessor_interface_assessment_section_form.failure_reason_notes.#{key}"
     end
 

--- a/app/view_objects/assessor_interface/further_information_request_view_object.rb
+++ b/app/view_objects/assessor_interface/further_information_request_view_object.rb
@@ -45,14 +45,38 @@ class AssessorInterface::FurtherInformationRequestViewObject
               I18n.t(
                 "assessor_interface.further_information_requests.edit.check_your_answers",
               ),
-            fields: {
-              item.id => {
-                title: item_text(item),
-                value: item.text? ? item.response : item.document,
-              },
-            },
+            fields: review_items_fields(item),
           },
-        }
+          work_history_summary_list_rows:
+            if item.work_history_contact?
+              [
+                {
+                  key: {
+                    text: "Contact name",
+                  },
+                  value: {
+                    text: item.work_history.contact_name,
+                  },
+                },
+                {
+                  key: {
+                    text: "Contact job",
+                  },
+                  value: {
+                    text: item.work_history.contact_job,
+                  },
+                },
+                {
+                  key: {
+                    text: "Contact email",
+                  },
+                  value: {
+                    text: item.work_history.contact_email,
+                  },
+                },
+              ]
+            end,
+        }.compact
       end
   end
 
@@ -73,6 +97,34 @@ class AssessorInterface::FurtherInformationRequestViewObject
       )
     when "document"
       "Upload your #{I18n.t("document.document_type.#{item.document.document_type}")} document"
+    when "work_history_contact"
+      "Please provide new contact information for your work history contact"
+    end
+  end
+
+  def review_items_fields(item)
+    if item.work_history_contact?
+      {
+        contact_name: {
+          title: "Contact name",
+          value: item.contact_name,
+        },
+        contact_job: {
+          title: "Contact job",
+          value: item.contact_job,
+        },
+        contact_email: {
+          title: "Contact email",
+          value: item.contact_email,
+        },
+      }
+    else
+      {
+        item.id => {
+          title: item_text(item),
+          value: item.text? ? item.response : item.document,
+        },
+      }
     end
   end
 end

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -51,7 +51,7 @@ module TeacherInterface
         .each_with_object({}) do |item, memo|
           memo[item.id] = {
             title: item_name(item),
-            value: item.text? ? item.response : item.document,
+            value: item_value(item),
             href: [
               :edit,
               :teacher_interface,
@@ -67,6 +67,17 @@ module TeacherInterface
 
     attr_reader :current_teacher, :params
 
+    def item_value(item)
+      if item.text?
+        item.response
+      elsif item.document?
+        item.document
+      elsif item.work_history_contact?
+        "Contact name: #{item.contact_name}<br/>
+         Contact job: #{item.contact_job}<br/> 
+         Contact email: #{item.contact_email}".html_safe
+      end
+    end
     def application_form
       @application_form ||= current_teacher.application_form
     end
@@ -77,6 +88,8 @@ module TeacherInterface
         I18n.t(
           "teacher_interface.further_information_request.show.failure_reason.#{item.failure_reason_key}",
         )
+      when "work_history_contact"
+        "Add your work history contact’s details"
       when "document"
         "Upload your #{I18n.t("document.document_type.#{item.document.document_type}")} document"
       end

--- a/app/views/assessor_interface/assessment_sections/_form.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_form.html.erb
@@ -70,6 +70,9 @@
                                     label: { text: t(view_object.notes_label_key_for(failure_reason:)), size: "s" },
                                     hint: { text: t(view_object.notes_hint_key_for(failure_reason:)) },
                                     placeholder: t(view_object.notes_placeholder_key_for(failure_reason:)) %>
+              <% if FailureReasons::chooses_work_history?(failure_reason:) %>
+                <%= f.govuk_collection_check_boxes :"#{failure_reason}_work_history_checked", view_object.work_histories, :id, :school_name, multiple: false, legend: { size: "s" } %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -7,6 +7,11 @@
   <h2 class="govuk-heading-m"><%= item.fetch(:heading) %></h2>
   <%= govuk_inset_text(text: item.fetch(:description)) %>
   <%= render(CheckYourAnswersSummary::Component.new(**item.fetch(:check_your_answers))) %>
+  <% if (item[:work_history_summary_list_rows]).present? %>
+    <%= govuk_details(summary_text: "Review previous referee details?") do %>
+      <%= govuk_summary_list(rows: item[:work_history_summary_list_rows]) %>
+    <% end %>
+  <% end %>
 <% end %>
 
 <% if policy(:assessor).update? && @view_object.can_update? %>

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "#{"Error: " if @further_information_request_item_text_form&.errors&.any?}Further information required" %>
+<% content_for :page_title, "#{"Error: " if @form&.errors&.any?}Further information required" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
 
 <h1 class="govuk-heading-l">Further information required</h1>
@@ -8,13 +8,35 @@
   <%= simple_format @further_information_request_item.failure_reason_assessor_feedback %>
 <% end %>
 
-<%= form_with model: @further_information_request_item_text_form, url: teacher_interface_application_form_further_information_request_further_information_request_item_path, method: :put do |f| %>
+<%= form_with model: @form, url: teacher_interface_application_form_further_information_request_further_information_request_item_path, method: :put do |f| %>
   <% if @further_information_request_item.text? %>
     <%= f.govuk_text_area :response, label: { size: "s" } %>
   <% end %>
 
   <% if @further_information_request_item.document? %>
     <p class="govuk-body">You can upload this document on the next screen.</p>
+  <% end %>
+
+  <% if @further_information_request_item.work_history_contact? %>
+    <% work_history = @further_information_request_item.work_history %>
+      <p class="govuk-body">Enter the contact details of a suitable referee who can verify your time spent working at <%= work_history.school_name %> from <%= work_history.start_date.to_fs(:month_and_year) %> <% if work_history.end_date.present? %>
+          to <%= work_history.end_date.to_fs(:month_and_year) %>
+      <% end %></p>
+
+      <%= f.govuk_text_field :contact_name, label: {text: "Contact name"} %>
+
+      <%= f.govuk_text_field :contact_job, label: {text: "Contact job"} %>
+
+      <%= f.govuk_email_field :contact_email, label: {text: "Contact email"} %>
+
+      <%= govuk_details(summary_text: "Choosing someone to verify this role") do %>
+
+        <p>A senior member of staff means either a headteacher/principal, an assistant/deputy head or a school business manager.</p>
+
+        <p>Make sure you have an up-to-date email address for the person you choose, because the reference they provide will be important to your application.</p>
+
+        <p>We’ll ask them to confirm that you worked at the school for the period you’ve told us about.</p>
+      <% end %>
   <% end %>
 
   <%= render "shared/save_submit_buttons", f: %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -203,6 +203,10 @@
     - failure_reason_key
     - failure_reason_assessor_feedback
     - response
+    - contact_name
+    - contact_job
+    - contact_email
+    - work_history_id
   :notes:
     - id
     - application_form_id
@@ -314,6 +318,9 @@
     - key
     - assessor_feedback
     - assessment_section_id
+  :selected_failure_reasons_work_histories:
+    - work_history_id
+    - selected_failure_reason_id
   :staff:
     - award_decline_permission
     - azure_ad_uid

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -21,6 +21,9 @@
   :further_information_request_items:
     - failure_reason_assessor_feedback
     - response
+    - contact_name
+    - contact_job
+    - contact_email
   :notes:
     - text
   :professional_standing_requests:

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -3,3 +3,5 @@
 Date::DATE_FORMATS[:long_ordinal_uk] = "%-d %B %Y"
 
 Time::DATE_FORMATS[:date_and_time] = "%e %B %Y at %l:%M %P"
+
+Date::DATE_FORMATS[:month_and_year] = "%B %Y"

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -271,6 +271,7 @@ en:
       assessor_interface_assessment_section_form:
         selected_failure_reasons: What are the reasons for your recommendation?
         scotland_full_registration: Does the applicant have or are they eligible for full registration?
+        school_details_cannot_be_verified_work_history_checked: Choose the schools that need reference details to be amended
       assessor_interface_filter_form:
         assessor_ids: Assessor name
         states: Status of application

--- a/db/migrate/20230713105500_add_work_histories_to_selected_failure_reasons.rb
+++ b/db/migrate/20230713105500_add_work_histories_to_selected_failure_reasons.rb
@@ -1,0 +1,14 @@
+class AddWorkHistoriesToSelectedFailureReasons < ActiveRecord::Migration[7.0]
+  def change
+    create_join_table "work_histories", "selected_failure_reasons"
+    add_reference :further_information_request_items,
+                  :work_history,
+                  foreign_key: true,
+                  null: true
+    change_table :further_information_request_items, bulk: true do |t|
+      t.column :contact_name, :string
+      t.column :contact_job, :string
+      t.column :contact_email, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -84,9 +84,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_070558) do
     t.bigint "english_language_provider_id"
     t.text "english_language_provider_reference", default: "", null: false
     t.datetime "awarded_at"
-    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "written_statement_confirmation", default: false, null: false
+    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "english_language_provider_other", default: false, null: false
     t.datetime "declined_at"
     t.boolean "waiting_on_professional_standing", default: false, null: false
@@ -97,8 +97,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_070558) do
     t.boolean "received_reference", default: false, null: false
     t.boolean "waiting_on_qualification", default: false, null: false
     t.boolean "received_qualification", default: false, null: false
-    t.boolean "written_statement_optional", default: false, null: false
     t.boolean "requires_preliminary_check", default: false, null: false
+    t.boolean "written_statement_optional", default: false, null: false
     t.boolean "overdue_further_information", default: false, null: false
     t.boolean "overdue_professional_standing", default: false, null: false
     t.boolean "overdue_qualification", default: false, null: false
@@ -137,7 +137,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_070558) do
     t.integer "age_range_min"
     t.integer "age_range_max"
     t.text "subjects", default: [], null: false, array: true
-    t.datetime "recommended_at", precision: nil
+    t.datetime "recommended_at"
     t.text "age_range_note", default: "", null: false
     t.text "subjects_note", default: "", null: false
     t.datetime "started_at"
@@ -166,8 +166,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_070558) do
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "eligibility_enabled", default: true, null: false
-    t.boolean "eligibility_skip_questions", default: false, null: false
     t.text "qualifications_information", default: "", null: false
+    t.boolean "eligibility_skip_questions", default: false, null: false
     t.boolean "requires_preliminary_check", default: false, null: false
     t.index ["code"], name: "index_countries_on_code", unique: true
   end
@@ -237,7 +237,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_070558) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "failure_reason_key", default: "", null: false
+    t.bigint "work_history_id"
+    t.string "contact_name"
+    t.string "contact_job"
+    t.string "contact_email"
     t.index ["further_information_request_id"], name: "index_fi_request_items_on_fi_request_id"
+    t.index ["work_history_id"], name: "index_further_information_request_items_on_work_history_id"
   end
 
   create_table "further_information_requests", force: :cascade do |t|
@@ -272,7 +277,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_070558) do
     t.text "location_note", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "reviewed_at", precision: nil
+    t.datetime "reviewed_at"
     t.boolean "passed"
     t.string "failure_assessor_note", default: "", null: false
     t.boolean "ready_for_review", default: false, null: false
@@ -287,7 +292,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_070558) do
     t.text "location_note", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "reviewed_at", precision: nil
+    t.datetime "reviewed_at"
     t.boolean "passed"
     t.string "failure_assessor_note", default: "", null: false
     t.index ["assessment_id"], name: "index_qualification_requests_on_assessment_id"
@@ -323,7 +328,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_070558) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "passed"
-    t.datetime "reviewed_at", precision: nil
+    t.datetime "reviewed_at"
     t.boolean "contact_response"
     t.string "contact_name", default: "", null: false
     t.string "contact_job", default: "", null: false
@@ -360,12 +365,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_070558) do
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
-    t.boolean "application_form_skip_work_history", default: false, null: false
     t.text "qualifications_information", default: "", null: false
+    t.boolean "application_form_skip_work_history", default: false, null: false
     t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_requires_submission_email", default: false, null: false
-    t.boolean "written_statement_optional", default: false, null: false
     t.boolean "requires_preliminary_check", default: false, null: false
+    t.boolean "written_statement_optional", default: false, null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
     t.index ["country_id"], name: "index_regions_on_country_id"
   end
@@ -385,6 +390,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_070558) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["assessment_section_id"], name: "index_as_failure_reason_assessment_section_id"
+  end
+
+  create_table "selected_failure_reasons_work_histories", id: false, force: :cascade do |t|
+    t.bigint "work_history_id", null: false
+    t.bigint "selected_failure_reason_id", null: false
   end
 
   create_table "sessions", force: :cascade do |t|
@@ -417,9 +427,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_070558) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "invitation_token"
-    t.datetime "invitation_created_at", precision: nil
-    t.datetime "invitation_sent_at", precision: nil
-    t.datetime "invitation_accepted_at", precision: nil
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
     t.integer "invitation_limit"
     t.string "invited_by_type"
     t.bigint "invited_by_id"
@@ -445,8 +455,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_070558) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at", precision: nil
-    t.datetime "last_sign_in_at", precision: nil
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.string "trn"
@@ -536,6 +546,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_12_070558) do
   add_foreign_key "assessments", "application_forms"
   add_foreign_key "dqt_trn_requests", "application_forms"
   add_foreign_key "eligibility_checks", "regions"
+  add_foreign_key "further_information_request_items", "work_histories"
   add_foreign_key "notes", "application_forms"
   add_foreign_key "notes", "staff", column: "author_id"
   add_foreign_key "professional_standing_requests", "assessments"

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -31,6 +31,7 @@ namespace :example_data do
     TimelineEvent.delete_all
     DQTTRNRequest.delete_all
     ReminderEmail.delete_all
+    FurtherInformationRequestItem.delete_all
     FurtherInformationRequest.delete_all
     ProfessionalStandingRequest.delete_all
     QualificationRequest.delete_all

--- a/spec/factories/further_information_request_items.rb
+++ b/spec/factories/further_information_request_items.rb
@@ -5,6 +5,9 @@
 # Table name: further_information_request_items
 #
 #  id                               :bigint           not null, primary key
+#  contact_email                    :string
+#  contact_job                      :string
+#  contact_name                     :string
 #  failure_reason_assessor_feedback :text
 #  failure_reason_key               :string           default(""), not null
 #  information_type                 :string
@@ -12,15 +15,28 @@
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
 #  further_information_request_id   :bigint
+#  work_history_id                  :bigint
 #
 # Indexes
 #
-#  index_fi_request_items_on_fi_request_id  (further_information_request_id)
+#  index_fi_request_items_on_fi_request_id                     (further_information_request_id)
+#  index_further_information_request_items_on_work_history_id  (work_history_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (work_history_id => work_histories.id)
 #
 FactoryBot.define do
   factory :further_information_request_item do
     association :further_information_request
-    failure_reason_assessor_feedback { Faker::Lorem.paragraph }
+    failure_reason_assessor_feedback do
+      {
+        notes: Faker::Lorem.paragraph,
+        contact_name: nil,
+        contact_job: nil,
+        contact_email: nil,
+      }
+    end
 
     trait :with_text_response do
       information_type { "text" }
@@ -34,6 +50,12 @@ FactoryBot.define do
       after(:create) do |item|
         create(:document, :identification, documentable: item)
       end
+    end
+
+    trait :with_work_history_contact_response do
+      information_type { "work_history_contact" }
+      failure_reason_key { "school_details_cannot_be_verified" }
+      association :work_history, :completed
     end
 
     trait :completed do

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -60,6 +60,17 @@ FactoryBot.define do
         )
         create(
           :further_information_request_item,
+          :with_work_history_contact_response,
+          further_information_request:,
+          work_history:
+            create(
+              :work_history,
+              :completed,
+              application_form: further_information_request.application_form,
+            ),
+        )
+        create(
+          :further_information_request_item,
           :with_document_response,
           further_information_request:,
         )

--- a/spec/models/further_information_request_item_spec.rb
+++ b/spec/models/further_information_request_item_spec.rb
@@ -3,6 +3,9 @@
 # Table name: further_information_request_items
 #
 #  id                               :bigint           not null, primary key
+#  contact_email                    :string
+#  contact_job                      :string
+#  contact_name                     :string
 #  failure_reason_assessor_feedback :text
 #  failure_reason_key               :string           default(""), not null
 #  information_type                 :string
@@ -10,10 +13,16 @@
 #  created_at                       :datetime         not null
 #  updated_at                       :datetime         not null
 #  further_information_request_id   :bigint
+#  work_history_id                  :bigint
 #
 # Indexes
 #
-#  index_fi_request_items_on_fi_request_id  (further_information_request_id)
+#  index_fi_request_items_on_fi_request_id                     (further_information_request_id)
+#  index_further_information_request_items_on_work_history_id  (work_history_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (work_history_id => work_histories.id)
 #
 
 require "rails_helper"
@@ -28,6 +37,7 @@ RSpec.describe FurtherInformationRequestItem do
     is_expected.to define_enum_for(:information_type).with_values(
       text: "text",
       document: "document",
+      work_history_contact: "work_history_contact",
     ).backed_by_column_of_type(:string)
   end
 

--- a/spec/services/destroy_application_form_spec.rb
+++ b/spec/services/destroy_application_form_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe DestroyApplicationForm do
   include_examples "deletes model", SelectedFailureReason
   include_examples "deletes model", Document, 16, 8
   include_examples "deletes model", FurtherInformationRequest
-  include_examples "deletes model", FurtherInformationRequestItem, 4, 2
+  include_examples "deletes model", FurtherInformationRequestItem, 6, 3
   include_examples "deletes model", Note
   include_examples "deletes model", ProfessionalStandingRequest
   include_examples "deletes model", Qualification
@@ -55,6 +55,6 @@ RSpec.describe DestroyApplicationForm do
   include_examples "deletes model", Teacher
   include_examples "deletes model", TimelineEvent
   include_examples "deletes model", Upload
-  include_examples "deletes model", WorkHistory
+  include_examples "deletes model", WorkHistory, 4, 2
   include_examples "deletes model", DQTTRNRequest
 end

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe UpdateAssessmentSection do
     { selected_failure_reason_key => selected_failure_reason_assessor_feedback }
   end
   let(:selected_failure_reason_key) { "identification_document_expired" }
-  let(:selected_failure_reason_assessor_feedback) { "Epic fail" }
+  let(:selected_failure_reason_assessor_feedback) { { notes: "Epic fail" } }
   let(:params) { { passed: false, selected_failure_reasons: } }
 
   subject { described_class.call(assessment_section:, user:, params:) }
@@ -67,7 +67,7 @@ RSpec.describe UpdateAssessmentSection do
             SelectedFailureReason.find_by(
               key: selected_failure_reason_key,
             ).assessor_feedback
-          }.to(selected_failure_reason_assessor_feedback)
+          }.to(selected_failure_reason_assessor_feedback[:notes])
         end
       end
 

--- a/spec/support/autoload/page_objects/assessor_interface/check_work_history.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_work_history.rb
@@ -11,6 +11,10 @@ module PageObjects
 
       sections :cards, WorkHistoryCard, ".govuk-summary-card"
 
+      sections :school_checkbox_items,
+               PageObjects::GovukCheckboxItem,
+               ".govuk-checkboxes__conditional .govuk-checkboxes__item"
+
       def most_recent_role
         cards&.second
       end

--- a/spec/support/autoload/page_objects/teacher_interface/further_information_required.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/further_information_required.rb
@@ -12,6 +12,12 @@ module PageObjects
         element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
         element :save_and_come_back_later_button,
                 ".govuk-button.govuk-button--secondary"
+        element :contact_name,
+                "#teacher-interface-further-information-request-item-work-history-contact-form-contact-name-field"
+        element :contact_job,
+                "#teacher-interface-further-information-request-item-work-history-contact-form-contact-job-field"
+        element :contact_email,
+                "#teacher-interface-further-information-request-item-work-history-contact-form-contact-email-field"
       end
     end
   end

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -331,6 +331,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
       .first
       .checkbox
       .click
+    check_work_history_page.school_checkbox_items.first.click
     check_work_history_page
       .form
       .failure_reason_note_textareas
@@ -425,6 +426,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
           :assessment_section,
           :work_history,
           assessment: application_form.assessment,
+          failure_reasons: %w[school_details_cannot_be_verified],
         )
         create(
           :assessment_section,

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -61,6 +61,10 @@ RSpec.describe "Assessor requesting further information", type: :system do
     application_form
   end
 
+  def given_there_is_an_application_form_with_work_history_contact_failure_reasons
+    application_form_for_work_history_contact
+  end
+
   def when_i_select_request_further_information
     complete_assessment_page.request_further_information.input.choose
   end
@@ -116,6 +120,34 @@ RSpec.describe "Assessor requesting further information", type: :system do
               :selected_failure_reason,
               key: "qualifications_dont_match_subjects",
               assessor_feedback: "A note.",
+            ),
+          ],
+        )
+      end
+  end
+
+  def application_form_for_work_history_contact
+    @application_form_for_work_history_contact ||=
+      create(
+        :application_form,
+        :with_personal_information,
+        :assessment_in_progress,
+        :with_assessment,
+      ).tap do |application_form|
+        application_form.assessment.sections << create(
+          :assessment_section,
+          :qualifications,
+          :failed,
+          selected_failure_reasons: [
+            build(
+              :selected_failure_reasons,
+              key: "school_details_cannot_be_verified",
+              assessor_feedback: {
+                note: "A note.",
+                contact_name: "james",
+                contact_job: "teacher",
+                contact_email: "email@sample.com",
+              },
             ),
           ],
         )

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -76,13 +76,13 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     rows =
       review_further_information_request_page.summary_lists.flat_map(&:rows)
 
-    expect(rows.count).to eq(2)
+    expect(rows.count).to eq(8)
 
     expect(rows.first.key.text).to eq(
       "Tell us more about the subjects you can teach",
     )
 
-    expect(rows.second.key.text).to eq("Upload your identity document")
+    expect(rows.last.key.text).to eq("Upload your identity document")
   end
 
   def when_i_mark_the_section_as_complete

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe "Teacher further information", type: :system do
     then_i_see_the(:further_information_requested_page)
     and_i_see_a_completed_document_task_list_item
 
+    when_i_click_the_work_history_contact_task_list_item
+    then_i_see_the(:further_information_required_page)
+    when_i_fill_in_the_work_history_contact_response
+    and_i_click_continue
+    and_i_see_the_completed_work_history_contact_list_item
+
     when_i_click_the_check_your_answers_button
     then_i_see_the(:check_further_information_request_answers_page)
     and_i_see_the_check_your_answers_items
@@ -90,8 +96,16 @@ RSpec.describe "Teacher further information", type: :system do
     expect(document_task_list_item.status_tag.text).to eq("COMPLETED")
   end
 
+  def and_i_see_the_completed_work_history_contact_list_item
+    expect(work_history_task_list_item.status_tag.text).to eq("COMPLETED")
+  end
+
   def when_i_click_the_text_task_list_item
     text_task_list_item.link.click
+  end
+
+  def when_i_click_the_work_history_contact_task_list_item
+    work_history_task_list_item.link.click
   end
 
   def when_i_click_the_document_task_list_item
@@ -101,6 +115,13 @@ RSpec.describe "Teacher further information", type: :system do
   def when_i_fill_in_the_response
     further_information_required_page.form.response_textarea.fill_in with:
       "Response"
+  end
+
+  def when_i_fill_in_the_work_history_contact_response
+    further_information_required_page.form.contact_name.fill_in with: "James"
+    further_information_required_page.form.contact_job.fill_in with: "Carpenter"
+    further_information_required_page.form.contact_email.fill_in with:
+      "jamescarpenter@sample.com"
   end
 
   def when_i_upload_a_file
@@ -130,13 +151,16 @@ RSpec.describe "Teacher further information", type: :system do
   def and_i_see_the_check_your_answers_items
     rows = check_further_information_request_answers_page.summary_list.rows
 
-    expect(rows.count).to eq(2)
+    expect(rows.count).to eq(3)
 
     expect(rows.first.key.text).to eq(
       "Tell us more about the subjects you can teach",
     )
+    expect(rows.second.key.text).to eq(
+      "Add your work history contact’s details",
+    )
 
-    expect(rows.second.key.text).to eq("Upload your identity document")
+    expect(rows.last.key.text).to eq("Upload your identity document")
   end
 
   def when_i_click_the_text_check_your_answers_item
@@ -156,7 +180,7 @@ RSpec.describe "Teacher further information", type: :system do
       "Further information successfully submitted",
     )
     expect(submitted_application_page.panel.body.text).to eq(
-      "Your application reference number\n#{ApplicationForm.last.reference}",
+      "Your application reference number\n#{@application_form.reference}",
     )
   end
 
@@ -201,6 +225,12 @@ RSpec.describe "Teacher further information", type: :system do
     check_further_information_request_answers_page.summary_list.rows.first
   end
 
+  def work_history_task_list_item
+    further_information_requested_page.task_list.find_item(
+      "Add your work history contact’s details",
+    )
+  end
+
   def document_task_list_item
     further_information_requested_page.task_list.find_item(
       "Upload your identity document",
@@ -208,6 +238,6 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def document_check_answers_item
-    check_further_information_request_answers_page.summary_list.rows.second
+    check_further_information_request_answers_page.summary_list.rows.last
   end
 end


### PR DESCRIPTION
The TRA have identified a number of applications from India where the referee for work history is not of an appropriate level.
The TRA are going to FI the applicant to get a new name and email address - the referee will be for the work period and school.

There are currently 182 applications where the TRA will be requesting this information.

This PR adds elements to the assessor interface to request further information for teachers and flag which work history items this applies to. Additionally this PR adds pages into the teaching interface to provide this information.