### PR TITLE
Change link on QTS award page

### DIFF
--- a/app/views/teacher_interface/application_forms/show/_awarded.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_awarded.html.erb
@@ -12,7 +12,7 @@
 
 <h3 class="govuk-heading-m">Find out more about teaching in England</h3>
 
-<p class="govuk-body">There’s more information about coming to teach in England, including details about visas and immigration, in the <a href="https://www.gov.uk/government/publications/teach-in-england-if-you-qualified-outside-the-uk/teach-in-england-if-you-qualified-outside-the-uk" class="govuk-link">Department for Education’s guidance for teachers who qualified outside the UK</a>.</p>
+<p class="govuk-body">There’s more information about coming to teach in England at: <a href="https://getintoteaching.education.gov.uk/non-uk-teachers" class="govuk-link">Get Into Teaching</a></p>
 
 <h3 class="govuk-heading-m">Search for a job in teaching</h3>
 


### PR DESCRIPTION
At present when an applicant is awarded QTS they are sent an email asking them to log into the system to get their TRN and further information.

Change the link on the award page to redirect to https://getintoteaching.education.gov.uk/non-uk-teachers.