### PR TITLE
Add review verifications task

### DIFF
--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -61,6 +61,38 @@ module AssessorInterface
       end
     end
 
+    def edit_review
+      authorize [:assessor_interface, professional_standing_request]
+
+      @form =
+        RequestableReviewForm.new(
+          requestable:,
+          user: current_staff,
+          passed: requestable.review_passed,
+          note: requestable.review_note,
+        )
+    end
+
+    def update_review
+      authorize [:assessor_interface, professional_standing_request]
+
+      @form =
+        RequestableReviewForm.new(
+          review_form_params.merge(requestable:, user: current_staff),
+        )
+
+      if @form.save
+        redirect_to [
+                      :assessor_interface,
+                      application_form,
+                      assessment,
+                      :review_verifications,
+                    ]
+      else
+        render :edit_review, status: :unprocessable_entity
+      end
+    end
+
     private
 
     def set_variables

--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -32,8 +32,9 @@ module AssessorInterface
       end
     end
 
-    def edit_review
-      authorize [:assessor_interface, professional_standing_request]
+    def edit_verify
+      authorize [:assessor_interface, professional_standing_request],
+                :edit_review?
 
       @form =
         RequestableReviewForm.new(
@@ -44,8 +45,9 @@ module AssessorInterface
         )
     end
 
-    def update_review
-      authorize [:assessor_interface, professional_standing_request]
+    def update_verify
+      authorize [:assessor_interface, professional_standing_request],
+                :update_review?
 
       @form =
         RequestableReviewForm.new(
@@ -55,7 +57,7 @@ module AssessorInterface
       if @form.save
         redirect_to [:assessor_interface, application_form]
       else
-        render :edit_review, status: :unprocessable_entity
+        render :edit_verify, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/assessor_interface/review_verifications_controller.rb
+++ b/app/controllers/assessor_interface/review_verifications_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module AssessorInterface
+  class ReviewVerificationsController < BaseController
+    before_action :authorize_assessor
+
+    def index
+      @application_form = assessment.application_form
+      @assessment = assessment
+
+      @professional_standing_request =
+        assessment.professional_standing_request if assessment.professional_standing_request.verify_failed?
+    end
+
+    private
+
+    def assessment
+      @assessment ||=
+        Assessment
+          .includes(:application_form)
+          .where(application_form_id: params[:application_form_id])
+          .find(params[:assessment_id])
+    end
+  end
+end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -93,10 +93,14 @@ class Assessment < ApplicationRecord
 
       if skip_verification?
         all_sections_or_further_information_requests_passed?
-      else
-        verify? && enough_reference_requests_review_passed? &&
+      elsif verify?
+        enough_reference_requests_review_passed? &&
           all_qualification_requests_review_passed? &&
           professional_standing_request_review_passed?
+      elsif review?
+        professional_standing_request_review_passed?
+      else
+        false
       end
     else
       all_sections_or_further_information_requests_passed?
@@ -111,6 +115,8 @@ class Assessment < ApplicationRecord
       any_further_information_request_failed?
     elsif verify?
       true # TODO: check the state of verification requests
+    elsif review?
+      professional_standing_request_review_failed?
     else
       false
     end
@@ -232,13 +238,22 @@ class Assessment < ApplicationRecord
     end
   end
 
-  def professional_standing_request_review_passed?
-    if !application_form.teaching_authority_provides_written_statement &&
-         professional_standing_request.present?
-      professional_standing_request.review_passed?
-    else
-      true
+  def professional_standing_request_review_failed?
+    if application_form.teaching_authority_provides_written_statement
+      return true
     end
+    return true if professional_standing_request.nil?
+
+    professional_standing_request.review_failed?
+  end
+
+  def professional_standing_request_review_passed?
+    if application_form.teaching_authority_provides_written_statement
+      return true
+    end
+    return true if professional_standing_request.nil?
+
+    professional_standing_request.review_passed?
   end
 
   def skip_verification?

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -78,6 +78,16 @@ module Requestable
     end
   end
 
+  def review_status
+    if review_passed?
+      "accepted"
+    elsif review_failed?
+      "rejected"
+    else
+      "not_started"
+    end
+  end
+
   def after_requested(user:)
     # implement logic after this requestable has been requested
   end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -361,7 +361,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
         if professional_standing_request.received? ||
              professional_standing_request.ready_for_review
           [
-            :review,
+            :verify,
             :assessor_interface,
             application_form,
             assessment,

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -429,7 +429,12 @@ class AssessorInterface::ApplicationFormsShowViewObject
         I18n.t(
           "assessor_interface.application_forms.show.assessment_tasks.items.review_verifications",
         ),
-      link: [:edit, :assessor_interface, application_form, assessment],
+      link: [
+        :assessor_interface,
+        application_form,
+        assessment,
+        :review_verifications,
+      ],
       status:
         if assessment.recommendable?
           :completed

--- a/app/views/assessor_interface/professional_standing_requests/edit_review.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_review.html.erb
@@ -1,0 +1,26 @@
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}Review LoPS" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+
+<%= form_with model: @form, url: [:review, :assessor_interface, @application_form, @assessment, :professional_standing_request] do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl">Review LoPS</h1>
+
+  <h2 class="govuk-heading-m"><%= region_certificate_name(@application_form.region) %></h2>
+
+  <%= govuk_inset_text do %>
+    <h3 class="govuk-heading-s">Internal note</h3>
+    <%= simple_format @professional_standing_request.verify_note %>
+  <% end %>
+
+  <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "After review, does the response confirm that this LoPS is legitimate?" } do %>
+    <%= f.govuk_radio_button :passed, :true, link_errors: true %>
+    <%= f.govuk_radio_button :passed, :false do %>
+      <%= f.govuk_text_area :note, label: { text: "Internal note: briefly explain why the document should not be accepted." } %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit do %>
+    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
+  <% end %>
+<% end %>

--- a/app/views/assessor_interface/professional_standing_requests/edit_verify.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_verify.html.erb
@@ -3,7 +3,7 @@
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{title}" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
-<%= form_with model: @form, url: [:review, :assessor_interface, @application_form, @assessment, :professional_standing_request] do |f| %>
+<%= form_with model: @form, url: [:verify, :assessor_interface, @application_form, @assessment, :professional_standing_request] do |f| %>
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl"><%= title %></h1>
@@ -22,7 +22,7 @@
     <% end %>
 
     <%= f.govuk_submit "Save and continue" do %>
-      <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
+      <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/assessor_interface/review_verifications/index.html.erb
+++ b/app/views/assessor_interface/review_verifications/index.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, "Review verifications" %>
+<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+
+<h1 class="govuk-heading-xl">Review verifications</h1>
+
+<%= govuk_table do |table|
+  if @professional_standing_request.present?
+    table.with_caption(text: "LoPS")
+    table.with_body do |body|
+      body.with_row do |row|
+        row.with_cell { govuk_link_to region_certificate_name(@application_form.region), [:verify, :assessor_interface, @application_form, @assessment, :professional_standing_request] }
+        row.with_cell { render(StatusTag::Component.new(@professional_standing_request.review_status)) }
+      end
+    end
+  end
+end %>
+
+<%= govuk_button_link_to "Back to overview", [:assessor_interface, @application_form] %>

--- a/app/views/assessor_interface/review_verifications/index.html.erb
+++ b/app/views/assessor_interface/review_verifications/index.html.erb
@@ -8,7 +8,7 @@
     table.with_caption(text: "LoPS")
     table.with_body do |body|
       body.with_row do |row|
-        row.with_cell { govuk_link_to region_certificate_name(@application_form.region), [:verify, :assessor_interface, @application_form, @assessment, :professional_standing_request] }
+        row.with_cell { govuk_link_to region_certificate_name(@application_form.region), [:review, :assessor_interface, @application_form, @assessment, :professional_standing_request] }
         row.with_cell { render(StatusTag::Component.new(@professional_standing_request.review_status)) }
       end
     end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.cache_store = :memory_store
 
   # Render exception templates instead of raising exceptions.
-  config.action_dispatch.show_exceptions = true
+  config.action_dispatch.show_exceptions = :all
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -240,7 +240,7 @@ en:
     professional_standing_requests:
       edit_location:
         title: Third-party professional standing – response received
-      edit_review:
+      edit_verify:
         passed: Does the response confirm that this document is legitimate?
         failure_assessor_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> Briefly explain why the document should not be accepted.'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,8 @@ Rails.application.routes.draw do
             get "location", to: "professional_standing_requests#edit_location"
             post "location",
                  to: "professional_standing_requests#update_location"
+            get "review", to: "professional_standing_requests#edit_review"
+            post "review", to: "professional_standing_requests#update_review"
             get "verify", to: "professional_standing_requests#edit_verify"
             post "verify", to: "professional_standing_requests#update_verify"
           end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,13 +128,6 @@ Rails.application.routes.draw do
                   path: "/qualification-requests",
                   only: %i[index edit update]
 
-        get "/preliminary-check",
-            to: "preliminary_checks#edit",
-            as: :preliminary_check
-        put "/preliminary-check",
-            to: "preliminary_checks#update",
-            as: :update_preliminary_check
-
         resources :reference_requests,
                   path: "/reference-requests",
                   only: %i[index edit update] do
@@ -142,6 +135,10 @@ Rails.application.routes.draw do
                to: "reference_requests#update_verify_references",
                on: :collection
         end
+
+        resources :review_verifications,
+                  path: "/review-verifications",
+                  only: %i[index]
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,8 +119,8 @@ Rails.application.routes.draw do
             get "location", to: "professional_standing_requests#edit_location"
             post "location",
                  to: "professional_standing_requests#update_location"
-            get "review", to: "professional_standing_requests#edit_review"
-            post "review", to: "professional_standing_requests#update_review"
+            get "verify", to: "professional_standing_requests#edit_verify"
+            post "verify", to: "professional_standing_requests#update_verify"
           end
         end
 

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -74,10 +74,6 @@ module PageObjects
         task_list.find_item("Review qualifications responses")
       end
 
-      def assessment_recommendation_task
-        task_list.find_item("Assessment recommendation")
-      end
-
       def verify_references_task
         task_list.find_item("Verify reference requests")
       end
@@ -88,6 +84,18 @@ module PageObjects
 
       def review_professional_standing_request_task
         task_list.find_item("Review LOPS response")
+      end
+
+      def assessment_decision_task
+        task_list.find_item("Assessment decision")
+      end
+
+      def review_verifications_task
+        task_list.find_item("Review verifications")
+      end
+
+      def verification_decision_task
+        task_list.find_item("Verification decision")
       end
     end
   end

--- a/spec/support/autoload/page_objects/assessor_interface/review_professional_standing_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/review_professional_standing_request.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class ReviewProfessionalStandingRequest < SitePrism::Page
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
+                "/professional-standing-request/review"
+
+      section :form, "form" do
+        section :yes_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(1)"
+        section :no_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(2)"
+        element :failure_reason_textarea, ".govuk-textarea"
+        element :submit_button, ".govuk-button"
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/review_verifications.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/review_verifications.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class ReviewVerifications < SitePrism::Page
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
+                "/review-verifications"
+
+      sections :rows, ".govuk-table__row" do
+        element :link, ".govuk-link"
+        element :tag, ".govuk-tag"
+      end
+
+      element :back_to_overview_button, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/verify_professional_standing_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/verify_professional_standing_request.rb
@@ -2,9 +2,9 @@
 
 module PageObjects
   module AssessorInterface
-    class EditProfessionalStandingRequestReview < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
-                "/professional-standing-request/review"
+    class VerifyProfessionalStandingRequest < SitePrism::Page
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
+                "/professional-standing-request/verify"
 
       section :form, "form" do
         section :yes_radio_item,

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -42,11 +42,6 @@ module PageHelpers
       PageObjects::AssessorInterface::EditProfessionalStandingRequestLocation.new
   end
 
-  def assessor_edit_professional_standing_request_review_page
-    @assessor_edit_professional_standing_request_review_page ||=
-      PageObjects::AssessorInterface::EditProfessionalStandingRequestReview.new
-  end
-
   def assessor_edit_qualification_request_page
     @assessor_edit_qualification_request_page ||=
       PageObjects::AssessorInterface::EditQualificationRequest.new
@@ -75,6 +70,11 @@ module PageHelpers
   def assessor_reverse_decision_page
     @assessor_reverse_decision_page ||=
       PageObjects::AssessorInterface::ReverseDecision.new
+  end
+
+  def assessor_verify_professional_standing_request_page
+    @assessor_verify_professional_standing_request_page ||=
+      PageObjects::AssessorInterface::VerifyProfessionalStandingRequest.new
   end
 
   def assessor_withdraw_application_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -72,6 +72,16 @@ module PageHelpers
       PageObjects::AssessorInterface::ReverseDecision.new
   end
 
+  def assessor_review_professional_standing_request_page
+    @assessor_review_professional_standing_request_page ||=
+      PageObjects::AssessorInterface::ReviewProfessionalStandingRequest.new
+  end
+
+  def assessor_review_verifications_page
+    @assessor_review_verifications_page ||=
+      PageObjects::AssessorInterface::ReviewVerifications.new
+  end
+
   def assessor_verify_professional_standing_request_page
     @assessor_verify_professional_standing_request_page ||=
       PageObjects::AssessorInterface::VerifyProfessionalStandingRequest.new

--- a/spec/system/assessor_interface/reviewing_verifications_spec.rb
+++ b/spec/system/assessor_interface/reviewing_verifications_spec.rb
@@ -10,15 +10,55 @@ RSpec.describe "Assessor reviewing verifications", type: :system do
   end
 
   it "sends for review" do
-    # TODO: review functionality is not built yet, this page can never be reached
     when_i_visit_the(
-      :assessor_assessment_recommendation_review_page,
-      application_form_id:,
-      assessment_id:,
+      :assessor_application_page,
+      application_id: application_form_id,
     )
     then_i_see_the(
       :assessor_application_page,
       application_id: application_form_id,
+    )
+
+    when_i_click_on_verification_decision
+    then_i_see_the(
+      :assessor_application_page,
+      application_id: application_form_id,
+    )
+
+    when_i_click_on_review_verifications
+    then_i_see_the(
+      :assessor_review_verifications_page,
+      application_form_id:,
+      assessment_id:,
+    )
+    and_i_see_the_lops_not_started
+
+    when_i_click_on_lops
+    then_i_see_the(
+      :assessor_review_professional_standing_request_page,
+      application_form_id:,
+      assessment_id:,
+    )
+
+    when_i_fill_in_the_review_lops_form
+    then_i_see_the(
+      :assessor_review_verifications_page,
+      application_form_id:,
+      assessment_id:,
+    )
+    and_i_see_the_lops_accepted
+
+    when_i_click_on_back_to_overview
+    then_i_see_the(
+      :assessor_application_page,
+      application_id: application_form_id,
+    )
+
+    when_i_click_on_assessment_decision
+    then_i_see_the(
+      :complete_assessment_page,
+      application_id: application_form_id,
+      assessment_id:,
     )
   end
 
@@ -28,10 +68,64 @@ RSpec.describe "Assessor reviewing verifications", type: :system do
     application_form
   end
 
+  def when_i_click_on_verification_decision
+    assessor_application_page.verification_decision_task.click
+
+    # TODO: review functionality is not built yet, this page can never be reached
+    application_form.assessment.review!
+
+    # TODO: reload the page
+    when_i_visit_the(
+      :assessor_application_page,
+      application_id: application_form_id,
+    )
+  end
+
+  def when_i_click_on_review_verifications
+    assessor_application_page.review_verifications_task.click
+  end
+
+  def when_i_click_on_assessment_decision
+    assessor_application_page.assessment_decision_task.click
+  end
+
+  def when_i_click_on_lops
+    assessor_review_verifications_page.rows.first.link.click
+  end
+
+  def when_i_fill_in_the_review_lops_form
+    form = assessor_review_professional_standing_request_page.form
+
+    form.yes_radio_item.choose
+    form.submit_button.click
+  end
+
+  def when_i_click_on_back_to_overview
+    assessor_review_verifications_page.back_to_overview_button.click
+  end
+
+  def and_i_see_the_lops_not_started
+    expect(assessor_review_verifications_page.rows.first.tag.text).to eq(
+      "NOT STARTED",
+    )
+  end
+
+  def and_i_see_the_lops_accepted
+    expect(assessor_review_verifications_page.rows.first.tag.text).to eq(
+      "ACCEPTED",
+    )
+  end
+
   def application_form
     @application_form ||=
       create(:application_form, :submitted).tap do |application_form|
-        assessment = create(:assessment, :verify, application_form:)
+        assessment =
+          create(
+            :assessment,
+            :verify,
+            application_form:,
+            induction_required: false,
+          )
         create(
           :professional_standing_request,
           :received,

--- a/spec/system/assessor_interface/verifying_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/verifying_professional_standing_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
 
     when_i_click_review_professional_standing_task
     then_i_see_the(
-      :assessor_edit_professional_standing_request_review_page,
-      application_id:,
+      :assessor_verify_professional_standing_request_page,
+      application_form_id:,
     )
 
     when_i_fill_in_the_review_form
@@ -67,7 +67,7 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
   end
 
   def when_i_fill_in_the_review_form
-    form = assessor_edit_professional_standing_request_review_page.form
+    form = assessor_verify_professional_standing_request_page.form
 
     form.yes_radio_item.choose
     form.submit_button.click
@@ -101,4 +101,6 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
   def application_id
     application_form.id
   end
+
+  alias_method :application_form_id, :application_id
 end


### PR DESCRIPTION
This adds the journey for reviewing verifications which works in combination with #1743 and #1744. I haven't added any tests yet, but they will be added later in a subsequent PR.

[Trello Card](https://trello.com/c/5dQ20LoI/2310-review-for-lops-award)

## Screenshots

![Screenshot 2023-10-06 at 14 47 52](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/78ef06f9-05a2-433d-af24-d9936f92ac71)
![Screenshot 2023-10-06 at 14 44 46](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/3abf516c-1e82-43b6-b2ec-658fdcb477db)
![Screenshot 2023-10-06 at 14 44 37](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/e1bbe071-b780-4a83-a78d-5503a99f138a)
![Screenshot 2023-10-06 at 14 33 49](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/47a4f566-e8f5-4994-96db-c71635d083f4)
