### PR TITLE
Remove requestable state

### DIFF
--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -9,7 +9,6 @@
 #  received_at                                 :datetime
 #  requested_at                                :datetime
 #  reviewed_at                                 :datetime
-#  state                                       :string           default("requested"), not null
 #  working_days_assessment_started_to_creation :integer
 #  working_days_received_to_recommendation     :integer
 #  working_days_since_received                 :integer

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -13,7 +13,6 @@
 #  received_at           :datetime
 #  requested_at          :datetime
 #  reviewed_at           :datetime
-#  state                 :string           default("requested"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  assessment_id         :bigint           not null

--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -12,7 +12,6 @@
 #  received_at           :datetime
 #  requested_at          :datetime
 #  reviewed_at           :datetime
-#  state                 :string           default("requested"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  assessment_id         :bigint           not null

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -31,7 +31,6 @@
 #  satisfied_comment               :text             default(""), not null
 #  satisfied_response              :boolean
 #  slug                            :string           not null
-#  state                           :string           default("requested"), not null
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
 #  assessment_id                   :bigint           not null

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -188,7 +188,6 @@
     - received_at
     - requested_at
     - reviewed_at
-    - state
     - updated_at
     - working_days_assessment_started_to_creation
     - working_days_received_to_recommendation
@@ -225,7 +224,6 @@
     - received_at
     - requested_at
     - reviewed_at
-    - state
     - updated_at
   :qualifications:
     - id
@@ -251,7 +249,6 @@
     - received_at
     - requested_at
     - reviewed_at
-    - state
     - updated_at
   :reference_requests:
     - additional_information_response
@@ -283,7 +280,6 @@
     - satisfied_comment
     - satisfied_response
     - slug
-    - state
     - updated_at
     - work_history_id
   :regions:

--- a/db/migrate/20230926101325_add_expired_at_to_requestables.rb
+++ b/db/migrate/20230926101325_add_expired_at_to_requestables.rb
@@ -4,21 +4,5 @@ class AddExpiredAtToRequestables < ActiveRecord::Migration[7.0]
     add_column :professional_standing_requests, :expired_at, :datetime
     add_column :qualification_requests, :expired_at, :datetime
     add_column :reference_requests, :expired_at, :datetime
-
-    FurtherInformationRequest.expired.each do |requestable|
-      requestable.update!(expired_at: requestable.expires_at)
-    end
-
-    ProfessionalStandingRequest.expired.each do |requestable|
-      requestable.update!(expired_at: requestable.expires_at)
-    end
-
-    QualificationRequest.expired.each do |requestable|
-      requestable.update!(expired_at: requestable.expires_at)
-    end
-
-    ReferenceRequest.expired.each do |requestable|
-      requestable.update!(expired_at: requestable.expires_at)
-    end
   end
 end

--- a/db/migrate/20230926162102_remove_state_from_requestables.rb
+++ b/db/migrate/20230926162102_remove_state_from_requestables.rb
@@ -1,0 +1,24 @@
+class RemoveStateFromRequestables < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :further_information_requests,
+                  :state,
+                  :string,
+                  null: false,
+                  default: "requested"
+    remove_column :professional_standing_requests,
+                  :state,
+                  :string,
+                  null: false,
+                  default: "requested"
+    remove_column :qualification_requests,
+                  :state,
+                  :string,
+                  null: false,
+                  default: "requested"
+    remove_column :reference_requests,
+                  :state,
+                  :string,
+                  null: false,
+                  default: "requested"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -246,7 +246,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
 
   create_table "further_information_requests", force: :cascade do |t|
     t.bigint "assessment_id", null: false
-    t.string "state", default: "requested", null: false
     t.datetime "received_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -273,7 +272,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
 
   create_table "professional_standing_requests", force: :cascade do |t|
     t.bigint "assessment_id", null: false
-    t.string "state", default: "requested", null: false
     t.datetime "received_at"
     t.text "location_note", default: "", null: false
     t.datetime "created_at", null: false
@@ -290,7 +288,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
   create_table "qualification_requests", force: :cascade do |t|
     t.bigint "assessment_id", null: false
     t.bigint "qualification_id", null: false
-    t.string "state", default: "requested", null: false
     t.datetime "received_at"
     t.text "location_note", default: "", null: false
     t.datetime "created_at", null: false
@@ -322,7 +319,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
     t.string "slug", null: false
     t.bigint "assessment_id", null: false
     t.bigint "work_history_id", null: false
-    t.string "state", default: "requested", null: false
     t.datetime "received_at"
     t.boolean "dates_response"
     t.boolean "hours_response"

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -188,10 +188,9 @@ def create_application_forms
           )
         elsif (work_history = application_form.work_histories.first) &&
               rand(3).zero?
-          reference_request_trait = ReferenceRequest.states.keys.sample
           FactoryBot.create(
             :reference_request,
-            reference_request_trait,
+            %i[requested received expired].sample,
             assessment:,
             work_history:,
           )
@@ -202,10 +201,9 @@ def create_application_forms
           )
         elsif (qualification = application_form.qualifications.first) &&
               rand(2).zero?
-          qualification_trait = ReferenceRequest.states.keys.sample
           FactoryBot.create(
             :qualification_request,
-            qualification_trait,
+            %i[requested received expired].sample,
             assessment:,
             qualification:,
           )
@@ -227,19 +225,6 @@ def create_application_forms
             waiting_on_further_information: true,
           )
         end
-      elsif (work_history = application_form.work_histories.first) &&
-            rand(2).zero?
-        FactoryBot.create(
-          :reference_request,
-          %i[requested received expired].sample,
-          assessment:,
-          work_history:,
-        )
-        application_form.update!(
-          statuses: %w[waiting_on_reference],
-          stage: "verification",
-          waiting_on_reference: true,
-        )
       end
     end
   end

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -11,7 +11,6 @@
 #  received_at                                 :datetime
 #  requested_at                                :datetime
 #  reviewed_at                                 :datetime
-#  state                                       :string           default("requested"), not null
 #  working_days_assessment_started_to_creation :integer
 #  working_days_received_to_recommendation     :integer
 #  working_days_since_received                 :integer

--- a/spec/factories/professional_standing_requests.rb
+++ b/spec/factories/professional_standing_requests.rb
@@ -13,7 +13,6 @@
 #  received_at           :datetime
 #  requested_at          :datetime
 #  reviewed_at           :datetime
-#  state                 :string           default("requested"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  assessment_id         :bigint           not null

--- a/spec/factories/qualification_requests.rb
+++ b/spec/factories/qualification_requests.rb
@@ -12,7 +12,6 @@
 #  received_at           :datetime
 #  requested_at          :datetime
 #  reviewed_at           :datetime
-#  state                 :string           default("requested"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  assessment_id         :bigint           not null

--- a/spec/factories/reference_requests.rb
+++ b/spec/factories/reference_requests.rb
@@ -31,7 +31,6 @@
 #  satisfied_comment               :text             default(""), not null
 #  satisfied_response              :boolean
 #  slug                            :string           not null
-#  state                           :string           default("requested"), not null
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
 #  assessment_id                   :bigint           not null

--- a/spec/forms/assessor_interface/professional_standing_request_location_form_spec.rb
+++ b/spec/forms/assessor_interface/professional_standing_request_location_form_spec.rb
@@ -66,10 +66,6 @@ RSpec.describe AssessorInterface::ProfessionalStandingRequestLocationForm,
 
       it { is_expected.to be true }
 
-      it "doesn't change the state" do
-        expect { save }.to_not change(requestable, :state)
-      end
-
       it "sets ready for review" do
         expect { save }.to change(requestable, :ready_for_review).to(true)
       end
@@ -80,10 +76,6 @@ RSpec.describe AssessorInterface::ProfessionalStandingRequestLocationForm,
       let(:ready_for_review) { "false" }
 
       it { is_expected.to be true }
-
-      it "doesn't change the state" do
-        expect { save }.to_not change(requestable, :state)
-      end
 
       it "doesn't set ready for review" do
         expect { save }.to_not change(requestable, :ready_for_review)

--- a/spec/forms/assessor_interface/qualification_request_form_spec.rb
+++ b/spec/forms/assessor_interface/qualification_request_form_spec.rb
@@ -126,10 +126,6 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
 
       it { is_expected.to be true }
 
-      it "doesn't change the state" do
-        expect { save }.to_not change(requestable, :state)
-      end
-
       it "sets passed" do
         expect { save }.to change(requestable, :passed).to(false)
       end
@@ -148,10 +144,6 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
       let(:failed) { "false" }
 
       it { is_expected.to be true }
-
-      it "doesn't change the state" do
-        expect { save }.to_not change(requestable, :state)
-      end
 
       it "doesn't set passed" do
         expect { save }.to_not change(requestable, :passed)

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -11,7 +11,6 @@
 #  received_at                                 :datetime
 #  requested_at                                :datetime
 #  reviewed_at                                 :datetime
-#  state                                       :string           default("requested"), not null
 #  working_days_assessment_started_to_creation :integer
 #  working_days_received_to_recommendation     :integer
 #  working_days_since_received                 :integer

--- a/spec/models/professional_standing_request_spec.rb
+++ b/spec/models/professional_standing_request_spec.rb
@@ -13,7 +13,6 @@
 #  received_at           :datetime
 #  requested_at          :datetime
 #  reviewed_at           :datetime
-#  state                 :string           default("requested"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  assessment_id         :bigint           not null

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -12,7 +12,6 @@
 #  received_at           :datetime
 #  requested_at          :datetime
 #  reviewed_at           :datetime
-#  state                 :string           default("requested"), not null
 #  created_at            :datetime         not null
 #  updated_at            :datetime         not null
 #  assessment_id         :bigint           not null

--- a/spec/models/reference_request_spec.rb
+++ b/spec/models/reference_request_spec.rb
@@ -31,7 +31,6 @@
 #  satisfied_comment               :text             default(""), not null
 #  satisfied_response              :boolean
 #  slug                            :string           not null
-#  state                           :string           default("requested"), not null
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
 #  assessment_id                   :bigint           not null


### PR DESCRIPTION
This removes the column from all the requestables as we're no longer using it for anything and it can be safely removed.

Depends on #1719 

[Trello Card](https://trello.com/c/kJ7RrYLn/2296-mark-lops-verification-to-be-done)