### PR TITLE
Add UpdateApplicationFormName service 

### DIFF
--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -147,8 +147,7 @@ class TimelineEvent < ApplicationRecord
             unless: :requestable_event_type?
 
   belongs_to :work_history, optional: true
-  validates :work_history_id,
-            :column_name,
+  validates :column_name,
             :old_value,
             :new_value,
             presence: true,

--- a/app/services/update_application_form_name.rb
+++ b/app/services/update_application_form_name.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class UpdateApplicationFormName
+  include ServicePattern
+
+  def initialize(application_form:, user:, given_names: nil, family_name: nil)
+    @application_form = application_form
+    @user = user
+    @given_names = given_names
+    @family_name = family_name
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      change_value("given_names", given_names)
+      change_value("family_name", family_name)
+    end
+  end
+
+  private
+
+  attr_reader :application_form, :user, :given_names, :family_name
+
+  def change_value(column_name, new_value)
+    return if new_value.blank?
+
+    old_value = application_form.send(column_name)
+    return if new_value == old_value
+
+    application_form.update!(column_name => new_value)
+    create_timeline_event(column_name, old_value, new_value)
+  end
+
+  def create_timeline_event(column_name, old_value, new_value)
+    TimelineEvent.create!(
+      event_type: "information_changed",
+      application_form:,
+      creator: user,
+      column_name:,
+      old_value:,
+      new_value:,
+    )
+  end
+end

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -94,4 +94,8 @@ en:
           QualificationRequest: A qualification has been assessed.
           ReferenceRequest: A reference has been assessed.
       columns:
-        contact_email: Reference contact email
+        contact_email: Reference email address
+        contact_job: Reference job
+        contact_name: Reference name
+        family_name: Family name
+        given_names: Given names

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -496,7 +496,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
 
     it "describes the event" do
       expect(component.text.squish).to include(
-        "Reference contact email has changed from #{old_value} to #{new_value}.",
+        "Reference email address has changed from #{old_value} to #{new_value}.",
       )
     end
 

--- a/spec/services/update_application_form_name_spec.rb
+++ b/spec/services/update_application_form_name_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UpdateApplicationFormName do
+  let(:application_form) do
+    create(:application_form, :submitted, :with_personal_information)
+  end
+  let(:user) { create(:staff, :confirmed) }
+  let(:new_given_names) { "New given names" }
+  let(:new_family_name) { "New family name" }
+
+  subject(:call) do
+    described_class.call(
+      application_form:,
+      user:,
+      given_names: new_given_names,
+      family_name: new_family_name,
+    )
+  end
+
+  it "changes the contact name" do
+    expect { call }.to change(application_form, :given_names).to(
+      new_given_names,
+    )
+  end
+
+  it "changes the contact job" do
+    expect { call }.to change(application_form, :family_name).to(
+      new_family_name,
+    )
+  end
+
+  it "records timeline events" do
+    expect { call }.to have_recorded_timeline_event(
+      :information_changed,
+      creator: user,
+      application_form:,
+    )
+  end
+end


### PR DESCRIPTION
This is a service which can be used to change the name of an applicant in an application form after it's been submitted. We want to add this functionality to the case management view, so we will need this service.

[Trello Card](https://trello.com/c/oexCVy9u/2153-add-a-service-for-changing-an-applicant-name)