### PR TITLE
Show multiple DQT matches

### DIFF
--- a/app/jobs/find_applicant_in_dqt_job.rb
+++ b/app/jobs/find_applicant_in_dqt_job.rb
@@ -4,7 +4,6 @@ class FindApplicantInDQTJob < ApplicationJob
   def perform(application_form_id:)
     application_form = ApplicationForm.find(application_form_id)
     teachers = FindTeachersInDQT.call(application_form:, reverse_name: true)
-
-    application_form.update!(dqt_match: teachers.first) if teachers.any?
+    application_form.update!(dqt_match: { teachers: })
   end
 end

--- a/app/lib/dqt/client/find_teachers.rb
+++ b/app/lib/dqt/client/find_teachers.rb
@@ -5,6 +5,7 @@ class DQT::Client::FindTeachers
   include DQT::Client::Connection
 
   attr_reader :application_form, :reverse_name
+
   def initialize(application_form:, reverse_name: false)
     @application_form = application_form
     @reverse_name = reverse_name

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -14,6 +14,10 @@ class AssessorInterface::ApplicationFormsShowViewObject
         .find(params[:id])
   end
 
+  def duplicate_matches
+    dqt_match.fetch("teachers", dqt_match.present? ? [dqt_match] : [])
+  end
+
   def task_list_sections
     [
       pre_assessment_task_list_section,
@@ -75,6 +79,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
   attr_reader :params, :current_staff
 
   delegate :assessment,
+           :dqt_match,
            :teacher,
            :teaching_authority_provides_written_statement,
            :work_histories,

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -2,20 +2,23 @@
 <% content_for :back_link_url, assessor_interface_application_forms_path %>
 
 <% application_form = @view_object.application_form %>
-<% assessment = @view_object.assessment %>
 
 <%= render "linked_application_forms",
            teacher: application_form.teacher,
            email_used_as_reference_in_this_application_form: @view_object.email_used_as_reference_in_this_application_form?,
            other_application_forms_where_email_used_as_reference: @view_object.other_application_forms_where_email_used_as_reference %>
 
-<% if @view_object.application_form.dqt_match.present? %>
+<% if (duplicate_matches = @view_object.duplicate_matches).present? %>
   <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
-    <% notification_banner.with_heading(text: "The application details match a record in DQT") %>
+    <% notification_banner.with_heading(text: "Application details match DQT record(s)") %>
 
-    <p class="govuk-body govuk-!-margin-bottom-1">
-      DQT contains a matching record for the name and date of birth of this applicant. <strong class="govuk-!-font-weight-bold">Teacher Reference Number: <%= @view_object.application_form.dqt_match["trn"] %></strong>.
-    </p>
+    <p class="govuk-body">The surname and date of birth used in this application matches the following records found in the Database of Qualified Teachers (DQT):</p>
+
+    <ul class="govuk-list govuk-list--bullet">
+      <% duplicate_matches.each do |match| %>
+        <li><%= match["first_name"] %> <%= match["last_name"] %>, TRN <%= match["trn"] %></li>
+      <% end %>
+    </ul>
   <% end %>
 <% end %>
 

--- a/spec/jobs/find_applicant_in_dqt_job_spec.rb
+++ b/spec/jobs/find_applicant_in_dqt_job_spec.rb
@@ -28,32 +28,30 @@ RSpec.describe FindApplicantInDQTJob do
 
       perform
 
-      expect(application_form.reload.dqt_match).to eq({})
+      expect(application_form.reload.dqt_match).to eq({ "teachers" => [] })
     end
 
     it "updates the application form with the TRN" do
-      result = {
-        date_of_birth: application_form.date_of_birth.iso8601.to_s,
-        first_name: "Jane",
-        last_name: "Smith",
-        trn: "1234567",
-      }
+      results = [
+        {
+          "date_of_birth" => application_form.date_of_birth.iso8601.to_s,
+          "first_name" => "Jane",
+          "last_name" => "Smith",
+          "trn" => "1234567",
+        },
+        {
+          "date_of_birth" => "1980-01-01",
+          "first_name" => "Janet",
+          "last_name" => "Jones",
+          "trn" => "7654321",
+        },
+      ]
 
-      allow(FindTeachersInDQT).to receive(:call).and_return(
-        [
-          result,
-          {
-            date_of_birth: "1980-01-01",
-            first_name: "Janet",
-            last_name: "Jones",
-            trn: "7654321",
-          },
-        ],
-      )
+      allow(FindTeachersInDQT).to receive(:call).and_return(results)
 
       perform
 
-      expect(application_form.reload.dqt_match).to eq(result.as_json)
+      expect(application_form.reload.dqt_match).to eq({ "teachers" => results })
     end
   end
 end

--- a/spec/system/assessor_interface/duplicate_applicant_application_form_spec.rb
+++ b/spec/system/assessor_interface/duplicate_applicant_application_form_spec.rb
@@ -31,11 +31,9 @@ RSpec.describe "Assessor views duplicate applicant's application form",
 
   def and_i_see_the_warning_of_an_existing_record_in_dqt
     expect(assessor_application_page).to have_content(
-      "The application details match a record in DQT",
+      "Application details match DQT record(s)",
     )
-    expect(assessor_application_page).to have_content(
-      "Teacher Reference Number: 7654322",
-    )
+    expect(assessor_application_page).to have_content("John Smith, TRN 7654322")
   end
 
   def and_the_applicant_matches_a_record_in_dqt
@@ -69,9 +67,9 @@ RSpec.describe "Assessor views duplicate applicant's application form",
 
   def dqt_match
     {
-      "firstName" => application_form.given_names,
-      "lastName" => application_form.family_name,
-      "dateOfBirth" => application_form.date_of_birth.iso8601.to_s,
+      "first_name" => "John",
+      "last_name" => "Smith",
+      "date_of_birth" => application_form.date_of_birth.iso8601.to_s,
       "trn" => "7654322",
     }
   end


### PR DESCRIPTION
This changes how we show potential matches in DQT to show all the potential matches rather than picking out the first one and only displaying that.

[Trello Card](https://trello.com/c/eATHjdh0/2292-surface-multiple-potential-matches-for-dqt-when-the-occur)

## Screenshots

<img width="670" alt="Screenshot 2023-09-24 at 15 57 15" src="https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/3805a02d-bcdd-4469-882a-8d4a3738a29f">
