### PR TITLE
Send application for review journey

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module AssessorInterface
+  class AssessmentRecommendationReviewController < BaseController
+    before_action :authorize_assessor
+    before_action :ensure_can_review
+    before_action :load_assessment_and_application_form
+
+    def edit
+      @professional_standing_request =
+        assessment.professional_standing_request if assessment.professional_standing_request.verify_failed?
+    end
+
+    def update
+      ActiveRecord::Base.transaction do
+        assessment.review!
+        ApplicationFormStatusUpdater.call(
+          application_form:,
+          user: current_staff,
+        )
+      end
+
+      redirect_to [:status, :assessor_interface, application_form]
+    end
+
+    private
+
+    def assessment
+      @assessment ||=
+        Assessment
+          .includes(:application_form)
+          .where(application_form_id: params[:application_form_id])
+          .find(params[:assessment_id])
+    end
+
+    delegate :application_form, to: :assessment
+
+    def ensure_can_review
+      unless assessment.can_review?
+        redirect_to [:assessor_interface, application_form]
+      end
+    end
+
+    def load_assessment_and_application_form
+      @assessment = assessment
+      @application_form = application_form
+    end
+  end
+end

--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -182,8 +182,9 @@ class ApplicationFormStatusUpdater
         "none"
       elsif preliminary_check?
         "admin"
-      elsif dqt_trn_request.present? || overdue_further_information ||
-            overdue_lops || overdue_qualification || overdue_reference ||
+      elsif dqt_trn_request.present? || assessment_in_review? ||
+            overdue_further_information || overdue_lops ||
+            overdue_qualification || overdue_reference ||
             received_further_information || received_lops ||
             received_qualification || received_reference
         "assessor"
@@ -203,7 +204,7 @@ class ApplicationFormStatusUpdater
            application_form.declined_at.present? ||
            application_form.awarded_at.present?
         "completed"
-      elsif dqt_trn_request.present?
+      elsif assessment_in_review? || dqt_trn_request.present?
         "review"
       elsif preliminary_check? ||
             (teaching_authority_provides_written_statement && waiting_on_lops)
@@ -240,6 +241,8 @@ class ApplicationFormStatusUpdater
       elsif assessment.present?
         if preliminary_check?
           %w[preliminary_check] + requestable_statuses
+        elsif assessment_in_review?
+          %w[review]
         elsif requestable_statuses.present?
           requestable_statuses
         elsif assessment.any_not_preliminary_section_finished?
@@ -268,6 +271,10 @@ class ApplicationFormStatusUpdater
         assessment.any_preliminary_section_failed? ||
           !assessment.all_preliminary_sections_passed?
       )
+  end
+
+  def assessment_in_review?
+    assessment&.review? || false
   end
 
   def requestable_statuses

--- a/app/views/assessor_interface/application_forms/status.html.erb
+++ b/app/views/assessor_interface/application_forms/status.html.erb
@@ -1,7 +1,9 @@
 <% content_for :page_title, "Application" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@view_object.application_form) %>
 
-<% if @view_object.application_form.waiting_on? %>
+<% if @view_object.assessment.review? %>
+  <%= govuk_panel(title_text: "Application sent for review") %>
+<% elsif @view_object.application_form.waiting_on? %>
   <%= govuk_panel(title_text: "Reference requests sent successfully") %>
 <% else %>
   <%= govuk_panel(title_text: "QTS application #{@view_object.application_form.reference} has been #{@view_object.status.downcase}") %>
@@ -11,7 +13,9 @@
   <p class="govuk-body">The status of this application has been changed to ’<%= @view_object.status %>‘.</p>
 <% end %>
 
-<% if @view_object.application_form.declined? %>
+<% if @view_object.assessment.review? %>
+  <p class="govuk-body">An assessor will now review the application and make a decision on awarding or declining QTS.</p>
+<% elsif @view_object.application_form.declined? %>
   <p class="govuk-body">The application will be deleted after 90 days unless the applicant chooses to appeal.</p>
 <% elsif @view_object.application_form.awarded_pending_checks? %>
   <p class="govuk-body">This status will appear while the award is reconciled with the information in the Database of Qualified Teachers (DQT).</p>

--- a/app/views/assessor_interface/assessment_recommendation_review/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_review/edit.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title, "Send application for review" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+
+<h1 class="govuk-heading-xl">Send application for review</h1>
+
+<p class="govuk-body">The following verification tasks have been flagged for review:</p>
+
+<%= govuk_table do |table|
+  if @professional_standing_request.present?
+    table.with_caption(text: "LoPS")
+    table.with_head do |head|
+      head.with_row do |row|
+        row.with_cell(text: "Internal note")
+        row.with_cell(text: "Status")
+      end
+    end
+    table.with_body do |body|
+      body.with_row do |row|
+        row.with_cell { simple_format @professional_standing_request.verify_note }
+        row.with_cell { render(StatusTag::Component.new(@professional_standing_request.status)) }
+      end
+    end
+  end
+end %>
+
+<%= govuk_button_to "Continue", [:assessor_interface, @application_form, @assessment, :assessment_recommendation_review], method: :put %>

--- a/app/views/assessor_interface/assessments/edit.html.erb
+++ b/app/views/assessor_interface/assessments/edit.html.erb
@@ -1,26 +1,34 @@
-<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{t("helpers.legend.assessor_interface_assessment_recommendation_form.recommendation")}" %>
+<% legend = if @assessment.verify?
+              t(".legend.verify")
+           elsif @assessment.review?
+             t(".legend.review")
+           else
+             t(".legend.other")
+           end %>
+
+<% hint = if @assessment.can_verify?
+           t(".hint.can_verify")
+         elsif @assessment.can_review?
+           t(".hint.can_review")
+         elsif @assessment.can_award?
+           t(".hint.can_award")
+         else
+           t(".hint.cant_award")
+         end %>
+
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}#{legend}" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
 <%= form_with model: @form, url: [:assessor_interface, @application_form, @assessment], method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%
-    hint = if @assessment.can_verify?
-             t(".hint.can_verify")
-           elsif @assessment.can_award?
-             t(".hint.can_award")
-           else
-             t(".hint.cant_award")
-           end
-  %>
-
   <%= f.govuk_collection_radio_buttons :recommendation,
                                        @assessment.available_recommendations,
                                        :itself,
-                                       legend: { size: "xl", tag: "h1" },
+                                       legend: { size: "xl", tag: "h1", text: legend },
                                        hint: { text: hint } %>
 
   <%= f.govuk_submit prevent_double_click: false do %>
-    <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
+    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
   <% end %>
 <% end %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -32,8 +32,13 @@ en:
 
     assessments:
       edit:
+        legend:
+          other: QTS review complete
+          review: Assessment decision
+          verify: Verification decision
         hint:
           can_award: You’ve completed your assessment of this QTS application and reviewed the work references.
+          can_review: You’ve completed your verification checks.
           can_verify: You’ve completed your review of this QTS application and marked all sections as complete to your satisfaction.
           cant_award: You’ve completed your review of this QTS application and marked 1 or more sections as not completed to your satisfaction.
 

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -275,8 +275,6 @@ en:
           document: "Example: The right-hand section of your teaching qualification document is missing, please take a new image and upload it."
           decline: "Example: We declined this QTS application as you already have another application in progress."
     legend:
-      assessor_interface_assessment_recommendation_form:
-        recommendation: QTS review completed
       assessor_interface_assessment_section_form:
         selected_failure_reasons: What are the reasons for your recommendation?
         scotland_full_registration: Does the applicant have or are they eligible for full registration?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,11 @@ Rails.application.routes.draw do
           post "confirm", to: "assessment_recommendation_decline#update_confirm"
         end
 
+        resource :assessment_recommendation_review,
+                 controller: "assessment_recommendation_review",
+                 path: "/recommendation/review",
+                 only: %i[edit update]
+
         resource :assessment_recommendation_verify,
                  controller: "assessment_recommendation_verify",
                  path: "/recommendation/verify",

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -57,6 +57,11 @@ FactoryBot.define do
       recommended_at { Time.zone.now }
     end
 
+    trait :verify do
+      recommendation { "verify" }
+      recommended_at { Time.zone.now }
+    end
+
     trait :with_preliminary_qualifications_section do
       after(:create) do |assessment, _evaulator|
         create(:assessment_section, :preliminary, :qualifications, assessment:)

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -52,6 +52,11 @@ FactoryBot.define do
       recommended_at { Time.zone.now }
     end
 
+    trait :review do
+      recommendation { "review" }
+      recommended_at { Time.zone.now }
+    end
+
     trait :with_preliminary_qualifications_section do
       after(:create) do |assessment, _evaulator|
         create(:assessment_section, :preliminary, :qualifications, assessment:)

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -430,6 +430,17 @@ RSpec.describe ApplicationFormStatusUpdater do
       end
     end
 
+    context "when a reviewed assessment" do
+      before do
+        application_form.update!(submitted_at: Time.zone.now)
+        create(:assessment, :review, application_form:)
+      end
+
+      include_examples "changes action required by", "assessor"
+      include_examples "changes stage", "review"
+      include_examples "changes statuses", %w[review]
+    end
+
     context "with a started assessment" do
       before do
         application_form.update!(submitted_at: Time.zone.now)

--- a/spec/support/autoload/page_objects/assessor_interface/assessment_recommendation_review.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/assessment_recommendation_review.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class AssessmentRecommendationReview < SitePrism::Page
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
+                "/recommendation/review/edit"
+
+      element :continue_button, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -22,6 +22,11 @@ module PageHelpers
       PageObjects::AssessorInterface::ApplicationStatus.new
   end
 
+  def assessor_assessment_recommendation_review_page
+    @assessor_assessment_recommendation_review_page ||=
+      PageObjects::AssessorInterface::AssessmentRecommendationReview.new
+  end
+
   def assessor_assessment_section_page
     @assessor_assessment_section_page ||=
       PageObjects::AssessorInterface::AssessmentSection.new

--- a/spec/system/assessor_interface/reviewing_verifications_spec.rb
+++ b/spec/system/assessor_interface/reviewing_verifications_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assessor reviewing verifications", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_an_assessor_user
+    given_there_is_an_application_form_with_failed_verifications
+  end
+
+  it "sends for review" do
+    # TODO: review functionality is not built yet, this page can never be reached
+    when_i_visit_the(
+      :assessor_assessment_recommendation_review_page,
+      application_form_id:,
+      assessment_id:,
+    )
+    then_i_see_the(
+      :assessor_application_page,
+      application_id: application_form_id,
+    )
+  end
+
+  private
+
+  def given_there_is_an_application_form_with_failed_verifications
+    application_form
+  end
+
+  def application_form
+    @application_form ||=
+      create(:application_form, :submitted).tap do |application_form|
+        assessment = create(:assessment, :verify, application_form:)
+        create(
+          :professional_standing_request,
+          :received,
+          assessment:,
+          verify_passed: false,
+        )
+      end
+  end
+
+  def application_form_id
+    application_form.id
+  end
+
+  def assessment_id
+    application_form.assessment.id
+  end
+end


### PR DESCRIPTION
This implements the "send application for review" journey where an admin can take an application and ask for an assessor to review the verification. There are still more parts of this journey which are yet to be built, but this is the first stage.

[Trello Card](https://trello.com/c/8sKZ1aEm/2309-lops-response-review)

## Screenshots

![Screenshot 2023-10-06 at 10 49 09](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/be8109d8-c176-46f6-b9e4-cad4b278d28a)
![Screenshot 2023-10-06 at 11 02 23](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/b2013f9f-ca2d-4dcb-961c-d81356d2f522)
![Screenshot 2023-10-06 at 11 05 30](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/e5e70e3a-535e-41cc-b695-0ad48664e94d)
