### PR TITLE
Allow admins to make recommendations

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
@@ -2,16 +2,19 @@
 
 module AssessorInterface
   class AssessmentRecommendationAwardController < BaseController
-    before_action :authorize_assessor, only: %i[edit update]
     before_action :ensure_can_award
     before_action :load_assessment_and_application_form
     before_action :load_important_notes, only: %i[edit update]
 
     def edit
+      authorize %i[assessor_interface assessment_recommendation]
+
       @form = AssessmentDeclarationAwardForm.new
     end
 
     def update
+      authorize %i[assessor_interface assessment_recommendation]
+
       @form =
         AssessmentDeclarationAwardForm.new(
           declaration:
@@ -35,11 +38,11 @@ module AssessorInterface
     end
 
     def age_range_subjects
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
     end
 
     def edit_age_range_subjects
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
 
       @form =
         ConfirmAgeRangeSubjectsForm.new(
@@ -53,7 +56,7 @@ module AssessorInterface
     end
 
     def update_age_range_subjects
-      authorize :assessor, :update?
+      authorize %i[assessor_interface assessment_recommendation], :update?
 
       @form =
         ConfirmAgeRangeSubjectsForm.new(
@@ -76,16 +79,16 @@ module AssessorInterface
     end
 
     def preview
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
     end
 
     def edit_confirm
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
       @form = AssessmentConfirmationForm.new
     end
 
     def update_confirm
-      authorize :assessor, :update?
+      authorize %i[assessor_interface assessment_recommendation], :update?
 
       @form =
         AssessmentConfirmationForm.new(

--- a/app/controllers/assessor_interface/assessment_recommendation_decline_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_decline_controller.rb
@@ -2,16 +2,18 @@
 
 module AssessorInterface
   class AssessmentRecommendationDeclineController < BaseController
-    before_action :authorize_assessor,
-                  except: %i[preview edit_confirm update_confirm]
     before_action :ensure_can_decline
     before_action :load_assessment_and_application_form
 
     def edit
+      authorize %i[assessor_interface assessment_recommendation]
+
       @form = AssessmentDeclarationDeclineForm.new
     end
 
     def update
+      authorize %i[assessor_interface assessment_recommendation]
+
       @form =
         AssessmentDeclarationDeclineForm.new(
           declaration:
@@ -42,16 +44,16 @@ module AssessorInterface
     end
 
     def preview
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
     end
 
     def edit_confirm
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
       @form = AssessmentConfirmationForm.new
     end
 
     def update_confirm
-      authorize :assessor, :update?
+      authorize %i[assessor_interface assessment_recommendation], :update?
 
       @form =
         AssessmentConfirmationForm.new(

--- a/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
@@ -2,11 +2,12 @@
 
 module AssessorInterface
   class AssessmentRecommendationVerifyController < BaseController
-    before_action :authorize_assessor, only: %i[edit update]
     before_action :ensure_can_verify
     before_action :load_assessment_and_application_form
 
     def edit
+      authorize %i[assessor_interface assessment_recommendation]
+
       redirect_to [
                     :verify_qualifications,
                     :assessor_interface,
@@ -17,6 +18,8 @@ module AssessorInterface
     end
 
     def update
+      authorize %i[assessor_interface assessment_recommendation]
+
       VerifyAssessment.call(
         assessment:,
         user: current_staff,
@@ -33,12 +36,13 @@ module AssessorInterface
     end
 
     def edit_verify_qualifications
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
+
       @form = VerifyQualificationsForm.new
     end
 
     def update_verify_qualifications
-      authorize :assessor, :update?
+      authorize %i[assessor_interface assessment_recommendation], :update?
 
       @form =
         VerifyQualificationsForm.new(
@@ -71,7 +75,7 @@ module AssessorInterface
     end
 
     def edit_qualification_requests
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
 
       @form =
         SelectQualificationsForm.new(
@@ -82,7 +86,7 @@ module AssessorInterface
     end
 
     def update_qualification_requests
-      authorize :assessor, :update?
+      authorize %i[assessor_interface assessment_recommendation], :update?
 
       qualification_ids =
         params.dig(
@@ -111,14 +115,14 @@ module AssessorInterface
     end
 
     def email_consent_letters
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
 
       @qualifications =
         application_form.qualifications.where(id: session[:qualification_ids])
     end
 
     def edit_verify_professional_standing
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
 
       if application_form.teaching_authority_provides_written_statement
         redirect_to [
@@ -135,7 +139,7 @@ module AssessorInterface
     end
 
     def update_verify_professional_standing
-      authorize :assessor, :update?
+      authorize %i[assessor_interface assessment_recommendation], :update?
 
       @form =
         VerifyProfessionalStandingForm.new(
@@ -168,11 +172,11 @@ module AssessorInterface
     end
 
     def contact_professional_standing
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
     end
 
     def edit_reference_requests
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
 
       @form =
         SelectWorkHistoriesForm.new(
@@ -183,7 +187,7 @@ module AssessorInterface
     end
 
     def update_reference_requests
-      authorize :assessor, :update?
+      authorize %i[assessor_interface assessment_recommendation], :update?
 
       work_history_ids =
         params.dig(
@@ -212,12 +216,12 @@ module AssessorInterface
     end
 
     def preview_referee
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
       @reference_requests = assessment.reference_requests
     end
 
     def preview_teacher
-      authorize :assessor, :edit?
+      authorize %i[assessor_interface assessment_recommendation], :edit?
     end
 
     private

--- a/app/controllers/assessor_interface/assessments_controller.rb
+++ b/app/controllers/assessor_interface/assessments_controller.rb
@@ -2,14 +2,17 @@
 
 module AssessorInterface
   class AssessmentsController < BaseController
-    before_action { authorize [:assessor_interface, assessment] }
     before_action :load_assessment_and_application_form
 
     def edit
+      authorize %i[assessor_interface assessment_recommendation]
+
       @form = AssessmentRecommendationForm.new(assessment:)
     end
 
     def update
+      authorize %i[assessor_interface assessment_recommendation]
+
       @form =
         AssessmentRecommendationForm.new(
           assessment:,
@@ -28,9 +31,11 @@ module AssessorInterface
     end
 
     def rollback
+      authorize [:assessor_interface, assessment]
     end
 
     def destroy
+      authorize [:assessor_interface, assessment]
       RollbackAssessment.call(assessment:, user: current_staff)
       redirect_to [:assessor_interface, application_form]
     rescue RollbackAssessment::InvalidState => e

--- a/app/policies/assessor_interface/assessment_recommendation_policy.rb
+++ b/app/policies/assessor_interface/assessment_recommendation_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AssessorInterface::AssessmentRecommendationPolicy < ApplicationPolicy
+  def update?
+    user.award_decline_permission || user.verify_permission
+  end
+end

--- a/spec/policies/assessor_interface/assessment_recommendation_policy_spec.rb
+++ b/spec/policies/assessor_interface/assessment_recommendation_policy_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::AssessmentRecommendationPolicy do
+  it_behaves_like "a policy"
+
+  let(:user) { nil }
+  let(:record) { nil }
+
+  subject(:policy) { described_class.new(user, record) }
+
+  describe "#index?" do
+    subject(:index?) { policy.index? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+
+  describe "#show?" do
+    subject(:show?) { policy.show? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+
+  describe "#create?" do
+    subject(:create?) { policy.create? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+
+  describe "#new?" do
+    subject(:new?) { policy.new? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+
+  describe "#update?" do
+    subject(:update?) { policy.update? }
+    it_behaves_like "a policy method requiring the award decline permission"
+    it_behaves_like "a policy method requiring the verify permission"
+  end
+
+  describe "#edit?" do
+    subject(:edit?) { policy.edit? }
+    it_behaves_like "a policy method requiring the award decline permission"
+    it_behaves_like "a policy method requiring the verify permission"
+  end
+
+  describe "#destroy?" do
+    subject(:destroy?) { policy.destroy? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+end


### PR DESCRIPTION
This creates a policy which allows users with the verify permission (as well as the existing award/decline permission) to make recommendations on the application. This is required for the new verification journey that allows admins to go on and award applications following assessment and verification.