### PR TITLE
Use hint text instead of placeholder

### DIFF
--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -30,7 +30,7 @@
     </section>
 
     <section id="app-applications-filters-reference">
-      <%= f.govuk_text_field :reference, label: { size: "s" }, placeholder: I18n.t("helpers.placeholder.assessor_interface_filter_form.reference") %>
+      <%= f.govuk_text_field :reference, label: { size: "s" } %>
     </section>
 
     <section id="app-applications-filters-name">

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -10,6 +10,8 @@ en:
           decline: As this reason triggers a decline, you do not need to add a note, but you can use the space below to add anything you feel might be helpful, if you want to.
       assessor_interface_create_note_form:
         text: Use the text box to add a note to the application history. Other assessors will be able to see any notes you add, but they will not be visible to the applicant.
+      assessor_interface_filter_form:
+        reference: "Example: 210245"
       assessor_interface_professional_standing_request_location_form:
         location_note: Use this space to add any useful notes, for example, where to locate the response.
       assessor_interface_work_history_contact_form:
@@ -263,8 +265,6 @@ en:
           text: "Example: The right-hand section of your teaching qualification document is missing, please take a new image and upload it."
           document: "Example: The right-hand section of your teaching qualification document is missing, please take a new image and upload it."
           decline: "Example: We declined this QTS application as you already have another application in progress."
-      assessor_interface_filter_form:
-        reference: "Example: 210245"
     legend:
       assessor_interface_assessment_recommendation_form:
         recommendation: QTS review completed


### PR DESCRIPTION
The placeholder shouldn't contain a hint text as it disappears once something has been typed in. This came from our accessibility audit.

[Trello Card](https://trello.com/c/0PN2a76n/2167-use-hint-text-rather-than-placeholders-in-case-management)

## Screenshot

<img width="332" alt="Screenshot 2023-08-09 at 15 31 26" src="https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/fc0db1cc-eab9-4caa-8b03-d5a7b724e3e4">
