### PR TITLE
Fix logic when to trigger a received reference

### DIFF
--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -121,7 +121,7 @@ class ApplicationFormStatusUpdater
           (region.checks_available? || most_recent_reference_request&.received?)
       true
     else
-      reference_requests.filter(&:requested?).empty?
+      reference_requests.all? { |r| r.received? || r.expired? }
     end
   end
 


### PR DESCRIPTION
This logic no longer works after we deployed https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/1719 as there are no longer three distinct states for a requestable. Instead, I've fixed the logic and made it clearer exactly what it's doing.