### PR TITLE
Access your teaching qualifications URL

### DIFF
--- a/app/jobs/update_dqt_trn_request_job.rb
+++ b/app/jobs/update_dqt_trn_request_job.rb
@@ -20,7 +20,13 @@ class UpdateDQTTRNRequestJob < ApplicationJob
     ApplicationFormStatusUpdater.call(application_form:, user: "DQT")
 
     unless potential_duplicate
-      AwardQTS.call(application_form:, user: "DQT", trn: response[:trn])
+      AwardQTS.call(
+        application_form:,
+        user: "DQT",
+        trn: response[:trn],
+        access_your_teaching_qualifications_url:
+          response[:access_your_teaching_qualifications_link],
+      )
       dqt_trn_request.complete!
     end
 

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -2,18 +2,19 @@
 #
 # Table name: teachers
 #
-#  id                 :bigint           not null, primary key
-#  canonical_email    :text             default(""), not null
-#  current_sign_in_at :datetime
-#  current_sign_in_ip :string
-#  email              :string           default(""), not null
-#  last_sign_in_at    :datetime
-#  last_sign_in_ip    :string
-#  sign_in_count      :integer          default(0), not null
-#  trn                :string
-#  uuid               :uuid             not null
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
+#  id                                      :bigint           not null, primary key
+#  access_your_teaching_qualifications_url :string
+#  canonical_email                         :text             default(""), not null
+#  current_sign_in_at                      :datetime
+#  current_sign_in_ip                      :string
+#  email                                   :string           default(""), not null
+#  last_sign_in_at                         :datetime
+#  last_sign_in_ip                         :string
+#  sign_in_count                           :integer          default(0), not null
+#  trn                                     :string
+#  uuid                                    :uuid             not null
+#  created_at                              :datetime         not null
+#  updated_at                              :datetime         not null
 #
 # Indexes
 #

--- a/app/services/award_qts.rb
+++ b/app/services/award_qts.rb
@@ -3,10 +3,17 @@
 class AwardQTS
   include ServicePattern
 
-  def initialize(application_form:, user:, trn:)
+  def initialize(
+    application_form:,
+    user:,
+    trn:,
+    access_your_teaching_qualifications_url:
+  )
     @application_form = application_form
     @user = user
     @trn = trn
+    @access_your_teaching_qualifications_url =
+      access_your_teaching_qualifications_url
   end
 
   def call
@@ -20,7 +27,7 @@ class AwardQTS
     raise MissingTRN if trn.blank?
 
     ActiveRecord::Base.transaction do
-      teacher.update!(trn:)
+      teacher.update!(trn:, access_your_teaching_qualifications_url:)
       application_form.update!(awarded_at: Time.zone.now)
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end
@@ -36,7 +43,10 @@ class AwardQTS
 
   private
 
-  attr_reader :application_form, :user, :trn
+  attr_reader :application_form,
+              :user,
+              :trn,
+              :access_your_teaching_qualifications_url
 
   delegate :teacher, to: :application_form
 end

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -12,3 +12,5 @@
     - confirmation_token
     - unlock_token
     - invitation_token
+  :teachers:
+    - access_your_teaching_qualifications_url

--- a/db/migrate/20230912144508_add_access_your_teaching_qualifications_url_to_teachers.rb
+++ b/db/migrate/20230912144508_add_access_your_teaching_qualifications_url_to_teachers.rb
@@ -1,0 +1,7 @@
+class AddAccessYourTeachingQualificationsUrlToTeachers < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    add_column :teachers, :access_your_teaching_qualifications_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_05_121903) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_12_144508) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -456,6 +456,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_05_121903) do
     t.string "trn"
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.text "canonical_email", default: "", null: false
+    t.string "access_your_teaching_qualifications_url"
     t.index "lower((email)::text)", name: "index_teacher_on_lower_email", unique: true
     t.index ["canonical_email"], name: "index_teachers_on_canonical_email"
     t.index ["uuid"], name: "index_teachers_on_uuid", unique: true

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -2,18 +2,19 @@
 #
 # Table name: teachers
 #
-#  id                 :bigint           not null, primary key
-#  canonical_email    :text             default(""), not null
-#  current_sign_in_at :datetime
-#  current_sign_in_ip :string
-#  email              :string           default(""), not null
-#  last_sign_in_at    :datetime
-#  last_sign_in_ip    :string
-#  sign_in_count      :integer          default(0), not null
-#  trn                :string
-#  uuid               :uuid             not null
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
+#  id                                      :bigint           not null, primary key
+#  access_your_teaching_qualifications_url :string
+#  canonical_email                         :text             default(""), not null
+#  current_sign_in_at                      :datetime
+#  current_sign_in_ip                      :string
+#  email                                   :string           default(""), not null
+#  last_sign_in_at                         :datetime
+#  last_sign_in_ip                         :string
+#  sign_in_count                           :integer          default(0), not null
+#  trn                                     :string
+#  uuid                                    :uuid             not null
+#  created_at                              :datetime         not null
+#  updated_at                              :datetime         not null
 #
 # Indexes
 #
@@ -26,5 +27,13 @@ FactoryBot.define do
     sequence(:email) { |n| "teacher#{n}@example.org" }
     uuid { SecureRandom.uuid }
     canonical_email { EmailAddress.canonical(email) }
+
+    trait :with_trn do
+      trn { Faker::Number.leading_zero_number(digits: 6) }
+    end
+
+    trait :with_access_your_teaching_qualifications_url do
+      access_your_teaching_qualifications_url { Faker::Internet.url }
+    end
   end
 end

--- a/spec/jobs/update_dqt_trn_request_job_spec.rb
+++ b/spec/jobs/update_dqt_trn_request_job_spec.rb
@@ -20,7 +20,11 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
       context "with a successful response" do
         before do
           expect(DQT::Client::CreateTRNRequest).to receive(:call).and_return(
-            { potential_duplicate: false, trn: "abcdef" },
+            {
+              potential_duplicate: false,
+              trn: "abcdef",
+              access_your_teaching_qualifications_link: "https://aytq.com",
+            },
           )
         end
 
@@ -40,6 +44,7 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
             application_form:,
             user: "DQT",
             trn: "abcdef",
+            access_your_teaching_qualifications_url: "https://aytq.com",
           )
           perform
         end
@@ -128,7 +133,11 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
       context "with a successful response" do
         before do
           expect(DQT::Client::ReadTRNRequest).to receive(:call).and_return(
-            { potential_duplicate: false, trn: "abcdef" },
+            {
+              potential_duplicate: false,
+              trn: "abcdef",
+              access_your_teaching_qualifications_link: "https://aytq.com",
+            },
           )
         end
 
@@ -148,6 +157,7 @@ RSpec.describe UpdateDQTTRNRequestJob, type: :job do
             application_form:,
             user: "DQT",
             trn: "abcdef",
+            access_your_teaching_qualifications_url: "https://aytq.com",
           )
           perform
         end

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -2,18 +2,19 @@
 #
 # Table name: teachers
 #
-#  id                 :bigint           not null, primary key
-#  canonical_email    :text             default(""), not null
-#  current_sign_in_at :datetime
-#  current_sign_in_ip :string
-#  email              :string           default(""), not null
-#  last_sign_in_at    :datetime
-#  last_sign_in_ip    :string
-#  sign_in_count      :integer          default(0), not null
-#  trn                :string
-#  uuid               :uuid             not null
-#  created_at         :datetime         not null
-#  updated_at         :datetime         not null
+#  id                                      :bigint           not null, primary key
+#  access_your_teaching_qualifications_url :string
+#  canonical_email                         :text             default(""), not null
+#  current_sign_in_at                      :datetime
+#  current_sign_in_ip                      :string
+#  email                                   :string           default(""), not null
+#  last_sign_in_at                         :datetime
+#  last_sign_in_ip                         :string
+#  sign_in_count                           :integer          default(0), not null
+#  trn                                     :string
+#  uuid                                    :uuid             not null
+#  created_at                              :datetime         not null
+#  updated_at                              :datetime         not null
 #
 # Indexes
 #

--- a/spec/services/award_qts_spec.rb
+++ b/spec/services/award_qts_spec.rb
@@ -6,8 +6,16 @@ RSpec.describe AwardQTS do
   let(:teacher) { create(:teacher) }
   let(:user) { create(:staff, :confirmed) }
   let(:trn) { "abcdef" }
+  let(:access_your_teaching_qualifications_url) { "https://aytq.com" }
 
-  subject(:call) { described_class.call(application_form:, user:, trn:) }
+  subject(:call) do
+    described_class.call(
+      application_form:,
+      user:,
+      trn:,
+      access_your_teaching_qualifications_url:,
+    )
+  end
 
   context "with a submitted application form" do
     let(:application_form) { create(:application_form, :submitted, teacher:) }
@@ -24,6 +32,13 @@ RSpec.describe AwardQTS do
 
     it "sets the TRN" do
       expect { call }.to change(teacher, :trn).to("abcdef")
+    end
+
+    it "sets the access your teaching qualifications URL" do
+      expect { call }.to change(
+        teacher,
+        :access_your_teaching_qualifications_url,
+      ).to("https://aytq.com")
     end
 
     it "sends an email" do
@@ -63,6 +78,13 @@ RSpec.describe AwardQTS do
       expect { call }.to change(teacher, :trn).to("abcdef")
     end
 
+    it "sets the access your teaching qualifications URL" do
+      expect { call }.to change(
+        teacher,
+        :access_your_teaching_qualifications_url,
+      ).to("https://aytq.com")
+    end
+
     it "sends an email" do
       expect { call }.to have_enqueued_mail(
         TeacherMailer,
@@ -94,8 +116,15 @@ RSpec.describe AwardQTS do
   context "with an awarded application form" do
     let(:application_form) { create(:application_form, :awarded, teacher:) }
 
-    it "doesn't set the TRN" do
+    it "doesn't change the TRN" do
       expect { call }.to_not change(teacher, :trn)
+    end
+
+    it "doesn't change the access your teaching qualifications URL" do
+      expect { call }.to_not change(
+        teacher,
+        :access_your_teaching_qualifications_url,
+      )
     end
 
     it "doesn't send an email" do


### PR DESCRIPTION
This adds the ability to retrieve and store the "access your teaching qualifications" URL on a teacher, in preparation for us showing them to the user in the future.

[Trello Card](https://trello.com/c/CJRDzW4v/2239-implement-new-qts-award-email-and-log-in-screen)