### PR TITLE
Make requestables verifiable

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -42,10 +42,8 @@
     <% elsif timeline_event.requestable_reviewed? && timeline_event.requestable.is_a?(FurtherInformationRequest) %>
       <p class="govuk-body">Further information request has been assessed.</p>
 
-      <% if (failure_assessor_note = description_vars[:failure_assessor_note]).present? %>
-        <%= govuk_inset_text do %>
-          <%= simple_format failure_assessor_note %>
-        <% end %>
+      <% if (note = description_vars[:note]).present? %>
+        <%= govuk_inset_text { simple_format note } %>
       <% end %>
     <% elsif timeline_event.information_changed? %>
       <p class="govuk-body">

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -140,13 +140,16 @@ module TimelineEntry
 
     def requestable_reviewed_vars
       {
-        passed: timeline_event.requestable.passed,
-        failure_assessor_note: timeline_event.requestable.failure_assessor_note,
+        passed: timeline_event.requestable.review_passed,
+        note: timeline_event.requestable.review_note,
       }
     end
 
     def requestable_verified_vars
-      {}
+      {
+        passed: timeline_event.requestable.verify_passed,
+        note: timeline_event.requestable.verify_note,
+      }
     end
 
     def information_changed_vars

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -41,9 +41,8 @@ module AssessorInterface
         RequestableReviewForm.new(
           requestable: view_object.further_information_request,
           user: current_staff,
-          passed: view_object.further_information_request.passed,
-          failure_assessor_note:
-            view_object.further_information_request.failure_assessor_note,
+          passed: view_object.further_information_request.review_passed,
+          note: view_object.further_information_request.review_note,
         )
     end
 
@@ -116,7 +115,7 @@ module AssessorInterface
     def requestable_review_form_params
       params.require(:assessor_interface_requestable_review_form).permit(
         :passed,
-        :failure_assessor_note,
+        :note,
       )
     end
   end

--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -39,8 +39,8 @@ module AssessorInterface
         RequestableReviewForm.new(
           requestable:,
           user: current_staff,
-          passed: requestable.passed,
-          failure_assessor_note: requestable.failure_assessor_note,
+          passed: requestable.review_passed,
+          note: requestable.review_note,
         )
     end
 
@@ -77,7 +77,7 @@ module AssessorInterface
       params.require(:assessor_interface_requestable_review_form).permit(
         :reviewed,
         :passed,
-        :failure_assessor_note,
+        :note,
       )
     end
 

--- a/app/controllers/assessor_interface/qualification_requests_controller.rb
+++ b/app/controllers/assessor_interface/qualification_requests_controller.rb
@@ -39,7 +39,7 @@ module AssessorInterface
           user: current_staff,
           received:,
           passed:,
-          failure_assessor_note: requestable.failure_assessor_note,
+          note: requestable.review_note,
           failed:,
         )
     end
@@ -74,7 +74,7 @@ module AssessorInterface
       params.require(:assessor_interface_qualification_request_form).permit(
         :received,
         :passed,
-        :failure_assessor_note,
+        :note,
         :failed,
       )
     end

--- a/app/controllers/assessor_interface/reference_requests_controller.rb
+++ b/app/controllers/assessor_interface/reference_requests_controller.rb
@@ -73,7 +73,7 @@ module AssessorInterface
     def requestable_review_form_params
       params.require(:assessor_interface_requestable_review_form).permit(
         :passed,
-        :failure_assessor_note,
+        :note,
       )
     end
 

--- a/app/forms/assessor_interface/professional_standing_request_location_form.rb
+++ b/app/forms/assessor_interface/professional_standing_request_location_form.rb
@@ -26,7 +26,7 @@ class AssessorInterface::ProfessionalStandingRequestLocationForm
       end
 
       if requestable.requested? && requestable.reviewed?
-        requestable.update!(passed: nil, reviewed_at: nil)
+        requestable.update!(review_passed: nil, reviewed_at: nil)
         ApplicationFormStatusUpdater.call(application_form:, user:)
       end
 

--- a/app/forms/assessor_interface/qualification_request_form.rb
+++ b/app/forms/assessor_interface/qualification_request_form.rb
@@ -13,10 +13,8 @@ class AssessorInterface::QualificationRequestForm
   attribute :passed, :boolean
   validates :passed, inclusion: [true, false], if: :received
 
-  attribute :failure_assessor_note, :string
-  validates :failure_assessor_note,
-            presence: true,
-            if: -> { received && passed == false }
+  attribute :note, :string
+  validates :note, presence: true, if: -> { received && passed == false }
 
   attribute :failed, :boolean
   validates :failed, inclusion: [true, false], unless: :received
@@ -32,14 +30,14 @@ class AssessorInterface::QualificationRequestForm
       end
 
       if review_passed.nil?
-        requestable.update!(passed: nil, reviewed_at: nil)
+        requestable.update!(review_passed: nil, reviewed_at: nil)
         ApplicationFormStatusUpdater.call(application_form:, user:)
       else
         ReviewRequestable.call(
           requestable:,
           user:,
           passed: review_passed,
-          failure_assessor_note:,
+          note:,
         )
       end
     end

--- a/app/forms/assessor_interface/requestable_review_form.rb
+++ b/app/forms/assessor_interface/requestable_review_form.rb
@@ -10,13 +10,13 @@ class AssessorInterface::RequestableReviewForm
   attribute :passed, :boolean
   validates :passed, inclusion: [true, false]
 
-  attribute :failure_assessor_note, :string
-  validates :failure_assessor_note, presence: true, if: -> { passed == false }
+  attribute :note, :string
+  validates :note, presence: true, if: -> { passed == false }
 
   def save
     return false if invalid?
 
-    ReviewRequestable.call(requestable:, user:, passed:, failure_assessor_note:)
+    ReviewRequestable.call(requestable:, user:, passed:, note:)
 
     true
   end

--- a/app/forms/assessor_interface/requestable_verify_form.rb
+++ b/app/forms/assessor_interface/requestable_verify_form.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AssessorInterface::RequestableVerifyForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :requestable, :user
+  validates :requestable, :user, presence: true
+
+  attribute :passed, :boolean
+  validates :passed, inclusion: [true, false]
+
+  attribute :note, :string
+  validates :note, presence: true, if: -> { passed == false }
+
+  def save
+    return false if invalid?
+
+    VerifyRequestable.call(requestable:, user:, passed:, note:)
+
+    true
+  end
+end

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -89,4 +89,8 @@ module Requestable
   def after_reviewed(user:)
     # implement logic after this requestable has been reviewed
   end
+
+  def after_verified(user:)
+    # implement logic after this requestable has been verified
+  end
 end

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -8,8 +8,6 @@ module Requestable
   included do
     belongs_to :assessment
 
-    validates :reviewed_at, presence: true, unless: -> { passed.nil? }
-
     scope :requested, -> { where.not(requested_at: nil) }
     scope :received, -> { where.not(received_at: nil) }
     scope :respondable,
@@ -36,29 +34,44 @@ module Requestable
     received_at != nil
   end
 
-  def reviewed!(passed)
-    update!(passed:, reviewed_at: Time.zone.now)
-  end
-
   def reviewed?
-    passed != nil
+    review_passed != nil
   end
 
-  def failed
-    return nil if passed.nil?
-    passed == false
+  def review_passed?
+    review_passed == true
+  end
+
+  def review_failed?
+    review_passed == false
+  end
+
+  def verified?
+    try(:verify_passed) != nil
+  end
+
+  def verify_passed?
+    try(:verify_passed) == true
+  end
+
+  def verify_failed?
+    try(:verify_passed) == false
   end
 
   def status
-    if reviewed_at.present?
-      passed ? "accepted" : "rejected"
-    elsif received_at.present? && expired_at.present?
+    if verify_passed? || review_passed?
+      "accepted"
+    elsif review_failed?
+      "rejected"
+    elsif verify_failed?
+      "review"
+    elsif received? && expired?
       "received_and_overdue"
-    elsif expired_at.present?
+    elsif expired?
       "overdue"
-    elsif received_at.present?
+    elsif received?
       "received"
-    elsif requested_at.present?
+    elsif requested?
       "waiting_on"
     else
       "not_started"

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -71,18 +71,18 @@ class FurtherInformationRequest < ApplicationRecord
   end
 
   def after_reviewed(user:)
-    items
-      .select(&:work_history_contact?)
-      .each do |item|
-        UpdateWorkHistoryContact.call(
-          user:,
-          work_history: item.work_history,
-          name: item.contact_name,
-          job: item.contact_job,
-          email: item.contact_email,
-        )
-      end
+    update_work_history_contact_items(user:) if review_passed?
+  end
+
+  def after_verified(user:)
+    update_work_history_contact_items(user:) if verify_passed?
   end
 
   delegate :teacher, to: :application_form
+
+  private
+
+  def update_work_history_contact_items(user:)
+    items.each { |item| item.update_work_history_contact(user:) }
+  end
 end

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -4,10 +4,10 @@
 #
 #  id                                          :bigint           not null, primary key
 #  expired_at                                  :datetime
-#  failure_assessor_note                       :string           default(""), not null
-#  passed                                      :boolean
 #  received_at                                 :datetime
 #  requested_at                                :datetime
+#  review_note                                 :string           default(""), not null
+#  review_passed                               :boolean
 #  reviewed_at                                 :datetime
 #  working_days_assessment_started_to_creation :integer
 #  working_days_received_to_recommendation     :integer

--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -57,4 +57,16 @@ class FurtherInformationRequestItem < ApplicationRecord
       failure_reason_key,
     )
   end
+
+  def update_work_history_contact(user:)
+    return unless work_history_contact?
+
+    UpdateWorkHistoryContact.call(
+      user:,
+      work_history:,
+      name: contact_name,
+      job: contact_job,
+      email: contact_email,
+    )
+  end
 end

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -4,18 +4,21 @@
 #
 # Table name: professional_standing_requests
 #
-#  id                    :bigint           not null, primary key
-#  expired_at            :datetime
-#  failure_assessor_note :string           default(""), not null
-#  location_note         :text             default(""), not null
-#  passed                :boolean
-#  ready_for_review      :boolean          default(FALSE), not null
-#  received_at           :datetime
-#  requested_at          :datetime
-#  reviewed_at           :datetime
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  assessment_id         :bigint           not null
+#  id               :bigint           not null, primary key
+#  expired_at       :datetime
+#  location_note    :text             default(""), not null
+#  ready_for_review :boolean          default(FALSE), not null
+#  received_at      :datetime
+#  requested_at     :datetime
+#  review_note      :string           default(""), not null
+#  review_passed    :boolean
+#  reviewed_at      :datetime
+#  verified_at      :datetime
+#  verify_note      :text             default(""), not null
+#  verify_passed    :boolean
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  assessment_id    :bigint           not null
 #
 # Indexes
 #

--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -4,18 +4,21 @@
 #
 # Table name: qualification_requests
 #
-#  id                    :bigint           not null, primary key
-#  expired_at            :datetime
-#  failure_assessor_note :string           default(""), not null
-#  location_note         :text             default(""), not null
-#  passed                :boolean
-#  received_at           :datetime
-#  requested_at          :datetime
-#  reviewed_at           :datetime
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  assessment_id         :bigint           not null
-#  qualification_id      :bigint           not null
+#  id               :bigint           not null, primary key
+#  expired_at       :datetime
+#  location_note    :text             default(""), not null
+#  received_at      :datetime
+#  requested_at     :datetime
+#  review_note      :string           default(""), not null
+#  review_passed    :boolean
+#  reviewed_at      :datetime
+#  verified_at      :datetime
+#  verify_note      :text             default(""), not null
+#  verify_passed    :boolean
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  assessment_id    :bigint           not null
+#  qualification_id :bigint           not null
 #
 # Indexes
 #

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -15,22 +15,25 @@
 #  dates_comment                   :text             default(""), not null
 #  dates_response                  :boolean
 #  expired_at                      :datetime
-#  failure_assessor_note           :string           default(""), not null
 #  hours_comment                   :text             default(""), not null
 #  hours_response                  :boolean
 #  lessons_comment                 :text             default(""), not null
 #  lessons_response                :boolean
 #  misconduct_comment              :text             default(""), not null
 #  misconduct_response             :boolean
-#  passed                          :boolean
 #  received_at                     :datetime
 #  reports_comment                 :text             default(""), not null
 #  reports_response                :boolean
 #  requested_at                    :datetime
+#  review_note                     :string           default(""), not null
+#  review_passed                   :boolean
 #  reviewed_at                     :datetime
 #  satisfied_comment               :text             default(""), not null
 #  satisfied_response              :boolean
 #  slug                            :string           not null
+#  verified_at                     :datetime
+#  verify_note                     :text             default(""), not null
+#  verify_passed                   :boolean
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
 #  assessment_id                   :bigint           not null

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -106,6 +106,10 @@ class ReferenceRequest < ApplicationRecord
     6.weeks
   end
 
+  def after_verified(*)
+    UpdateAssessmentInductionRequired.call(assessment:)
+  end
+
   def after_reviewed(*)
     UpdateAssessmentInductionRequired.call(assessment:)
   end

--- a/app/services/update_assessment_induction_required.rb
+++ b/app/services/update_assessment_induction_required.rb
@@ -35,7 +35,7 @@ class UpdateAssessmentInductionRequired
       else
         WorkHistory.joins(:reference_request).where(
           reference_requests: {
-            passed: true,
+            review_passed: true,
             assessment:,
           },
         )

--- a/app/services/verify_requestable.rb
+++ b/app/services/verify_requestable.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class VerifyRequestable
+  include ServicePattern
+
+  def initialize(requestable:, user:, passed:, note:)
+    @requestable = requestable
+    @user = user
+    @passed = passed
+    @note = note
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      requestable.update!(
+        verify_passed: passed,
+        verify_note: note,
+        verified_at: Time.zone.now,
+      )
+
+      requestable.after_verified(user:)
+      application_form.reload
+
+      create_timeline_event
+
+      ApplicationFormStatusUpdater.call(application_form:, user:)
+    end
+  end
+
+  private
+
+  attr_reader :requestable, :user, :passed, :note
+
+  def create_timeline_event
+    TimelineEvent.create!(
+      creator: user,
+      event_type: "requestable_verified",
+      requestable:,
+      application_form:,
+    )
+  end
+
+  delegate :application_form, to: :requestable
+end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -234,7 +234,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
       status:
         if further_information_request.requested?
           :cannot_start
-        elsif further_information_request.passed.nil?
+        elsif further_information_request.review_passed.nil?
           :not_started
         elsif assessment.request_further_information?
           :in_progress

--- a/app/view_objects/assessor_interface/further_information_request_view_object.rb
+++ b/app/view_objects/assessor_interface/further_information_request_view_object.rb
@@ -81,7 +81,7 @@ class AssessorInterface::FurtherInformationRequestViewObject
   end
 
   def can_update?
-    further_information_request.passed.nil? ||
+    further_information_request.review_passed.nil? ||
       assessment.request_further_information?
   end
 

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -21,7 +21,7 @@
     <%= f.govuk_radio_buttons_fieldset :passed, legend: { size: "s", text: t(".passed") } do %>
       <%= f.govuk_radio_button :passed, :true, link_errors: true %>
       <%= f.govuk_radio_button :passed, :false do %>
-        <%= f.govuk_text_area :failure_assessor_note, label: { text: t(".failure_assessor_note").html_safe } %>
+        <%= f.govuk_text_area :note, label: { text: t(".failure_assessor_note").html_safe } %>
       <% end %>
     <% end %>
 

--- a/app/views/assessor_interface/professional_standing_requests/edit_review.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_review.html.erb
@@ -17,7 +17,7 @@
     <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: t(".passed"), size: "s" } do %>
       <%= f.govuk_radio_button :passed, :true, link_errors: true %>
       <%= f.govuk_radio_button :passed, :false do %>
-        <%= f.govuk_text_area :failure_assessor_note, label: { text: t(".failure_assessor_note").html_safe } %>
+        <%= f.govuk_text_area :note, label: { text: t(".failure_assessor_note").html_safe } %>
       <% end %>
     <% end %>
 

--- a/app/views/assessor_interface/qualification_requests/edit.html.erb
+++ b/app/views/assessor_interface/qualification_requests/edit.html.erb
@@ -13,7 +13,7 @@
       <%= f.govuk_radio_buttons_fieldset :passed, legend: { size: "s" } do %>
         <%= f.govuk_radio_button :passed, :true, link_errors: true %>
         <%= f.govuk_radio_button :passed, :false do %>
-          <%= f.govuk_text_area :failure_assessor_note, label: { text: t("helpers.label.assessor_interface_qualification_request_form.failure_assessor_note").html_safe } %>
+          <%= f.govuk_text_area :note, label: { text: t("helpers.label.assessor_interface_qualification_request_form.failure_assessor_note").html_safe } %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/assessor_interface/reference_requests/edit.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit.html.erb
@@ -54,7 +54,7 @@
     <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: t(".passed"), size: "s" } do %>
       <%= f.govuk_radio_button :passed, :true, link_errors: true %>
       <%= f.govuk_radio_button :passed, :false do %>
-        <%= f.govuk_text_area :failure_assessor_note, label: { text: t(".failure_assessor_note").html_safe } %>
+        <%= f.govuk_text_area :note, label: { text: t(".failure_assessor_note").html_safe } %>
       <% end %>
     <% end %>
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -182,11 +182,11 @@
     - assessment_id
     - created_at
     - expired_at
-    - failure_assessor_note
     - id
-    - passed
     - received_at
     - requested_at
+    - review_note
+    - review_passed
     - reviewed_at
     - updated_at
     - working_days_assessment_started_to_creation
@@ -216,15 +216,18 @@
     - assessment_id
     - created_at
     - expired_at
-    - failure_assessor_note
     - id
     - location_note
-    - passed
     - ready_for_review
     - received_at
     - requested_at
+    - review_note
+    - review_passed
     - reviewed_at
     - updated_at
+    - verified_at
+    - verify_note
+    - verify_passed
   :qualifications:
     - id
     - application_form_id
@@ -241,15 +244,18 @@
     - assessment_id
     - created_at
     - expired_at
-    - failure_assessor_note
     - id
     - location_note
-    - passed
     - qualification_id
     - received_at
     - requested_at
+    - review_note
+    - review_passed
     - reviewed_at
     - updated_at
+    - verified_at
+    - verify_note
+    - verify_passed
   :reference_requests:
     - additional_information_response
     - assessment_id
@@ -263,7 +269,6 @@
     - dates_comment
     - dates_response
     - expired_at
-    - failure_assessor_note
     - hours_comment
     - hours_response
     - id
@@ -271,16 +276,20 @@
     - lessons_response
     - misconduct_comment
     - misconduct_response
-    - passed
     - received_at
     - reports_comment
     - reports_response
     - requested_at
+    - review_note
+    - review_passed
     - reviewed_at
     - satisfied_comment
     - satisfied_response
     - slug
     - updated_at
+    - verified_at
+    - verify_note
+    - verify_passed
     - work_history_id
   :regions:
     - application_form_skip_work_history

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -17,7 +17,7 @@
     - has_work_history
     - subjects
   :further_information_requests:
-    - failure_assessor_note
+    - review_note
   :further_information_request_items:
     - failure_reason_assessor_feedback
     - response
@@ -28,6 +28,8 @@
     - text
   :professional_standing_requests:
     - location_note
+    - review_note
+    - verify_note
   :qualifications:
     - institution_name
     - institution_country_code
@@ -36,10 +38,12 @@
     - certificate_date
   :qualification_requests:
     - location_note
-    - failure_assessor_note
+    - review_note
+    - verify_note
   :reference_requests:
     - additional_information_response
-    - failure_assessor_note
+    - review_note
+    - verify_note
   :selected_failure_reasons:
     - assessor_feedback
   :staff:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -389,11 +389,15 @@ en:
               inclusion: Select whether you want to mark this qualification as ‘Rejected’
         assessor_interface/requestable_review_form:
           attributes:
-            reviewed:
-              inclusion: Select whether you have reviewed the request
             passed:
               inclusion: Select whether you are satisfied with the request
-            failure_assessor_note:
+            note:
+              blank: Enter why you are not satisfied
+        assessor_interface/requestable_verify_form:
+          attributes:
+            passed:
+              inclusion: Select whether you are satisfied with the request
+            note:
               blank: Enter why you are not satisfied
         assessor_interface/select_qualifications_form:
           attributes:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -128,6 +128,10 @@ en:
         passed_options:
           true: "Yes"
           false: "No"
+      assessor_interface_requestable_verify_form:
+        passed_options:
+          true: "Yes"
+          false: "No"
       assessor_interface_verify_professional_standing_form:
         verify_professional_standing_options:
           true: Yes, verify letter of professional standing

--- a/db/migrate/20231004150531_add_verification_to_requestables.rb
+++ b/db/migrate/20231004150531_add_verification_to_requestables.rb
@@ -1,0 +1,35 @@
+class AddVerificationToRequestables < ActiveRecord::Migration[7.0]
+  def change
+    change_table :further_information_requests, bulk: true do |t|
+      t.rename :passed, :review_passed
+      t.rename :failure_assessor_note, :review_note
+    end
+
+    change_table :professional_standing_requests, bulk: true do |t|
+      t.rename :passed, :review_passed
+      t.rename :failure_assessor_note, :review_note
+
+      t.boolean :verify_passed
+      t.text :verify_note, default: "", null: false
+      t.datetime :verified_at
+    end
+
+    change_table :qualification_requests, bulk: true do |t|
+      t.rename :passed, :review_passed
+      t.rename :failure_assessor_note, :review_note
+
+      t.boolean :verify_passed
+      t.text :verify_note, default: "", null: false
+      t.datetime :verified_at
+    end
+
+    change_table :reference_requests, bulk: true do |t|
+      t.rename :passed, :review_passed
+      t.rename :failure_assessor_note, :review_note
+
+      t.boolean :verify_passed
+      t.text :verify_note, default: "", null: false
+      t.datetime :verified_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_04_150531) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -249,8 +249,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
     t.datetime "received_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "passed"
-    t.string "failure_assessor_note", default: "", null: false
+    t.boolean "review_passed"
+    t.string "review_note", default: "", null: false
     t.integer "working_days_received_to_recommendation"
     t.integer "working_days_since_received"
     t.integer "working_days_assessment_started_to_creation"
@@ -277,11 +277,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "reviewed_at", precision: nil
-    t.boolean "passed"
-    t.string "failure_assessor_note", default: "", null: false
+    t.boolean "review_passed"
+    t.string "review_note", default: "", null: false
     t.boolean "ready_for_review", default: false, null: false
     t.datetime "requested_at"
     t.datetime "expired_at"
+    t.boolean "verify_passed"
+    t.text "verify_note", default: "", null: false
+    t.datetime "verified_at"
     t.index ["assessment_id"], name: "index_professional_standing_requests_on_assessment_id"
   end
 
@@ -293,10 +296,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "reviewed_at", precision: nil
-    t.boolean "passed"
-    t.string "failure_assessor_note", default: "", null: false
+    t.boolean "review_passed"
+    t.string "review_note", default: "", null: false
     t.datetime "requested_at"
     t.datetime "expired_at"
+    t.boolean "verify_passed"
+    t.text "verify_note", default: "", null: false
+    t.datetime "verified_at"
     t.index ["assessment_id"], name: "index_qualification_requests_on_assessment_id"
     t.index ["qualification_id"], name: "index_qualification_requests_on_qualification_id"
   end
@@ -328,7 +334,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
     t.text "additional_information_response", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "passed"
+    t.boolean "review_passed"
     t.datetime "reviewed_at", precision: nil
     t.boolean "contact_response"
     t.string "contact_name", default: "", null: false
@@ -343,9 +349,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_29_084821) do
     t.text "misconduct_comment", default: "", null: false
     t.boolean "satisfied_response"
     t.text "satisfied_comment", default: "", null: false
-    t.string "failure_assessor_note", default: "", null: false
+    t.string "review_note", default: "", null: false
     t.datetime "requested_at"
     t.datetime "expired_at"
+    t.boolean "verify_passed"
+    t.text "verify_note", default: "", null: false
+    t.datetime "verified_at"
     t.index ["assessment_id"], name: "index_reference_requests_on_assessment_id"
     t.index ["slug"], name: "index_reference_requests_on_slug", unique: true
     t.index ["work_history_id"], name: "index_reference_requests_on_work_history_id"

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -412,10 +412,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
 
   context "further information request reviewed" do
     let(:further_information_request) do
-      create(
-        :further_information_request,
-        failure_assessor_note: "For this reason.",
-      )
+      create(:further_information_request, review_note: "For this reason.")
     end
 
     let(:timeline_event) do

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -6,10 +6,10 @@
 #
 #  id                                          :bigint           not null, primary key
 #  expired_at                                  :datetime
-#  failure_assessor_note                       :string           default(""), not null
-#  passed                                      :boolean
 #  received_at                                 :datetime
 #  requested_at                                :datetime
+#  review_note                                 :string           default(""), not null
+#  review_passed                               :boolean
 #  reviewed_at                                 :datetime
 #  working_days_assessment_started_to_creation :integer
 #  working_days_received_to_recommendation     :integer

--- a/spec/factories/further_information_requests.rb
+++ b/spec/factories/further_information_requests.rb
@@ -45,13 +45,13 @@ FactoryBot.define do
 
     trait :passed do
       reviewed
-      passed { true }
+      review_passed { true }
     end
 
     trait :failed do
       reviewed
-      passed { false }
-      failure_assessor_note { "Notes." }
+      review_passed { false }
+      review_note { "Notes." }
     end
 
     trait :with_items do

--- a/spec/factories/professional_standing_requests.rb
+++ b/spec/factories/professional_standing_requests.rb
@@ -4,18 +4,21 @@
 #
 # Table name: professional_standing_requests
 #
-#  id                    :bigint           not null, primary key
-#  expired_at            :datetime
-#  failure_assessor_note :string           default(""), not null
-#  location_note         :text             default(""), not null
-#  passed                :boolean
-#  ready_for_review      :boolean          default(FALSE), not null
-#  received_at           :datetime
-#  requested_at          :datetime
-#  reviewed_at           :datetime
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  assessment_id         :bigint           not null
+#  id               :bigint           not null, primary key
+#  expired_at       :datetime
+#  location_note    :text             default(""), not null
+#  ready_for_review :boolean          default(FALSE), not null
+#  received_at      :datetime
+#  requested_at     :datetime
+#  review_note      :string           default(""), not null
+#  review_passed    :boolean
+#  reviewed_at      :datetime
+#  verified_at      :datetime
+#  verify_note      :text             default(""), not null
+#  verify_passed    :boolean
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  assessment_id    :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/qualification_requests.rb
+++ b/spec/factories/qualification_requests.rb
@@ -4,18 +4,21 @@
 #
 # Table name: qualification_requests
 #
-#  id                    :bigint           not null, primary key
-#  expired_at            :datetime
-#  failure_assessor_note :string           default(""), not null
-#  location_note         :text             default(""), not null
-#  passed                :boolean
-#  received_at           :datetime
-#  requested_at          :datetime
-#  reviewed_at           :datetime
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  assessment_id         :bigint           not null
-#  qualification_id      :bigint           not null
+#  id               :bigint           not null, primary key
+#  expired_at       :datetime
+#  location_note    :text             default(""), not null
+#  received_at      :datetime
+#  requested_at     :datetime
+#  review_note      :string           default(""), not null
+#  review_passed    :boolean
+#  reviewed_at      :datetime
+#  verified_at      :datetime
+#  verify_note      :text             default(""), not null
+#  verify_passed    :boolean
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  assessment_id    :bigint           not null
+#  qualification_id :bigint           not null
 #
 # Indexes
 #

--- a/spec/factories/reference_requests.rb
+++ b/spec/factories/reference_requests.rb
@@ -15,22 +15,25 @@
 #  dates_comment                   :text             default(""), not null
 #  dates_response                  :boolean
 #  expired_at                      :datetime
-#  failure_assessor_note           :string           default(""), not null
 #  hours_comment                   :text             default(""), not null
 #  hours_response                  :boolean
 #  lessons_comment                 :text             default(""), not null
 #  lessons_response                :boolean
 #  misconduct_comment              :text             default(""), not null
 #  misconduct_response             :boolean
-#  passed                          :boolean
 #  received_at                     :datetime
 #  reports_comment                 :text             default(""), not null
 #  reports_response                :boolean
 #  requested_at                    :datetime
+#  review_note                     :string           default(""), not null
+#  review_passed                   :boolean
 #  reviewed_at                     :datetime
 #  satisfied_comment               :text             default(""), not null
 #  satisfied_response              :boolean
 #  slug                            :string           not null
+#  verified_at                     :datetime
+#  verify_note                     :text             default(""), not null
+#  verify_passed                   :boolean
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
 #  assessment_id                   :bigint           not null

--- a/spec/factories/reference_requests.rb
+++ b/spec/factories/reference_requests.rb
@@ -83,13 +83,13 @@ FactoryBot.define do
 
     trait :passed do
       reviewed
-      passed { true }
+      review_passed { true }
     end
 
     trait :failed do
       reviewed
-      passed { false }
-      failure_assessor_note { "Notes." }
+      review_passed { false }
+      review_note { "Notes." }
     end
 
     trait :receivable do

--- a/spec/forms/assessor_interface/qualification_request_form_spec.rb
+++ b/spec/forms/assessor_interface/qualification_request_form_spec.rb
@@ -8,18 +8,11 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
 
   let(:received) { "" }
   let(:passed) { "" }
-  let(:failure_assessor_note) { "" }
+  let(:note) { "" }
   let(:failed) { "" }
 
   subject(:form) do
-    described_class.new(
-      requestable:,
-      user:,
-      received:,
-      passed:,
-      failure_assessor_note:,
-      failed:,
-    )
+    described_class.new(requestable:, user:, received:, passed:, note:, failed:)
   end
 
   describe "validations" do
@@ -37,7 +30,7 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
       context "and not passed" do
         let(:passed) { "false" }
 
-        it { is_expected.to validate_presence_of(:failure_assessor_note) }
+        it { is_expected.to validate_presence_of(:note) }
       end
     end
 
@@ -61,8 +54,8 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
         expect { save }.to change(requestable, :received_at).from(nil)
       end
 
-      it "sets passed" do
-        expect { save }.to change(requestable, :passed).to(true)
+      it "sets review passed" do
+        expect { save }.to change(requestable, :review_passed).to(true)
       end
 
       it "records a received timeline event" do
@@ -85,7 +78,7 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
     context "when received and not passed" do
       let(:received) { "true" }
       let(:passed) { "false" }
-      let(:failure_assessor_note) { "Note." }
+      let(:note) { "Note." }
 
       it { is_expected.to be true }
 
@@ -93,14 +86,12 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
         expect { save }.to change(requestable, :received_at).from(nil)
       end
 
-      it "sets passed" do
-        expect { save }.to change(requestable, :passed).to(false)
+      it "sets review passed" do
+        expect { save }.to change(requestable, :review_passed).to(false)
       end
 
-      it "sets passed" do
-        expect { save }.to change(requestable, :failure_assessor_note).to(
-          "Note.",
-        )
+      it "sets review note" do
+        expect { save }.to change(requestable, :review_note).to("Note.")
       end
 
       it "records a received timeline event" do
@@ -126,8 +117,8 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
 
       it { is_expected.to be true }
 
-      it "sets passed" do
-        expect { save }.to change(requestable, :passed).to(false)
+      it "sets review passed" do
+        expect { save }.to change(requestable, :review_passed).to(false)
       end
 
       it "records an assessed timeline event" do
@@ -145,8 +136,8 @@ RSpec.describe AssessorInterface::QualificationRequestForm, type: :model do
 
       it { is_expected.to be true }
 
-      it "doesn't set passed" do
-        expect { save }.to_not change(requestable, :passed)
+      it "doesn't set review passed" do
+        expect { save }.to_not change(requestable, :review_passed)
       end
 
       it "doesn't record a reviewed timeline event" do

--- a/spec/forms/assessor_interface/requestable_review_form_spec.rb
+++ b/spec/forms/assessor_interface/requestable_review_form_spec.rb
@@ -6,11 +6,9 @@ RSpec.describe AssessorInterface::RequestableReviewForm, type: :model do
   let(:requestable) { create(:reference_request, :received) }
   let(:user) { create(:staff) }
   let(:passed) { nil }
-  let(:failure_assessor_note) { "" }
+  let(:note) { "" }
 
-  subject(:form) do
-    described_class.new(requestable:, user:, passed:, failure_assessor_note:)
-  end
+  subject(:form) { described_class.new(requestable:, user:, passed:, note:) }
 
   describe "validations" do
     it { is_expected.to allow_values(true, false).for(:passed) }
@@ -18,7 +16,7 @@ RSpec.describe AssessorInterface::RequestableReviewForm, type: :model do
     context "when not passed" do
       let(:passed) { "false" }
 
-      it { is_expected.to validate_presence_of(:failure_assessor_note) }
+      it { is_expected.to validate_presence_of(:note) }
     end
   end
 
@@ -28,8 +26,10 @@ RSpec.describe AssessorInterface::RequestableReviewForm, type: :model do
     context "when passed is true" do
       let(:passed) { true }
 
-      it "updates passed field" do
-        expect { save }.to change(requestable, :passed).from(nil).to(true)
+      it "updates review passed field" do
+        expect { save }.to change(requestable, :review_passed).from(nil).to(
+          true,
+        )
       end
 
       it "sets reviewed at" do
@@ -48,16 +48,18 @@ RSpec.describe AssessorInterface::RequestableReviewForm, type: :model do
 
     context "when passed is false" do
       let(:passed) { false }
-      let(:failure_assessor_note) { "Note." }
+      let(:note) { "Note." }
 
-      it "updates passed field" do
-        expect { save }.to change(requestable, :passed).from(nil).to(false)
+      it "updates review passed field" do
+        expect { save }.to change(requestable, :review_passed).from(nil).to(
+          false,
+        )
       end
 
-      it "updates failure_assessor_note field" do
-        expect { save }.to change(requestable, :failure_assessor_note).from(
-          "",
-        ).to("Note.")
+      it "updates review note field" do
+        expect { save }.to change(requestable, :review_note).from("").to(
+          "Note.",
+        )
       end
 
       it "sets reviewed at" do

--- a/spec/forms/assessor_interface/requestable_verify_form_spec.rb
+++ b/spec/forms/assessor_interface/requestable_verify_form_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::RequestableVerifyForm, type: :model do
+  let(:requestable) { create(:reference_request, :received) }
+  let(:user) { create(:staff) }
+  let(:passed) { nil }
+  let(:note) { "" }
+
+  subject(:form) { described_class.new(requestable:, user:, passed:, note:) }
+
+  describe "validations" do
+    it { is_expected.to allow_values(true, false).for(:passed) }
+
+    context "when not passed" do
+      let(:passed) { "false" }
+
+      it { is_expected.to validate_presence_of(:note) }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    context "when passed is true" do
+      let(:passed) { true }
+
+      it "updates review passed field" do
+        expect { save }.to change(requestable, :verify_passed).from(nil).to(
+          true,
+        )
+      end
+
+      it "sets reviewed at" do
+        freeze_time do
+          expect { save }.to change(requestable, :verified_at).from(nil).to(
+            Time.zone.now,
+          )
+        end
+      end
+
+      it "updates induction required" do
+        expect(UpdateAssessmentInductionRequired).to receive(:call)
+        save # rubocop:disable Rails/SaveBang
+      end
+    end
+
+    context "when passed is false" do
+      let(:passed) { false }
+      let(:note) { "Note." }
+
+      it "updates review passed field" do
+        expect { save }.to change(requestable, :verify_passed).from(nil).to(
+          false,
+        )
+      end
+
+      it "updates review note field" do
+        expect { save }.to change(requestable, :verify_note).from("").to(
+          "Note.",
+        )
+      end
+
+      it "sets reviewed at" do
+        freeze_time do
+          expect { save }.to change(requestable, :verified_at).from(nil).to(
+            Time.zone.now,
+          )
+        end
+      end
+
+      it "updates induction required" do
+        expect(UpdateAssessmentInductionRequired).to receive(:call)
+        save # rubocop:disable Rails/SaveBang
+      end
+    end
+  end
+end

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -6,10 +6,10 @@
 #
 #  id                                          :bigint           not null, primary key
 #  expired_at                                  :datetime
-#  failure_assessor_note                       :string           default(""), not null
-#  passed                                      :boolean
 #  received_at                                 :datetime
 #  requested_at                                :datetime
+#  review_note                                 :string           default(""), not null
+#  review_passed                               :boolean
 #  reviewed_at                                 :datetime
 #  working_days_assessment_started_to_creation :integer
 #  working_days_received_to_recommendation     :integer

--- a/spec/models/professional_standing_request_spec.rb
+++ b/spec/models/professional_standing_request_spec.rb
@@ -4,18 +4,21 @@
 #
 # Table name: professional_standing_requests
 #
-#  id                    :bigint           not null, primary key
-#  expired_at            :datetime
-#  failure_assessor_note :string           default(""), not null
-#  location_note         :text             default(""), not null
-#  passed                :boolean
-#  ready_for_review      :boolean          default(FALSE), not null
-#  received_at           :datetime
-#  requested_at          :datetime
-#  reviewed_at           :datetime
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  assessment_id         :bigint           not null
+#  id               :bigint           not null, primary key
+#  expired_at       :datetime
+#  location_note    :text             default(""), not null
+#  ready_for_review :boolean          default(FALSE), not null
+#  received_at      :datetime
+#  requested_at     :datetime
+#  review_note      :string           default(""), not null
+#  review_passed    :boolean
+#  reviewed_at      :datetime
+#  verified_at      :datetime
+#  verify_note      :text             default(""), not null
+#  verify_passed    :boolean
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  assessment_id    :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -4,18 +4,21 @@
 #
 # Table name: qualification_requests
 #
-#  id                    :bigint           not null, primary key
-#  expired_at            :datetime
-#  failure_assessor_note :string           default(""), not null
-#  location_note         :text             default(""), not null
-#  passed                :boolean
-#  received_at           :datetime
-#  requested_at          :datetime
-#  reviewed_at           :datetime
-#  created_at            :datetime         not null
-#  updated_at            :datetime         not null
-#  assessment_id         :bigint           not null
-#  qualification_id      :bigint           not null
+#  id               :bigint           not null, primary key
+#  expired_at       :datetime
+#  location_note    :text             default(""), not null
+#  received_at      :datetime
+#  requested_at     :datetime
+#  review_note      :string           default(""), not null
+#  review_passed    :boolean
+#  reviewed_at      :datetime
+#  verified_at      :datetime
+#  verify_note      :text             default(""), not null
+#  verify_passed    :boolean
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  assessment_id    :bigint           not null
+#  qualification_id :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/reference_request_spec.rb
+++ b/spec/models/reference_request_spec.rb
@@ -15,22 +15,25 @@
 #  dates_comment                   :text             default(""), not null
 #  dates_response                  :boolean
 #  expired_at                      :datetime
-#  failure_assessor_note           :string           default(""), not null
 #  hours_comment                   :text             default(""), not null
 #  hours_response                  :boolean
 #  lessons_comment                 :text             default(""), not null
 #  lessons_response                :boolean
 #  misconduct_comment              :text             default(""), not null
 #  misconduct_response             :boolean
-#  passed                          :boolean
 #  received_at                     :datetime
 #  reports_comment                 :text             default(""), not null
 #  reports_response                :boolean
 #  requested_at                    :datetime
+#  review_note                     :string           default(""), not null
+#  review_passed                   :boolean
 #  reviewed_at                     :datetime
 #  satisfied_comment               :text             default(""), not null
 #  satisfied_response              :boolean
 #  slug                            :string           not null
+#  verified_at                     :datetime
+#  verify_note                     :text             default(""), not null
+#  verify_passed                   :boolean
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
 #  assessment_id                   :bigint           not null

--- a/spec/services/review_requestable_spec.rb
+++ b/spec/services/review_requestable_spec.rb
@@ -6,14 +6,12 @@ RSpec.describe ReviewRequestable do
   let(:requestable) { create(:further_information_request, :received) }
   let(:user) { create(:staff) }
   let(:passed) { true }
-  let(:failure_assessor_note) { "Note" }
+  let(:note) { "Note" }
 
-  subject(:call) do
-    described_class.call(requestable:, user:, passed:, failure_assessor_note:)
-  end
+  subject(:call) { described_class.call(requestable:, user:, passed:, note:) }
 
-  describe "requestable passed" do
-    subject { requestable.passed }
+  describe "requestable review decision" do
+    subject { requestable.review_passed }
 
     it { is_expected.to be_nil }
 
@@ -24,8 +22,8 @@ RSpec.describe ReviewRequestable do
     end
   end
 
-  describe "requestable failure_assessor_note" do
-    subject { requestable.failure_assessor_note }
+  describe "requestable review note" do
+    subject { requestable.review_note }
 
     it { is_expected.to be_blank }
 

--- a/spec/services/verify_requestable_spec.rb
+++ b/spec/services/verify_requestable_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe VerifyRequestable do
+  let(:requestable) { create(:professional_standing_request, :received) }
+  let(:user) { create(:staff) }
+  let(:passed) { true }
+  let(:note) { "Note" }
+
+  subject(:call) { described_class.call(requestable:, user:, passed:, note:) }
+
+  describe "requestable verify decision" do
+    subject { requestable.verify_passed }
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "requestable verify note" do
+    subject { requestable.verify_note }
+
+    it { is_expected.to be_blank }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to eq("Note") }
+    end
+  end
+
+  it "records a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :requestable_verified,
+      creator: user,
+      requestable:,
+    )
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/edit_qualification_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/edit_qualification_request.rb
@@ -21,8 +21,8 @@ module PageObjects
                 "#assessor-interface-qualification-request-form-passed-false-field",
                 visible: false
 
-        element :failure_assessor_note_field,
-                "#assessor-interface-qualification-request-form-failure-assessor-note-field"
+        element :note_field,
+                "#assessor-interface-qualification-request-form-note-field"
 
         element :failed_yes_radio_item,
                 "#assessor-interface-qualification-request-form-failed-true-field",

--- a/spec/support/shared_examples/requestable.rb
+++ b/spec/support/shared_examples/requestable.rb
@@ -9,12 +9,7 @@ RSpec.shared_examples "a requestable" do
     it { is_expected.to_not validate_presence_of(:requested_at) }
     it { is_expected.to_not validate_presence_of(:received_at) }
     it { is_expected.to_not validate_presence_of(:expired_at) }
-
-    context "when reviewed" do
-      before { subject.passed = [true, false].sample }
-
-      it { is_expected.to validate_presence_of(:reviewed_at) }
-    end
+    it { is_expected.to_not validate_presence_of(:reviewed_at) }
   end
 
   describe "#requested!" do
@@ -53,33 +48,15 @@ RSpec.shared_examples "a requestable" do
     end
   end
 
-  [true, false].each do |passed|
-    describe "#reviewed!(#{passed})" do
-      let(:call) { subject.reviewed!(passed) }
-
-      it "changes passed field" do
-        expect { call }.to change(subject, :passed).from(nil).to(passed)
-      end
-
-      it "sets the reviewed at date" do
-        freeze_time do
-          expect { call }.to change(subject, :reviewed_at).from(nil).to(
-            Time.zone.now,
-          )
-        end
-      end
-    end
-  end
-
   describe "#status" do
     it "is accepted when passed is true" do
-      subject.passed = true
+      subject.review_passed = true
       subject.reviewed_at = Time.zone.now
       expect(subject.status).to eq("accepted")
     end
 
     it "is rejected when passed is false" do
-      subject.passed = false
+      subject.review_passed = false
       subject.reviewed_at = Time.zone.now
       expect(subject.status).to eq("rejected")
     end

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
   end
 
   it "further information request passed and assessment finished" do
-    further_information_request.reviewed!(true)
+    further_information_request.update!(review_passed: true)
     further_information_request.assessment.award!
 
     when_i_visit_the(:assessor_application_page, application_id:)

--- a/spec/system/assessor_interface/verifying_qualifications_spec.rb
+++ b/spec/system/assessor_interface/verifying_qualifications_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe "Assessor verifying qualifications", type: :system do
 
     form.received_yes_radio_item.choose
     form.passed_no_radio_item.choose
-    form.failure_assessor_note_field.fill_in with: "Note."
+    form.note_field.fill_in with: "Note."
     form.submit_button.click
   end
 

--- a/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
 
     context "when not passed and not recommended" do
       before do
-        further_information_request.reviewed!(true)
+        further_information_request.update!(review_passed: true)
         assessment.request_further_information!
       end
       it { is_expected.to be true }
@@ -93,7 +93,7 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
 
     context "when passed and not recommended" do
       before do
-        further_information_request.reviewed!(true)
+        further_information_request.update!(review_passed: true)
         assessment.request_further_information!
       end
       it { is_expected.to be true }
@@ -101,7 +101,7 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
 
     context "when not passed and recommended" do
       before do
-        further_information_request.update!(passed: nil)
+        further_information_request.update!(review_passed: nil)
         assessment.award!
       end
       it { is_expected.to be true }
@@ -109,7 +109,7 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
 
     context "when passed and recommended" do
       before do
-        further_information_request.reviewed!(true)
+        further_information_request.update!(review_passed: true)
         assessment.award!
       end
       it { is_expected.to be false }


### PR DESCRIPTION
This updates the requestables to allow them to be verified by an admin user by adding the necessary database fields and service class.

Depends on #1732 

[Trello Card](https://trello.com/c/8sKZ1aEm/2309-lops-response-review)