### PR TITLE
Update application form status after submission

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -111,7 +111,6 @@ class ApplicationForm < ApplicationRecord
   belongs_to :assessor, class_name: "Staff", optional: true
   belongs_to :reviewer, class_name: "Staff", optional: true
 
-  validates :submitted_at, presence: true, unless: :draft?
   validates :awarded_at, absence: true, if: :declined_at?
   validates :awarded_at, absence: true, if: :withdrawn_at?
   validates :declined_at, absence: true, if: :awarded_at?

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -287,18 +287,6 @@ RSpec.describe ApplicationForm, type: :model do
       it { is_expected.to validate_absence_of(:english_language_provider) }
     end
 
-    context "when submitted" do
-      before { application_form.status = "submitted" }
-
-      it { is_expected.to_not be_valid }
-
-      context "with submitted_at" do
-        before { application_form.submitted_at = Time.zone.now }
-
-        it { is_expected.to be_valid }
-      end
-    end
-
     context "when awarded and declined" do
       before do
         application_form.assign_attributes(

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -21,6 +21,20 @@ RSpec.describe SubmitApplicationForm do
     end
   end
 
+  describe "application form preliminary check status" do
+    subject(:submitted?) { application_form.preliminary_check? }
+
+    it { is_expected.to be false }
+
+    context "when calling the service" do
+      let(:region) { create(:region, :requires_preliminary_check) }
+
+      before { call }
+
+      it { is_expected.to be true }
+    end
+  end
+
   describe "compacting blank subjects" do
     subject(:subjects) { application_form.subjects }
 


### PR DESCRIPTION
This ensures that the application forms end up in the right status after being submitted (whether that's submitted or preliminary check). This fixes a bug that was introduced in https://github.com/DFE-Digital/apply-for-qualified-teacher-status/commit/ad5d73d7fc07c04964d29fbe4ff4f3a83353d653.