### PR TITLE
Fix withdraw permission in staff list

### DIFF
--- a/app/views/support_interface/staff/index.html.erb
+++ b/app/views/support_interface/staff/index.html.erb
@@ -58,7 +58,7 @@
 
     summary_list.with_row do |row|
       row.with_key { t("activerecord.attributes.staff.withdraw_permission") }
-      row.with_value { govuk_boolean_tag(staff.support_console_permission) }
+      row.with_value { govuk_boolean_tag(staff.withdraw_permission) }
       row.with_action(
         href: edit_support_interface_staff_path(staff),
         visually_hidden_text: t("activerecord.attributes.staff.withdraw_permission")


### PR DESCRIPTION
It's currently showing the support console permission rather than withdrawn.