### PR TITLE
Add action required by workflow and filter

### DIFF
--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -159,5 +159,16 @@ module TimelineEntry
         new_value: timeline_event.new_value,
       }
     end
+
+    def action_required_by_changed_vars
+      {
+        action:
+          if timeline_event.new_value == "none"
+            "no"
+          else
+            timeline_event.new_value
+          end,
+      }
+    end
   end
 end

--- a/app/forms/assessor_interface/filter_form.rb
+++ b/app/forms/assessor_interface/filter_form.rb
@@ -4,12 +4,13 @@ class AssessorInterface::FilterForm
   include ActiveModel::Model
   include ActiveRecord::AttributeAssignment
 
-  attr_accessor :assessor_ids,
+  attr_accessor :action_required_by,
+                :assessor_ids,
+                :email,
                 :location,
                 :name,
                 :reference,
-                :email,
                 :statuses,
-                :submitted_at_before,
-                :submitted_at_after
+                :submitted_at_after,
+                :submitted_at_before
 end

--- a/app/lib/filters/action_required_by.rb
+++ b/app/lib/filters/action_required_by.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Filters::ActionRequiredBy < Filters::Base
+  def apply
+    return scope if action_required_by.empty?
+
+    scope.where(action_required_by:)
+  end
+
+  def action_required_by
+    Array(params[:action_required_by]).compact_blank
+  end
+end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -3,6 +3,7 @@
 # Table name: application_forms
 #
 #  id                                            :bigint           not null, primary key
+#  action_required_by                            :string           default("none"), not null
 #  age_range_max                                 :integer
 #  age_range_min                                 :integer
 #  age_range_status                              :string           default("not_started"), not null
@@ -67,6 +68,7 @@
 #
 # Indexes
 #
+#  index_application_forms_on_action_required_by            (action_required_by)
 #  index_application_forms_on_assessor_id                   (assessor_id)
 #  index_application_forms_on_english_language_provider_id  (english_language_provider_id)
 #  index_application_forms_on_family_name                   (family_name)
@@ -121,6 +123,14 @@ class ApplicationForm < ApplicationRecord
   validates :english_language_provider,
             absence: true,
             if: :english_language_provider_other
+
+  enum action_required_by: {
+         admin: "admin",
+         assessor: "assessor",
+         external: "external",
+         none: "none",
+       },
+       _prefix: true
 
   enum status: {
          draft: "draft",

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -17,10 +17,10 @@
       <div class="app-checkbox-filter__container">
         <div class="app-checkbox-filter__container-inner">
           <%= f.govuk_check_boxes_fieldset :assessor_ids, legend: { size: "s" }, small: true do %>
-            <%- @view_object.assessor_filter_options.each do |option| -%>
+            <% @view_object.assessor_filter_options.each do |option| %>
               <%= f.govuk_check_box :assessor_ids, option.id, label: { text: option.name }, checked: @view_object.filter_form.assessor_ids&.include?(option.id.to_s) %>
-            <%- end -%>
-          <%- end -%>
+            <% end %>
+          <% end %>
         </div>
       </div>
     </section>
@@ -48,6 +48,14 @@
       <% end %>
     </section>
 
+    <section id="app-applications-filters-action-required-by">
+      <%= f.govuk_check_boxes_fieldset :action_required_by, legend: { size: "s" }, small: true do %>
+        <% @view_object.action_required_by_filter_options.each do |option| %>
+          <%= f.govuk_check_box :action_required_by, option.id, label: { text: option.label }, checked: @view_object.filter_form.action_required_by&.include?(option.id) %>
+        <% end %>
+      <% end %>
+    </section>
+
     <section id="app-applications-filters-status">
       <%= f.govuk_check_boxes_fieldset :statuses, legend: { size: "s" }, small: true do %>
         <% @view_object.status_filter_options.each do |option, suboptions| %>
@@ -67,7 +75,7 @@
         <% end %>
       <% end %>
     </section>
-  <%- end -%>
+  <% end %>
 </div>
 
 <div class="govuk-grid-column-two-thirds">

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -22,68 +22,69 @@
     - blob_id
     - created_at
   :application_forms:
-    - id
-    - reference
-    - status
-    - overdue_further_information
-    - overdue_professional_standing
-    - overdue_qualification
-    - overdue_reference
-    - received_further_information
-    - received_professional_standing
-    - received_qualification
-    - received_reference
-    - waiting_on_further_information
-    - waiting_on_professional_standing
-    - waiting_on_qualification
-    - waiting_on_reference
-    - personal_information_status
-    - identification_document_status
-    - qualifications_status
-    - age_range_status
-    - subjects_status
-    - work_history_status
-    - registration_number_status
-    - written_statement_status
-    - teacher_id
-    - created_at
-    - updated_at
-    - given_names
-    - family_name
-    - date_of_birth
-    - age_range_min
+    - action_required_by
     - age_range_max
-    - has_alternative_name
-    - alternative_given_names
+    - age_range_min
+    - age_range_status
     - alternative_family_name
-    - region_id
-    - registration_number
-    - has_work_history
-    - subjects
+    - alternative_given_names
     - assessor_id
-    - reviewer_id
-    - submitted_at
     - awarded_at
-    - declined_at
-    - withdrawn_at
-    - working_days_since_submission
-    - needs_work_history
-    - needs_written_statement
-    - needs_registration_number
-    - teaching_authority_provides_written_statement
-    - written_statement_confirmation
-    - written_statement_optional
     - confirmed_no_sanctions
-    - english_language_status
+    - created_at
+    - date_of_birth
+    - declined_at
+    - dqt_match
     - english_language_citizenship_exempt
-    - english_language_qualification_exempt
     - english_language_proof_method
     - english_language_provider_id
     - english_language_provider_other
     - english_language_provider_reference
+    - english_language_qualification_exempt
+    - english_language_status
+    - family_name
+    - given_names
+    - has_alternative_name
+    - has_work_history
+    - id
+    - identification_document_status
+    - needs_registration_number
+    - needs_work_history
+    - needs_written_statement
+    - overdue_further_information
+    - overdue_professional_standing
+    - overdue_qualification
+    - overdue_reference
+    - personal_information_status
+    - qualifications_status
+    - received_further_information
+    - received_professional_standing
+    - received_qualification
+    - received_reference
     - reduced_evidence_accepted
+    - reference
+    - region_id
+    - registration_number
+    - registration_number_status
     - requires_preliminary_check
-    - dqt_match
+    - reviewer_id
+    - status
+    - subjects
+    - subjects_status
+    - submitted_at
+    - teacher_id
+    - teaching_authority_provides_written_statement
+    - updated_at
+    - waiting_on_further_information
+    - waiting_on_professional_standing
+    - waiting_on_qualification
+    - waiting_on_reference
+    - withdrawn_at
+    - work_history_status
+    - working_days_since_submission
+    - written_statement_confirmation
+    - written_statement_optional
+    - written_statement_status
   :assessment_sections:
     - id
     - assessment_id

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -38,6 +38,7 @@ en:
 
     timeline_entry:
       title:
+        action_required_by_changed: Workflow changed
         assessor_assigned: Assessor assigned
         reviewer_assigned: Reviewer assigned
         state_changed: Status changed
@@ -68,9 +69,10 @@ en:
           ReferenceRequest: Reference assessed
         information_changed: Information changed after submission
       description:
+        action_required_by_changed: Application requires %{action} action.
         assessor_assigned: "%{assignee_name} is assigned as the assessor."
         reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
-        state_changed: Status changed from %{old_state} to %{new_state}
+        state_changed: Status changed from %{old_state} to %{new_state}.
         note_created: "%{text}"
         email_sent: "%{subject}"
         requestable_requested:

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -38,7 +38,7 @@ en:
 
     timeline_entry:
       title:
-        action_required_by_changed: Workflow changed
+        action_required_by_changed: Action required by changed
         assessor_assigned: Assessor assigned
         reviewer_assigned: Reviewer assigned
         state_changed: Status changed

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -101,10 +101,10 @@ en:
       assessor_interface_create_note_form:
         text: Add a note to this application
       assessor_interface_filter_form:
+        email: Applicant email
         location: Country trained in
         name: Applicant name
         reference: Application reference number
-        email: Applicant email
       assessor_interface_professional_standing_request_location_form:
         received_options:
           true: "Yes"
@@ -277,6 +277,7 @@ en:
         scotland_full_registration: Does the applicant have or are they eligible for full registration?
         school_details_cannot_be_verified_work_history_checked: Choose the schools that need reference details to be amended
       assessor_interface_filter_form:
+        action_required_by: Action required by
         assessor_ids: Assessor name
         states: Status of application
         submitted_at: Created date

--- a/db/migrate/20230906085009_add_action_required_by_to_application_forms.rb
+++ b/db/migrate/20230906085009_add_action_required_by_to_application_forms.rb
@@ -1,0 +1,10 @@
+class AddActionRequiredByToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_forms,
+               :action_required_by,
+               :string,
+               default: "none",
+               null: false
+    add_index :application_forms, :action_required_by
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -105,6 +105,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_12_144508) do
     t.boolean "overdue_reference", default: false, null: false
     t.jsonb "dqt_match", default: {}
     t.datetime "withdrawn_at"
+    t.string "action_required_by", default: "none", null: false
+    t.index ["action_required_by"], name: "index_application_forms_on_action_required_by"
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["english_language_provider_id"], name: "index_application_forms_on_english_language_provider_id"
     t.index ["family_name"], name: "index_application_forms_on_family_name"

--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -23,4 +23,15 @@ namespace :application_forms do
     count = BackfillPreliminaryChecks.call(user:)
     puts "Updated #{count} applications."
   end
+
+  desc "Update the statuses of all application forms."
+  task :update_statuses, %i[staff_email] => :environment do |_task, args|
+    user = Staff.find_by!(email: args[:staff_email])
+    ApplicationForm
+      .order(:id)
+      .find_each do |application_form|
+        ApplicationFormStatusUpdater.call(application_form:, user:)
+        puts "#{application_form.reference}: #{application_form.action_required_by} - #{application_form.status}"
+      end
+  end
 end

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -504,4 +504,18 @@ RSpec.describe TimelineEntry::Component, type: :component do
       expect(component.text).to include(creator.name)
     end
   end
+
+  context "action required by changed" do
+    let(:timeline_event) do
+      create(:timeline_event, :action_required_by_changed, new_value: "none")
+    end
+
+    it "describes the event" do
+      expect(component.text.squish).to include("Application requires no action")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
 end

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -3,6 +3,7 @@
 # Table name: application_forms
 #
 #  id                                            :bigint           not null, primary key
+#  action_required_by                            :string           default("none"), not null
 #  age_range_max                                 :integer
 #  age_range_min                                 :integer
 #  age_range_status                              :string           default("not_started"), not null
@@ -67,6 +68,7 @@
 #
 # Indexes
 #
+#  index_application_forms_on_action_required_by            (action_required_by)
 #  index_application_forms_on_assessor_id                   (assessor_id)
 #  index_application_forms_on_english_language_provider_id  (english_language_provider_id)
 #  index_application_forms_on_family_name                   (family_name)

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -124,7 +124,24 @@ FactoryBot.define do
       written_statement_status { "completed" }
     end
 
+    trait :action_required_by_admin do
+      action_required_by { "admin" }
+    end
+
+    trait :action_required_by_assessor do
+      action_required_by { "assessor" }
+    end
+
+    trait :action_required_by_external do
+      action_required_by { "external" }
+    end
+
+    trait :action_required_by_none do
+      action_required_by { "none" }
+    end
+
     trait :submitted do
+      action_required_by_assessor
       status { "submitted" }
       submitted_at { Time.zone.now }
       working_days_since_submission { 0 }
@@ -143,6 +160,7 @@ FactoryBot.define do
 
     trait :preliminary_check do
       submitted
+      action_required_by_admin
       requires_preliminary_check { true }
       status { "preliminary_check" }
     end
@@ -154,6 +172,7 @@ FactoryBot.define do
 
     trait :waiting_on do
       submitted
+      action_required_by_external
       status { "waiting_on" }
     end
 
@@ -172,25 +191,28 @@ FactoryBot.define do
       status { "awarded_pending_checks" }
     end
 
+    trait :potential_duplicate_in_dqt do
+      submitted
+      status { "potential_duplicate_in_dqt" }
+    end
+
     trait :awarded do
       submitted
+      action_required_by_none
       status { "awarded" }
       awarded_at { Time.zone.now }
     end
 
     trait :declined do
       submitted
+      action_required_by_none
       status { "declined" }
       declined_at { Time.zone.now }
     end
 
-    trait :potential_duplicate_in_dqt do
-      submitted
-      status { "potential_duplicate_in_dqt" }
-    end
-
     trait :withdrawn do
       submitted
+      action_required_by_none
       status { "withdrawn" }
       withdrawn_at { Time.zone.now }
     end

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -105,5 +105,11 @@ FactoryBot.define do
       old_value { Faker::Internet.email }
       new_value { Faker::Internet.email }
     end
+
+    trait :action_required_by_changed do
+      event_type { "action_required_by_changed" }
+      old_value { %w[admin assessor external none].sample }
+      new_value { %w[admin assessor external none].sample }
+    end
   end
 end

--- a/spec/lib/filters/action_required_by_spec.rb
+++ b/spec/lib/filters/action_required_by_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Filters::ActionRequiredBy do
+  subject(:filtered_scope) { described_class.apply(scope:, params:) }
+
+  context "the params includes a action_required_by" do
+    let(:params) { { action_required_by: "assessor" } }
+    let(:scope) { ApplicationForm.all }
+
+    let!(:included) { create(:application_form, :action_required_by_assessor) }
+    let!(:excluded) { create(:application_form, :action_required_by_admin) }
+
+    it { is_expected.to contain_exactly(included) }
+  end
+
+  context "the params include multiple action_required_by" do
+    let(:params) { { action_required_by: %w[assessor external] } }
+    let(:scope) { ApplicationForm.all }
+
+    let!(:included) { create(:application_form, :action_required_by_assessor) }
+    let!(:excluded) { create(:application_form, :action_required_by_admin) }
+
+    it { is_expected.to contain_exactly(included) }
+  end
+
+  context "the params don't include action_required_by" do
+    let(:params) { {} }
+    let(:scope) { double }
+
+    it { is_expected.to eq(scope) }
+  end
+end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -3,6 +3,7 @@
 # Table name: application_forms
 #
 #  id                                            :bigint           not null, primary key
+#  action_required_by                            :string           default("none"), not null
 #  age_range_max                                 :integer
 #  age_range_min                                 :integer
 #  age_range_status                              :string           default("not_started"), not null
@@ -67,6 +68,7 @@
 #
 # Indexes
 #
+#  index_application_forms_on_action_required_by            (action_required_by)
 #  index_application_forms_on_assessor_id                   (assessor_id)
 #  index_application_forms_on_english_language_provider_id  (english_language_provider_id)
 #  index_application_forms_on_family_name                   (family_name)
@@ -101,6 +103,16 @@ RSpec.describe ApplicationForm, type: :model do
 
   describe "columns" do
     it do
+      is_expected.to define_enum_for(:action_required_by)
+        .with_values(
+          admin: "admin",
+          assessor: "assessor",
+          external: "external",
+          none: "none",
+        )
+        .with_prefix
+        .backed_by_column_of_type(:string)
+
       is_expected.to define_enum_for(:status).with_values(
         draft: "draft",
         submitted: "submitted",

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe TimelineEvent do
 
     it do
       is_expected.to define_enum_for(:event_type).with_values(
+        action_required_by_changed: "action_required_by_changed",
         age_range_subjects_verified: "age_range_subjects_verified",
         assessment_section_recorded: "assessment_section_recorded",
         assessor_assigned: "assessor_assigned",
@@ -385,6 +386,29 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:column_name) }
       it { is_expected.to validate_absence_of(:old_value) }
       it { is_expected.to validate_absence_of(:new_value) }
+    end
+
+    context "with an action required by changed event type" do
+      before { timeline_event.event_type = :action_required_by_changed }
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
+      it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
+      it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
+      it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:age_range_min) }
+      it { is_expected.to validate_absence_of(:age_range_max) }
+      it { is_expected.to validate_absence_of(:subjects) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_presence_of(:old_value) }
+      it { is_expected.to validate_presence_of(:new_value) }
     end
   end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/applications.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/applications.rb
@@ -40,6 +40,11 @@ module PageObjects
                 "#assessor_interface_filter_form_submitted_at_before_1i"
       end
 
+      section :action_required_by_filter,
+              "#app-applications-filters-action-required-by" do
+        sections :items, GovukCheckboxItem, ".govuk-checkboxes__item"
+      end
+
       section :status_filter, "#app-applications-filters-status" do
         sections :statuses, GovukCheckboxItem, ".govuk-checkboxes__item"
       end

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe "Assessor filtering application forms", type: :system do
     then_i_see_a_list_of_applications_filtered_by_submitted_at
 
     when_i_clear_the_filters
+    and_i_apply_the_action_required_by_filter
+    then_i_see_a_list_of_applications_filtered_by_action_required_by
+
+    when_i_clear_the_filters
     and_i_apply_the_status_filter
     then_i_see_a_list_of_applications_filtered_by_state
   end
@@ -124,6 +128,24 @@ RSpec.describe "Assessor filtering application forms", type: :system do
     expect(applications_page.search_results.first.name.text).to eq("John Smith")
   end
 
+  def and_i_apply_the_action_required_by_filter
+    admin_action_item =
+      applications_page.action_required_by_filter.items.find do |item|
+        item.label.text == "Admin (1)"
+      rescue Capybara::ElementNotFound
+        false
+      end
+    admin_action_item.checkbox.click
+    applications_page.apply_filters.click
+  end
+
+  def then_i_see_a_list_of_applications_filtered_by_action_required_by
+    expect(applications_page.search_results.count).to eq(1)
+    expect(applications_page.search_results.first.name.text).to eq(
+      "Emma Dubois",
+    )
+  end
+
   def and_i_apply_the_status_filter
     awarded_state =
       applications_page.status_filter.statuses.find do |status|
@@ -155,6 +177,7 @@ RSpec.describe "Assessor filtering application forms", type: :system do
       create(
         :application_form,
         :submitted,
+        :action_required_by_admin,
         region: create(:region, country: create(:country, code: "FR")),
         given_names: "Emma",
         family_name: "Dubois",
@@ -165,6 +188,7 @@ RSpec.describe "Assessor filtering application forms", type: :system do
       create(
         :application_form,
         :submitted,
+        :action_required_by_assessor,
         region: create(:region, country: create(:country, code: "ES")),
         given_names: "Arnold",
         family_name: "Drummond",


### PR DESCRIPTION
This adds a new field on application forms (`actionable_by`) and implements the logic for when the value of this field changes. See individual commits for more details.

[Trello Card](https://trello.com/c/XN5Omc6e/2264-add-flagging-actionable-applications)

## Screenshots

![Screenshot 2023-09-08 at 14 57 40](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/3c271d0f-31ba-419c-a86b-8392e38a9667)
![Screenshot 2023-09-08 at 15 27 34](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/7b2e9aa9-902f-4042-a26a-ea95dbbbbb97)
