### PR TITLE
Don't set started at on preliminary assessment sections

### DIFF
--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -76,7 +76,7 @@ class UpdateAssessmentSection
   end
 
   def update_assessment_started_at
-    return if assessment.started_at
+    return if assessment.started_at || assessment_section.preliminary
     assessment.update!(started_at: Time.zone.now)
   end
 

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -121,7 +121,15 @@ RSpec.describe UpdateAssessmentSection do
     context "with an existing assessment started at" do
       before { assessment.update!(started_at: Date.new(2021, 1, 1)) }
 
-      it "doesn't change the assessor" do
+      it "doesn't change the started" do
+        expect { subject }.to_not change(assessment, :started_at)
+      end
+    end
+
+    context "with a preliminary assessment section" do
+      before { assessment_section.update!(preliminary: true) }
+
+      it "doesn't change the started" do
         expect { subject }.to_not change(assessment, :started_at)
       end
     end


### PR DESCRIPTION
This doesn't count as part of the assessment, so we shouldn't be recording the started at date of the assessment as part of the preliminary check.