### PR TITLE
Make default queue highest priority

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,6 +2,6 @@
 :verbose: false
 :concurrency: 10
 :queues:
+  - default
   - mailer
   - analytics
-  - default


### PR DESCRIPTION
Most of the jobs end up on the default queue, and the analytics are the least important jobs so we can move them to the bottom.