### PR TITLE
2262 add verification permission

### DIFF
--- a/app/controllers/staff/invitations_controller.rb
+++ b/app/controllers/staff/invitations_controller.rb
@@ -18,6 +18,7 @@ class Staff::InvitationsController < Devise::InvitationsController
         change_work_history_permission
         reverse_decision_permission
         support_console_permission
+        verify_permission
         withdraw_permission
       ],
     )

--- a/app/controllers/support_interface/staff_controller.rb
+++ b/app/controllers/support_interface/staff_controller.rb
@@ -33,6 +33,7 @@ class SupportInterface::StaffController < SupportInterface::BaseController
       :change_work_history_permission,
       :reverse_decision_permission,
       :support_console_permission,
+      :verify_permission,
       :withdraw_permission,
     )
   end

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -34,6 +34,7 @@
 #  support_console_permission     :boolean          default(FALSE), not null
 #  unconfirmed_email              :string
 #  unlock_token                   :string
+#  verify_permission              :boolean          default(FALSE), not null
 #  withdraw_permission            :boolean          default(FALSE), not null
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -11,7 +11,7 @@
     <%= govuk_table do |table|
       table.with_colgroup do |colgroup|
         colgroup.with_col(span: 1)
-        colgroup.with_col(span: 6)
+        colgroup.with_col(span: 7)
         colgroup.with_col(span: 1)
       end
 
@@ -29,6 +29,7 @@
           row.with_cell(header: true, text: "Change work history")
           row.with_cell(header: true, text: "Reverse decisions")
           row.with_cell(header: true, text: "Support console")
+          row.with_cell(header: true, text: "Verify applicants")
           row.with_cell(header: true, text: "Withdraw")
           row.with_cell(header: true, text: "Actions", numeric: true)
         end
@@ -44,6 +45,7 @@
             row.with_cell { govuk_boolean_tag(staff.change_work_history_permission) }
             row.with_cell { govuk_boolean_tag(staff.reverse_decision_permission) }
             row.with_cell { govuk_boolean_tag(staff.support_console_permission) }
+            row.with_cell { govuk_boolean_tag(staff.verify_permission) }
             row.with_cell { govuk_boolean_tag(staff.withdraw_permission) }
 
             row.with_cell(numeric: true) do

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -18,7 +18,7 @@
       table.with_head do |head|
         head.with_row do |row|
           row.with_cell(scope: false)
-          row.with_cell(header: true, text: "Permissions", colspan: 5)
+          row.with_cell(header: true, text: "Permissions", colspan: 7)
           row.with_cell(scope: false)
         end
 

--- a/app/views/support_interface/staff/_permissions_fields.html.erb
+++ b/app/views/support_interface/staff/_permissions_fields.html.erb
@@ -14,6 +14,9 @@
   <%= f.govuk_check_box :support_console_permission, 1, 0, multiple: false, link_errors: true,
                         label: { text: t("activerecord.attributes.staff.support_console_permission") } %>
 
+  <%= f.govuk_check_box :verify_permission, 1, 0, multiple: false, link_errors: true,
+                        label: { text: t("activerecord.attributes.staff.verify_permission") } %>
+
   <%= f.govuk_check_box :withdraw_permission, 1, 0, multiple: false, link_errors: true,
                         label: { text: t("activerecord.attributes.staff.withdraw_permission") } %>
 <% end %>

--- a/app/views/support_interface/staff/index.html.erb
+++ b/app/views/support_interface/staff/index.html.erb
@@ -66,6 +66,15 @@
     end
 
     summary_list.with_row do |row|
+      row.with_key { t("activerecord.attributes.staff.verify_permission") }
+      row.with_value { govuk_boolean_tag(staff.verify_permission) }
+      row.with_action(
+        href: edit_support_interface_staff_path(staff),
+        visually_hidden_text: t("activerecord.attributes.staff.verify_permission")
+      )
+    end
+
+    summary_list.with_row do |row|
       row.with_key { t("activerecord.attributes.staff.withdraw_permission") }
       row.with_value { govuk_boolean_tag(staff.withdraw_permission) }
       row.with_action(

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -357,6 +357,7 @@
     - support_console_permission
     - unconfirmed_email
     - updated_at
+    - verify_permission
     - withdraw_permission
   :teachers:
     - canonical_email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,6 +51,7 @@ en:
         change_work_history_permission: Change work history references
         reverse_decision_permission: Reverse decisions
         support_console_permission: Support console access
+        verify_permission: Verify applicants
         withdraw_permission: Withdraw
     errors:
       models:

--- a/db/migrate/20230929084821_add_verification_permission_to_staff_users.rb
+++ b/db/migrate/20230929084821_add_verification_permission_to_staff_users.rb
@@ -1,0 +1,5 @@
+class AddVerificationPermissionToStaffUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :staff, :verify_permission, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_26_101325) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -449,6 +449,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_26_101325) do
     t.boolean "reverse_decision_permission", default: false, null: false
     t.boolean "withdraw_permission", default: false, null: false
     t.boolean "change_name_permission", default: false, null: false
+    t.boolean "verify_permission", default: false, null: false
     t.index "lower((email)::text)", name: "index_staff_on_lower_email", unique: true
     t.index ["confirmation_token"], name: "index_staff_on_confirmation_token", unique: true
     t.index ["invitation_token"], name: "index_staff_on_invitation_token", unique: true

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -60,6 +60,7 @@ def staff_members
       change_work_history_permission: false,
       reverse_decision_permission: false,
       support_console_permission: false,
+      verify_permission: false,
       withdraw_permission: false,
     },
     {
@@ -70,6 +71,7 @@ def staff_members
       change_work_history_permission: false,
       reverse_decision_permission: false,
       support_console_permission: false,
+      verify_permission: false,
       withdraw_permission: false,
     },
     {
@@ -80,6 +82,7 @@ def staff_members
       change_work_history_permission: true,
       reverse_decision_permission: true,
       support_console_permission: true,
+      verify_permission: false,
       withdraw_permission: true,
     },
     {
@@ -90,6 +93,18 @@ def staff_members
       change_work_history_permission: false,
       reverse_decision_permission: false,
       support_console_permission: false,
+      verify_permission: false,
+      withdraw_permission: false,
+    },
+    {
+      name: "Victarion Verifier",
+      email: "victarion-verifier@example.com",
+      award_decline_permission: false,
+      change_name_permission: false,
+      change_work_history_permission: false,
+      reverse_decision_permission: false,
+      support_console_permission: false,
+      verify_permission: true,
       withdraw_permission: false,
     },
   ]

--- a/spec/factories/staff.rb
+++ b/spec/factories/staff.rb
@@ -34,6 +34,7 @@
 #  support_console_permission     :boolean          default(FALSE), not null
 #  unconfirmed_email              :string
 #  unlock_token                   :string
+#  verify_permission              :boolean          default(FALSE), not null
 #  withdraw_permission            :boolean          default(FALSE), not null
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null

--- a/spec/factories/staff.rb
+++ b/spec/factories/staff.rb
@@ -80,6 +80,10 @@ FactoryBot.define do
       support_console_permission { true }
     end
 
+    trait :with_verification_permission do
+      verify_permission { true }
+    end
+
     trait :with_withdraw_permission do
       withdraw_permission { true }
     end

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -34,6 +34,7 @@
 #  support_console_permission     :boolean          default(FALSE), not null
 #  unconfirmed_email              :string
 #  unlock_token                   :string
+#  verify_permission              :boolean          default(FALSE), not null
 #  withdraw_permission            :boolean          default(FALSE), not null
 #  created_at                     :datetime         not null
 #  updated_at                     :datetime         not null

--- a/spec/system/support_interface/staff_spec.rb
+++ b/spec/system/support_interface/staff_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe "Staff support", type: :system do
   end
 
   def when_i_click_on_the_helpdesk_user
-    find(:xpath, "(//a[text()='Change'])[7]").click
+    find(:xpath, "(//a[text()='Change'])[8]").click
   end
 
   def then_i_see_the_staff_edit_form


### PR DESCRIPTION
We need a new permission for staff users which captures whether they’ve got access to do new verification journey.

Added a migration to store the new permission on the staff model, and update the support console/example data to support this new permission.