### PR TITLE
Check virus scan result after 5 seconds

### DIFF
--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -72,6 +72,11 @@ module TeacherInterface
     def fetch_and_update_malware_scan_results
       document.uploads.each do |upload|
         # We need a delay here to ensure that the upload has been scanned before fetching the result.
+
+        FetchMalwareScanResultJob.set(wait: 5.seconds).perform_later(
+          upload_id: upload.id,
+        )
+
         FetchMalwareScanResultJob.set(wait: 2.minutes).perform_later(
           upload_id: upload.id,
         )


### PR DESCRIPTION
Currently we wait 2 minutes before checking the virus scan result. This was chosen to guarantee that we get back a result, but most scan results happen a lot sooner, so we could try checking for a result sooner.