### PR TITLE
Remove preliminary check from region

### DIFF
--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -35,7 +35,6 @@ class SupportInterface::RegionsController < SupportInterface::BaseController
       :application_form_skip_work_history,
       :qualifications_information,
       :reduced_evidence_accepted,
-      :requires_preliminary_check,
       :sanction_check,
       :status_check,
       :teaching_authority_address,

--- a/app/lib/application_form_factory.rb
+++ b/app/lib/application_form_factory.rb
@@ -58,7 +58,6 @@ class ApplicationFormFactory
   end
 
   def requires_preliminary_check
-    region.requires_preliminary_check ||
-      region.country.requires_preliminary_check
+    region.country.requires_preliminary_check
   end
 end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -58,9 +58,7 @@ class Region < ApplicationRecord
 
   scope :requires_preliminary_check,
         -> {
-          joins(:country).where(requires_preliminary_check: true).or(
-            where(country: { requires_preliminary_check: true }),
-          )
+          joins(:country).where(country: { requires_preliminary_check: true })
         }
 
   def checks_available?

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -7,7 +7,6 @@
 #  name                                          :string           default(""), not null
 #  qualifications_information                    :text             default(""), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null
-#  requires_preliminary_check                    :boolean          default(FALSE), not null
 #  sanction_check                                :string           default("none"), not null
 #  status_check                                  :string           default("none"), not null
 #  teaching_authority_address                    :text             default(""), not null

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -15,7 +15,7 @@ class SubmitApplicationForm
       application_form.subjects.compact_blank!
       application_form.working_days_since_submission = 0
       application_form.requires_preliminary_check =
-        region.requires_preliminary_check
+        region.country.requires_preliminary_check
       application_form.submitted_at = Time.zone.now
 
       assessment = AssessmentFactory.call(application_form:)

--- a/app/views/shared/eligible_region_content_components/_proof_of_recognition.html.erb
+++ b/app/views/shared/eligible_region_content_components/_proof_of_recognition.html.erb
@@ -46,7 +46,7 @@
       </p>
     <% end %>
 
-    <% if region.requires_preliminary_check || region.country.requires_preliminary_check %>
+    <% if region.country.requires_preliminary_check %>
       <p class="govuk-body govuk-!-font-weight-bold">
         Do not request this document yet – we’ll carry out some checks on your application first. If your application passes these checks, we’ll then email you and ask you to request the document.
       </p>

--- a/app/views/shared/support_interface/forms/_requires_preliminary_check.html.erb
+++ b/app/views/shared/support_interface/forms/_requires_preliminary_check.html.erb
@@ -1,8 +1,0 @@
-<%= f.govuk_collection_radio_buttons :requires_preliminary_check,
-                                     [
-                                       OpenStruct.new(value: :true, label: "Yes"),
-                                       OpenStruct.new(value: :false, label: "No")
-                                     ],
-                                     :value,
-                                     :label,
-                                     legend: { text: "Will applications be subject to a preliminary check?", size: "s" } %>

--- a/app/views/support_interface/countries/edit.html.erb
+++ b/app/views/support_interface/countries/edit.html.erb
@@ -22,7 +22,14 @@
                                          :label,
                                          legend: { text: "Do we accept applications from this country?", size: "s" } %>
 
-    <%= render "shared/support_interface/forms/requires_preliminary_check", f: %>
+    <%= f.govuk_collection_radio_buttons :requires_preliminary_check,
+                                         [
+                                           OpenStruct.new(value: :true, label: "Yes"),
+                                           OpenStruct.new(value: :false, label: "No")
+                                         ],
+                                         :value,
+                                         :label,
+                                         legend: { text: "Will applications be subject to a preliminary check?", size: "s" } %>
   <% end %>
 
   <%= render "shared/support_interface/forms/eligibility_checker", f: %>

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -7,7 +7,6 @@
 
   <%= f.govuk_check_box :application_form_skip_work_history, 1, 0, multiple: false, link_errors: true, small: true, label: { text: "Skip work history" } %>
 
-  <%= render "shared/support_interface/forms/requires_preliminary_check", f: %>
   <%= render "shared/support_interface/forms/status_sanctions_checks", f: %>
   <%= render "shared/support_interface/forms/teaching_authority_form_fields", f: %>
 

--- a/app/views/support_interface/regions/preview.html.erb
+++ b/app/views/support_interface/regions/preview.html.erb
@@ -14,7 +14,6 @@
   <%= f.hidden_field :application_form_skip_work_history, value: @region.application_form_skip_work_history %>
   <%= f.hidden_field :qualifications_information, value: @region.qualifications_information %>
   <%= f.hidden_field :reduced_evidence_accepted, value: @region.reduced_evidence_accepted %>
-  <%= f.hidden_field :requires_preliminary_check, value: @region.requires_preliminary_check %>
   <%= f.hidden_field :sanction_check, value: @region.sanction_check %>
   <%= f.hidden_field :status_check, value: @region.status_check %>
   <%= f.hidden_field :teaching_authority_address, value: @region.teaching_authority_address %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -304,7 +304,6 @@
     - teaching_authority_requires_submission_email
     - qualifications_information
     - written_statement_optional
-    - requires_preliminary_check
   :reminder_emails:
     - id
     - created_at

--- a/db/migrate/20230905111854_remove_requires_preliminary_check_from_regions.rb
+++ b/db/migrate/20230905111854_remove_requires_preliminary_check_from_regions.rb
@@ -1,0 +1,9 @@
+class RemoveRequiresPreliminaryCheckFromRegions < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :regions,
+                  :requires_preliminary_check,
+                  :boolean,
+                  default: false,
+                  null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_21_124846) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_05_111854) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -84,9 +84,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_124846) do
     t.bigint "english_language_provider_id"
     t.text "english_language_provider_reference", default: "", null: false
     t.datetime "awarded_at"
+    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
     t.boolean "written_statement_confirmation", default: false, null: false
-    t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "english_language_provider_other", default: false, null: false
     t.datetime "declined_at"
     t.boolean "waiting_on_professional_standing", default: false, null: false
@@ -97,8 +97,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_124846) do
     t.boolean "received_reference", default: false, null: false
     t.boolean "waiting_on_qualification", default: false, null: false
     t.boolean "received_qualification", default: false, null: false
-    t.boolean "requires_preliminary_check", default: false, null: false
     t.boolean "written_statement_optional", default: false, null: false
+    t.boolean "requires_preliminary_check", default: false, null: false
     t.boolean "overdue_further_information", default: false, null: false
     t.boolean "overdue_professional_standing", default: false, null: false
     t.boolean "overdue_qualification", default: false, null: false
@@ -137,7 +137,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_124846) do
     t.integer "age_range_min"
     t.integer "age_range_max"
     t.text "subjects", default: [], null: false, array: true
-    t.datetime "recommended_at"
+    t.datetime "recommended_at", precision: nil
     t.text "age_range_note", default: "", null: false
     t.text "subjects_note", default: "", null: false
     t.datetime "started_at"
@@ -156,19 +156,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_124846) do
     t.string "code", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "teaching_authority_address", default: "", null: false
-    t.text "teaching_authority_emails", default: [], null: false, array: true
-    t.text "teaching_authority_websites", default: [], null: false, array: true
-    t.text "teaching_authority_certificate", default: "", null: false
     t.text "teaching_authority_other", default: "", null: false
-    t.text "teaching_authority_name", default: "", null: false
-    t.string "teaching_authority_online_checker_url", default: "", null: false
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "eligibility_enabled", default: true, null: false
-    t.text "qualifications_information", default: "", null: false
     t.boolean "eligibility_skip_questions", default: false, null: false
+    t.text "qualifications_information", default: "", null: false
     t.boolean "requires_preliminary_check", default: false, null: false
+    t.text "teaching_authority_websites", default: [], null: false, array: true
+    t.string "teaching_authority_online_checker_url", default: "", null: false
+    t.text "teaching_authority_name", default: "", null: false
+    t.text "teaching_authority_emails", default: [], null: false, array: true
+    t.text "teaching_authority_certificate", default: "", null: false
+    t.text "teaching_authority_address", default: "", null: false
     t.index ["code"], name: "index_countries_on_code", unique: true
   end
 
@@ -277,7 +277,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_124846) do
     t.text "location_note", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "reviewed_at"
+    t.datetime "reviewed_at", precision: nil
     t.boolean "passed"
     t.string "failure_assessor_note", default: "", null: false
     t.boolean "ready_for_review", default: false, null: false
@@ -292,7 +292,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_124846) do
     t.text "location_note", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "reviewed_at"
+    t.datetime "reviewed_at", precision: nil
     t.boolean "passed"
     t.string "failure_assessor_note", default: "", null: false
     t.index ["assessment_id"], name: "index_qualification_requests_on_assessment_id"
@@ -328,7 +328,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_124846) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "passed"
-    t.datetime "reviewed_at"
+    t.datetime "reviewed_at", precision: nil
     t.boolean "contact_response"
     t.string "contact_name", default: "", null: false
     t.string "contact_job", default: "", null: false
@@ -365,11 +365,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_124846) do
     t.string "teaching_authority_status_information", default: "", null: false
     t.string "teaching_authority_sanction_information", default: "", null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
-    t.text "qualifications_information", default: "", null: false
     t.boolean "application_form_skip_work_history", default: false, null: false
+    t.text "qualifications_information", default: "", null: false
     t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_requires_submission_email", default: false, null: false
-    t.boolean "requires_preliminary_check", default: false, null: false
     t.boolean "written_statement_optional", default: false, null: false
     t.index ["country_id", "name"], name: "index_regions_on_country_id_and_name", unique: true
     t.index ["country_id"], name: "index_regions_on_country_id"
@@ -427,9 +426,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_124846) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "invitation_token"
-    t.datetime "invitation_created_at"
-    t.datetime "invitation_sent_at"
-    t.datetime "invitation_accepted_at"
+    t.datetime "invitation_created_at", precision: nil
+    t.datetime "invitation_sent_at", precision: nil
+    t.datetime "invitation_accepted_at", precision: nil
     t.integer "invitation_limit"
     t.string "invited_by_type"
     t.bigint "invited_by_id"
@@ -455,8 +454,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_21_124846) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
+    t.datetime "current_sign_in_at", precision: nil
+    t.datetime "last_sign_in_at", precision: nil
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.string "trn"

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -52,5 +52,9 @@ FactoryBot.define do
       teaching_authority_emails { [Faker::Internet.email] }
       teaching_authority_websites { [Faker::Internet.url] }
     end
+
+    trait :requires_preliminary_check do
+      requires_preliminary_check { true }
+    end
   end
 end

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -48,12 +48,12 @@ FactoryBot.define do
       reduced_evidence_accepted { true }
     end
 
-    trait :requires_preliminary_check do
-      requires_preliminary_check { true }
-    end
-
     trait :written_statement_optional do
       written_statement_optional { true }
+    end
+
+    trait :teaching_authority_provides_written_statement do
+      teaching_authority_provides_written_statement { true }
     end
 
     trait :online_checks do

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -7,7 +7,6 @@
 #  name                                          :string           default(""), not null
 #  qualifications_information                    :text             default(""), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null
-#  requires_preliminary_check                    :boolean          default(FALSE), not null
 #  sanction_check                                :string           default("none"), not null
 #  status_check                                  :string           default("none"), not null
 #  teaching_authority_address                    :text             default(""), not null

--- a/spec/lib/application_form_factory_spec.rb
+++ b/spec/lib/application_form_factory_spec.rb
@@ -125,7 +125,9 @@ RSpec.describe ApplicationFormFactory do
     end
 
     context "when preliminary check is required" do
-      let(:region) { create(:region, requires_preliminary_check: true) }
+      let(:region) do
+        create(:region, country: create(:country, :requires_preliminary_check))
+      end
 
       it "sets requires preliminary check" do
         expect(application_form.requires_preliminary_check).to be true

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -7,7 +7,6 @@
 #  name                                          :string           default(""), not null
 #  qualifications_information                    :text             default(""), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null
-#  requires_preliminary_check                    :boolean          default(FALSE), not null
 #  sanction_check                                :string           default("none"), not null
 #  status_check                                  :string           default("none"), not null
 #  teaching_authority_address                    :text             default(""), not null

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -77,9 +77,6 @@ RSpec.describe Region, type: :model do
 
       let!(:normal_region) { create(:region) }
       let!(:preliminary_region) do
-        create(:region, requires_preliminary_check: true)
-      end
-      let!(:preliminary_country_region) do
         create(
           :region,
           country: create(:country, requires_preliminary_check: true),
@@ -88,7 +85,6 @@ RSpec.describe Region, type: :model do
 
       it { is_expected.to_not include(normal_region) }
       it { is_expected.to include(preliminary_region) }
-      it { is_expected.to include(preliminary_country_region) }
     end
   end
 

--- a/spec/services/backfill_preliminary_checks_spec.rb
+++ b/spec/services/backfill_preliminary_checks_spec.rb
@@ -63,7 +63,9 @@ RSpec.describe BackfillPreliminaryChecks do
     end
 
     context "with a preliminary checked region" do
-      let(:region) { create(:region, :requires_preliminary_check) }
+      let(:region) do
+        create(:region, country: create(:country, :requires_preliminary_check))
+      end
 
       it "backfills the submitted application form" do
         call

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe SubmitApplicationForm do
 
     context "when teaching authority provides the written statement" do
       before do
-        region.update!(requires_preliminary_check: false)
+        region.country.update!(requires_preliminary_check: false)
         application_form.update!(
           teaching_authority_provides_written_statement: true,
         )

--- a/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
+++ b/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
@@ -127,26 +127,25 @@ RSpec.describe "Assessor pre-assessment tasks", type: :system do
 
   def application_form
     @application_form ||=
-      begin
-        application_form =
+      create(
+        :application_form,
+        :preliminary_check,
+        :with_personal_information,
+        assessor: Staff.last,
+        teaching_authority_provides_written_statement: true,
+        region:
           create(
-            :application_form,
-            :preliminary_check,
-            :with_personal_information,
-            assessor: Staff.last,
-            teaching_authority_provides_written_statement: true,
-          )
+            :region,
+            :teaching_authority_provides_written_statement,
+            country: create(:country, :requires_preliminary_check),
+          ),
+      ).tap do |application_form|
         create(
           :assessment,
           :with_preliminary_qualifications_section,
           :with_professional_standing_request,
           application_form:,
         )
-        application_form.region.update!(
-          requires_preliminary_check: true,
-          teaching_authority_provides_written_statement: true,
-        )
-        application_form
       end
   end
 

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe "Countries support", type: :system do
     when_i_select_yes_teaching_authority_requires_submission_email
     when_i_fill_qualifications_information
     when_i_check_written_statement_optional
-    when_i_check_requires_preliminary_check
     and_i_click_preview
     then_i_see_the_preview
     and_i_click_save
@@ -239,8 +238,6 @@ RSpec.describe "Countries support", type: :system do
   end
 
   def when_i_check_requires_preliminary_check
-    choose "region-requires-preliminary-check-true-field", visible: false
-  rescue Capybara::ElementNotFound
     choose "support-interface-country-form-requires-preliminary-check-true-field",
            visible: false
   end


### PR DESCRIPTION
This removes the fields from regions as we only ever set this at a country-level, it should make the support console simpler and remove any confusion about where to set this.

[Trello Card](https://trello.com/c/vit18758/2245-remove-requires-preliminary-check-from-region)