### PR TITLE
Only set work_history_checked attributes where necessary

### DIFF
--- a/app/forms/assessor_interface/assessment_section_form.rb
+++ b/app/forms/assessor_interface/assessment_section_form.rb
@@ -124,7 +124,9 @@ class AssessorInterface::AssessmentSectionForm
       selected_failure_reasons_hash.each do |key, notes|
         attributes["#{key}_checked"] = true
         attributes["#{key}_notes"] = notes[:assessor_feedback]
-        attributes["#{key}_work_history_checked"] = notes[:work_history_ids]
+        if FailureReasons.chooses_work_history?(failure_reason: key)
+          attributes["#{key}_work_history_checked"] = notes[:work_history_ids]
+        end
       end
 
       if assessment_section.preliminary? && assessment_section.passed?


### PR DESCRIPTION
This attribute will only exist if the failure reason is able to be associated with a work history, so we should only set the attribute in that case.

This should fix: https://dfe-teacher-services.sentry.io/issues/4445860540/