### PR TITLE
Rename professional standing request location

### DIFF
--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -4,8 +4,8 @@ module AssessorInterface
   class ProfessionalStandingRequestsController < BaseController
     before_action :set_variables
 
-    def edit_location
-      authorize [:assessor_interface, professional_standing_request], :show?
+    def edit_locate
+      authorize [:assessor_interface, professional_standing_request]
 
       @form =
         ProfessionalStandingRequestLocationForm.new(
@@ -17,8 +17,8 @@ module AssessorInterface
         )
     end
 
-    def update_location
-      authorize [:assessor_interface, professional_standing_request], :show?
+    def update_locate
+      authorize [:assessor_interface, professional_standing_request]
 
       @form =
         ProfessionalStandingRequestLocationForm.new(

--- a/app/policies/assessor_interface/professional_standing_request_policy.rb
+++ b/app/policies/assessor_interface/professional_standing_request_policy.rb
@@ -5,6 +5,12 @@ class AssessorInterface::ProfessionalStandingRequestPolicy < ApplicationPolicy
     true
   end
 
+  def update_locate?
+    true
+  end
+
+  alias_method :edit_locate?, :update_locate?
+
   def update_request?
     user.verify_permission
   end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -112,7 +112,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
           "assessor_interface.application_forms.show.assessment_tasks.items.await_professional_standing_request",
         ),
       link: [
-        :location,
+        :locate,
         :assessor_interface,
         application_form,
         assessment,
@@ -328,7 +328,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
           "assessor_interface.application_forms.show.assessment_tasks.items.locate_professional_standing_request",
         ),
       link: [
-        :location,
+        :locate,
         :assessor_interface,
         application_form,
         assessment,

--- a/app/views/assessor_interface/professional_standing_requests/edit_locate.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_locate.html.erb
@@ -3,7 +3,7 @@
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{title}" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
-<%= form_with model: @form, url: [:location, :assessor_interface, @application_form, @assessment, :professional_standing_request] do |f| %>
+<%= form_with model: @form, url: [:locate, :assessor_interface, @application_form, @assessment, :professional_standing_request] do |f| %>
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl"><%= title %></h1>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -238,8 +238,6 @@ en:
         failure_assessor_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> Explain why this section is not completed to your satisfaction'
 
     professional_standing_requests:
-      edit_location:
-        title: Third-party professional standing – response received
       edit_verify:
         passed: Does the response confirm that this document is legitimate?
         failure_assessor_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> Briefly explain why the document should not be accepted.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,9 +116,8 @@ Rails.application.routes.draw do
                  path: "/professional-standing-request",
                  only: [] do
           member do
-            get "location", to: "professional_standing_requests#edit_location"
-            post "location",
-                 to: "professional_standing_requests#update_location"
+            get "locate", to: "professional_standing_requests#edit_locate"
+            post "locate", to: "professional_standing_requests#update_locate"
             get "review", to: "professional_standing_requests#edit_review"
             post "review", to: "professional_standing_requests#update_review"
             get "verify", to: "professional_standing_requests#edit_verify"

--- a/spec/policies/assessor_interface/professional_standing_request_policy_spec.rb
+++ b/spec/policies/assessor_interface/professional_standing_request_policy_spec.rb
@@ -52,6 +52,20 @@ RSpec.describe AssessorInterface::ProfessionalStandingRequestPolicy do
     it { is_expected.to be false }
   end
 
+  describe "#update_locate?" do
+    subject(:update_locate?) { policy.update_locate? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be true }
+  end
+
+  describe "#edit_locate?" do
+    subject(:edit?) { policy.edit_locate? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be true }
+  end
+
   describe "#update_request?" do
     subject(:update_request?) { policy.update_request? }
     it_behaves_like "a policy method requiring the verify permission"

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PageObjects
   module AssessorInterface
     class Application < SitePrism::Page

--- a/spec/support/autoload/page_objects/assessor_interface/locate_professional_standing_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/locate_professional_standing_request.rb
@@ -2,9 +2,9 @@
 
 module PageObjects
   module AssessorInterface
-    class EditProfessionalStandingRequestLocation < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
-                "/professional-standing-request/location"
+    class LocateProfessionalStandingRequest < SitePrism::Page
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
+                "/professional-standing-request/locate"
 
       section :form, "form" do
         element :received_checkbox, ".govuk-checkboxes__input", visible: false

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -37,11 +37,6 @@ module PageHelpers
       PageObjects::AssessorInterface::EditApplication.new
   end
 
-  def assessor_edit_professional_standing_request_location_page
-    @assessor_edit_professional_standing_request_location_page ||=
-      PageObjects::AssessorInterface::EditProfessionalStandingRequestLocation.new
-  end
-
   def assessor_edit_qualification_request_page
     @assessor_edit_qualification_request_page ||=
       PageObjects::AssessorInterface::EditQualificationRequest.new
@@ -55,6 +50,11 @@ module PageHelpers
   def assessor_edit_work_history_page
     @assessor_edit_work_history_page ||=
       PageObjects::AssessorInterface::EditWorkHistory.new
+  end
+
+  def assessor_locate_professional_standing_request_page
+    @assessor_locate_professional_standing_request_page ||=
+      PageObjects::AssessorInterface::LocateProfessionalStandingRequest.new
   end
 
   def assessor_qualification_requests_page

--- a/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe "Assessor awaiting professional standing", type: :system do
     and_i_see_a_waiting_on_status
     and_i_click_awaiting_professional_standing
     then_i_see_the(
-      :assessor_edit_professional_standing_request_location_page,
-      application_id:,
+      :assessor_locate_professional_standing_request_page,
+      application_form_id:,
     )
 
     when_i_fill_in_the_form
@@ -41,7 +41,7 @@ RSpec.describe "Assessor awaiting professional standing", type: :system do
   end
 
   def when_i_fill_in_the_form
-    form = assessor_edit_professional_standing_request_location_page.form
+    form = assessor_locate_professional_standing_request_page.form
 
     form.received_checkbox.click
     form.note_textarea.fill_in with: "Note."
@@ -77,7 +77,9 @@ RSpec.describe "Assessor awaiting professional standing", type: :system do
       )
   end
 
-  def application_id
+  def application_form_id
     application_form.id
   end
+
+  alias_method :application_id, :application_form_id
 end

--- a/spec/system/assessor_interface/verifying_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/verifying_professional_standing_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
     and_i_see_a_waiting_on_status
     and_i_click_record_professional_standing_task
     then_i_see_the(
-      :assessor_edit_professional_standing_request_location_page,
-      application_id:,
+      :assessor_locate_professional_standing_request_page,
+      application_form_id:,
     )
 
     when_i_fill_in_the_location_form
@@ -45,10 +45,7 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
   end
 
   def and_i_click_record_professional_standing_task
-    assessor_application_page
-      .record_professional_standing_request_task
-      .link
-      .click
+    assessor_application_page.record_professional_standing_request_task.click
   end
 
   def when_i_click_review_professional_standing_task
@@ -59,7 +56,7 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
   end
 
   def when_i_fill_in_the_location_form
-    form = assessor_edit_professional_standing_request_location_page.form
+    form = assessor_locate_professional_standing_request_page.form
 
     form.received_yes_radio_item.choose
     form.note_textarea.fill_in with: "Note."


### PR DESCRIPTION
I've renamed it to locate to match the action style we've gone with for review, verify and request.