### PR TITLE
Remove proof of recognition requirements

### DIFF
--- a/app/helpers/proof_of_recognition_helper.rb
+++ b/app/helpers/proof_of_recognition_helper.rb
@@ -3,21 +3,19 @@ module ProofOfRecognitionHelper
 
   def proof_of_recognition_requirements_for(region:)
     if region.status_check_written? && region.sanction_check_written?
-      return(
-        written_status_reasons.insert(2, *written_sanction_reasons(region))
-      )
+      status_reasons.insert(2, *sanction_reasons(region))
+    elsif region.status_check_written?
+      status_reasons
+    elsif region.sanction_check_written?
+      sanction_reasons(region)
+    else
+      []
     end
-
-    return written_status_reasons if region.status_check_written?
-    return written_sanction_reasons(region) if region.sanction_check_written?
-    []
   end
 
   def proof_of_recognition_description_for(region:)
-    if region.teaching_authority_provides_written_statement?
-      "The document must confirm:"
-    elsif !region.status_check_written? && region.sanction_check_written? &&
-          !region.application_form_skip_work_history?
+    if !region.status_check_written? && region.sanction_check_written? &&
+         !region.application_form_skip_work_history
       "In the #{region_certificate_name(region)} the #{region_teaching_authority_name(region)} must confirm " \
         "that your authorisation to teach has never been:"
     else
@@ -27,7 +25,7 @@ module ProofOfRecognitionHelper
 
   private
 
-  def written_status_reasons
+  def status_reasons
     [
       "that you’ve completed a teaching qualification/teacher training",
       "that you’ve successfully completed any period of professional experience comparable to an induction period" \
@@ -37,14 +35,13 @@ module ProofOfRecognitionHelper
     ]
   end
 
-  def written_sanction_reasons(region)
-    if region.teaching_authority_provides_written_statement? ||
-         region.status_check_written?
+  def sanction_reasons(region)
+    if region.status_check_written?
       [
         "that your authorisation to teach has never been suspended, barred, cancelled, revoked or restricted, " \
           "and that you have no sanctions against you",
       ]
-    elsif region.application_form_skip_work_history?
+    elsif region.application_form_skip_work_history
       [
         "if you have completed your induction in #{CountryName.from_region(region, with_definite_article: true)}",
       ]

--- a/app/views/shared/eligible_region_content_components/_proof_of_recognition.html.erb
+++ b/app/views/shared/eligible_region_content_components/_proof_of_recognition.html.erb
@@ -54,20 +54,6 @@
       <%= render "shared/teaching_authority_contact_information", region: %>
     <% end %>
 
-    <% if (requirements = proof_of_recognition_requirements_for(region:)).count == 1 %>
-      <p class="govuk-body">
-        <%= proof_of_recognition_description_for(region:).chomp(":") %>
-        <%= requirements.first %>
-      </p>
-    <% else %>
-      <p class="govuk-body"><%= proof_of_recognition_description_for(region:) %></p>
-      <ul class="govuk-list govuk-list--bullet">
-        <% requirements.each do |requirement| %>
-          <li><%= requirement %></li>
-        <% end %>
-      </ul>
-    <% end %>
-
     <% if teaching_authority_provides_written_statement %>
       <p class="govuk-body">
         This must be dated within 6 months of you applying for QTS.
@@ -76,6 +62,21 @@
       <p class="govuk-body">
         If we do not receive the document within 180 days of the date that you submit your application, we’ll need to close your application.
       </p>
+    <% else %>
+      <% requirements = proof_of_recognition_requirements_for(region:) %>
+      <% if requirements.count == 1 %>
+        <p class="govuk-body">
+          <%= proof_of_recognition_description_for(region:).chomp(":") %>
+          <%= requirements.first %>
+        </p>
+      <% elsif requirements.count > 1 %>
+        <p class="govuk-body"><%= proof_of_recognition_description_for(region:) %></p>
+        <ul class="govuk-list govuk-list--bullet">
+          <% requirements.each do |requirement| %>
+            <li><%= requirement %></li>
+          <% end %>
+        </ul>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/spec/helpers/proof_of_recognition_helper_spec.rb
+++ b/spec/helpers/proof_of_recognition_helper_spec.rb
@@ -8,22 +8,20 @@ RSpec.describe ProofOfRecognitionHelper do
       status_check_online?: status,
       sanction_check_written?: sanction,
       sanction_check_online?: sanction,
-      teaching_authority_provides_written_statement?:
-        teaching_authority_provides_written_statement,
-      application_form_skip_work_history?: application_form_skip_work_history,
+      application_form_skip_work_history:,
       teaching_authority_name: "teaching authority",
       teaching_authority_certificate: "letter",
     )
   end
+
   let(:status) { false }
   let(:sanction) { false }
-  let(:teaching_authority_provides_written_statement) { false }
   let(:application_form_skip_work_history) { false }
 
   describe "proof_of_recognition_requirements_for" do
     subject { proof_of_recognition_requirements_for(region:) }
 
-    context "written status" do
+    context "with only a written status" do
       let(:status) { true }
 
       it do
@@ -39,7 +37,7 @@ RSpec.describe ProofOfRecognitionHelper do
       end
     end
 
-    context "written sanction only without statement provided" do
+    context "with only a written sanction" do
       let(:sanction) { true }
 
       it do
@@ -55,23 +53,10 @@ RSpec.describe ProofOfRecognitionHelper do
       end
     end
 
-    context "written sanction only with statement provided" do
-      let(:sanction) { true }
-      let(:teaching_authority_provides_written_statement) { true }
-      it do
-        is_expected.to match_array(
-          [
-            "that your authorisation to teach has never been suspended, barred, cancelled, revoked or restricted," \
-              " and that you have no sanctions against you",
-          ],
-        )
-      end
-    end
-
-    context "both" do
+    context "with a written sanction and a written status" do
       let(:sanction) { true }
       let(:status) { true }
-      let(:teaching_authority_provides_written_statement) { true }
+
       it do
         is_expected.to match_array(
           [
@@ -99,10 +84,10 @@ RSpec.describe ProofOfRecognitionHelper do
     end
   end
 
-  describe "proof_of_recognition_description_for" do
+  describe "#proof_of_recognition_description_for" do
     subject { proof_of_recognition_description_for(region:) }
 
-    context "written status only without statement provided" do
+    context "with only a written status" do
       let(:status) { true }
 
       it do
@@ -110,20 +95,9 @@ RSpec.describe ProofOfRecognitionHelper do
       end
     end
 
-    context "written status only with statement provided" do
-      let(:status) { true }
-      let(:teaching_authority_provides_written_statement) { true }
-      it { is_expected.to eq("The document must confirm:") }
-    end
-
-    context "written sanction only with statement provided" do
+    context "with only a written sanction" do
       let(:sanction) { true }
-      let(:teaching_authority_provides_written_statement) { true }
-      it { is_expected.to eq("The document must confirm:") }
-    end
 
-    context "written sanction only with statement provided without statement provided" do
-      let(:sanction) { true }
       it do
         is_expected.to eq(
           "In the letter the teaching authority must confirm that your authorisation to teach has never been:",
@@ -131,32 +105,13 @@ RSpec.describe ProofOfRecognitionHelper do
       end
     end
 
-    context "both with written statement provided" do
+    context "with a written sanction and a written status" do
       let(:sanction) { true }
       let(:status) { true }
-      let(:teaching_authority_provides_written_statement) { true }
-      it { is_expected.to eq("The document must confirm:") }
-    end
 
-    context "both without written statement provided" do
-      let(:sanction) { true }
-      let(:status) { true }
       it do
         is_expected.to eq("In the letter the teaching authority must confirm:")
       end
-    end
-
-    context "both with written statement provided" do
-      let(:sanction) { true }
-      let(:status) { true }
-      let(:teaching_authority_provides_written_statement) { true }
-      it { is_expected.to eq("The document must confirm:") }
-    end
-
-    context "a country which provides the written statement" do
-      let(:teaching_authority_provides_written_statement) { true }
-
-      it { is_expected.to eq("The document must confirm:") }
     end
   end
 end


### PR DESCRIPTION
This removes the requirements if the teaching authority provides us directly with the written statement, as there's nothing that the applicant can do in this case to change what's shown on the document.

[Trello Card](https://trello.com/c/evf3nkKC/2209-update-hong-kong-content-proof-that-youre-recognised-as-a-teacher)