### PR TITLE
Improve "Sign in with Active Directory" flow

### DIFF
--- a/app/controllers/assessor_interface/base_controller.rb
+++ b/app/controllers/assessor_interface/base_controller.rb
@@ -2,10 +2,10 @@
 
 class AssessorInterface::BaseController < ApplicationController
   include AssessorCurrentNamespace
+  include StaffAuthenticatable
 
   layout "two_thirds"
 
-  before_action :authenticate_staff!
   after_action :verify_authorized
 
   def authorize_assessor
@@ -15,6 +15,4 @@ class AssessorInterface::BaseController < ApplicationController
   def authorize_note
     authorize :note
   end
-
-  alias_method :pundit_user, :current_staff
 end

--- a/app/controllers/concerns/staff_authenticatable.rb
+++ b/app/controllers/concerns/staff_authenticatable.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module StaffAuthenticatable
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate_staff!
+    alias_method :pundit_user, :current_staff
+  end
+
+  def authenticate_staff!
+    if staff_signed_in? ||
+         !FeatureFlags::FeatureFlag.active?(:sign_in_with_active_directory)
+      super
+    else
+      session[:staff_return_to] = request.fullpath
+      redirect_to omniauth_authorize_path(:staff, :azure_activedirectory_v2)
+    end
+  end
+end

--- a/app/controllers/staff/omniauth_callbacks_controller.rb
+++ b/app/controllers/staff/omniauth_callbacks_controller.rb
@@ -1,4 +1,8 @@
+# frozen_string_literal: true
+
 class Staff::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  skip_before_action :authenticate
+
   def azure_activedirectory_v2
     auth = request.env["omniauth.auth"]
     email = auth["info"]["email"]

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -3,20 +3,8 @@ class Staff::SessionsController < Devise::SessionsController
 
   layout "two_thirds"
 
-  # GET /resource/sign_in
-  # def new
-  #   super
-  # end
-
-  # POST /resource/sign_in
-  # def create
-  #   super
-  # end
-
-  # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
+  def signed_out
+  end
 
   protected
 
@@ -25,7 +13,7 @@ class Staff::SessionsController < Devise::SessionsController
   end
 
   def after_sign_out_path_for(_resource)
-    new_staff_session_path
+    staff_signed_out_path
   end
 
   def set_flash_message(*)

--- a/app/controllers/support_interface/base_controller.rb
+++ b/app/controllers/support_interface/base_controller.rb
@@ -2,13 +2,12 @@
 
 class SupportInterface::BaseController < ApplicationController
   include SupportCurrentNamespace
+  include StaffAuthenticatable
 
-  before_action :authenticate_staff!, :authorize_support
+  before_action :authorize_support
   after_action :verify_authorized
 
   def authorize_support
     authorize :support
   end
-
-  alias_method :pundit_user, :current_staff
 end

--- a/app/views/staff/mailer/invitation_instructions.text.erb
+++ b/app/views/staff/mailer/invitation_instructions.text.erb
@@ -1,8 +1,9 @@
 <%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %>
 
 <%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %>
+
 <% if FeatureFlags::FeatureFlag.active?(:sign_in_with_active_directory) %>
-  <%= new_staff_session_url %>
+  <%= omniauth_authorize_url(:staff, :azure_activedirectory_v2) %>
 <% else %>
   <%= accept_invitation_url(@resource, invitation_token: @token) %>
 <% end %>

--- a/app/views/staff/sessions/new.html.erb
+++ b/app/views/staff/sessions/new.html.erb
@@ -1,24 +1,18 @@
 <h1 class="govuk-heading-l">Log in</h1>
 
-<% unless FeatureFlags::FeatureFlag.active?(:sign_in_with_active_directory) %>
-  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-    <%= f.govuk_error_summary %>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <%= f.govuk_error_summary %>
 
-    <%= f.govuk_email_field :email, autocomplete: "email", label: { text: "Email" } %>
-    <%= f.govuk_password_field :password, autocomplete: "current-password", label: { text: "Password" } %>
+  <%= f.govuk_email_field :email, autocomplete: "email", label: { text: "Email" } %>
+  <%= f.govuk_password_field :password, autocomplete: "current-password", label: { text: "Password" } %>
 
-    <% if devise_mapping.rememberable? %>
-      <%= f.govuk_check_boxes_fieldset :remember_me, multiple: false, legend: nil do %>
-        <%= f.govuk_check_box :remember_me, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Remember me?" } %>
-      <% end %>
+  <% if devise_mapping.rememberable? %>
+    <%= f.govuk_check_boxes_fieldset :remember_me, multiple: false, legend: nil do %>
+      <%= f.govuk_check_box :remember_me, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Remember me?" } %>
     <% end %>
-
-    <%= f.govuk_submit %>
   <% end %>
-<% end %>
 
-<% if FeatureFlags::FeatureFlag.active?(:sign_in_with_active_directory) %>
-  <%= govuk_button_to "Sign in with Active Directory", omniauth_authorize_path(:staff, :azure_activedirectory_v2), method: :post, id: "button-sign-in-with-active-directory"%>
+  <%= f.govuk_submit %>
 <% end %>
 
 <%= render "staff/shared/links" %>

--- a/app/views/staff/sessions/signed_out.html.erb
+++ b/app/views/staff/sessions/signed_out.html.erb
@@ -1,0 +1,7 @@
+<% content_for :page_title, "You’ve signed out" %>
+
+<h1 class="govuk-heading-xl">You’ve signed out</h1>
+
+<p class="govuk-body-m">
+  You are now signed out of <%= t("service.name.assessor") %>.
+</p>

--- a/app/views/staff/shared/_links.html.erb
+++ b/app/views/staff/shared/_links.html.erb
@@ -21,7 +21,7 @@
 
   <%- if devise_mapping.omniauthable? %>
     <%- resource_class.omniauth_providers.each do |provider| %>
-      <%= govuk_link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+      <%= govuk_link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
     <% end %>
   <% end %>
 </p>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,2 @@
+OmniAuth.config.allowed_request_methods = %i[post get]
+OmniAuth.config.silence_get_warning = true

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,3 @@
-Rails.application.config.action_dispatch.cookies_same_site_protection = nil
-
 Rails.application.config.session_store :active_record_store,
                                        key: "_session_id",
                                        secure: Rails.env.production?,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -203,6 +203,12 @@ Rails.application.routes.draw do
                omniauth_callbacks: "staff/omniauth_callbacks",
              }
 
+  devise_scope :staff do
+    get "/staff/signed_out",
+        to: "staff/sessions#signed_out",
+        as: "staff_signed_out"
+  end
+
   namespace :teacher_interface, path: "/teacher" do
     root to: redirect("/teacher/application")
 

--- a/spec/requests/staff_sign_in_spec.rb
+++ b/spec/requests/staff_sign_in_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "Staff sign in", type: :request do
+  before do
+    FeatureFlags::FeatureFlag.activate(:service_open)
+    FeatureFlags::FeatureFlag.activate(:sign_in_with_active_directory)
+  end
+
+  after do
+    FeatureFlags::FeatureFlag.deactivate(:service_open)
+    FeatureFlags::FeatureFlag.deactivate(:sign_in_with_active_directory)
+  end
+
+  shared_examples "an Azure login" do
+    it "redirects to Azure login" do
+      expect(response).to redirect_to("/staff/auth/azure_activedirectory_v2")
+    end
+  end
+
+  describe "GET /assessor/applications" do
+    before { get "/assessor/applications" }
+
+    it_behaves_like "an Azure login"
+  end
+
+  describe "GET /support/countries" do
+    before { get "/support/countries" }
+
+    it_behaves_like "an Azure login"
+  end
+end

--- a/spec/support/autoload/page_objects/staff/signed_out.rb
+++ b/spec/support/autoload/page_objects/staff/signed_out.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Staff
+    class SignedOut < SitePrism::Page
+      set_url "/staff/signed_out"
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -223,6 +223,10 @@ module PageHelpers
       PageObjects::AssessorInterface::ReviewFurtherInformationRequest.new
   end
 
+  def staff_signed_out_page
+    @staff_signed_out_page ||= PageObjects::Staff::SignedOut.new
+  end
+
   def start_page
     @start_page ||= PageObjects::EligibilityInterface::Start.new
   end

--- a/spec/system/assessor_interface/authentication_spec.rb
+++ b/spec/system/assessor_interface/authentication_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Assessor authentication", type: :system do
     then_i_see_the(:applications_page)
 
     when_i_click_sign_out
-    then_i_see_the(:login_page)
+    then_i_see_the(:staff_signed_out_page)
   end
 
   private

--- a/spec/system/assessor_interface/authentication_spec.rb
+++ b/spec/system/assessor_interface/authentication_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor authentication", type: :system do
   it "allows signing in and signing out" do
-    given_that_sign_in_with_active_directory_is_deactivated
     given_the_service_is_open
     given_staff_exist
 
@@ -18,18 +17,6 @@ RSpec.describe "Assessor authentication", type: :system do
     then_i_see_the(:login_page)
   end
 
-  it "allows signing in and signing out via azure AD" do
-    given_that_sign_in_with_active_directory_is_activated
-    given_the_service_is_open
-    given_staff_exist
-
-    when_i_visit_the(:applications_page)
-    then_i_see_the(:login_page)
-
-    when_i_login_with_azure_ad
-    then_i_see_the_azure_login_page
-  end
-
   private
 
   def given_staff_exist
@@ -40,23 +27,7 @@ RSpec.describe "Assessor authentication", type: :system do
     login_page.submit(email: "staff@example.com", password: "password")
   end
 
-  def when_i_login_with_azure_ad
-    login_page.azure_sign_in.click
-  end
-
-  def then_i_see_the_azure_login_page
-    expect(page.current_url).to include("https://login.microsoftonline.com/")
-  end
-
   def when_i_click_sign_out
     applications_page.header.sign_out_link.click
-  end
-
-  def given_that_sign_in_with_active_directory_is_activated
-    FeatureFlags::FeatureFlag.activate(:sign_in_with_active_directory)
-  end
-
-  def given_that_sign_in_with_active_directory_is_deactivated
-    FeatureFlags::FeatureFlag.deactivate(:sign_in_with_active_directory)
   end
 end


### PR DESCRIPTION
Instead of taking users to a sign in page where they have to click on the "Sign in with Active Directory" button, we will redirect users directly to the Active Directory sign in page and then the user will automatically be taken back to the page they tried to access.

Tested and seems to be working in Safari, I believe the issue is related to a bug where cookies are not sent to a redirect via a initial POST method:

- https://github.com/omniauth/omniauth-oauth2/blob/3e7ee11c84153e6f0c19d38a5e63cda550f6925c/lib/omniauth/strategies/oauth2.rb#L87
- https://bugs.webkit.org/show_bug.cgi?id=219650
- https://bugs.webkit.org/show_bug.cgi?id=188165

[Trello Card](https://trello.com/c/jT1WHmVj/2048-turn-on-sign-in-with-active-directory)