### PR TITLE
Reformat support console questions to nest application_form_skip_work…

### DIFF
--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -32,10 +32,10 @@ class SupportInterface::RegionsController < SupportInterface::BaseController
 
   def region_params
     params.require(:region).permit(
-      :application_form_skip_work_history,
+      :all_sections_necessary,
+      :work_history_section_to_omit,
       :other_information,
       :qualifications_information,
-      :reduced_evidence_accepted,
       :requires_preliminary_check,
       :sanction_check,
       :sanction_information,

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -86,4 +86,41 @@ class Region < ApplicationRecord
     teaching_authority_name.present? || teaching_authority_address.present? ||
       teaching_authority_emails.present? || teaching_authority_websites.present?
   end
+
+  def all_sections_necessary
+    !application_form_skip_work_history && !reduced_evidence_accepted
+  end
+
+  def all_sections_necessary=(value)
+    application_form_skip_work_history_will_change!
+    reduced_evidence_accepted_will_change!
+
+    if value
+      self.application_form_skip_work_history = false
+      self.reduced_evidence_accepted = false
+    end
+  end
+
+  def work_history_section_to_omit
+    if application_form_skip_work_history
+      "whole_section"
+    elsif reduced_evidence_accepted
+      "contact_details"
+    end
+  end
+
+  def work_history_section_to_omit=(value)
+    return if all_sections_necessary
+    application_form_skip_work_history_will_change!
+    reduced_evidence_accepted_will_change!
+
+    case value
+    when "whole_section"
+      self.application_form_skip_work_history = true
+      self.reduced_evidence_accepted = false
+    when "contact_details"
+      self.application_form_skip_work_history = false
+      self.reduced_evidence_accepted = true
+    end
+  end
 end

--- a/app/views/support_interface/countries/index.html.erb
+++ b/app/views/support_interface/countries/index.html.erb
@@ -37,11 +37,11 @@
             <% end %>
 
             <% if region.application_form_skip_work_history %>
-              <%= govuk_tag(text: "Work history removed", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
+              <%= govuk_tag(text: "No work history section required", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
             <% end %>
 
             <% if region.reduced_evidence_accepted %>
-              <%= govuk_tag(text: "Accepts reduced evidence", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
+              <%= govuk_tag(text: "No work history contact details required", colour: "yellow", classes: ["govuk-!-margin-left-2"]) %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -15,24 +15,21 @@
                                        legend: { text: "Will applications be subject to a preliminary check?" } %>
 
   <%= f.govuk_fieldset legend: { text: "Application form changes" } do %>
-    <%= f.govuk_collection_radio_buttons :application_form_skip_work_history,
-                                         [
-                                           OpenStruct.new(value: :true, label: "Yes"),
-                                           OpenStruct.new(value: :false, label: "No")
-                                         ],
-                                         :value,
-                                         :label,
-                                         legend: { text: "Remove work history?", size: "s" } %>
 
-    <%= f.govuk_collection_radio_buttons :reduced_evidence_accepted,
-                                         [
-                                           OpenStruct.new(value: :true, label: "Yes"),
-                                           OpenStruct.new(value: :false, label: "No")
-                                         ],
-                                         :value,
-                                         :label,
-                                         legend: { text: "Remove work history contact details and allow applicant to choose any SELT provider to prove their English proficiency?", size: "s" },
-                                         hint: { text: "Allows QTS to be awarded without any work references being provided." } %>
+    <%= f.govuk_radio_buttons_fieldset(:all_sections_necessary, legend: { size: 's', text: 'Do applicants need to complete all sections of the application form?' }) do %>
+      <%= f.govuk_radio_button :all_sections_necessary, :true, label: { text: 'Yes' }, link_errors: true %>
+      <%= f.govuk_radio_button :all_sections_necessary, :false, label: { text: 'No' } do %>
+        <%= f.govuk_collection_select :work_history_section_to_omit,
+                                      [
+                                        OpenStruct.new(id: "whole_section", name: "Work history (whole section)"),
+                                        OpenStruct.new(id: "contact_details", name: "Work history contact details (QTS can be awarded without work references and applicants can choose any SELT provider)."),
+                                      ],
+                                      :id,
+                                      :name,
+                                      label: { text: "Which sections will be removed?", size: "s" } %>
+
+      <% end %>
+    <% end %>
 
     <%= f.govuk_collection_radio_buttons :written_statement_optional,
                                          [


### PR DESCRIPTION
…_history and reduced_evidence_accepted questions

There are currently two items of information that some applicants provide differently to others:

Remove work history

Remove work history contact details & allow applicant to choose any SELT provider to prove their English proficiency

These correspond to the fields application_form_skip_work_history and reduced_evidence_accepted.

We need to add a way of letting users choose these options in the support console.

This is in adherance with new design priorities.