### PR TITLE
Improve content related to work experience

### DIFF
--- a/app/views/eligibility_interface/work_experience/new.html.erb
+++ b/app/views/eligibility_interface/work_experience/new.html.erb
@@ -17,9 +17,8 @@
   <% end %>
 
   <%= govuk_details(summary_text: "How to calculate your work experience") do %>
-    <p>We need to know how long you’ve spent actively teaching. This can include scheduled school holiday periods, but cannot include any other time you’ve spent away from teaching.</p>
-    <p>To work out your experience, add up the time you’ve spent employed as a teacher, including any scheduled school holidays.</p>
-    <p>If you have 9 months or more (this is equivalent to 1 academic year) but less than 20 months (this is equivalent to 2 academic years), you may still be awarded QTS, but you’ll need to complete a 2-year ‘statutory induction’ period as a newly qualified teacher.</p>
+    <p>Add up the months you’ve spent employed as a teacher. This should include school holidays but not include any other time spent away from teaching.</p>
+    <p>You’ll need to complete a 2-year ‘statutory induction’ period as a newly qualified teacher if you’re awarded QTS and have between 9 and 20 months of teaching experience. This statutory induction is not required if you have more than 20 months experience.</p>
   <% end %>
 
   <%= f.govuk_submit %>

--- a/app/views/shared/eligible_region_content_components/_proof_of_work_history.html.erb
+++ b/app/views/shared/eligible_region_content_components/_proof_of_work_history.html.erb
@@ -1,6 +1,6 @@
 <p class="govuk-body">You need to show you’ve been employed as a teacher in a school for at least 9 months or more.</p>
 
-<p class="govuk-body">The teaching roles you include as proof can be from working in any country but must have occurred after becoming qualified to teach.</p>
+<p class="govuk-inset-text">The teaching roles you include as proof can be from working in any country but must have occurred after becoming qualified to teach.</p>
 
 <% if region.reduced_evidence_accepted %>
   <p class="govuk-body">You’ll need to tell us about any professional teaching work experience where you:</p>

--- a/app/views/teacher_interface/work_histories/_school_form.html.erb
+++ b/app/views/teacher_interface/work_histories/_school_form.html.erb
@@ -1,29 +1,29 @@
-<%= form_with model: form, url: @form.work_history.new_record? ? %i[teacher_interface application_form work_histories] : [:school, :teacher_interface, :application_form, form.work_history], method: :post do |f| %>
+<%= form_with model: form, url: form.work_history.new_record? ? %i[teacher_interface application_form work_histories] : [:school, :teacher_interface, :application_form, form.work_history], method: :post do |f| %>
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-l">
     <%= t("application_form.work_history.school.heading.#{form.work_history.locale_key}") %>
   </h1>
 
-  <p class="govuk-body">Tell us about the teaching roles you’ve held <b>since completing</b> your teaching qualification.</p>
-  <p class="govuk-inset-text">We cannot accept roles that took place before you became recognised as a teacher.</p>
-  <p class="govuk-body">
-    If you started a role before you were recognised as a teacher, but you continued in the same role once you became recognised,
-    only the part of that role that took place after you were recognised will count towards your QTS application.
-  </p>
+  <p class="govuk-body">You must only add teaching employment roles gained <span class="govuk-!-font-weight-bold">after</span> becoming a teacher. The teaching roles you provide can be from working in any country.</p>
+  <p class="govuk-inset-text">We cannot accept any teaching experience gained before you were qualified.</p>
 
   <% if form.work_history.new_record? %>
     <%= f.govuk_check_boxes_fieldset :meets_all_requirements, legend: nil, multiple: false do %>
-      <p class="govuk-body">Every role you add must meet <strong class="govuk-!-font-weight-bold">ALL</strong> of the following requirements.</p>
+      <p class="govuk-body">Each role you add must meet <strong class="govuk-!-font-weight-bold">all</strong> of the following requirements.</p>
+
+      <p class="govuk-body">You were:</p>
 
       <ul class="govuk-list govuk-list--bullet">
-        <li>You were qualified to teach while working this role.</li>
-        <li>You worked unsupervised with children aged between 5 and 16 years.</li>
-        <li>You were solely responsible for planning, preparing and delivering lessons to at least 4 students at a time.</li>
-        <li>You were solely responsible for assessing and reporting on the progress of those students.</li>
+        <li>teaching in this role after qualifying</li>
+        <li>unsupervised when working with children aged between 5 and 16 years</li>
+        <li>solely responsible for planning, preparing and delivering lessons to at least 4 students at a time</li>
+        <li>solely responsible for assessing and reporting on the progress of those student</li>
       </ul>
 
-      <p class="govuk-body">We cannot consider any teaching roles that do not meet ALL of these requirements.</p>
+      <% unless form.work_history.application_form.reduced_evidence_accepted %>
+        <p class="govuk-body">We’ll contact the references you’ve provided to verify your work history before awarding QTS.</p>
+      <% end %>
 
       <%= f.govuk_check_box :meets_all_requirements, 1, 0, multiple: false, link_errors: true, label: {
         text: "The role I’m about to add meets ALL of these requirements.", size: "s"

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -23,7 +23,7 @@ en:
       eligibility_interface_region_form:
         region_id: This means you have all the qualifications needed to teach in a state school.<br /><br />You’ll need to show that you completed your teaching qualification in the country that you select.
       eligibility_interface_work_experience_form:
-        work_experience: We need to know how long you’ve been employed as a teacher, since completing your teaching qualification.<br /><br />You can include teaching work experience gained from any country.
+        work_experience: You can include teaching work experience gained from any country.
       qualification:
         add_another: You can use the next section to tell us about additional degrees if you want to.
       teacher:


### PR DESCRIPTION
This clarifies that the work experience doesn't have to have been in the UK, but it does need to have been after the teaching qualification.

[Trello Card](https://trello.com/c/TBnGHcDj/2204-add-content-about-teaching-experience-from-any-country-being-valid)