### PR TITLE
Fix reference to passed field

### DIFF
--- a/app/controllers/assessor_interface/qualification_requests_controller.rb
+++ b/app/controllers/assessor_interface/qualification_requests_controller.rb
@@ -21,8 +21,17 @@ module AssessorInterface
           false
         end
 
-      passed = (requestable.review_passed? if requestable.received?)
-      failed = (requestable.review_failed? if requestable.expired?)
+      passed = (requestable.review_passed if requestable.received?)
+
+      failed =
+        if requestable.expired?
+          case requestable.review_passed
+          when true
+            false
+          when false
+            true
+          end
+        end
 
       @form =
         QualificationRequestForm.new(

--- a/app/controllers/assessor_interface/qualification_requests_controller.rb
+++ b/app/controllers/assessor_interface/qualification_requests_controller.rb
@@ -21,17 +21,8 @@ module AssessorInterface
           false
         end
 
-      passed = (requestable.passed if requestable.received?)
-
-      failed =
-        if requestable.expired?
-          case requestable.passed
-          when true
-            false
-          when false
-            true
-          end
-        end
+      passed = (requestable.review_passed? if requestable.received?)
+      failed = (requestable.review_failed? if requestable.expired?)
 
       @form =
         QualificationRequestForm.new(


### PR DESCRIPTION
The field no longer exists and has been replaced with `review_passed?`.

This should fix: https://dfe-teacher-services.sentry.io/issues/4529235517/?referrer=slack&notification_uuid=0d34115a-51a4-4db7-a5cc-f1b570de60a6&alert_rule_id=11189458&alert_type=issue