### PR TITLE
Improve design of countries index page

### DIFF
--- a/app/controllers/support_interface/countries_controller.rb
+++ b/app/controllers/support_interface/countries_controller.rb
@@ -5,6 +5,7 @@ module SupportInterface
     def index
       authorize [:support_interface, Country]
       @countries = Country.includes(:regions).order(:code)
+      render layout: "full_from_desktop"
     end
 
     def edit

--- a/app/controllers/support_interface/countries_controller.rb
+++ b/app/controllers/support_interface/countries_controller.rb
@@ -4,7 +4,10 @@ module SupportInterface
   class CountriesController < BaseController
     def index
       authorize [:support_interface, Country]
-      @countries = Country.includes(:regions).order(:code)
+      @countries =
+        Country
+          .includes(:regions)
+          .sort_by { |country| CountryName.from_country(country) }
       render layout: "full_from_desktop"
     end
 

--- a/app/forms/support_interface/country_form.rb
+++ b/app/forms/support_interface/country_form.rb
@@ -42,14 +42,23 @@ class SupportInterface::CountryForm
   end
 
   def assign_country_attributes
-    country.assign_attributes(
-      eligibility_enabled:,
-      eligibility_skip_questions:,
-      other_information:,
-      qualifications_information:,
-      sanction_information:,
-      status_information:,
-    )
+    country.assign_attributes(eligibility_enabled:, eligibility_skip_questions:)
+
+    if has_regions
+      country.assign_attributes(
+        other_information:,
+        qualifications_information:,
+        sanction_information:,
+        status_information:,
+      )
+    else
+      country.assign_attributes(
+        other_information: "",
+        qualifications_information: "",
+        sanction_information: "",
+        status_information: "",
+      )
+    end
   end
 
   def diff_actions

--- a/app/views/support_interface/countries/index.html.erb
+++ b/app/views/support_interface/countries/index.html.erb
@@ -1,60 +1,58 @@
-<% content_for :page_title, 'Countries' %>
+<% content_for :page_title, "Countries" %>
 
 <h1 class="govuk-heading-l">Countries</h1>
 
-<div class="govuk-grid-row">
-  <% @countries.order(:code).each do |country| %>
-    <div class="govuk-width-container">
-      <table class="govuk-table">
-        <thead class="govuk-table__head">
-          <tr class="govuk-table__row">
-            <th class="govuk-table__header" colspan="2">
-              <h2 class="govuk-heading-m">
-                <%= govuk_link_to CountryName.from_country(country), edit_support_interface_country_path(country) %>
-                <code class="govuk-tag app-country-code-tag govuk-!-margin-left-2"><%= country.code %></code>
+<% @countries.each do |country| %>
+  <div class="govuk-width-container">
+    <table class="govuk-table">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" colspan="2">
+            <h2 class="govuk-heading-m">
+              <%= govuk_link_to CountryName.from_country(country), edit_support_interface_country_path(country) %>
+              <code class="govuk-tag app-country-code-tag govuk-!-margin-left-2"><%= country.code %></code>
 
-                <% if country.eligibility_enabled %>
-                  <%= govuk_tag(text: "Eligible", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
-                <% else %>
-                  <%= govuk_tag(text: "Ineligible", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
+              <% if country.eligibility_enabled %>
+                <%= govuk_tag(text: "Eligible", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
+              <% else %>
+                <%= govuk_tag(text: "Ineligible", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
+              <% end %>
+
+              <% if country.eligibility_skip_questions %>
+                <%= govuk_tag(text: "Skips questions", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
+              <% end %>
+            </h2>
+          </th>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% country.regions.order(:name).each_slice(4) do |regions| %>
+          <% regions.each do |region| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell govuk-!-width-one-third">
+                <a class="govuk-link" href="<%= edit_support_interface_region_path(region) %>">
+                  <% if region.name.present? %>
+                    <%= region.name %>
+                  <% else %>
+                    <em>National</em>
+                  <% end %>
+                </a>
+              </td>
+
+              <td class="govuk-table__cell">
+                <% if region.application_form_skip_work_history %>
+                  <%= govuk_tag(text: "Skips work history", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
                 <% end %>
 
-                <% if country.eligibility_skip_questions %>
-                  <%= govuk_tag(text: "Skips questions", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
+                <% if region.reduced_evidence_accepted %>
+                  <%= govuk_tag(text: "Accepts reduced evidence", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
                 <% end %>
-              </h2>
-            </th>
-          </tr>
-        </thead>
-
-        <tbody>
-          <% country.regions.order(:name).each_slice(4) do |regions| %>
-            <% regions.each do |region| %>
-              <tr class="govuk-table__row">
-                <td class="govuk-table__cell govuk-!-width-one-third">
-                  <a class="govuk-link" href="<%= edit_support_interface_region_path(region) %>">
-                    <% if region.name.present? %>
-                      <%= region.name %>
-                    <% else %>
-                      <em>National</em>
-                    <% end %>
-                  </a>
-                </td>
-
-                <td class="govuk-table__cell">
-                  <% if region.application_form_skip_work_history %>
-                    <%= govuk_tag(text: "Skips work history", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
-                  <% end %>
-
-                  <% if region.reduced_evidence_accepted %>
-                    <%= govuk_tag(text: "Accepts reduced evidence", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
-                  <% end %>
-                </td>
-              </tr>
-            <% end %>
+              </td>
+            </tr>
           <% end %>
-        </tbody>
-      </table>
-    </div>
-  <% end %>
-</div>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/support_interface/countries/index.html.erb
+++ b/app/views/support_interface/countries/index.html.erb
@@ -3,56 +3,49 @@
 <h1 class="govuk-heading-l">Countries</h1>
 
 <% @countries.each do |country| %>
-  <div class="govuk-width-container">
-    <table class="govuk-table">
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header" colspan="2">
-            <h2 class="govuk-heading-m">
-              <%= govuk_link_to CountryName.from_country(country), edit_support_interface_country_path(country) %>
-              <code class="govuk-tag app-country-code-tag govuk-!-margin-left-2"><%= country.code %></code>
+  <%= govuk_table do |table| %>
+    <%= table.with_head do |head| %>
+      <%= head.with_row do |row| %>
+        <%= row.with_cell do %>
+          <h2 class="govuk-heading-m">
+            <%= govuk_link_to CountryName.from_country(country), [:edit, :support_interface, country] %>
 
-              <% if country.eligibility_enabled %>
-                <%= govuk_tag(text: "Eligible", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
-              <% else %>
-                <%= govuk_tag(text: "Ineligible", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
-              <% end %>
+            <% if country.eligibility_enabled %>
+              <%= govuk_tag(text: "Eligible", colour: "green", classes: ["govuk-!-margin-left-2"]) %>
+            <% else %>
+              <%= govuk_tag(text: "Ineligible", colour: "red", classes: ["govuk-!-margin-left-2"]) %>
+            <% end %>
 
-              <% if country.eligibility_skip_questions %>
-                <%= govuk_tag(text: "Skips questions", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
-              <% end %>
-            </h2>
-          </th>
-        </tr>
-      </thead>
+            <% if country.eligibility_skip_questions %>
+              <%= govuk_tag(text: "Reduced eligibility", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
+            <% else %>
+              <%= govuk_tag(text: "Standard eligibility", colour: "grey", classes: ["govuk-!-margin-left-2"]) %>
+            <% end %>
+          </h2>
+        <% end %>
+      <% end %>
+    <% end %>
 
-      <tbody>
-        <% country.regions.order(:name).each_slice(4) do |regions| %>
-          <% regions.each do |region| %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell govuk-!-width-one-third">
-                <a class="govuk-link" href="<%= edit_support_interface_region_path(region) %>">
-                  <% if region.name.present? %>
-                    <%= region.name %>
-                  <% else %>
-                    <em>National</em>
-                  <% end %>
-                </a>
-              </td>
+    <%= table.with_body do |body| %>
+      <%= country.regions.order(:name).each do |region| %>
+        <%= body.with_row do |row| %>
+          <%= row.with_cell do %>
+            <%= govuk_link_to region.name.presence || "National", [:edit, :support_interface, region] %>
 
-              <td class="govuk-table__cell">
-                <% if region.application_form_skip_work_history %>
-                  <%= govuk_tag(text: "Skips work history", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
-                <% end %>
+            <% if region.requires_preliminary_check %>
+              <%= govuk_tag(text: "Requires preliminary check", colour: "blue", classes: ["govuk-!-margin-left-2"]) %>
+            <% end %>
 
-                <% if region.reduced_evidence_accepted %>
-                  <%= govuk_tag(text: "Accepts reduced evidence", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
-                <% end %>
-              </td>
-            </tr>
+            <% if region.application_form_skip_work_history %>
+              <%= govuk_tag(text: "Work history removed", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
+            <% end %>
+
+            <% if region.reduced_evidence_accepted %>
+              <%= govuk_tag(text: "Accepts reduced evidence", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
+            <% end %>
           <% end %>
         <% end %>
-      </tbody>
-    </table>
-  </div>
+      <% end %>
+    <% end %>
+  <% end %>
 <% end %>


### PR DESCRIPTION
This improves the design of the index page, making the various parts clearer and highlighting various parts of the countries and regions.

[Trello Card](https://trello.com/c/HW9U66FU/2260-combine-region-and-country-pages-if-theres-only-one-region)