### PR TITLE
Fix issue where subjects cannot be cleared

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
@@ -150,8 +150,11 @@ module AssessorInterface
         :age_range_max,
         :age_range_note,
         :subject_1,
+        :subject_1_raw,
         :subject_2,
+        :subject_2_raw,
         :subject_3,
+        :subject_3_raw,
         :subjects_note,
       )
     end

--- a/app/forms/assessor_interface/check_age_range_subjects_form.rb
+++ b/app/forms/assessor_interface/check_age_range_subjects_form.rb
@@ -26,8 +26,11 @@ class AssessorInterface::CheckAgeRangeSubjectsForm < AssessorInterface::Assessme
         age_range_max
         age_range_note
         subject_1
+        subject_1_raw
         subject_2
+        subject_2_raw
         subject_3
+        subject_3_raw
         subjects_note
       ]
       [args, kwargs]

--- a/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
+++ b/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
@@ -24,11 +24,15 @@ module AssessorInterface::AgeRangeSubjectsForm
               }
 
     attribute :subject_1, :string
+    attribute :subject_1_raw, :string
     attribute :subject_2, :string
+    attribute :subject_2_raw, :string
     attribute :subject_3, :string
+    attribute :subject_3_raw, :string
     attribute :subjects_note, :string
 
     validates :subject_1, presence: true
+    validates :subject_1_raw, presence: true
   end
 
   def save
@@ -52,7 +56,11 @@ module AssessorInterface::AgeRangeSubjectsForm
   end
 
   def update_subjects
-    subjects = [subject_1, subject_2, subject_3].compact_blank
+    subjects = [
+      subject_1_raw.present? ? subject_1 : "",
+      subject_2_raw.present? ? subject_2 : "",
+      subject_3_raw.present? ? subject_3 : "",
+    ].compact_blank
     note = subjects_note.presence || ""
     assessment.update!(subjects:, subjects_note: note)
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -54,6 +54,6 @@ var loadCountryAutoComplete = () => {
 };
 
 loadCountryAutoComplete();
-dfeAutocomplete({});
+dfeAutocomplete({ rawAttribute: true });
 
 checkboxSearchFilter("app-applications-filters-assessor", "Search assessors");

--- a/app/lib/dqt/subject.rb
+++ b/app/lib/dqt/subject.rb
@@ -2,13 +2,13 @@
 
 class DQT::Subject
   class << self
-    def for_id(id)
+    def for(value)
       # these three subjects are not coded by HESA so we've agreed these encodings with the DQT team
-      return "999001" if id == "citizenship"
-      return "999002" if id == "physical_education"
-      return "999003" if id == "design_and_technology"
+      return "999001" if value == "citizenship"
+      return "999002" if value == "physical_education"
+      return "999003" if value == "design_and_technology"
 
-      MAPPING.invert.fetch(id)
+      MAPPING.invert.fetch(value)
     end
 
     # https://www.hesa.ac.uk/collection/c22053/xml/c22053/c22053codelists.xsd

--- a/app/lib/dqt/trn_request_params.rb
+++ b/app/lib/dqt/trn_request_params.rb
@@ -67,7 +67,7 @@ module DQT
     end
 
     def subjects
-      assessment.subjects.map { |id| Subject.for_id(id) }
+      assessment.subjects.map { |value| Subject.for(value) }
     end
 
     def teaching_qualification

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -3,24 +3,24 @@
 class Subject
   include ActiveModel::Model
 
-  attr_accessor :id, :name
+  attr_accessor :value, :name
 
   class << self
     def all
-      @all = find(ALL_IDS)
+      @all = find(ALL_VALUES)
     end
 
-    def find(ids)
-      (ALL_IDS & ids).map { |id| create(id:) }
+    def find(values)
+      (ALL_VALUES & values).map { |value| create(value:) }
     end
 
     private
 
-    def create(id:)
-      Subject.new(id:, name: I18n.t("subjects.#{id}"))
+    def create(value:)
+      Subject.new(value:, name: I18n.t("subjects.#{value}"))
     end
 
-    ALL_IDS = %w[
+    ALL_VALUES = %w[
       ancient_hebrew
       applied_biology
       applied_chemistry

--- a/app/views/shared/_age_range_subjects_form_fields.html.erb
+++ b/app/views/shared/_age_range_subjects_form_fields.html.erb
@@ -17,10 +17,10 @@
     form_field: f.govuk_select(
       field,
       options_for_select(
-        Subject.all.map { |subject| [subject.name, subject.id] }.unshift([nil, nil]),
+        dfe_autocomplete_options(Subject.all),
         f.object.send(field),
-        ),
-      )
+      ),
+    )
   ) %>
 <% end %>
 

--- a/spec/lib/dqt/subject_spec.rb
+++ b/spec/lib/dqt/subject_spec.rb
@@ -3,14 +3,14 @@
 require "rails_helper"
 
 RSpec.describe DQT::Subject do
-  describe "#for_id" do
-    subject(:dqt_code) { described_class.for_id(id) }
+  describe "#for" do
+    subject(:dqt_code) { described_class.for(value) }
 
-    shared_examples "DQT code" do |id|
-      let(:id) { id }
+    shared_examples "DQT code" do |value|
+      let(:value) { value }
       it { is_expected.to_not be_nil }
     end
 
-    Subject.all.map { |subject| it_behaves_like "DQT code", subject.id }
+    Subject.all.map { |subject| it_behaves_like "DQT code", subject.value }
   end
 end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Subject do
 
     it "contains the right elements" do
       expect(find.count).to eq(2)
-      expect(find.first.id).to eq("ancient_hebrew")
-      expect(find.second.id).to eq("economics")
+      expect(find.first.value).to eq("ancient_hebrew")
+      expect(find.second.value).to eq("economics")
     end
   end
 end

--- a/spec/support/shared_examples/age_range_subjects_form.rb
+++ b/spec/support/shared_examples/age_range_subjects_form.rb
@@ -34,6 +34,7 @@ RSpec.shared_examples_for "an age range subjects form" do
     it { is_expected.to_not validate_presence_of(:age_range_note) }
 
     it { is_expected.to validate_presence_of(:subject_1) }
+    it { is_expected.to validate_presence_of(:subject_1_raw) }
     it { is_expected.to_not validate_presence_of(:subject_2) }
     it { is_expected.to_not validate_presence_of(:subject_3) }
     it { is_expected.to_not validate_presence_of(:subjects_note) }
@@ -48,7 +49,12 @@ RSpec.shared_examples_for "an age range subjects form" do
 
     describe "with valid attributes and no note" do
       let(:age_range_subjects_attributes) do
-        { age_range_min: "7", age_range_max: "11", subject_1: "Subject" }
+        {
+          age_range_min: "7",
+          age_range_max: "11",
+          subject_1: "Subject",
+          subject_1_raw: "Subject",
+        }
       end
 
       it { is_expected.to be true }
@@ -79,6 +85,7 @@ RSpec.shared_examples_for "an age range subjects form" do
           age_range_max: "11",
           age_range_note: "A note.",
           subject_1: "Subject",
+          subject_1_raw: "Subject",
           subjects_note: "Another note.",
         }
       end


### PR DESCRIPTION
This fixes an issue with the age range/subjects form that prevents subjects from being cleared once they've been entered by using the `rawAttribute` feature of the DfE autocomplete component.

[Trello Card](https://trello.com/c/5OFNGZfX/2232-cannot-delete-a-subject)