### PR TITLE
Remove migrate_state_changed Rake task

### DIFF
--- a/lib/tasks/timeline_events.rake
+++ b/lib/tasks/timeline_events.rake
@@ -1,8 +1,0 @@
-namespace :timeline_events do
-  desc "Migrate state_changed events"
-  task migrate_state_changed: :environment do
-    TimelineEvent.where(event_type: "state_changed").update_all(
-      event_type: "status_changed",
-    )
-  end
-end


### PR DESCRIPTION
This can be removed as it's now been run in production.

Depends on #1715 

[Trello Card](https://trello.com/c/vBBKmKoB/835-stop-using-oldstate-newstate-in-timeline-events)