### PR TITLE
Stop using requestable state

### DIFF
--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -8,11 +8,6 @@ class PersonasController < ApplicationController
 
   def index
     @staff = Staff.all
-
-    @reference_requests =
-      ReferenceRequest.states.values.filter_map do |state|
-        ReferenceRequest.find_by(state:)
-      end
   end
 
   def eligible_sign_in

--- a/app/jobs/expire_requestable_job.rb
+++ b/app/jobs/expire_requestable_job.rb
@@ -2,8 +2,12 @@
 
 class ExpireRequestableJob < ApplicationJob
   def perform(requestable)
-    if requestable.requested? && requestable.expires_at.present? &&
-         Time.zone.now > requestable.expires_at
+    if requestable.received? || requestable.expired? ||
+         !requestable.requested? || requestable.expires_at.nil?
+      return
+    end
+
+    if Time.zone.now > requestable.expires_at
       ExpireRequestable.call(requestable:, user: "Expirer")
     end
   end

--- a/app/jobs/expire_requestables_job.rb
+++ b/app/jobs/expire_requestables_job.rb
@@ -2,8 +2,12 @@
 
 class ExpireRequestablesJob < ApplicationJob
   def perform(requestable_class_name)
-    requestable_class_name.constantize.requested.find_each do |requestable|
-      ExpireRequestableJob.perform_later(requestable)
-    end
+    requestable_class_name
+      .constantize
+      .requested
+      .where(expired_at: nil, received_at: nil)
+      .find_each do |requestable|
+        ExpireRequestableJob.perform_later(requestable)
+      end
   end
 end

--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -302,11 +302,15 @@ class ApplicationFormStatusUpdater
   end
 
   def waiting_on?(requestables:)
-    requestables.reject(&:reviewed?).any?(&:requested?)
+    requestables
+      .reject(&:reviewed?)
+      .reject(&:expired?)
+      .reject(&:received?)
+      .any?(&:requested?)
   end
 
   def received?(requestables:)
-    requestables.reject(&:reviewed?).any?(&:received?)
+    requestables.reject(&:reviewed?).reject(&:expired?).any?(&:received?)
   end
 
   def create_timeline_event(event_type:, **kwargs)

--- a/app/models/concerns/expirable.rb
+++ b/app/models/concerns/expirable.rb
@@ -9,6 +9,14 @@ module Expirable
     requested_at + expires_after
   end
 
+  def expired!
+    update!(expired_at: Time.zone.now)
+  end
+
+  def expired?
+    expired_at != nil
+  end
+
   def after_expired(user:)
     # implement logic after an expiration of this object
   end

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -32,9 +32,11 @@ class FurtherInformationRequest < ApplicationRecord
 
   scope :remindable,
         -> do
-          requested.joins(assessment: :application_form).merge(
-            ApplicationForm.assessable,
-          )
+          where
+            .not(requested_at: nil)
+            .where(expired_at: nil)
+            .joins(assessment: :application_form)
+            .merge(ApplicationForm.assessable)
         end
 
   FOUR_WEEK_COUNTRY_CODES = %w[AU CA GI NZ US].freeze

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -9,7 +9,7 @@
 #  received_at                                 :datetime
 #  requested_at                                :datetime
 #  reviewed_at                                 :datetime
-#  state                                       :string           not null
+#  state                                       :string           default("requested"), not null
 #  working_days_assessment_started_to_creation :integer
 #  working_days_received_to_recommendation     :integer
 #  working_days_since_received                 :integer

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -13,7 +13,7 @@
 #  received_at           :datetime
 #  requested_at          :datetime
 #  reviewed_at           :datetime
-#  state                 :string           not null
+#  state                 :string           default("requested"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  assessment_id         :bigint           not null

--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -12,7 +12,7 @@
 #  received_at           :datetime
 #  requested_at          :datetime
 #  reviewed_at           :datetime
-#  state                 :string           not null
+#  state                 :string           default("requested"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  assessment_id         :bigint           not null

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -58,9 +58,11 @@ class ReferenceRequest < ApplicationRecord
 
   scope :remindable,
         -> do
-          requested.joins(assessment: :application_form).merge(
-            ApplicationForm.assessable,
-          )
+          where
+            .not(requested_at: nil)
+            .where(expired_at: nil)
+            .joins(assessment: :application_form)
+            .merge(ApplicationForm.assessable)
         end
 
   with_options if: :received? do

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -31,7 +31,7 @@
 #  satisfied_comment               :text             default(""), not null
 #  satisfied_response              :boolean
 #  slug                            :string           not null
-#  state                           :string           not null
+#  state                           :string           default("requested"), not null
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
 #  assessment_id                   :bigint           not null

--- a/app/services/request_requestable.rb
+++ b/app/services/request_requestable.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class RequestRequestable
+  include ServicePattern
+
+  def initialize(requestable:, user:)
+    @requestable = requestable
+    @user = user
+  end
+
+  def call
+    raise AlreadyRequested if requestable.requested?
+
+    ActiveRecord::Base.transaction do
+      requestable.requested!
+      create_timeline_event
+      ApplicationFormStatusUpdater.call(application_form:, user:)
+    end
+
+    requestable.after_requested(user:)
+  end
+
+  class AlreadyRequested < StandardError
+  end
+
+  private
+
+  attr_reader :requestable, :user
+
+  delegate :application_form, to: :requestable
+
+  def create_timeline_event
+    creator = user.is_a?(String) ? nil : user
+    creator_name = user.is_a?(String) ? user : ""
+
+    TimelineEvent.create!(
+      application_form:,
+      creator:,
+      creator_name:,
+      event_type: "requestable_requested",
+      requestable:,
+    )
+  end
+end

--- a/app/services/send_reminder_email.rb
+++ b/app/services/send_reminder_email.rb
@@ -19,7 +19,6 @@ class SendReminderEmail
   attr_reader :remindable
 
   def send_reminder?
-    return false if remindable.try(:expired_at).present?
     return false unless remindable.expires_at
 
     remindable.should_send_reminder_email?(

--- a/app/services/verify_assessment.rb
+++ b/app/services/verify_assessment.rb
@@ -57,35 +57,24 @@ class VerifyAssessment
     return if application_form.teaching_authority_provides_written_statement
 
     ProfessionalStandingRequest
-      .create!(assessment:, requested_at: Time.zone.now)
-      .tap { |requestable| create_timeline_event(requestable) }
+      .create!(assessment:)
+      .tap { |requestable| RequestRequestable.call(requestable:, user:) }
   end
 
   def create_qualification_requests
     qualifications.map do |qualification|
       QualificationRequest
-        .create!(assessment:, qualification:, requested_at: Time.zone.now)
-        .tap { |requestable| create_timeline_event(requestable) }
+        .create!(assessment:, qualification:)
+        .tap { |requestable| RequestRequestable.call(requestable:, user:) }
     end
   end
 
   def create_reference_requests
     work_histories.map do |work_history|
       ReferenceRequest
-        .create!(assessment:, work_history:, requested_at: Time.zone.now)
-        .tap { |requestable| create_timeline_event(requestable) }
+        .create!(assessment:, work_history:)
+        .tap { |requestable| RequestRequestable.call(requestable:, user:) }
     end
-  end
-
-  def create_timeline_event(requestable)
-    TimelineEvent.create!(
-      application_form:,
-      creator: user,
-      event_type: "requestable_requested",
-      requestable:,
-    )
-
-    requestable.after_requested(user:)
   end
 
   def send_reference_request_emails(reference_requests)

--- a/app/view_objects/teacher_interface/application_form_show_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_show_view_object.rb
@@ -119,6 +119,12 @@ class TeacherInterface::ApplicationFormShowViewObject
     professional_standing_request&.expired? || false
   end
 
+  def request_further_information?
+    further_information_request.present? &&
+      further_information_request.requested? &&
+      !further_information_request.received?
+  end
+
   def request_professional_standing_certificate?
     teaching_authority_provides_written_statement &&
       professional_standing_request&.requested? &&

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -11,8 +11,7 @@ module TeacherInterface
       @further_information_request ||=
         FurtherInformationRequest
           .joins(:assessment)
-          .requested
-          .where(assessments: { application_form: })
+          .where(received_at: nil, assessments: { application_form: })
           .find(params[:id])
     end
 
@@ -74,7 +73,7 @@ module TeacherInterface
         item.document
       elsif item.work_history_contact?
         "Contact name: #{item.contact_name}<br/>
-         Contact job: #{item.contact_job}<br/> 
+         Contact job: #{item.contact_job}<br/>
          Contact email: #{item.contact_email}".html_safe
       end
     end

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -149,37 +149,3 @@
     end %>
   <% end %>
 </section>
-
-<section id="app-personas-references" class="app-personas">
-  <h2 class="govuk-heading-l">References</h2>
-
-  <% if @reference_requests.empty? %>
-    <p class="govuk-body">No reference requests.</p>
-  <% else %>
-    <%= govuk_table do |table|
-      table.with_head do |head|
-        head.with_row do |row|
-          row.with_cell(header: true, text: "Teacher email")
-          row.with_cell(header: true, text: "State")
-          row.with_cell(header: true, text: "Actions", numeric: true)
-        end
-      end
-
-      table.with_body do |body|
-        @reference_requests.each do |reference_request|
-          body.with_row do |row|
-            row.with_cell(text: reference_request.application_form.teacher.email)
-
-            row.with_cell(width: "one-third") do
-              render(StatusTag::Component.new(status: reference_request.state))
-            end
-
-            row.with_cell(numeric: true) do
-              govuk_button_link_to "Sign&nbsp;in".html_safe, teacher_interface_reference_request_path(slug: reference_request.slug)
-            end
-          end
-        end
-      end
-    end %>
-  <% end %>
-</section>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -8,7 +8,7 @@
   <%= render "teacher_interface/application_forms/show/declined", view_object: @view_object %>
 <% elsif @view_object.application_form.awarded? %>
   <%= render "teacher_interface/application_forms/show/awarded", view_object: @view_object %>
-<% elsif @view_object.further_information_request&.requested? %>
+<% elsif @view_object.request_further_information? %>
   <%= render "teacher_interface/application_forms/show/further_information_requested", view_object: @view_object %>
 <% elsif @view_object.request_professional_standing_certificate? %>
   <%= render "teacher_interface/application_forms/show/request_professional_standing_certificate", view_object: @view_object %>

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -30,6 +30,7 @@ en:
       received_professional_standing: Received professional standing
       received_qualification: Received qualification
       received_reference: Received reference
+      received_and_overdue: Received (overdue)
       rejected: Rejected
       requested: Waiting on
       review: Review

--- a/db/migrate/20230926142509_change_requestables_state_default.rb
+++ b/db/migrate/20230926142509_change_requestables_state_default.rb
@@ -1,0 +1,20 @@
+class ChangeRequestablesStateDefault < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :further_information_requests,
+                          :state,
+                          from: nil,
+                          to: "requested"
+    change_column_default :professional_standing_requests,
+                          :state,
+                          from: nil,
+                          to: "requested"
+    change_column_default :qualification_requests,
+                          :state,
+                          from: nil,
+                          to: "requested"
+    change_column_default :reference_requests,
+                          :state,
+                          from: nil,
+                          to: "requested"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -246,7 +246,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
 
   create_table "further_information_requests", force: :cascade do |t|
     t.bigint "assessment_id", null: false
-    t.string "state", null: false
+    t.string "state", default: "requested", null: false
     t.datetime "received_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -273,7 +273,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
 
   create_table "professional_standing_requests", force: :cascade do |t|
     t.bigint "assessment_id", null: false
-    t.string "state", null: false
+    t.string "state", default: "requested", null: false
     t.datetime "received_at"
     t.text "location_note", default: "", null: false
     t.datetime "created_at", null: false
@@ -290,7 +290,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
   create_table "qualification_requests", force: :cascade do |t|
     t.bigint "assessment_id", null: false
     t.bigint "qualification_id", null: false
-    t.string "state", null: false
+    t.string "state", default: "requested", null: false
     t.datetime "received_at"
     t.text "location_note", default: "", null: false
     t.datetime "created_at", null: false
@@ -322,7 +322,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
     t.string "slug", null: false
     t.bigint "assessment_id", null: false
     t.bigint "work_history_id", null: false
-    t.string "state", null: false
+    t.string "state", default: "requested", null: false
     t.datetime "received_at"
     t.boolean "dates_response"
     t.boolean "hours_response"

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -189,10 +189,9 @@ def create_application_forms
         end
       elsif (work_history = application_form.work_histories.first) &&
             rand(2).zero?
-        reference_request_trait = ReferenceRequest.states.keys.sample
         FactoryBot.create(
           :reference_request,
-          reference_request_trait,
+          %i[requested received expired].sample,
           assessment:,
           work_history:,
         )

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -27,34 +27,32 @@ FactoryBot.define do
   factory :further_information_request do
     association :assessment
 
-    requested
-
     trait :requested do
-      state { "requested" }
       requested_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end
 
     trait :received do
-      state { "received" }
       received_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end
 
     trait :expired do
-      state { "expired" }
       expired_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end
 
-    trait :passed do
-      passed { true }
-      reviewed_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
+    trait :reviewed do
       received
+      reviewed_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
+    end
+
+    trait :passed do
+      reviewed
+      passed { true }
     end
 
     trait :failed do
+      reviewed
       passed { false }
-      reviewed_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
       failure_assessor_note { "Notes." }
-      received
     end
 
     trait :with_items do

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -11,7 +11,7 @@
 #  received_at                                 :datetime
 #  requested_at                                :datetime
 #  reviewed_at                                 :datetime
-#  state                                       :string           not null
+#  state                                       :string           default("requested"), not null
 #  working_days_assessment_started_to_creation :integer
 #  working_days_received_to_recommendation     :integer
 #  working_days_since_received                 :integer

--- a/spec/factories/professional_standing_requests.rb
+++ b/spec/factories/professional_standing_requests.rb
@@ -13,7 +13,7 @@
 #  received_at           :datetime
 #  requested_at          :datetime
 #  reviewed_at           :datetime
-#  state                 :string           not null
+#  state                 :string           default("requested"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  assessment_id         :bigint           not null

--- a/spec/factories/professional_standing_requests.rb
+++ b/spec/factories/professional_standing_requests.rb
@@ -30,21 +30,16 @@ FactoryBot.define do
   factory :professional_standing_request do
     association :assessment
 
-    requested
-
     trait :requested do
-      state { "requested" }
       requested_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end
 
     trait :received do
-      state { "received" }
       received_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
       receivable
     end
 
     trait :expired do
-      state { "expired" }
       expired_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end
 

--- a/spec/factories/qualification_requests.rb
+++ b/spec/factories/qualification_requests.rb
@@ -12,7 +12,7 @@
 #  received_at           :datetime
 #  requested_at          :datetime
 #  reviewed_at           :datetime
-#  state                 :string           not null
+#  state                 :string           default("requested"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  assessment_id         :bigint           not null

--- a/spec/factories/qualification_requests.rb
+++ b/spec/factories/qualification_requests.rb
@@ -33,21 +33,16 @@ FactoryBot.define do
     association :assessment
     association :qualification, :completed
 
-    requested
-
     trait :requested do
-      state { "requested" }
       requested_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end
 
     trait :received do
-      state { "received" }
       received_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
       receivable
     end
 
     trait :expired do
-      state { "expired" }
       expired_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end
 

--- a/spec/factories/reference_requests.rb
+++ b/spec/factories/reference_requests.rb
@@ -31,7 +31,7 @@
 #  satisfied_comment               :text             default(""), not null
 #  satisfied_response              :boolean
 #  slug                            :string           not null
-#  state                           :string           not null
+#  state                           :string           default("requested"), not null
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
 #  assessment_id                   :bigint           not null

--- a/spec/factories/reference_requests.rb
+++ b/spec/factories/reference_requests.rb
@@ -61,35 +61,33 @@ FactoryBot.define do
       )
     end
 
-    requested
-
     trait :requested do
-      state { "requested" }
       requested_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end
 
     trait :received do
-      state { "received" }
       received_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
       receivable
     end
 
     trait :expired do
-      state { "expired" }
       expired_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end
 
-    trait :passed do
-      passed { true }
-      reviewed_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
+    trait :reviewed do
       received
+      reviewed_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
+    end
+
+    trait :passed do
+      reviewed
+      passed { true }
     end
 
     trait :failed do
+      reviewed
       passed { false }
       failure_assessor_note { "Notes." }
-      reviewed_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
-      received
     end
 
     trait :receivable do

--- a/spec/forms/assessor_interface/professional_standing_request_location_form_spec.rb
+++ b/spec/forms/assessor_interface/professional_standing_request_location_form_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe AssessorInterface::ProfessionalStandingRequestLocationForm,
 
       it { is_expected.to be true }
 
-      it "changes the state" do
-        expect { save }.to change(requestable, :state).to("received")
+      it "sets the received at date" do
+        expect { save }.to change(requestable, :received_at).from(nil)
       end
 
       it "sets the location note" do

--- a/spec/forms/assessor_interface/qualification_request_form_spec.rb
+++ b/spec/forms/assessor_interface/qualification_request_form_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
 
       it { is_expected.to be true }
 
-      it "changes the state" do
-        expect { save }.to change(requestable, :state).to("received")
+      it "sets the received at date" do
+        expect { save }.to change(requestable, :received_at).from(nil)
       end
 
       it "sets passed" do
@@ -89,8 +89,8 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
 
       it { is_expected.to be true }
 
-      it "changes the state" do
-        expect { save }.to change(requestable, :state).to("received")
+      it "sets the received at date" do
+        expect { save }.to change(requestable, :received_at).from(nil)
       end
 
       it "sets passed" do

--- a/spec/jobs/expire_requestable_job_spec.rb
+++ b/spec/jobs/expire_requestable_job_spec.rb
@@ -36,12 +36,12 @@ RSpec.describe ExpireRequestableJob do
       end
 
       context "when less than six weeks old" do
-        let(:requested_at) { (6.weeks - 1.hour).ago }
+        let(:requested_at) { (6.weeks - 2.hours).ago }
         it_behaves_like "not expired requestable"
       end
 
       context "when it is more than six weeks old" do
-        let(:requested_at) { (6.weeks + 1.hour).ago }
+        let(:requested_at) { (6.weeks + 2.hours).ago }
         it_behaves_like "expired requestable"
       end
 

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe ApplicationFormStatusUpdater do
           application_form.update!(
             teaching_authority_provides_written_statement: true,
           )
-          create(:professional_standing_request, assessment:)
+          create(:professional_standing_request, :requested, assessment:)
         end
 
         include_examples "changes action required by", "admin"

--- a/spec/lib/application_mailer_observer_spec.rb
+++ b/spec/lib/application_mailer_observer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ApplicationMailerObserver do
   end
 
   context "with a referee mailer" do
-    let(:reference_request) { create(:reference_request) }
+    let(:reference_request) { create(:reference_request, :requested) }
     let(:application_form) { reference_request.assessment.application_form }
     let(:message) { RefereeMailer.with(reference_request:).reference_requested }
 

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RefereeMailer, type: :mailer do
   end
 
   let(:reference_request) do
-    create(:reference_request, assessment:, work_history:)
+    create(:reference_request, :requested, assessment:, work_history:)
   end
 
   describe "#reference_reminder" do

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe FurtherInformationRequest do
       let(:expected) do
         create(
           :further_information_request,
+          :requested,
           assessment:
             create(
               :assessment,

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -11,7 +11,7 @@
 #  received_at                                 :datetime
 #  requested_at                                :datetime
 #  reviewed_at                                 :datetime
-#  state                                       :string           not null
+#  state                                       :string           default("requested"), not null
 #  working_days_assessment_started_to_creation :integer
 #  working_days_received_to_recommendation     :integer
 #  working_days_since_received                 :integer

--- a/spec/models/professional_standing_request_spec.rb
+++ b/spec/models/professional_standing_request_spec.rb
@@ -13,7 +13,7 @@
 #  received_at           :datetime
 #  requested_at          :datetime
 #  reviewed_at           :datetime
-#  state                 :string           not null
+#  state                 :string           default("requested"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  assessment_id         :bigint           not null

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -12,7 +12,7 @@
 #  received_at           :datetime
 #  requested_at          :datetime
 #  reviewed_at           :datetime
-#  state                 :string           not null
+#  state                 :string           default("requested"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  assessment_id         :bigint           not null

--- a/spec/models/reference_request_spec.rb
+++ b/spec/models/reference_request_spec.rb
@@ -31,7 +31,7 @@
 #  satisfied_comment               :text             default(""), not null
 #  satisfied_response              :boolean
 #  slug                            :string           not null
-#  state                           :string           not null
+#  state                           :string           default("requested"), not null
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
 #  assessment_id                   :bigint           not null

--- a/spec/models/reference_request_spec.rb
+++ b/spec/models/reference_request_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe ReferenceRequest do
       let(:expected) do
         create(
           :reference_request,
+          :requested,
           assessment:
             create(
               :assessment,

--- a/spec/services/expire_requestable_spec.rb
+++ b/spec/services/expire_requestable_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ExpireRequestable do
     end
 
     context "with requested FI request" do
-      let(:requestable) { create(:further_information_request) }
+      let(:requestable) { create(:further_information_request, :requested) }
 
       it_behaves_like "expiring a requestable"
       it_behaves_like "declining the application"
@@ -60,7 +60,7 @@ RSpec.describe ExpireRequestable do
     end
 
     context "with a requested professional standing request" do
-      let(:requestable) { create(:professional_standing_request) }
+      let(:requestable) { create(:professional_standing_request, :requested) }
 
       it_behaves_like "expiring a requestable"
 
@@ -88,7 +88,7 @@ RSpec.describe ExpireRequestable do
     end
 
     context "with a requested reference request" do
-      let(:requestable) { create(:reference_request) }
+      let(:requestable) { create(:reference_request, :requested) }
 
       it_behaves_like "expiring a requestable"
     end

--- a/spec/services/request_requestable_spec.rb
+++ b/spec/services/request_requestable_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RequestRequestable do
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:requestable) do
+    create(
+      :qualification_request,
+      assessment: create(:assessment, application_form:),
+    )
+  end
+  let(:user) { "John Smith" }
+
+  subject(:call) { described_class.call(requestable:, user:) }
+
+  context "with an already requested requestable" do
+    before { requestable.requested! }
+
+    it "raises an error" do
+      expect { call }.to raise_error(RequestRequestable::AlreadyRequested)
+    end
+  end
+
+  it "changes the requestable state to requested" do
+    expect { call }.to change(requestable, :requested?).from(false).to(true)
+  end
+
+  it "changes the requestable requested at" do
+    freeze_time do
+      expect { call }.to change(requestable, :requested_at).from(nil).to(
+        Time.current,
+      )
+    end
+  end
+
+  it "records a requestable requested timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :requestable_requested,
+      requestable:,
+    )
+  end
+end

--- a/spec/services/rollback_assessment_spec.rb
+++ b/spec/services/rollback_assessment_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe RollbackAssessment do
     let(:assessment) { create(:assessment, :award, application_form:) }
 
     context "having requested verification" do
-      before { create(:reference_request, assessment:) }
+      before { create(:reference_request, :requested, assessment:) }
 
       it "sets the assessment to unknown" do
         expect { call }.to change(assessment, :verify?).to(true)
@@ -31,7 +31,7 @@ RSpec.describe RollbackAssessment do
     end
 
     context "having requested further information" do
-      before { create(:further_information_request, assessment:) }
+      before { create(:further_information_request, :requested, assessment:) }
 
       it "sets the assessment to unknown" do
         expect { call }.to change(assessment, :request_further_information?).to(
@@ -74,7 +74,7 @@ RSpec.describe RollbackAssessment do
     let(:assessment) { create(:assessment, :decline, application_form:) }
 
     context "having requested verification" do
-      before { create(:reference_request, assessment:) }
+      before { create(:reference_request, :requested, assessment:) }
 
       it "sets the assessment to unknown" do
         expect { call }.to change(assessment, :verify?).to(true)
@@ -93,7 +93,7 @@ RSpec.describe RollbackAssessment do
     end
 
     context "having requested further information" do
-      before { create(:further_information_request, assessment:) }
+      before { create(:further_information_request, :requested, assessment:) }
 
       it "sets the assessment to unknown" do
         expect { call }.to change(assessment, :request_further_information?).to(

--- a/spec/support/autoload/page_objects/personas.rb
+++ b/spec/support/autoload/page_objects/personas.rb
@@ -18,10 +18,5 @@ module PageObjects
       element :heading, "h2"
       elements :buttons, ".govuk-button"
     end
-
-    section :references, "#app-personas-references" do
-      element :heading, "h2"
-      elements :buttons, ".govuk-button"
-    end
   end
 end

--- a/spec/support/shared_examples/requestable.rb
+++ b/spec/support/shared_examples/requestable.rb
@@ -1,41 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "a requestable" do
-  it do
-    is_expected.to define_enum_for(:state).with_values(
-      requested: "requested",
-      received: "received",
-      expired: "expired",
-    ).backed_by_column_of_type(:string)
-  end
-
   describe "associations" do
     it { is_expected.to belong_to(:assessment) }
   end
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:state) }
-
+    it { is_expected.to_not validate_presence_of(:requested_at) }
     it { is_expected.to_not validate_presence_of(:received_at) }
     it { is_expected.to_not validate_presence_of(:expired_at) }
-
-    context "when received" do
-      before { subject.state = "requested" }
-
-      it { is_expected.to validate_presence_of(:requested_at) }
-    end
-
-    context "when received" do
-      before { subject.state = "received" }
-
-      it { is_expected.to validate_presence_of(:received_at) }
-    end
-
-    context "when expired" do
-      before { subject.state = "expired" }
-
-      it { is_expected.to validate_presence_of(:expired_at) }
-    end
 
     context "when reviewed" do
       before { subject.passed = [true, false].sample }
@@ -49,17 +22,15 @@ RSpec.shared_examples "a requestable" do
 
     it "sets the requested at date" do
       freeze_time do
-        expect { call }.to change(subject, :requested_at).to(Time.zone.now)
+        expect { call }.to change(subject, :requested_at).from(nil).to(
+          Time.zone.now,
+        )
       end
     end
   end
 
   describe "#received!" do
     let(:call) { subject.received! }
-
-    it "changes the state" do
-      expect { call }.to change(subject, :received?).from(false).to(true)
-    end
 
     it "sets the received at date" do
       freeze_time do
@@ -72,10 +43,6 @@ RSpec.shared_examples "a requestable" do
 
   describe "#expired!" do
     let(:call) { subject.expired! }
-
-    it "changes the state" do
-      expect { call }.to change(subject, :expired?).from(false).to(true)
-    end
 
     it "sets the received at date" do
       freeze_time do
@@ -105,20 +72,35 @@ RSpec.shared_examples "a requestable" do
   end
 
   describe "#status" do
-    it "is the same as state when passed is nil and state is defined" do
-      subject.passed = nil
-      subject.state = "received"
-      expect(subject.status).to eq("received")
-    end
-
     it "is accepted when passed is true" do
       subject.passed = true
+      subject.reviewed_at = Time.zone.now
       expect(subject.status).to eq("accepted")
     end
 
     it "is rejected when passed is false" do
       subject.passed = false
+      subject.reviewed_at = Time.zone.now
       expect(subject.status).to eq("rejected")
+    end
+
+    it "is received when received at is set" do
+      subject.received_at = Time.zone.now
+      expect(subject.status).to eq("received")
+    end
+
+    it "is overdue when expired at is set" do
+      subject.expired_at = Time.zone.now
+      expect(subject.status).to eq("overdue")
+    end
+
+    it "is waiting on when requested at is set" do
+      subject.requested_at = Time.zone.now
+      expect(subject.status).to eq("waiting_on")
+    end
+
+    it "is not started by default" do
+      expect(subject.status).to eq("not_started")
     end
   end
 

--- a/spec/system/assessor_interface/change_work_history_spec.rb
+++ b/spec/system/assessor_interface/change_work_history_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe "Assessor change work history", type: :system do
 
   def reference_request
     @reference_request ||=
-      create(:reference_request, assessment:, work_history:)
+      create(:reference_request, :requested, assessment:, work_history:)
   end
 
   def assessor

--- a/spec/system/personas_spec.rb
+++ b/spec/system/personas_spec.rb
@@ -35,9 +35,6 @@ RSpec.describe "Personas", type: :system do
       then_i_see_the(:teacher_application_page)
 
       when_i_visit_the(:personas_page)
-
-      when_i_sign_in_as_a_reference_persona
-      then_i_see_the(:teacher_reference_requested_page)
     end
   end
 
@@ -66,8 +63,6 @@ RSpec.describe "Personas", type: :system do
 
     teacher = create(:teacher, email: "teacher@example.com")
     create(:application_form, teacher:)
-
-    create(:reference_request, :requested)
   end
 
   def when_i_sign_in_as_a_staff_persona
@@ -80,10 +75,6 @@ RSpec.describe "Personas", type: :system do
 
   def when_i_sign_in_as_a_teacher_persona
     personas_page.teachers.buttons.first.click
-  end
-
-  def when_i_sign_in_as_a_reference_persona
-    personas_page.references.buttons.first.click
   end
 
   def and_i_see_no_personas

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -119,7 +119,6 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       context "and professional standing request received" do
         before do
           professional_standing_request.update!(
-            state: "received",
             received_at: 1.day.ago,
             location_note: "wat",
           )

--- a/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_show_view_object_spec.rb
@@ -356,7 +356,7 @@ RSpec.describe TeacherInterface::ApplicationFormShowViewObject do
         )
       end
 
-      before { create(:professional_standing_request, assessment:) }
+      before { create(:professional_standing_request, :requested, assessment:) }
 
       it { is_expected.to be false }
 


### PR DESCRIPTION
In #1717 we introduced new date/time fields which means we can remove the `state` field as it's no longer used (we can instead look at whether any of the date/time fields are `nil`).

[Trello Card](https://trello.com/c/kJ7RrYLn/2296-mark-lops-verification-to-be-done)