### PR TITLE
Update DQT environment URLs for test and dev

### DIFF
--- a/config/dqt.yml
+++ b/config/dqt.yml
@@ -1,5 +1,5 @@
 development:
-  url: <%= ENV.fetch("DQT_API_URL", "https://qualified-teachers-api-dev.london.cloudapps.digital") %>
+  url: <%= ENV.fetch("DQT_API_URL", "https://dev.teacher-qualifications-api.education.gov.uk") %>
   api_key: <%= ENV["DQT_API_KEY"] %>
 
 production:

--- a/terraform/application/config/development/variables.tfvars.json
+++ b/terraform/application/config/development/variables.tfvars.json
@@ -1,7 +1,7 @@
 {
   "app_environment": "development",
   "cluster": "test",
-  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital",
+  "dqt_api_url": "https://dev.teacher-qualifications-api.education.gov.uk",
   "enable_monitoring": false,
   "external_hostname": "dev.apply-for-qts-in-england.education.gov.uk",
   "namespace": "tra-development",

--- a/terraform/application/config/review/variables.tfvars.json
+++ b/terraform/application/config/review/variables.tfvars.json
@@ -2,7 +2,7 @@
   "app_environment": "review",
   "cluster": "test",
   "deploy_azure_backing_services": false,
-  "dqt_api_url": "https://qualified-teachers-api-dev.london.cloudapps.digital",
+  "dqt_api_url": "https://dev.teacher-qualifications-api.education.gov.uk",
   "enable_monitoring": false,
   "namespace": "tra-development",
   "uploads_storage_environment_tag": "Test"

--- a/terraform/application/config/test/variables.tfvars.json
+++ b/terraform/application/config/test/variables.tfvars.json
@@ -1,7 +1,7 @@
 {
   "app_environment": "test",
   "cluster": "test",
-  "dqt_api_url": "https://test-teacher-qualifications-api.education.gov.uk",
+  "dqt_api_url": "https://test.teacher-qualifications-api.education.gov.uk",
   "enable_monitoring": false,
   "external_hostname": "test.apply-for-qts-in-england.education.gov.uk",
   "namespace": "tra-test",


### PR DESCRIPTION
The URL is changing as it's being moved to the new cloud platform.