### PR TITLE
Rename award/decline permission

### DIFF
--- a/app/controllers/staff/invitations_controller.rb
+++ b/app/controllers/staff/invitations_controller.rb
@@ -13,7 +13,7 @@ class Staff::InvitationsController < Devise::InvitationsController
       :invite,
       keys: %i[
         name
-        award_decline_permission
+        assess_permission
         change_name_permission
         change_work_history_permission
         reverse_decision_permission

--- a/app/controllers/support_interface/staff_controller.rb
+++ b/app/controllers/support_interface/staff_controller.rb
@@ -28,7 +28,7 @@ class SupportInterface::StaffController < SupportInterface::BaseController
 
   def staff_params
     params.require(:staff).permit(
-      :award_decline_permission,
+      :assess_permission,
       :change_name_permission,
       :change_work_history_permission,
       :reverse_decision_permission,

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -69,7 +69,7 @@ class Staff < ApplicationRecord
 
   validates :name, presence: true
 
-  scope :assessors, -> { where(award_decline_permission: true) }
+  scope :assessors, -> { where(assess_permission: true) }
 
   def send_devise_notification(notification, *args)
     devise_mailer.send(notification, self, *args).deliver_later

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -3,7 +3,7 @@
 # Table name: staff
 #
 #  id                             :bigint           not null, primary key
-#  award_decline_permission       :boolean          default(FALSE)
+#  assess_permission              :boolean          default(FALSE)
 #  azure_ad_uid                   :string
 #  change_name_permission         :boolean          default(FALSE), not null
 #  change_work_history_permission :boolean          default(FALSE), not null

--- a/app/policies/assessor_interface/assessment_policy.rb
+++ b/app/policies/assessor_interface/assessment_policy.rb
@@ -2,7 +2,7 @@
 
 class AssessorInterface::AssessmentPolicy < ApplicationPolicy
   def update?
-    user.award_decline_permission
+    user.assess_permission
   end
 
   def destroy?

--- a/app/policies/assessor_interface/assessment_recommendation_policy.rb
+++ b/app/policies/assessor_interface/assessment_recommendation_policy.rb
@@ -2,6 +2,6 @@
 
 class AssessorInterface::AssessmentRecommendationPolicy < ApplicationPolicy
   def update?
-    user.award_decline_permission || user.verify_permission
+    user.assess_permission || user.verify_permission
   end
 end

--- a/app/policies/assessor_interface/professional_standing_request_policy.rb
+++ b/app/policies/assessor_interface/professional_standing_request_policy.rb
@@ -24,7 +24,7 @@ class AssessorInterface::ProfessionalStandingRequestPolicy < ApplicationPolicy
   alias_method :edit_verify?, :update_verify?
 
   def update_review?
-    user.award_decline_permission
+    user.assess_permission
   end
 
   alias_method :edit_review?, :update_review?

--- a/app/policies/assessor_policy.rb
+++ b/app/policies/assessor_policy.rb
@@ -10,14 +10,14 @@ class AssessorPolicy < ApplicationPolicy
   end
 
   def create?
-    user.award_decline_permission?
+    user.assess_permission
   end
 
   def update?
-    user.award_decline_permission?
+    user.assess_permission
   end
 
   def destroy?
-    user.award_decline_permission?
+    user.assess_permission
   end
 end

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -24,7 +24,7 @@
 
         head.with_row do |row|
           row.with_cell(header: true, text: "Email")
-          row.with_cell(header: true, text: "Award/decline")
+          row.with_cell(header: true, text: "Assess applicants")
           row.with_cell(header: true, text: "Change names")
           row.with_cell(header: true, text: "Change work history")
           row.with_cell(header: true, text: "Reverse decisions")
@@ -40,7 +40,7 @@
           body.with_row do |row|
             row.with_cell(text: staff.email)
 
-            row.with_cell { govuk_boolean_tag(staff.award_decline_permission) }
+            row.with_cell { govuk_boolean_tag(staff.assess_permission) }
             row.with_cell { govuk_boolean_tag(staff.change_name_permission) }
             row.with_cell { govuk_boolean_tag(staff.change_work_history_permission) }
             row.with_cell { govuk_boolean_tag(staff.reverse_decision_permission) }

--- a/app/views/support_interface/staff/_permissions_fields.html.erb
+++ b/app/views/support_interface/staff/_permissions_fields.html.erb
@@ -1,6 +1,6 @@
 <%= f.govuk_check_boxes_fieldset :permissions do %>
-  <%= f.govuk_check_box :award_decline_permission, 1, 0, multiple: false,
-                        label: { text: t("activerecord.attributes.staff.award_decline_permission") } %>
+  <%= f.govuk_check_box :assess_permission, 1, 0, multiple: false,
+                        label: { text: t("activerecord.attributes.staff.assess_permission") } %>
 
   <%= f.govuk_check_box :change_name_permission, 1, 0, multiple: false,
                         label: { text: t("activerecord.attributes.staff.change_name_permission") } %>

--- a/app/views/support_interface/staff/index.html.erb
+++ b/app/views/support_interface/staff/index.html.erb
@@ -21,11 +21,11 @@
     end
 
     summary_list.with_row do |row|
-      row.with_key { t("activerecord.attributes.staff.award_decline_permission") }
-      row.with_value { govuk_boolean_tag(staff.award_decline_permission) }
+      row.with_key { t("activerecord.attributes.staff.assess_permission") }
+      row.with_value { govuk_boolean_tag(staff.assess_permission) }
       row.with_action(
         href: edit_support_interface_staff_path(staff),
-        visually_hidden_text: t("activerecord.attributes.staff.award_decline_permission")
+        visually_hidden_text: t("activerecord.attributes.staff.assess_permission")
       )
     end
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -332,7 +332,7 @@
     - work_history_id
     - selected_failure_reason_id
   :staff:
-    - award_decline_permission
+    - assess_permission
     - azure_ad_uid
     - change_name_permission
     - change_work_history_permission

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,7 +46,7 @@ en:
   activerecord:
     attributes:
       staff:
-        award_decline_permission: Award/decline (assessor)
+        assess_permission: Assess applicants
         change_name_permission: Change applicant’s name
         change_work_history_permission: Change work history references
         reverse_decision_permission: Reverse decisions

--- a/db/migrate/20231010075849_rename_staff_award_decline_permission.rb
+++ b/db/migrate/20231010075849_rename_staff_award_decline_permission.rb
@@ -1,0 +1,5 @@
+class RenameStaffAwardDeclinePermission < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :staff, :award_decline_permission, :assess_permission
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_04_150531) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_10_075849) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -447,7 +447,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_04_150531) do
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
     t.text "name", default: "", null: false
-    t.boolean "award_decline_permission", default: false
+    t.boolean "assess_permission", default: false
     t.boolean "support_console_permission", default: false, null: false
     t.string "azure_ad_uid"
     t.boolean "change_work_history_permission", default: false, null: false

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -55,7 +55,7 @@ def staff_members
     {
       name: "Dave Assessor",
       email: "assessor-dave@example.com",
-      award_decline_permission: true,
+      assess_permission: true,
       change_name_permission: false,
       change_work_history_permission: false,
       reverse_decision_permission: false,
@@ -66,7 +66,7 @@ def staff_members
     {
       name: "Beryl Assessor",
       email: "assessor-beryl@example.com",
-      award_decline_permission: true,
+      assess_permission: true,
       change_name_permission: false,
       change_work_history_permission: false,
       reverse_decision_permission: false,
@@ -77,7 +77,7 @@ def staff_members
     {
       name: "Sally Manager",
       email: "manager-sally@example.com",
-      award_decline_permission: false,
+      assess_permission: false,
       change_name_permission: true,
       change_work_history_permission: true,
       reverse_decision_permission: true,
@@ -88,7 +88,7 @@ def staff_members
     {
       name: "Antonio Helpdesk",
       email: "helpdesk-antonio@example.com",
-      award_decline_permission: false,
+      assess_permission: false,
       change_name_permission: false,
       change_work_history_permission: false,
       reverse_decision_permission: false,
@@ -99,7 +99,7 @@ def staff_members
     {
       name: "Victarion Verifier",
       email: "victarion-verifier@example.com",
-      award_decline_permission: false,
+      assess_permission: false,
       change_name_permission: false,
       change_work_history_permission: false,
       reverse_decision_permission: false,

--- a/spec/controllers/assessor_interface/uploads_controller_spec.rb
+++ b/spec/controllers/assessor_interface/uploads_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe AssessorInterface::UploadsController, type: :controller do
   before { FeatureFlags::FeatureFlag.activate(:service_open) }
 
-  let(:staff) { create(:staff, :with_award_decline_permission, :confirmed) }
+  let(:staff) { create(:staff, :with_assess_permission, :confirmed) }
   let(:application_form) { create(:application_form) }
 
   before { sign_in staff, scope: :staff }

--- a/spec/factories/staff.rb
+++ b/spec/factories/staff.rb
@@ -60,8 +60,8 @@ FactoryBot.define do
       confirmed_at { Time.zone.now }
     end
 
-    trait :with_award_decline_permission do
-      award_decline_permission { true }
+    trait :with_assess_permission do
+      assess_permission { true }
     end
 
     trait :with_change_name_permission do

--- a/spec/factories/staff.rb
+++ b/spec/factories/staff.rb
@@ -3,7 +3,7 @@
 # Table name: staff
 #
 #  id                             :bigint           not null, primary key
-#  award_decline_permission       :boolean          default(FALSE)
+#  assess_permission              :boolean          default(FALSE)
 #  azure_ad_uid                   :string
 #  change_name_permission         :boolean          default(FALSE), not null
 #  change_work_history_permission :boolean          default(FALSE), not null

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -72,15 +72,13 @@ RSpec.describe Staff, type: :model do
     describe ".assessors" do
       subject { described_class.assessors }
 
-      context "when award_decline_permission == true" do
-        let(:with_award_decline_permission) do
-          create(:staff, :with_award_decline_permission)
-        end
+      context "when assess_permission == true" do
+        let(:with_assess_permission) { create(:staff, :with_assess_permission) }
 
-        it { is_expected.to include(with_award_decline_permission) }
+        it { is_expected.to include(with_assess_permission) }
       end
 
-      context "when with_award_decline_permission == false" do
+      context "when with_assess_permission == false" do
         let(:non_assessor) { create(:staff) }
 
         it { is_expected.not_to include(non_assessor) }

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -3,7 +3,7 @@
 # Table name: staff
 #
 #  id                             :bigint           not null, primary key
-#  award_decline_permission       :boolean          default(FALSE)
+#  assess_permission              :boolean          default(FALSE)
 #  azure_ad_uid                   :string
 #  change_name_permission         :boolean          default(FALSE), not null
 #  change_work_history_permission :boolean          default(FALSE), not null

--- a/spec/support/shared_examples/policy.rb
+++ b/spec/support/shared_examples/policy.rb
@@ -23,7 +23,7 @@ RSpec.shared_examples "a policy method requiring the award decline permission" d
   end
 
   context "with permission" do
-    let(:user) { create(:staff, :with_award_decline_permission) }
+    let(:user) { create(:staff, :with_assess_permission) }
     it { is_expected.to be true }
   end
 end

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -80,7 +80,7 @@ module SystemHelpers
     user =
       create(
         :staff,
-        :with_award_decline_permission,
+        :with_assess_permission,
         :confirmed,
         name: "Authorized User",
       )

--- a/spec/system/assessor_interface/change_application_form_name_spec.rb
+++ b/spec/system/assessor_interface/change_application_form_name_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe "Assessor change application form name", type: :system do
   alias_method :application_id, :application_form_id
 
   def assessor
-    create(:staff, :confirmed, :with_award_decline_permission)
+    create(:staff, :confirmed, :with_assess_permission)
   end
 
   def manager

--- a/spec/system/assessor_interface/change_work_history_spec.rb
+++ b/spec/system/assessor_interface/change_work_history_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe "Assessor change work history", type: :system do
   end
 
   def assessor
-    create(:staff, :confirmed, :with_award_decline_permission)
+    create(:staff, :confirmed, :with_assess_permission)
   end
 
   def manager

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -209,8 +209,8 @@ RSpec.describe "Assessor filtering application forms", type: :system do
 
   def assessors
     @assessors ||= [
-      create(:staff, :with_award_decline_permission, name: "Fal Staff"),
-      create(:staff, :with_award_decline_permission, name: "Wag Staff"),
+      create(:staff, :with_assess_permission, name: "Fal Staff"),
+      create(:staff, :with_assess_permission, name: "Wag Staff"),
     ]
   end
 end

--- a/spec/system/assessor_interface/reverse_decision_spec.rb
+++ b/spec/system/assessor_interface/reverse_decision_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe "Assessor reverse decision", type: :system do
   delegate :id, to: :assessment, prefix: true
 
   def assessor
-    create(:staff, :confirmed, :with_award_decline_permission)
+    create(:staff, :confirmed, :with_assess_permission)
   end
 
   def manager

--- a/spec/system/assessor_interface/withdraw_application_spec.rb
+++ b/spec/system/assessor_interface/withdraw_application_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Assessor withdraw application", type: :system do
   delegate :id, to: :assessment, prefix: true
 
   def assessor
-    create(:staff, :confirmed, :with_award_decline_permission)
+    create(:staff, :confirmed, :with_assess_permission)
   end
 
   def manager

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
     end
 
     context "with an assessor user" do
-      let!(:staff) { create(:staff, :with_award_decline_permission) }
+      let!(:staff) { create(:staff, :with_assess_permission) }
 
       it { is_expected.to include(staff) }
     end


### PR DESCRIPTION
This renames the permission as it does more than just allow awards and declines, and this works better with the new `verify_permission` field.

[Trello Card](https://trello.com/c/MToXbrNQ/2316-rename-award-decline-permission)