### PR TITLE
Rename state_changed to status_changed

### DIFF
--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -41,16 +41,16 @@ module TimelineEntry
 
     private
 
-    def state_changed_vars
+    def status_changed_vars
       {
-        old_state:
+        old_status:
           render(
             StatusTag::Component.new(
               status: timeline_event.old_state,
               class_context: "timeline-event",
             ),
           ).strip,
-        new_state:
+        new_status:
           render(
             StatusTag::Component.new(
               status: timeline_event.new_state,

--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -28,7 +28,7 @@ class ApplicationFormStatusUpdater
       if (old_status = application_form.status) != status
         application_form.update!(status:)
         create_timeline_event(
-          event_type: "state_changed",
+          event_type: "status_changed",
           old_state: old_status,
           new_state: status,
         )

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -76,7 +76,7 @@ class TimelineEvent < ApplicationRecord
          requestable_requested: "requestable_requested",
          reviewer_assigned: "reviewer_assigned",
          stage_changed: "stage_changed",
-         state_changed: "state_changed",
+         status_changed: "status_changed",
        }
 
   validates :creator, presence: true, unless: -> { creator_name.present? }
@@ -93,11 +93,11 @@ class TimelineEvent < ApplicationRecord
   validates :old_state,
             :new_state,
             presence: true,
-            if: -> { state_changed? || assessment_section_recorded? }
+            if: -> { status_changed? || assessment_section_recorded? }
   validates :old_state,
             :new_state,
             absence: true,
-            unless: -> { state_changed? || assessment_section_recorded? }
+            unless: -> { status_changed? || assessment_section_recorded? }
 
   validates :assessment_section,
             presence: true,
@@ -164,6 +164,7 @@ class TimelineEvent < ApplicationRecord
               action_required_by_changed? || information_changed? ||
                 stage_changed?
             end
+
   validates :column_name, presence: true, if: :information_changed?
   validates :work_history_id,
             :column_name,

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -72,7 +72,7 @@ en:
           QualificationRequest: Qualification assessed
           ReferenceRequest: Reference assessed
         stage_changed: Stage changed
-        state_changed: Status changed
+        status_changed: Status changed
       description:
         action_required_by_changed: Application requires %{action} action.
         assessor_assigned: "%{assignee_name} is assigned as the assessor."
@@ -100,7 +100,7 @@ en:
           QualificationRequest: A qualification has been assessed.
           ReferenceRequest: A reference has been assessed.
         stage_changed: Stage changed from %{old_stage} to %{new_stage}.
-        state_changed: Status changed from %{old_state} to %{new_state}.
+        status_changed: Status changed from %{old_status} to %{new_status}.
       columns:
         contact_email: Reference email address
         contact_job: Reference job

--- a/lib/tasks/timeline_events.rake
+++ b/lib/tasks/timeline_events.rake
@@ -1,0 +1,8 @@
+namespace :timeline_events do
+  desc "Migrate state_changed events"
+  task migrate_state_changed: :environment do
+    TimelineEvent.where(event_type: "state_changed").update_all(
+      event_type: "status_changed",
+    )
+  end
+end

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -8,7 +8,12 @@ RSpec.describe TimelineEntry::Component, type: :component do
 
   context "with a creator name" do
     let(:timeline_event) do
-      create(:timeline_event, :state_changed, creator_name: "DQT", creator: nil)
+      create(
+        :timeline_event,
+        :status_changed,
+        creator_name: "DQT",
+        creator: nil,
+      )
     end
 
     it "describes the event" do
@@ -50,7 +55,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     let(:timeline_event) do
       create(
         :timeline_event,
-        :state_changed,
+        :status_changed,
         old_state: "submitted",
         new_state: "awarded",
       )

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -185,7 +185,7 @@ FactoryBot.define do
       after(:create) do |application_form, _evaluator|
         create(
           :timeline_event,
-          :state_changed,
+          :status_changed,
           application_form:,
           creator: application_form.teacher,
           old_state: "draft",

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -66,8 +66,8 @@ FactoryBot.define do
       association :assignee, factory: :staff
     end
 
-    trait :state_changed do
-      event_type { "state_changed" }
+    trait :status_changed do
+      event_type { "status_changed" }
       old_state { ApplicationForm.statuses.keys.sample }
       new_state { ApplicationForm.statuses.keys.sample }
     end

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ApplicationFormStatusUpdater do
 
     it "records a timeline event" do
       expect { call }.to have_recorded_timeline_event(
-        :state_changed,
+        :status_changed,
         creator: user,
         application_form:,
         old_state: "draft",
@@ -433,7 +433,7 @@ RSpec.describe ApplicationFormStatusUpdater do
       end
 
       it "doesn't record a timeline event" do
-        expect { call }.to_not have_recorded_timeline_event(:state_changed)
+        expect { call }.to_not have_recorded_timeline_event(:status_changed)
       end
       it "doesn't change the stage from draft" do
         expect { call }.to_not change(application_form, :stage).from("draft")

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe TimelineEvent do
         requestable_requested: "requestable_requested",
         reviewer_assigned: "reviewer_assigned",
         stage_changed: "stage_changed",
-        state_changed: "state_changed",
+        status_changed: "status_changed",
       ).backed_by_column_of_type(:string)
     end
 
@@ -142,8 +142,8 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:new_value) }
     end
 
-    context "with a state changed event type" do
-      before { timeline_event.event_type = :state_changed }
+    context "with a status changed event type" do
+      before { timeline_event.event_type = :status_changed }
 
       it { is_expected.to validate_absence_of(:assignee) }
       it { is_expected.to validate_presence_of(:old_state) }

--- a/spec/services/rollback_assessment_spec.rb
+++ b/spec/services/rollback_assessment_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe RollbackAssessment do
 
       it "records a timeline event" do
         expect { call }.to have_recorded_timeline_event(
-          :state_changed,
+          :status_changed,
           creator: user,
         )
       end
@@ -45,7 +45,7 @@ RSpec.describe RollbackAssessment do
 
       it "records a timeline event" do
         expect { call }.to have_recorded_timeline_event(
-          :state_changed,
+          :status_changed,
           creator: user,
         )
       end
@@ -62,7 +62,7 @@ RSpec.describe RollbackAssessment do
 
       it "records a timeline event" do
         expect { call }.to have_recorded_timeline_event(
-          :state_changed,
+          :status_changed,
           creator: user,
         )
       end
@@ -86,7 +86,7 @@ RSpec.describe RollbackAssessment do
 
       it "records a timeline event" do
         expect { call }.to have_recorded_timeline_event(
-          :state_changed,
+          :status_changed,
           creator: user,
         )
       end
@@ -107,7 +107,7 @@ RSpec.describe RollbackAssessment do
 
       it "records a timeline event" do
         expect { call }.to have_recorded_timeline_event(
-          :state_changed,
+          :status_changed,
           creator: user,
         )
       end
@@ -124,7 +124,7 @@ RSpec.describe RollbackAssessment do
 
       it "records a timeline event" do
         expect { call }.to have_recorded_timeline_event(
-          :state_changed,
+          :status_changed,
           creator: user,
         )
       end
@@ -169,7 +169,7 @@ RSpec.describe RollbackAssessment do
 
     it "records a timeline event" do
       expect { call }.to have_recorded_timeline_event(
-        :state_changed,
+        :status_changed,
         creator: user,
       )
     end

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe SubmitApplicationForm do
 
   it "records a timeline event" do
     expect { call }.to have_recorded_timeline_event(
-      :state_changed,
+      :status_changed,
       creator: user,
       application_form:,
       old_state: "draft",

--- a/spec/system/assessor_interface/view_timeline_events_spec.rb
+++ b/spec/system/assessor_interface/view_timeline_events_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Assessor view timeline events", type: :system do
         application_form =
           create(:application_form, :submitted, :with_assessment)
         create(:timeline_event, :assessor_assigned, application_form:)
-        create(:timeline_event, :state_changed, application_form:)
+        create(:timeline_event, :status_changed, application_form:)
         create(:timeline_event, :note_created, application_form:)
         application_form
       end


### PR DESCRIPTION
We're going to rename this to `status_changed` to better represent how we show it to users.

Depends on #1708 

[Trello Card](https://trello.com/c/vBBKmKoB/835-stop-using-oldstate-newstate-in-timeline-events)