### PR TITLE
Only change to assessment in progress if not preliminary

### DIFF
--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -141,7 +141,7 @@ class ApplicationFormStatusUpdater
             waiting_on_professional_standing || waiting_on_qualification ||
             waiting_on_reference
         "waiting_on"
-      elsif assessment&.started?
+      elsif assessment&.any_not_preliminary_section_finished?
         "assessment_in_progress"
       elsif application_form.submitted_at.present?
         "submitted"

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -79,10 +79,6 @@ class Assessment < ApplicationRecord
     )
   end
 
-  def started?
-    any_section_finished?
-  end
-
   def completed?
     award? || decline?
   end
@@ -162,14 +158,14 @@ class Assessment < ApplicationRecord
     sections.preliminary.any?(&:failed)
   end
 
+  def any_not_preliminary_section_finished?
+    sections.not_preliminary.any?(&:finished?)
+  end
+
   private
 
   def all_sections_finished?
     sections.all?(&:finished?)
-  end
-
-  def any_section_finished?
-    sections.any?(&:finished?)
   end
 
   def all_sections_passed?

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -76,7 +76,7 @@ class UpdateAssessmentSection
   end
 
   def update_assessment_started_at
-    return if assessment.started_at || assessment_section.preliminary
+    return if assessment.started_at
     assessment.update!(started_at: Time.zone.now)
   end
 

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -121,15 +121,7 @@ RSpec.describe UpdateAssessmentSection do
     context "with an existing assessment started at" do
       before { assessment.update!(started_at: Date.new(2021, 1, 1)) }
 
-      it "doesn't change the started" do
-        expect { subject }.to_not change(assessment, :started_at)
-      end
-    end
-
-    context "with a preliminary assessment section" do
-      before { assessment_section.update!(preliminary: true) }
-
-      it "doesn't change the started" do
+      it "doesn't change the assessor" do
         expect { subject }.to_not change(assessment, :started_at)
       end
     end


### PR DESCRIPTION
This changes the logic so applications will only move to assessment in progress if there are non-preliminary sections finished.