### PR TITLE
Update "Get an advisor" link

### DIFF
--- a/app/views/teacher_interface/application_forms/show/_awarded.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_awarded.html.erb
@@ -20,5 +20,5 @@
 
 <h3 class="govuk-heading-m">Get support with your application</h3>
 
-<p class="govuk-body">If you’re applying for a secondary school maths, physics or modern foreign languages teaching role in England, use the Get into Teaching service for one-to-one support with your application through <%= govuk_link_to "Get an advisor", "https://adviser-getintoteaching.education.gov.uk" %>.</p>
+<p class="govuk-body">If you’re applying for a secondary school maths, physics or modern foreign languages teaching role in England, use the Get into Teaching service for one-to-one support with your application through <%= govuk_link_to "Get an advisor", "https://getintoteaching.education.gov.uk/teacher-training-adviser/sign_up/identity" %>.</p>
 <p class="govuk-body">Your adviser can help with writing a personal statement, preparing for an interview and accessing courses to enhance your subject knowledge.</p>


### PR DESCRIPTION
The existing link is redirecting to this new location, so we should update our link to avoid the extra redirection and in case the original link breaks.