### PR TITLE
Add professional standing request policy

### DIFF
--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -5,7 +5,7 @@ module AssessorInterface
     before_action :set_variables
 
     def edit_location
-      authorize :note, :edit?
+      authorize [:assessor_interface, professional_standing_request]
 
       @form =
         ProfessionalStandingRequestLocationForm.new(
@@ -18,7 +18,7 @@ module AssessorInterface
     end
 
     def update_location
-      authorize :note, :update?
+      authorize [:assessor_interface, professional_standing_request]
 
       @form =
         ProfessionalStandingRequestLocationForm.new(
@@ -33,7 +33,7 @@ module AssessorInterface
     end
 
     def edit_review
-      authorize :assessor, :edit?
+      authorize [:assessor_interface, professional_standing_request]
 
       @form =
         RequestableReviewForm.new(
@@ -45,7 +45,7 @@ module AssessorInterface
     end
 
     def update_review
-      authorize :assessor, :update?
+      authorize [:assessor_interface, professional_standing_request]
 
       @form =
         RequestableReviewForm.new(

--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -5,7 +5,7 @@ module AssessorInterface
     before_action :set_variables
 
     def edit_location
-      authorize [:assessor_interface, professional_standing_request]
+      authorize [:assessor_interface, professional_standing_request], :show?
 
       @form =
         ProfessionalStandingRequestLocationForm.new(
@@ -18,7 +18,7 @@ module AssessorInterface
     end
 
     def update_location
-      authorize [:assessor_interface, professional_standing_request]
+      authorize [:assessor_interface, professional_standing_request], :show?
 
       @form =
         ProfessionalStandingRequestLocationForm.new(

--- a/app/policies/assessor_interface/professional_standing_request_policy.rb
+++ b/app/policies/assessor_interface/professional_standing_request_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AssessorInterface::ProfessionalStandingRequestPolicy < ApplicationPolicy
+  def update_location?
+    true
+  end
+
+  alias_method :edit_location?, :update_location?
+
+  def update_review?
+    user.award_decline_permission
+  end
+
+  alias_method :edit_review?, :update_review?
+end

--- a/app/policies/assessor_interface/professional_standing_request_policy.rb
+++ b/app/policies/assessor_interface/professional_standing_request_policy.rb
@@ -1,11 +1,21 @@
 # frozen_string_literal: true
 
 class AssessorInterface::ProfessionalStandingRequestPolicy < ApplicationPolicy
-  def update_location?
+  def show?
     true
   end
 
-  alias_method :edit_location?, :update_location?
+  def update_request?
+    user.verify_permission
+  end
+
+  alias_method :edit_request?, :update_request?
+
+  def update_verify?
+    user.verify_permission
+  end
+
+  alias_method :edit_verify?, :update_verify?
 
   def update_review?
     user.award_decline_permission

--- a/spec/factories/staff.rb
+++ b/spec/factories/staff.rb
@@ -80,7 +80,7 @@ FactoryBot.define do
       support_console_permission { true }
     end
 
-    trait :with_verification_permission do
+    trait :with_verify_permission do
       verify_permission { true }
     end
 

--- a/spec/policies/assessor_interface/professional_standing_request_policy_spec.rb
+++ b/spec/policies/assessor_interface/professional_standing_request_policy_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe AssessorInterface::ProfessionalStandingRequestPolicy do
     subject(:show?) { policy.show? }
 
     let(:user) { create(:staff, :confirmed) }
-    it { is_expected.to be false }
+    it { is_expected.to be true }
   end
 
   describe "#create?" do
@@ -52,18 +52,24 @@ RSpec.describe AssessorInterface::ProfessionalStandingRequestPolicy do
     it { is_expected.to be false }
   end
 
-  describe "#update_location?" do
-    subject(:update_location?) { policy.update_location? }
-
-    let(:user) { create(:staff, :confirmed) }
-    it { is_expected.to be true }
+  describe "#update_request?" do
+    subject(:update_request?) { policy.update_request? }
+    it_behaves_like "a policy method requiring the verify permission"
   end
 
-  describe "#edit_review?" do
-    subject(:edit_location?) { policy.edit_location? }
+  describe "#edit_request?" do
+    subject(:edit_request?) { policy.edit_request? }
+    it_behaves_like "a policy method requiring the verify permission"
+  end
 
-    let(:user) { create(:staff, :confirmed) }
-    it { is_expected.to be true }
+  describe "#update_verify?" do
+    subject(:update_review?) { policy.update_verify? }
+    it_behaves_like "a policy method requiring the verify permission"
+  end
+
+  describe "#edit_verify?" do
+    subject(:edit_review?) { policy.edit_verify? }
+    it_behaves_like "a policy method requiring the verify permission"
   end
 
   describe "#update_review?" do

--- a/spec/policies/assessor_interface/professional_standing_request_policy_spec.rb
+++ b/spec/policies/assessor_interface/professional_standing_request_policy_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::ProfessionalStandingRequestPolicy do
+  it_behaves_like "a policy"
+
+  let(:user) { nil }
+  let(:record) { nil }
+
+  subject(:policy) { described_class.new(user, record) }
+
+  describe "#index?" do
+    subject(:index?) { policy.index? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+
+  describe "#show?" do
+    subject(:show?) { policy.show? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+
+  describe "#create?" do
+    subject(:create?) { policy.create? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+
+  describe "#new?" do
+    subject(:new?) { policy.new? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+
+  describe "#update?" do
+    subject(:update?) { policy.update? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+
+  describe "#edit?" do
+    subject(:edit?) { policy.edit? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+
+  describe "#update_location?" do
+    subject(:update_location?) { policy.update_location? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be true }
+  end
+
+  describe "#edit_review?" do
+    subject(:edit_location?) { policy.edit_location? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be true }
+  end
+
+  describe "#update_review?" do
+    subject(:update_review?) { policy.update_review? }
+    it_behaves_like "a policy method requiring the award decline permission"
+  end
+
+  describe "#edit_review?" do
+    subject(:edit_review?) { policy.edit_review? }
+    it_behaves_like "a policy method requiring the award decline permission"
+  end
+
+  describe "#destroy?" do
+    subject(:destroy?) { policy.destroy? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+end

--- a/spec/support/shared_examples/policy.rb
+++ b/spec/support/shared_examples/policy.rb
@@ -64,18 +64,6 @@ RSpec.shared_examples "a policy method requiring the reverse decision permission
   end
 end
 
-RSpec.shared_examples "a policy method requiring the withdraw permission" do
-  context "without permission" do
-    let(:user) { create(:staff) }
-    it { is_expected.to be false }
-  end
-
-  context "with permission" do
-    let(:user) { create(:staff, :with_withdraw_permission) }
-    it { is_expected.to be true }
-  end
-end
-
 RSpec.shared_examples "a policy method requiring the support console permission" do
   context "without permission" do
     let(:user) { create(:staff) }
@@ -84,6 +72,30 @@ RSpec.shared_examples "a policy method requiring the support console permission"
 
   context "with permission" do
     let(:user) { create(:staff, :with_support_console_permission) }
+    it { is_expected.to be true }
+  end
+end
+
+RSpec.shared_examples "a policy method requiring the verify permission" do
+  context "without permission" do
+    let(:user) { create(:staff) }
+    it { is_expected.to be false }
+  end
+
+  context "with permission" do
+    let(:user) { create(:staff, :with_verify_permission) }
+    it { is_expected.to be true }
+  end
+end
+
+RSpec.shared_examples "a policy method requiring the withdraw permission" do
+  context "without permission" do
+    let(:user) { create(:staff) }
+    it { is_expected.to be false }
+  end
+
+  context "with permission" do
+    let(:user) { create(:staff, :with_withdraw_permission) }
     it { is_expected.to be true }
   end
 end


### PR DESCRIPTION
This adds a new policy for the professional standing requests controller in the assessor interface, this is backwards compatible with the existing controller methods, but also sets up the new ones:

- `show` - This will represent the page containing links to either request or review the LoPS.
- `edit_request` and `update_request` - To request the LoPS.
- `edit_verify` and `update_verify` - For an admin to verify the LoPS.
- `edit_review` and `update_review` - For an assessor to review the LoPS if it's not been verified.