### PR TITLE
Add application form stage

### DIFF
--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -21,6 +21,7 @@ module StatusTag
 
     COLOURS = {
       accepted: "green",
+      assessment: "blue",
       assessment_in_progress: "blue",
       awarded: "green",
       awarded_pending_checks: "turquoise",
@@ -37,6 +38,7 @@ module StatusTag
       overdue_qualification: "pink",
       overdue_reference: "pink",
       potential_duplicate_in_dqt: "pink",
+      pre_assessment: "pink",
       preliminary_check: "pink",
       received: "purple",
       received_further_information: "purple",
@@ -45,8 +47,10 @@ module StatusTag
       received_reference: "purple",
       rejected: "red",
       requested: "yellow",
+      review: "purple",
       submitted: "grey",
       valid: "green",
+      verification: "yellow",
       waiting_on: "yellow",
       waiting_on_further_information: "yellow",
       waiting_on_professional_standing: "yellow",

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -170,5 +170,24 @@ module TimelineEntry
           end,
       }
     end
+
+    def stage_changed_vars
+      {
+        old_stage:
+          render(
+            StatusTag::Component.new(
+              status: timeline_event.old_value,
+              class_context: "timeline-event",
+            ),
+          ).strip,
+        new_stage:
+          render(
+            StatusTag::Component.new(
+              status: timeline_event.new_value,
+              class_context: "timeline-event",
+            ),
+          ).strip,
+      }
+    end
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -43,6 +43,7 @@
 #  registration_number                           :text
 #  registration_number_status                    :string           default("not_started"), not null
 #  requires_preliminary_check                    :boolean          default(FALSE), not null
+#  stage                                         :string           default("draft"), not null
 #  status                                        :string           default("draft"), not null
 #  subjects                                      :text             default([]), not null, is an Array
 #  subjects_status                               :string           default("not_started"), not null
@@ -76,6 +77,7 @@
 #  index_application_forms_on_reference                     (reference) UNIQUE
 #  index_application_forms_on_region_id                     (region_id)
 #  index_application_forms_on_reviewer_id                   (reviewer_id)
+#  index_application_forms_on_stage                         (stage)
 #  index_application_forms_on_status                        (status)
 #  index_application_forms_on_teacher_id                    (teacher_id)
 #
@@ -131,6 +133,17 @@ class ApplicationForm < ApplicationRecord
          none: "none",
        },
        _prefix: true
+
+  enum stage: {
+         draft: "draft",
+         pre_assessment: "pre_assessment",
+         not_started: "not_started",
+         assessment: "assessment",
+         verification: "verification",
+         review: "review",
+         completed: "completed",
+       },
+       _suffix: true
 
   enum status: {
          draft: "draft",

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -75,6 +75,7 @@ class TimelineEvent < ApplicationRecord
          requestable_received: "requestable_received",
          requestable_requested: "requestable_requested",
          reviewer_assigned: "reviewer_assigned",
+         stage_changed: "stage_changed",
          state_changed: "state_changed",
        }
 
@@ -152,11 +153,17 @@ class TimelineEvent < ApplicationRecord
   validates :old_value,
             :new_value,
             presence: true,
-            if: -> { action_required_by_changed? || information_changed? }
+            if: -> do
+              action_required_by_changed? || information_changed? ||
+                stage_changed?
+            end
   validates :old_value,
             :new_value,
             absence: true,
-            unless: -> { action_required_by_changed? || information_changed? }
+            unless: -> do
+              action_required_by_changed? || information_changed? ||
+                stage_changed?
+            end
   validates :column_name, presence: true, if: :information_changed?
   validates :work_history_id,
             :column_name,

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -68,6 +68,7 @@
     - registration_number_status
     - requires_preliminary_check
     - reviewer_id
+    - stage
     - status
     - subjects
     - subjects_status

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -2,6 +2,7 @@ en:
   components:
     status_tag:
       accepted: Accepted
+      assessment: Assessment
       assessment_in_progress: Assessment in progress
       awarded: Awarded
       awarded_pending_checks: Award pending
@@ -19,6 +20,7 @@ en:
       overdue_qualification: Overdue qualification
       overdue_reference: Overdue reference
       potential_duplicate_in_dqt: Potential duplication in DQT
+      pre_assessment: Pre-assessment
       preliminary_check: Preliminary check
       received: Received
       received_further_information: Received further information
@@ -27,8 +29,10 @@ en:
       received_reference: Received reference
       rejected: Rejected
       requested: Waiting on
+      review: Review
       submitted: Not started
       valid: Valid
+      verification: Verification
       waiting_on: Waiting on
       waiting_on_further_information: Waiting on further information
       waiting_on_professional_standing: Waiting on professional standing
@@ -39,14 +43,14 @@ en:
     timeline_entry:
       title:
         action_required_by_changed: Action required by changed
-        assessor_assigned: Assessor assigned
-        reviewer_assigned: Reviewer assigned
-        state_changed: Status changed
-        assessment_section_completed: Section completed
-        note_created: Note created
-        email_sent: Email sent
         age_range_subjects_verified: Age range and subjects verified
+        assessment_section_completed: Section completed
         assessment_section_recorded: Assessment section recorded
+        assessor_assigned: Assessor assigned
+        email_sent: Email sent
+        information_changed: Information changed after submission
+        note_created: Note created
+        reviewer_assigned: Reviewer assigned
         requestable_requested:
           FurtherInformationRequest: Further information requested
           ProfessionalStandingRequest: Professional standing requested
@@ -67,14 +71,14 @@ en:
           ProfessionalStandingRequest: Professional standing assessed
           QualificationRequest: Qualification assessed
           ReferenceRequest: Reference assessed
-        information_changed: Information changed after submission
+        stage_changed: Stage changed
+        state_changed: Status changed
       description:
         action_required_by_changed: Application requires %{action} action.
         assessor_assigned: "%{assignee_name} is assigned as the assessor."
-        reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
-        state_changed: Status changed from %{old_state} to %{new_state}.
-        note_created: "%{text}"
         email_sent: "%{subject}"
+        note_created: "%{text}"
+        reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
         requestable_requested:
           FurtherInformationRequest: Further information has been requested.
           ProfessionalStandingRequest: The professional standing has been requested.
@@ -95,6 +99,8 @@ en:
           ProfessionalStandingRequest: The professional standing request has been assessed.
           QualificationRequest: A qualification has been assessed.
           ReferenceRequest: A reference has been assessed.
+        stage_changed: Stage changed from %{old_stage} to %{new_stage}.
+        state_changed: Status changed from %{old_state} to %{new_state}.
       columns:
         contact_email: Reference email address
         contact_job: Reference job

--- a/db/migrate/20230914084340_add_stage_to_application_forms.rb
+++ b/db/migrate/20230914084340_add_stage_to_application_forms.rb
@@ -1,0 +1,10 @@
+class AddStageToApplicationForms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :application_forms,
+               :stage,
+               :string,
+               default: "draft",
+               null: false
+    add_index :application_forms, :stage
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_12_144508) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_14_084340) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -106,6 +106,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_12_144508) do
     t.jsonb "dqt_match", default: {}
     t.datetime "withdrawn_at"
     t.string "action_required_by", default: "none", null: false
+    t.string "stage", default: "draft", null: false
     t.index ["action_required_by"], name: "index_application_forms_on_action_required_by"
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["english_language_provider_id"], name: "index_application_forms_on_english_language_provider_id"
@@ -114,6 +115,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_12_144508) do
     t.index ["reference"], name: "index_application_forms_on_reference", unique: true
     t.index ["region_id"], name: "index_application_forms_on_region_id"
     t.index ["reviewer_id"], name: "index_application_forms_on_reviewer_id"
+    t.index ["stage"], name: "index_application_forms_on_stage"
     t.index ["status"], name: "index_application_forms_on_status"
     t.index ["teacher_id"], name: "index_application_forms_on_teacher_id"
   end

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -518,4 +518,24 @@ RSpec.describe TimelineEntry::Component, type: :component do
       expect(component.text).to include(creator.name)
     end
   end
+
+  context "stage changed" do
+    let(:timeline_event) { create(:timeline_event, :stage_changed) }
+    let(:old_stage) do
+      I18n.t("components.status_tag.#{timeline_event.old_value}")
+    end
+    let(:new_stage) do
+      I18n.t("components.status_tag.#{timeline_event.new_value}")
+    end
+
+    it "describes the event" do
+      expect(component.text.squish).to include(
+        "Stage changed from #{old_stage} to #{new_stage}",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
 end

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -43,6 +43,7 @@
 #  registration_number                           :text
 #  registration_number_status                    :string           default("not_started"), not null
 #  requires_preliminary_check                    :boolean          default(FALSE), not null
+#  stage                                         :string           default("draft"), not null
 #  status                                        :string           default("draft"), not null
 #  subjects                                      :text             default([]), not null, is an Array
 #  subjects_status                               :string           default("not_started"), not null
@@ -76,6 +77,7 @@
 #  index_application_forms_on_reference                     (reference) UNIQUE
 #  index_application_forms_on_region_id                     (region_id)
 #  index_application_forms_on_reviewer_id                   (reviewer_id)
+#  index_application_forms_on_stage                         (stage)
 #  index_application_forms_on_status                        (status)
 #  index_application_forms_on_teacher_id                    (teacher_id)
 #

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -142,8 +142,42 @@ FactoryBot.define do
       action_required_by { "none" }
     end
 
-    trait :submitted do
+    trait :draft_stage do
+      stage { "draft" }
+      action_required_by_none
+    end
+
+    trait :pre_assessment_stage do
+      stage { "pre_assessment" }
+      action_required_by_admin
+    end
+
+    trait :not_started_stage do
+      stage { "not_started" }
       action_required_by_assessor
+    end
+
+    trait :assessment_stage do
+      stage { "assessment" }
+      action_required_by_assessor
+    end
+
+    trait :verification_stage do
+      stage { "verification" }
+    end
+
+    trait :review_stage do
+      stage { "review" }
+      action_required_by_assessor
+    end
+
+    trait :completed_stage do
+      stage { "completed" }
+      action_required_by_none
+    end
+
+    trait :submitted do
+      not_started_stage
       status { "submitted" }
       submitted_at { Time.zone.now }
       working_days_since_submission { 0 }
@@ -162,59 +196,65 @@ FactoryBot.define do
 
     trait :preliminary_check do
       submitted
-      action_required_by_admin
+      pre_assessment_stage
       requires_preliminary_check { true }
       status { "preliminary_check" }
     end
 
     trait :assessment_in_progress do
       submitted
+      assessment_stage
       status { "assessment_in_progress" }
     end
 
     trait :waiting_on do
       submitted
       action_required_by_external
+      verification_stage
       status { "waiting_on" }
     end
 
     trait :received do
       submitted
+      verification_stage
       status { "received" }
     end
 
     trait :overdue do
       submitted
+      verification_stage
       status { "overdue" }
     end
 
     trait :awarded_pending_checks do
       submitted
+      review_stage
       status { "awarded_pending_checks" }
     end
 
     trait :potential_duplicate_in_dqt do
       submitted
+      review_stage
       status { "potential_duplicate_in_dqt" }
     end
 
     trait :awarded do
       submitted
-      action_required_by_none
+      completed_stage
       status { "awarded" }
       awarded_at { Time.zone.now }
     end
 
     trait :declined do
       submitted
-      action_required_by_none
+      completed_stage
       status { "declined" }
       declined_at { Time.zone.now }
     end
 
     trait :withdrawn do
       submitted
-      action_required_by_none
+      completed_stage
       status { "withdrawn" }
       withdrawn_at { Time.zone.now }
     end

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -111,5 +111,11 @@ FactoryBot.define do
       old_value { %w[admin assessor external none].sample }
       new_value { %w[admin assessor external none].sample }
     end
+
+    trait :stage_changed do
+      event_type { "stage_changed" }
+      old_value { ApplicationForm.stages.values.sample }
+      new_value { ApplicationForm.stages.values.sample }
+    end
   end
 end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -43,6 +43,7 @@
 #  registration_number                           :text
 #  registration_number_status                    :string           default("not_started"), not null
 #  requires_preliminary_check                    :boolean          default(FALSE), not null
+#  stage                                         :string           default("draft"), not null
 #  status                                        :string           default("draft"), not null
 #  subjects                                      :text             default([]), not null, is an Array
 #  subjects_status                               :string           default("not_started"), not null
@@ -76,6 +77,7 @@
 #  index_application_forms_on_reference                     (reference) UNIQUE
 #  index_application_forms_on_region_id                     (region_id)
 #  index_application_forms_on_reviewer_id                   (reviewer_id)
+#  index_application_forms_on_stage                         (stage)
 #  index_application_forms_on_status                        (status)
 #  index_application_forms_on_teacher_id                    (teacher_id)
 #
@@ -111,6 +113,19 @@ RSpec.describe ApplicationForm, type: :model do
           none: "none",
         )
         .with_prefix
+        .backed_by_column_of_type(:string)
+
+      is_expected.to define_enum_for(:stage)
+        .with_values(
+          draft: "draft",
+          pre_assessment: "pre_assessment",
+          not_started: "not_started",
+          assessment: "assessment",
+          verification: "verification",
+          review: "review",
+          completed: "completed",
+        )
+        .with_suffix
         .backed_by_column_of_type(:string)
 
       is_expected.to define_enum_for(:status).with_values(

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe TimelineEvent do
         requestable_received: "requestable_received",
         requestable_requested: "requestable_requested",
         reviewer_assigned: "reviewer_assigned",
+        stage_changed: "stage_changed",
         state_changed: "state_changed",
       ).backed_by_column_of_type(:string)
     end
@@ -390,6 +391,29 @@ RSpec.describe TimelineEvent do
 
     context "with an action required by changed event type" do
       before { timeline_event.event_type = :action_required_by_changed }
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:old_state) }
+      it { is_expected.to validate_absence_of(:new_state) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
+      it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
+      it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
+      it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:age_range_min) }
+      it { is_expected.to validate_absence_of(:age_range_max) }
+      it { is_expected.to validate_absence_of(:subjects) }
+      it { is_expected.to validate_absence_of(:requestable_id) }
+      it { is_expected.to validate_absence_of(:requestable_type) }
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_presence_of(:old_value) }
+      it { is_expected.to validate_presence_of(:new_value) }
+    end
+
+    context "with a stage changed event type" do
+      before { timeline_event.event_type = :stage_changed }
 
       it { is_expected.to validate_absence_of(:assignee) }
       it { is_expected.to validate_absence_of(:old_state) }


### PR DESCRIPTION
This adds the new stage field to application forms which we'll be using in the future to allow users to filter on.

Depends on #1671.

[Trello Card](https://trello.com/c/9sZ5E9w8/2265-update-statuses-for-verification-and-review)