### PR TITLE
Update signed out content

### DIFF
--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -53,7 +53,6 @@ class Teachers::SessionsController < Devise::SessionsController
   end
 
   def signed_out
-    @duration = params[:new_regulations] == "true" ? "6 months" : "60 days"
   end
 
   protected
@@ -62,13 +61,8 @@ class Teachers::SessionsController < Devise::SessionsController
     stored_location_for(resource) || teacher_interface_root_path
   end
 
-  def after_sign_out_path_for(resource)
-    return teacher_signed_out_path unless resource.is_a?(Teacher)
-
-    teacher_signed_out_path(
-      new_regulations:
-        resource.application_form&.created_under_new_regulations?,
-    )
+  def after_sign_out_path_for(_resource)
+    teacher_signed_out_path
   end
 
   private

--- a/app/views/teachers/sessions/signed_out.html.erb
+++ b/app/views/teachers/sessions/signed_out.html.erb
@@ -1,29 +1,19 @@
-<% content_for :page_title, "We’ve saved your in-progress QTS application" %>
+<% content_for :page_title, "We’ve saved your QTS application progress" %>
 
-<h1 class="govuk-heading-xl">We’ve saved your in-progress QTS application</h1>
+<h1 class="govuk-heading-xl">We’ve saved your QTS application progress</h1>
 
 <p class="govuk-body-m">
-  We’ve signed you out of the Apply for qualified teacher status (QTS) service.
+  You’ve been signed out of the Apply for qualified teacher status in England service.
+  All the information you’ve added to your application so far has been saved.
 </p>
 
 <p class="govuk-body">
-  We’ve saved the information you’ve added to your application so far.
-</p>
-
-<p class="govuk-body">
-  We’ll keep your in-progress application open for <%= @duration %> from the date you started it.
-  If you do not complete it within this time, you’ll need to make a new application.
+  We’ll keep your application open for 6 months from the date you started it.
+  If you do not submit it within this time, you’ll need to make a new application.
 </p>
 
 <h2 class="govuk-heading-m">Continuing your application</h2>
 
 <p class="govuk-body">
-  You can get back to your application (and see how long you have left to complete it) using the link below.
-  The link will take you to the beginning of the service, but you can use your email address to sign in and continue your application.
-</p>
-
-<p class="govuk-body"><%= govuk_link_to new_teacher_session_url, new_teacher_session_url %></p>
-
-<p class="govuk-body">
-  If you do not continue your application within <%= @duration %> you’ll need to start a new application.
+  Use your email address to <%= govuk_link_to "sign in", new_teacher_session_url %> and complete your application.
 </p>


### PR DESCRIPTION
This updates the content that a teacher sees when they sign out of the service, as requested by our content designer.

[Trello Card](https://trello.com/c/SR3LZMdL/2288-content-tweak-for-weve-saved-your-in-progress-application)

## Screenshots

<img width="669" alt="Screenshot 2023-09-24 at 15 37 57" src="https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/f601349a-7d92-41f5-892b-07ab9ee75a2d">
