### PR TITLE
Remove leading and trailing whitespace from filters

### DIFF
--- a/app/lib/filters/email.rb
+++ b/app/lib/filters/email.rb
@@ -4,7 +4,7 @@ module Filters
   class Email < Base
     def apply
       if email.present?
-        scope.joins(:teacher).where("teachers.email = ?", email.downcase)
+        scope.joins(:teacher).where("teachers.email = ?", email.strip.downcase)
       else
         scope
       end

--- a/app/lib/filters/name.rb
+++ b/app/lib/filters/name.rb
@@ -5,7 +5,10 @@ module Filters
     def apply
       return scope if name.blank?
 
-      scope.where("CONCAT(given_names, ' ', family_name) ilike ?", "%#{name}%")
+      scope.where(
+        "CONCAT(given_names, ' ', family_name) ilike ?",
+        "%#{name.strip}%",
+      )
     end
 
     private

--- a/app/lib/filters/reference.rb
+++ b/app/lib/filters/reference.rb
@@ -4,7 +4,7 @@ module Filters
   class Reference < Base
     def apply
       if reference.present?
-        scope.where("reference ILIKE ?", "%#{reference}%")
+        scope.where("reference ILIKE ?", "%#{reference.strip}%")
       else
         scope
       end

--- a/spec/lib/filters/email_spec.rb
+++ b/spec/lib/filters/email_spec.rb
@@ -31,6 +31,40 @@ RSpec.describe Filters::Email do
 
       it { is_expected.to contain_exactly(included) }
     end
+
+    context "with trailing whitespace" do
+      let(:params) { { email: "Jane.Smith@example.com    " } }
+      let(:scope) { ApplicationForm.all }
+      let!(:included) { create(:application_form, teacher:) }
+
+      before do
+        create(
+          :application_form,
+          teacher: create(:teacher, email: "jane.jones@example.com"),
+        )
+      end
+
+      it "returns a filtered scope" do
+        expect(subject).to contain_exactly(included)
+      end
+    end
+
+    context "with leading whitespace" do
+      let(:params) { { email: "    Jane.Smith@example.com" } }
+      let(:scope) { ApplicationForm.all }
+      let!(:included) { create(:application_form, teacher:) }
+
+      before do
+        create(
+          :application_form,
+          teacher: create(:teacher, email: "jane.jones@example.com"),
+        )
+      end
+
+      it "returns a filtered scope" do
+        expect(subject).to contain_exactly(included)
+      end
+    end
   end
 
   context "the params don't include email" do

--- a/spec/lib/filters/name_spec.rb
+++ b/spec/lib/filters/name_spec.rb
@@ -97,6 +97,36 @@ RSpec.describe Filters::Name do
       end
     end
 
+    context "with trailing whitespace" do
+      let(:params) { { name: "Jane Smith    " } }
+      let(:scope) { ApplicationForm.all }
+      let!(:included) do
+        create(:application_form, given_names: "Jane", family_name: "Smith")
+      end
+      let!(:excluded) do
+        create(:application_form, given_names: "Tom", family_name: "Bombadil")
+      end
+
+      it "returns a filtered scope" do
+        expect(subject).to contain_exactly(included)
+      end
+    end
+
+    context "with leading whitespace" do
+      let(:params) { { name: "    Jane Smith" } }
+      let(:scope) { ApplicationForm.all }
+      let!(:included) do
+        create(:application_form, given_names: "Jane", family_name: "Smith")
+      end
+      let!(:excluded) do
+        create(:application_form, given_names: "Tom", family_name: "Bombadil")
+      end
+
+      it "returns a filtered scope" do
+        expect(subject).to contain_exactly(included)
+      end
+    end
+
     context "match with different case" do
       let(:params) { { name: "daVe" } }
 

--- a/spec/lib/filters/reference_spec.rb
+++ b/spec/lib/filters/reference_spec.rb
@@ -40,4 +40,26 @@ RSpec.describe Filters::Reference do
 
     it { is_expected.to eq(scope) }
   end
+
+  context "with trailing whitespace" do
+    let(:params) { { reference: "ABCDEF    " } }
+    let(:scope) { ApplicationForm.all }
+    let!(:included) { create(:application_form, reference: "ABCDEF") }
+    let!(:excluded) { create(:application_form, reference: "QRHGF") }
+
+    it "returns a filtered scope" do
+      expect(subject).to contain_exactly(included)
+    end
+  end
+
+  context "with leading whitespace" do
+    let(:params) { { reference: "    ABCDEF" } }
+    let(:scope) { ApplicationForm.all }
+    let!(:included) { create(:application_form, reference: "ABCDEF") }
+    let!(:excluded) { create(:application_form, reference: "QRHGF") }
+
+    it "returns a filtered scope" do
+      expect(subject).to contain_exactly(included)
+    end
+  end
 end


### PR DESCRIPTION
On the teachers page in the assessors section there are various text boxes used to filter teachers down to the one we want. Currently any leading or trailing whitespace will cause a teacher not to match. I.e “James Franco    “ =/= “James Franco”.  We should trim the input leading or trailing whitespace before applying the filter so that it works more intuitively.