### PR TITLE
Improve flaky reminder email test

### DIFF
--- a/spec/services/send_reminder_email_spec.rb
+++ b/spec/services/send_reminder_email_spec.rb
@@ -123,13 +123,13 @@ RSpec.describe SendReminderEmail do
       end
 
       context "with less than two weeks remaining" do
-        let(:application_created_at) { (6.months - 13.days).ago }
+        let(:application_created_at) { (6.months - 8.days).ago }
         include_examples "first reminder email",
                          "sends an application not submitted email"
       end
 
       context "with less than one week remaining" do
-        let(:application_created_at) { (6.months - 6.days).ago }
+        let(:application_created_at) { (6.months - 1.day).ago }
         include_examples "second reminder email",
                          "sends an application not submitted email"
       end


### PR DESCRIPTION
This improves a flaky test related to reminder emails by making the threshold requirement less strict. Currently this test can fail as the number of days left can fluctuate between around 13-15 days due to the fact that "6 months ago" varies according to the number of days in each month.