### PR TITLE
Update DQT preproduction URL

### DIFF
--- a/terraform/application/config/preproduction/variables.tfvars.json
+++ b/terraform/application/config/preproduction/variables.tfvars.json
@@ -1,7 +1,7 @@
 {
   "app_environment": "preproduction",
   "cluster": "test",
-  "dqt_api_url": "https://preprod-teacher-qualifications-api.education.gov.uk",
+  "dqt_api_url": "https://preprod.teacher-qualifications-api.education.gov.uk",
   "enable_monitoring": false,
   "external_hostname": "preprod.apply-for-qts-in-england.education.gov.uk",
   "namespace": "tra-test",


### PR DESCRIPTION
The URL is changing as it's being migrated to a new cloud platform.