### PR TITLE
Improve content around further information and virus scanning

### DIFF
--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -135,16 +135,15 @@ module CheckYourAnswersSummary
             .order(:created_at)
             .select { |upload| upload.attachment.present? }
 
-        html = format_array(uploads, field)
-
         malware_scan_active =
           FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
 
-        if malware_scan_active && scope.scan_result_suspect.exists?
-          "#{html}<br /><br /><em>One or more upload has been deleted by the virus scanner.</em>"
-        else
-          html
-        end
+        [
+          format_array(uploads, field),
+          if malware_scan_active && scope.scan_result_suspect.exists?
+            "<em>One or more upload has been deleted by the virus scanner.</em>"
+          end,
+        ].compact_blank.join("<br /><br />").html_safe
       end
     end
 

--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -54,7 +54,6 @@ class AssessmentFactory
           FailureReasons::EL_EXEMPTION_BY_CITIZENSHIP_ID_UNCONFIRMED
         end
       ),
-      FailureReasons::UPLOADED_FILE_SUSPECT,
       FailureReasons::DUPLICATE_APPLICATION,
       FailureReasons::APPLICANT_ALREADY_QTS,
       FailureReasons::APPLICANT_ALREADY_DQT,
@@ -140,7 +139,6 @@ class AssessmentFactory
       FailureReasons::DEGREE_TRANSCRIPT_ILLEGIBLE,
       FailureReasons::ADDITIONAL_DEGREE_CERTIFICATE_ILLEGIBLE,
       FailureReasons::ADDITIONAL_DEGREE_TRANSCRIPT_ILLEGIBLE,
-      FailureReasons::UPLOADED_FILE_SUSPECT,
     ].compact
 
     AssessmentSection.new(key: "qualifications", checks:, failure_reasons:)
@@ -165,7 +163,6 @@ class AssessmentFactory
     failure_reasons = [
       FailureReasons::NOT_QUALIFIED_TO_TEACH_MAINSTREAM,
       FailureReasons::AGE_RANGE,
-      FailureReasons::UPLOADED_FILE_SUSPECT,
     ]
 
     AssessmentSection.new(key: "age_range_subjects", checks:, failure_reasons:)
@@ -189,7 +186,6 @@ class AssessmentFactory
           [
             FailureReasons::EL_MOI_NOT_TAUGHT_IN_ENGLISH,
             FailureReasons::EL_MOI_INVALID_FORMAT,
-            FailureReasons::UPLOADED_FILE_SUSPECT,
           ]
         else
           [
@@ -292,7 +288,6 @@ class AssessmentFactory
       FailureReasons::CONFIRM_AGE_RANGE_SUBJECTS,
       FailureReasons::QUALIFIED_TO_TEACH,
       FailureReasons::FULL_PROFESSIONAL_STATUS,
-      FailureReasons::UPLOADED_FILE_SUSPECT,
     ].compact
 
     AssessmentSection.new(

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -61,7 +61,6 @@ class FailureReasons
     SCHOOL_DETAILS_CANNOT_BE_VERIFIED = "school_details_cannot_be_verified",
     TEACHING_CERTIFICATE_ILLEGIBLE = "teaching_certificate_illegible",
     TEACHING_TRANSCRIPT_ILLEGIBLE = "teaching_transcript_illegible",
-    UPLOADED_FILE_SUSPECT = "uploaded_file_suspect",
     UNRECOGNISED_REFERENCES = "unrecognised_references",
     WORK_HISTORY_BREAK = "work_history_break",
     WRITTEN_STATEMENT_ILLEGIBLE = "written_statement_illegible",

--- a/app/views/teacher_interface/application_forms/show/_complete.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_complete.html.erb
@@ -7,7 +7,7 @@
 <% if view_object.further_information_request&.received? %>
   <h3 class="govuk-heading-m">You’ve successfully submitted your further information</h3>
   <p class="govuk-body">We’ve sent you an email to confirm that we’ve received it.</p>
-  <p class="govuk-body">Once the assessor has checked the documents to make sure you’ve provided all of the requested information, they’ll continue reviewing your QTS application.</p>
+  <p class="govuk-body">The assessor will continue to review your QTS application once they’ve checked that the further information you’ve provided can be accepted.</p>
   <p class="govuk-body">You can now close this page.</p>
 <% else %>
   <p class="govuk-body">We’ve received your application for QTS and we’ve sent you a confirmation email.</p>

--- a/app/views/teacher_interface/application_forms/show/_further_information_requested.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_further_information_requested.html.erb
@@ -1,8 +1,11 @@
 <h2 class="govuk-heading-m">We need some more information</h2>
+
 <p class="govuk-body">The assessor needs you to provide some additional information so they can continue reviewing your application.</p>
+
 <div class="govuk-inset-text">
   You may need to upload 1 or more documents. Make sure any files you upload clearly show the whole document or page, and that any text is easy to read.
 </div>
+
 <p class="govuk-body">You must add all of the requested information, so the assessor can continue reviewing your QTS application.</p>
-<p class="govuk-body">The next screen will take you to the first section you need to complete.</p>
+
 <%= govuk_start_button(text: "Start now", href: teacher_interface_application_form_further_information_request_path(view_object.further_information_request)) %>

--- a/app/views/teacher_interface/further_information_requests/edit.html.erb
+++ b/app/views/teacher_interface/further_information_requests/edit.html.erb
@@ -1,9 +1,7 @@
-<% content_for :page_title, "Check your answers before submitting your application" %>
+<% content_for :page_title, "Check your answers before submitting" %>
 <% content_for :back_link_url, back_history_path(origin: true, default: teacher_interface_application_form_further_information_request_path(@view_object.further_information_request)) %>
 
-<h1 class="govuk-heading-xl">
-  Check your answers before submitting your application
-</h1>
+<h1 class="govuk-heading-xl">Check your answers before submitting</h1>
 
 <%= render(CheckYourAnswersSummary::Component.new(
   id: "check-your-answers",

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -201,7 +201,6 @@ en:
           teaching_qualifications_from_ineligible_country: The teaching qualifications were completed in an ineligible country.
           teaching_qualifications_not_at_required_level: The teaching qualifications do not meet the required academic level (level 6).
           teaching_transcript_illegible: The teaching qualification transcript (or translation) is illegible or in a format that we cannot accept.
-          uploaded_file_suspect: We were unable to open one of the files provided. The applicant will need to submit a new file.
           unrecognised_references: Application contained 1 or more references that cannot be considered.
           work_history_break: There is an unexplained break in the applicant’s work history.
           work_history_duration: The applicant’s work experience does not meet the minimum duration requirements.

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -57,7 +57,6 @@ RSpec.describe AssessmentFactory do
               identification_document_expired
               identification_document_illegible
               identification_document_mismatch
-              uploaded_file_suspect
               duplicate_application
               applicant_already_qts
               applicant_already_dqt
@@ -123,7 +122,6 @@ RSpec.describe AssessmentFactory do
                   degree_transcript_illegible
                   additional_degree_certificate_illegible
                   additional_degree_transcript_illegible
-                  uploaded_file_suspect
                 ],
               )
             end
@@ -172,7 +170,6 @@ RSpec.describe AssessmentFactory do
                   degree_transcript_illegible
                   additional_degree_certificate_illegible
                   additional_degree_transcript_illegible
-                  uploaded_file_suspect
                 ],
               )
             end
@@ -225,7 +222,6 @@ RSpec.describe AssessmentFactory do
                   degree_transcript_illegible
                   additional_degree_certificate_illegible
                   additional_degree_transcript_illegible
-                  uploaded_file_suspect
                 ],
               )
             end
@@ -278,7 +274,6 @@ RSpec.describe AssessmentFactory do
                   degree_transcript_illegible
                   additional_degree_certificate_illegible
                   additional_degree_transcript_illegible
-                  uploaded_file_suspect
                 ],
               )
             end
@@ -304,11 +299,7 @@ RSpec.describe AssessmentFactory do
               %w[qualified_in_mainstream_education age_range_subjects_matches],
             )
             expect(section.failure_reasons).to eq(
-              %w[
-                not_qualified_to_teach_mainstream
-                age_range
-                uploaded_file_suspect
-              ],
+              %w[not_qualified_to_teach_mainstream age_range],
             )
           end
         end
@@ -334,11 +325,7 @@ RSpec.describe AssessmentFactory do
             )
 
             expect(section.failure_reasons).to eq(
-              %w[
-                not_qualified_to_teach_mainstream
-                age_range
-                uploaded_file_suspect
-              ],
+              %w[not_qualified_to_teach_mainstream age_range],
             )
           end
         end
@@ -485,7 +472,6 @@ RSpec.describe AssessmentFactory do
                 confirm_age_range_subjects
                 qualified_to_teach
                 full_professional_status
-                uploaded_file_suspect
               ],
             )
           end
@@ -529,7 +515,6 @@ RSpec.describe AssessmentFactory do
                 confirm_age_range_subjects
                 qualified_to_teach
                 full_professional_status
-                uploaded_file_suspect
               ],
             )
           end
@@ -563,7 +548,6 @@ RSpec.describe AssessmentFactory do
                 confirm_age_range_subjects
                 qualified_to_teach
                 full_professional_status
-                uploaded_file_suspect
               ],
             )
           end


### PR DESCRIPTION
This makes a few changes to the content related to virus scanning and further information as requested by our content designer.

[Trello Card](https://trello.com/c/EOLzhoTa/2158-virus-scan-failures-content-and-fi-response-dev-card)