### PR TITLE
Add missing target for checkboxes

### DIFF
--- a/app/views/assessor_interface/assessment_sections/_form.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_form.html.erb
@@ -62,9 +62,10 @@
     <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "Has the applicant completed this section to your satisfaction?" } do %>
       <%= f.govuk_radio_button :passed, true, label: { text: "Yes" }, link_errors: true %>
       <%= f.govuk_radio_button :passed, false, label: { text: "No" } do %>
-        <%= f.govuk_check_boxes_fieldset :selected_failure_reasons, legend: { size: "s" }  do %>
+        <div id="assessor-interface-assessment-section-form-selected-failure-reasons-field-error"></div>
+        <%= f.govuk_check_boxes_fieldset :selected_failure_reasons, legend: { size: "s" } do %>
           <% view_object.failure_reasons.each do |failure_reason| %>
-            <%= f.govuk_check_box "#{failure_reason}_checked".to_sym, true, label: { text: t(failure_reason, scope: %i[assessor_interface assessment_sections failure_reasons as_statement]) }, link_errors: true do %>
+            <%= f.govuk_check_box "#{failure_reason}_checked".to_sym, true, label: { text: t(failure_reason, scope: %i[assessor_interface assessment_sections failure_reasons as_statement]) } do %>
               <%= f.govuk_text_area "#{failure_reason}_notes".to_sym,
                                     label: { text: t(view_object.notes_label_key_for(failure_reason:)), size: "s" },
                                     hint: { text: t(view_object.notes_hint_key_for(failure_reason:)) },


### PR DESCRIPTION
When an error occurs in the form we get a link which links to the relevant field with the error. Unfortunately this doesn't work for the checkboxes because we're not using the field as intented, instead we're using a fieldset but each checkbox as got its own name, so we never end up with a suitable target. This commit adds an invisible div target which can be used to link to.

[Trello Card](https://trello.com/c/L98M2axS/2161-ensure-error-messages-link-to-fields)

## Screenshot

<img width="932" alt="Screenshot 2023-08-07 at 17 21 05" src="https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/98943c52-e562-4242-a4e4-b5e832a1ab35">
