### PR TITLE
Add requestable verified timeline event

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -39,7 +39,7 @@
           </ul>
         <% end %>
       <% end %>
-    <% elsif timeline_event.requestable_assessed? && timeline_event.requestable.is_a?(FurtherInformationRequest) %>
+    <% elsif timeline_event.requestable_reviewed? && timeline_event.requestable.is_a?(FurtherInformationRequest) %>
       <p class="govuk-body">Further information request has been assessed.</p>
 
       <% if (failure_assessor_note = description_vars[:failure_assessor_note]).present? %>

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -138,18 +138,15 @@ module TimelineEntry
 
     alias_method :requestable_expired_vars, :requestable_received_vars
 
-    def requestable_assessed_vars
-      requestable = timeline_event.requestable
+    def requestable_reviewed_vars
+      {
+        passed: timeline_event.requestable.passed,
+        failure_assessor_note: timeline_event.requestable.failure_assessor_note,
+      }
+    end
 
-      case requestable
-      when FurtherInformationRequest
-        {
-          passed: requestable.passed,
-          failure_assessor_note: requestable.failure_assessor_note,
-        }
-      else
-        {}
-      end
+    def requestable_verified_vars
+      {}
     end
 
     def information_changed_vars

--- a/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
+++ b/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
@@ -68,7 +68,7 @@ module AssessorInterface::AgeRangeSubjectsForm
   def create_timeline_event
     TimelineEvent.create!(
       creator: user,
-      event_type: :age_range_subjects_verified,
+      event_type: "age_range_subjects_verified",
       application_form:,
       assessment:,
       age_range_min: assessment.age_range_min,

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -68,10 +68,11 @@ class TimelineEvent < ApplicationRecord
          email_sent: "email_sent",
          information_changed: "information_changed",
          note_created: "note_created",
-         requestable_assessed: "requestable_assessed",
          requestable_expired: "requestable_expired",
          requestable_received: "requestable_received",
          requestable_requested: "requestable_requested",
+         requestable_reviewed: "requestable_reviewed",
+         requestable_verified: "requestable_verified",
          reviewer_assigned: "reviewer_assigned",
          stage_changed: "stage_changed",
          status_changed: "status_changed",
@@ -161,7 +162,7 @@ class TimelineEvent < ApplicationRecord
             unless: :information_changed?
 
   def requestable_event_type?
-    requestable_requested? || requestable_received? || requestable_expired? ||
-      requestable_assessed?
+    requestable_expired? || requestable_received? || requestable_requested? ||
+      requestable_reviewed? || requestable_verified?
   end
 end

--- a/app/services/create_note.rb
+++ b/app/services/create_note.rb
@@ -15,7 +15,7 @@ class CreateNote
 
       TimelineEvent.create!(
         application_form:,
-        event_type: :note_created,
+        event_type: "note_created",
         creator: author,
         note:,
       )

--- a/app/services/review_requestable.rb
+++ b/app/services/review_requestable.rb
@@ -30,7 +30,7 @@ class ReviewRequestable
   def create_timeline_event
     TimelineEvent.create!(
       creator: user,
-      event_type: "requestable_assessed",
+      event_type: "requestable_reviewed",
       requestable:,
       application_form:,
     )

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -67,7 +67,7 @@ class UpdateAssessmentSection
 
     TimelineEvent.create!(
       creator: user,
-      event_type: :assessment_section_recorded,
+      event_type: "assessment_section_recorded",
       assessment_section:,
       application_form:,
       old_value: old_status,

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -73,11 +73,16 @@ en:
           ProfessionalStandingRequest: Professional standing expired
           QualificationRequest: Qualification expired
           ReferenceRequest: Reference expired
-        requestable_assessed:
+        requestable_reviewed:
           FurtherInformationRequest: Further information assessed
-          ProfessionalStandingRequest: Professional standing assessed
-          QualificationRequest: Qualification assessed
-          ReferenceRequest: Reference assessed
+          ProfessionalStandingRequest: Professional standing reviewed
+          QualificationRequest: Qualification reviewed
+          ReferenceRequest: Reference reviewed
+        requestable_verified:
+          FurtherInformationRequest: Further information verified
+          ProfessionalStandingRequest: Professional standing verified
+          QualificationRequest: Qualification verified
+          ReferenceRequest: Reference verified
         stage_changed: Stage changed
         status_changed: Status changed
       description:
@@ -101,11 +106,16 @@ en:
           ProfessionalStandingRequest: The professional standing request has expired.
           QualificationRequest: A qualification request has expired.
           ReferenceRequest: A reference has expired.
-        requestable_assessed:
+        requestable_reviewed:
           FurtherInformationRequest: Further information request has been assessed.
-          ProfessionalStandingRequest: The professional standing request has been assessed.
-          QualificationRequest: A qualification has been assessed.
-          ReferenceRequest: A reference has been assessed.
+          ProfessionalStandingRequest: The professional standing request has been reviewed.
+          QualificationRequest: A qualification has been reviewed.
+          ReferenceRequest: A reference has been reviewed.
+        requestable_verified:
+          FurtherInformationRequest: Further information request has been verified.
+          ProfessionalStandingRequest: The professional standing request has been verified.
+          QualificationRequest: A qualification has been verified.
+          ReferenceRequest: A reference has been verified.
         stage_changed: Stage changed from %{old_stage} to %{new_stage}.
         status_changed: Status changed from %{old_status} to %{new_status}.
       columns:

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -410,7 +410,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
   end
 
-  context "further information request assessed" do
+  context "further information request reviewed" do
     let(:further_information_request) do
       create(
         :further_information_request,
@@ -421,7 +421,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     let(:timeline_event) do
       create(
         :timeline_event,
-        :requestable_assessed,
+        :requestable_reviewed,
         requestable: further_information_request,
       )
     end
@@ -438,18 +438,18 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
   end
 
-  context "professional standing request assessed" do
+  context "professional standing request reviewed" do
     let(:timeline_event) do
       create(
         :timeline_event,
-        :requestable_assessed,
+        :requestable_reviewed,
         requestable: create(:professional_standing_request),
       )
     end
 
     it "describes the event" do
       expect(component.text).to include(
-        "The professional standing request has been assessed.",
+        "The professional standing request has been reviewed.",
       )
     end
 
@@ -458,17 +458,17 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
   end
 
-  context "qualification request assessed" do
+  context "qualification request reviewed" do
     let(:timeline_event) do
       create(
         :timeline_event,
-        :requestable_assessed,
+        :requestable_reviewed,
         requestable: create(:qualification_request),
       )
     end
 
     it "describes the event" do
-      expect(component.text).to include("A qualification has been assessed.")
+      expect(component.text).to include("A qualification has been reviewed.")
     end
 
     it "attributes to the creator" do
@@ -476,17 +476,73 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
   end
 
-  context "reference request assessed" do
+  context "reference request reviewed" do
     let(:timeline_event) do
       create(
         :timeline_event,
-        :requestable_assessed,
+        :requestable_reviewed,
         requestable: create(:reference_request),
       )
     end
 
     it "describes the event" do
-      expect(component.text).to include("A reference has been assessed.")
+      expect(component.text).to include("A reference has been reviewed.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "professional standing request verified" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_verified,
+        requestable: create(:professional_standing_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include(
+        "The professional standing request has been verified.",
+      )
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "qualification request verified" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_verified,
+        requestable: create(:qualification_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("A qualification has been verified.")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
+  context "reference request verified" do
+    let(:timeline_event) do
+      create(
+        :timeline_event,
+        :requestable_verified,
+        requestable: create(:reference_request),
+      )
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("A reference has been verified.")
     end
 
     it "attributes to the creator" do

--- a/spec/forms/assessor_interface/qualification_request_form_spec.rb
+++ b/spec/forms/assessor_interface/qualification_request_form_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
         )
       end
 
-      it "records an assessed timeline event" do
+      it "records an reviewed timeline event" do
         expect { save }.to have_recorded_timeline_event(
-          :requestable_assessed,
+          :requestable_reviewed,
           creator: user,
           requestable:,
         )
@@ -111,9 +111,9 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
         )
       end
 
-      it "records an assessed timeline event" do
+      it "records an reviewed timeline event" do
         expect { save }.to have_recorded_timeline_event(
-          :requestable_assessed,
+          :requestable_reviewed,
           creator: user,
           requestable:,
         )
@@ -136,7 +136,7 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
 
       it "records an assessed timeline event" do
         expect { save }.to have_recorded_timeline_event(
-          :requestable_assessed,
+          :requestable_reviewed,
           creator: user,
           requestable:,
         )
@@ -157,9 +157,9 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
         expect { save }.to_not change(requestable, :passed)
       end
 
-      it "doesn't record an assessed timeline event" do
+      it "doesn't record a reviewed timeline event" do
         expect { save }.to_not have_recorded_timeline_event(
-          :requestable_assessed,
+          :requestable_reviewed,
         )
       end
     end

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -84,10 +84,11 @@ RSpec.describe TimelineEvent do
         email_sent: "email_sent",
         information_changed: "information_changed",
         note_created: "note_created",
-        requestable_assessed: "requestable_assessed",
+        requestable_reviewed: "requestable_reviewed",
         requestable_expired: "requestable_expired",
         requestable_received: "requestable_received",
         requestable_requested: "requestable_requested",
+        requestable_verified: "requestable_verified",
         reviewer_assigned: "reviewer_assigned",
         stage_changed: "stage_changed",
         status_changed: "status_changed",
@@ -334,8 +335,39 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:new_value) }
     end
 
-    context "with a requestable assessed event type" do
-      before { timeline_event.event_type = :requestable_assessed }
+    context "with a requestable reviewed event type" do
+      before { timeline_event.event_type = :requestable_reviewed }
+
+      it { is_expected.to validate_absence_of(:assignee) }
+      it { is_expected.to validate_absence_of(:assessment_section) }
+      it { is_expected.to validate_absence_of(:note) }
+      it { is_expected.to validate_absence_of(:mailer_class_name) }
+      it { is_expected.to validate_absence_of(:mailer_action_name) }
+      it { is_expected.to validate_absence_of(:message_subject) }
+      it { is_expected.to validate_absence_of(:assessment) }
+      it { is_expected.to validate_absence_of(:age_range_min) }
+      it { is_expected.to validate_absence_of(:age_range_max) }
+      it { is_expected.to validate_absence_of(:subjects) }
+      it { is_expected.to validate_presence_of(:requestable_id) }
+      it { is_expected.to validate_presence_of(:requestable_type) }
+      it do
+        is_expected.to validate_inclusion_of(:requestable_type).in_array(
+          %w[
+            FurtherInformationRequest
+            ProfessionalStandingRequest
+            QualificationRequest
+            ReferenceRequest
+          ],
+        )
+      end
+      it { is_expected.to validate_absence_of(:work_history_id) }
+      it { is_expected.to validate_absence_of(:column_name) }
+      it { is_expected.to validate_absence_of(:old_value) }
+      it { is_expected.to validate_absence_of(:new_value) }
+    end
+
+    context "with a requestable verified event type" do
+      before { timeline_event.event_type = :requestable_reviewed }
 
       it { is_expected.to validate_absence_of(:assignee) }
       it { is_expected.to validate_absence_of(:assessment_section) }

--- a/spec/services/review_requestable_spec.rb
+++ b/spec/services/review_requestable_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ReviewRequestable do
 
   it "records a timeline event" do
     expect { call }.to have_recorded_timeline_event(
-      :requestable_assessed,
+      :requestable_reviewed,
       creator: user,
       requestable:,
     )


### PR DESCRIPTION
Also renamed the requestable assessed timeline event to requestable reviewed to better match what this timeline event will represent. This is necessary to build the review journey.

[Trello Card](https://trello.com/c/8sKZ1aEm/2309-lops-response-review)