### PR TITLE
Improve decline page content

### DIFF
--- a/app/views/teacher_interface/application_forms/show/_awarded.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_awarded.html.erb
@@ -12,13 +12,13 @@
 
 <h3 class="govuk-heading-m">Find out more about teaching in England</h3>
 
-<p class="govuk-body">There’s more information about coming to teach in England at: <a href="https://getintoteaching.education.gov.uk/non-uk-teachers" class="govuk-link">Get Into Teaching</a></p>
+<p class="govuk-body">There’s more information about coming to teach in England at <%= govuk_link_to "Get Into Teaching", "https://getintoteaching.education.gov.uk/non-uk-teachers" %>.</p>
 
 <h3 class="govuk-heading-m">Search for a job in teaching</h3>
 
-<p class="govuk-body">You can search for a teaching job using <a href="https://teaching-vacancies.service.gov.uk" class="govuk-link">Teaching Vacancies</a>. It’s the official government service that schools use to list their teaching roles. You can also sign up to alerts for the latest jobs matching your key search criteria.</p>
+<p class="govuk-body">You can search for a teaching job using <%= govuk_link_to "Teaching Vacancies", "https://teaching-vacancies.service.gov.uk" %>. It’s the official government service that schools use to list their teaching roles. You can also sign up to alerts for the latest jobs matching your key search criteria.</p>
 
 <h3 class="govuk-heading-m">Get support with your application</h3>
 
-<p class="govuk-body">If you’re applying for a secondary school maths, physics or modern foreign languages teaching role in England, use the Get into Teaching service for one-to-one support with your application through <a href="https://adviser-getintoteaching.education.gov.uk" class="govuk-link">Get an advisor</a>.</p>
+<p class="govuk-body">If you’re applying for a secondary school maths, physics or modern foreign languages teaching role in England, use the Get into Teaching service for one-to-one support with your application through <%= govuk_link_to "Get an advisor", "https://adviser-getintoteaching.education.gov.uk" %>.</p>
 <p class="govuk-body">Your adviser can help with writing a personal statement, preparing for an interview and accessing courses to enhance your subject knowledge.</p>

--- a/app/views/teacher_interface/application_forms/show/_declined.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_declined.html.erb
@@ -2,19 +2,17 @@
 
 <h3 class="govuk-heading-m">Why your application was declined</h3>
 
-<%- if view_object.show_further_information_request_expired_content? -%>
+<% if view_object.show_further_information_request_expired_content? %>
   <%= govuk_inset_text(text: t(".further_information_request_expired")) %>
-<%- end -%>
+<% end %>
 
-<%- if view_object.show_professional_standing_request_expired_content? -%>
-  <%= govuk_inset_text(
-        text: t(
-          ".professional_standing_request_expired",
-          certificate_name: region_certificate_name(view_object.region),
-          teaching_authority_name: region_teaching_authority_name(view_object.region)
-        )
-      ) %>
-<%- end -%>
+<% if view_object.show_professional_standing_request_expired_content? %>
+  <%= govuk_inset_text(text: t(
+    ".professional_standing_request_expired",
+    certificate_name: region_certificate_name(view_object.region),
+    teaching_authority_name: region_teaching_authority_name(view_object.region)
+  )) %>
+<% end %>
 
 <% if (sections = view_object.notes_from_assessors).present? %>
   <h4 class="govuk-heading-s">Notes from the assessor:</h4>
@@ -48,9 +46,7 @@
 
   <p class="govuk-body">If you reapply for QTS, you will not be able to review the details of your previous application.</p>
 
-  <p class="govuk-body">
-    <%= govuk_button_link_to "Apply again", new_teacher_interface_application_form_path %>
-  </p>
+  <p class="govuk-body"><%= govuk_button_link_to "Apply again", new_teacher_interface_application_form_path %></p>
 
   <p class="govuk-body">You may want to explore other routes to teaching in England. QTS is not a requirement to teach in independent (private) schools, academies, free schools and in the further education (FE) sector in England.</p>
 
@@ -62,8 +58,8 @@
     <li><%= govuk_link_to "Academies and Free Schools", "https://www.gov.uk/types-of-school" %></li>
   </ul>
 
-  <p class="govuk-body">For further information on other routes to gaining QTS visit <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas" class="govuk-link">Get into teaching</a>.</p>
-  <p class="govuk-body">You can also learn more about <a href="https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student" class="govuk-link">training to teach in England</a>.</p>
+  <p class="govuk-body">For further information on other routes to gaining QTS visit <%= govuk_link_to "Get Into Teaching", "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas" %>.</p>
+  <p class="govuk-body">You can also learn more about <%= govuk_link_to "training to teach in England", "https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student" %>.</p>
 
   <p class="govuk-body">You have the right of appeal to the Head of Teacher Qualifications and/or the County Court against this decision.</p>
 <% end %>

--- a/app/views/teacher_interface/application_forms/show/_declined.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_declined.html.erb
@@ -39,14 +39,16 @@
   <%= govuk_inset_text { simple_format recommendation_assessor_note } %>
 <% end %>
 
-<h3 class="govuk-heading-m">What you can do next</h3>
-
 <% unless view_object.declined_cannot_reapply? %>
+  <h3 class="govuk-heading-m">What you can do next</h3>
+
   <p class="govuk-body">While your QTS application was declined this time, you can make a new application in future, if you’re able to address the decline reasons we’ve set out.</p>
 
   <p class="govuk-body">If you reapply for QTS, you will not be able to review the details of your previous application.</p>
 
   <p class="govuk-body"><%= govuk_button_link_to "Apply again", new_teacher_interface_application_form_path %></p>
+
+  <h3 class="govuk-heading-m">Other routes to teaching in England</h3>
 
   <p class="govuk-body">You may want to explore other routes to teaching in England. QTS is not a requirement to teach in independent (private) schools, academies, free schools and in the further education (FE) sector in England.</p>
 
@@ -60,8 +62,20 @@
 
   <p class="govuk-body">For further information on other routes to gaining QTS visit <%= govuk_link_to "Get Into Teaching", "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas" %>.</p>
   <p class="govuk-body">You can also learn more about <%= govuk_link_to "training to teach in England", "https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student" %>.</p>
-
-  <p class="govuk-body">You have the right of appeal to the Head of Teacher Qualifications and/or the County Court against this decision.</p>
 <% end %>
 
-<p class="govuk-body">If you want to appeal, you should contact <%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %> and do so within 4 months of this notification.</p>
+<h3 class="govuk-heading-m">Decision review</h3>
+
+<p class="govuk-body">Applicants who have been declined for QTS are entitled to a review of the decline decision by a Casework Manager.</p>
+<p class="govuk-body">If you would like to request a decision review, you will need to provide:</p>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>formal evidence and reasoning as to how you meet the required assessment criteria</li>
+  <li>additional information not included in your original application that would support your decision review</li>
+</ul>
+
+<p class="govuk-body">Your request for review must be received within 28 days of receipt of the decision to decline QTS.</p>
+
+<p class="govuk-body">Email your request for review, including the information required as above, to <%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %>.</p>
+
+<p class="govuk-body">If you are not satisfied with the outcome of the decision review, you can request a final formal appeal to a senior Teacher Qualification Manager.</p>


### PR DESCRIPTION
This makes a few changes to the content on the decline page to clarify exactly the decision review process.

Depends on #1646

[Trello Card](https://trello.com/c/SfbjKXJZ/2200-update-appeal-wording-on-decline-notification)

## Screenshots

![Screenshot 2023-08-22 at 11 42 32](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/16efc711-1db0-461c-8b83-d827fd757f62)
![Screenshot 2023-08-22 at 11 42 35](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/69f37370-54d7-40be-8d8e-54c1efe87433)
