### PR TITLE
2320 refactor page objects to add a namespace prefix

### DIFF
--- a/app/views/eligibility_interface/work_experience/new.html.erb
+++ b/app/views/eligibility_interface/work_experience/new.html.erb
@@ -1,4 +1,3 @@
-
 <% content_for :page_title, "#{'Error: ' if @work_experience_form.errors.any?}#{t("helpers.legend.eligibility_interface_work_experience_form.work_experience")}" %>
 <% content_for :back_link_url, back_link_url(@eligibility_check.qualified_for_subject_required? ? eligibility_interface_qualified_for_subject_path : eligibility_interface_teach_children_path) %>
 

--- a/app/views/eligibility_interface/work_experience/new.html.erb
+++ b/app/views/eligibility_interface/work_experience/new.html.erb
@@ -1,3 +1,4 @@
+
 <% content_for :page_title, "#{'Error: ' if @work_experience_form.errors.any?}#{t("helpers.legend.eligibility_interface_work_experience_form.work_experience")}" %>
 <% content_for :back_link_url, back_link_url(@eligibility_check.qualified_for_subject_required? ? eligibility_interface_qualified_for_subject_path : eligibility_interface_teach_children_path) %>
 

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -18,7 +18,8 @@ module PageHelpers
   end
 
   def assessor_applications_page
-    @assessor_applications_page ||= PageObjects::AssessorInterface::Applications.new
+    @assessor_applications_page ||=
+      PageObjects::AssessorInterface::Applications.new
   end
 
   def assessor_application_status_page
@@ -32,16 +33,18 @@ module PageHelpers
   end
 
   def assessor_assign_assessor_page
-    @assessor_assign_assessor_page ||= PageObjects::AssessorInterface::AssignAssessor.new
+    @assessor_assign_assessor_page ||=
+      PageObjects::AssessorInterface::AssignAssessor.new
   end
 
   def assessor_assessment_section_page
     @assessor_assessment_section_page ||=
       PageObjects::AssessorInterface::AssessmentSection.new
   end
-  
+
   def assessor_assign_reviewer_page
-    @assessor_assign_reviewer_page ||= PageObjects::AssessorInterface::AssignReviewer.new
+    @assessor_assign_reviewer_page ||=
+      PageObjects::AssessorInterface::AssignReviewer.new
   end
 
   def assessor_check_english_language_proficiency_page
@@ -197,7 +200,7 @@ module PageHelpers
     @assessor_review_verifications_page ||=
       PageObjects::AssessorInterface::ReviewVerifications.new
   end
-  
+
   def assessor_timeline_page
     @assessor_timeline_page ||= PageObjects::AssessorInterface::Timeline.new
   end
@@ -208,7 +211,8 @@ module PageHelpers
   end
 
   def assessor_qualified_for_subject_page
-    @assessor_qualified_for_subject_page ||= PageObjects::AssessorInterface::CreateNote.new
+    @assessor_qualified_for_subject_page ||=
+      PageObjects::AssessorInterface::CreateNote.new
   end
 
   def assessor_verify_age_range_subjects_page
@@ -244,15 +248,18 @@ module PageHelpers
   end
 
   def eligibility_ineligible_page
-    @eligibility_ineligible_page = PageObjects::EligibilityInterface::Ineligible.new
+    @eligibility_ineligible_page =
+      PageObjects::EligibilityInterface::Ineligible.new
   end
 
   def eligibility_misconduct_page
-    @eligibility_misconduct_page ||= PageObjects::EligibilityInterface::Misconduct.new
+    @eligibility_misconduct_page ||=
+      PageObjects::EligibilityInterface::Misconduct.new
   end
 
   def eligibility_qualification_page
-    @eligibility_qualification_page ||= PageObjects::EligibilityInterface::Qualification.new
+    @eligibility_qualification_page ||=
+      PageObjects::EligibilityInterface::Qualification.new
   end
 
   def eligibility_region_page
@@ -366,7 +373,6 @@ module PageHelpers
     @teacher_check_work_histories_page ||=
       PageObjects::TeacherInterface::CheckWorkHistories.new
   end
-
 
   def teacher_check_your_answers_page
     @teacher_check_your_answers_page =

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -17,6 +17,11 @@ module PageHelpers
       PageObjects::AssessorInterface::Application.new
   end
 
+
+  def assessor_applications_page
+    @assessor_applications_page ||= PageObjects::AssessorInterface::Applications.new
+  end
+
   def assessor_application_status_page
     @assessor_application_status_page ||=
       PageObjects::AssessorInterface::ApplicationStatus.new
@@ -94,10 +99,6 @@ module PageHelpers
   def assessor_withdraw_application_page
     @assessor_withdraw_application_page ||=
       PageObjects::AssessorInterface::WithdrawApplication.new
-  end
-
-  def applications_page
-    @applications_page ||= PageObjects::AssessorInterface::Applications.new
   end
 
   def assign_assessor_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -108,11 +108,6 @@ module PageHelpers
       PageObjects::AssessorInterface::WithdrawApplication.new
   end
 
-  def check_further_information_request_answers_page
-    @check_further_information_request_answers_page =
-      PageObjects::TeacherInterface::CheckFurtherInformationRequestAnswers.new
-  end
-
   def check_personal_information_page
     @check_personal_information_page ||=
       PageObjects::AssessorInterface::CheckPersonalInformation.new
@@ -310,6 +305,11 @@ module PageHelpers
   def teacher_check_english_language_page
     @teacher_check_english_language_page ||=
       PageObjects::TeacherInterface::CheckEnglishLanguage.new
+  end
+
+  def teacher_check_further_information_request_answers_page
+    @teacher_check_further_information_request_answers_page =
+      PageObjects::TeacherInterface::CheckFurtherInformationRequestAnswers.new
   end
 
   def teacher_check_personal_information_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -7,8 +7,8 @@ module PageHelpers
     send(page.to_sym).load(**args)
   end
 
-  def age_range_subjects_assessment_recommendation_award_page
-    @age_range_subjects_assessment_recommendation_award_page ||=
+  def assessor_age_range_subjects_assessment_recommendation_award_page
+    @assessor_age_range_subjects_assessment_recommendation_award_page ||=
       PageObjects::AssessorInterface::AgeRangeSubjectsAssessmentRecommendationAward.new
   end
 

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -37,14 +37,14 @@ module PageHelpers
       PageObjects::AssessorInterface::AssignAssessor.new
   end
 
-  def assessor_assessment_section_page
-    @assessor_assessment_section_page ||=
-      PageObjects::AssessorInterface::AssessmentSection.new
-  end
-
   def assessor_assign_reviewer_page
     @assessor_assign_reviewer_page ||=
       PageObjects::AssessorInterface::AssignReviewer.new
+  end
+
+  def assessor_assessment_section_page
+    @assessor_assessment_section_page ||=
+      PageObjects::AssessorInterface::AssessmentSection.new
   end
 
   def assessor_check_english_language_proficiency_page
@@ -291,6 +291,16 @@ module PageHelpers
 
   def personas_page
     @personas_page ||= PageObjects::Personas.new
+  end
+
+  def support_edit_english_language_provider_page
+    @support_edit_english_language_provider_page ||=
+      PageObjects::SupportInterface::EditEnglishLanguageProvider.new
+  end
+
+  def support_english_language_providers_index_page
+    @support_english_language_providers_index_page ||=
+      PageObjects::SupportInterface::EnglishLanguageProvidersIndex.new
   end
 
   def staff_signed_out_page
@@ -592,15 +602,5 @@ module PageHelpers
   def teacher_written_statement_page
     @teacher_written_statement_page =
       PageObjects::TeacherInterface::WrittenStatement.new
-  end
-
-  def support_edit_english_language_provider_page
-    @support_edit_english_language_provider_page ||=
-      PageObjects::SupportInterface::EditEnglishLanguageProvider.new
-  end
-
-  def support_english_language_providers_index_page
-    @support_english_language_providers_index_page ||=
-      PageObjects::SupportInterface::EnglishLanguageProvidersIndex.new
   end
 end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -44,9 +44,29 @@ module PageHelpers
     @assessor_assign_reviewer_page ||= PageObjects::AssessorInterface::AssignReviewer.new
   end
 
+  def assessor_check_english_language_proficiency_page
+    @assessor_check_english_language_proficiency_page ||=
+      PageObjects::AssessorInterface::CheckEnglishLanguageProficiency.new
+  end
+
   def assessor_check_personal_information_page
     @assessor_check_personal_information_page ||=
       PageObjects::AssessorInterface::CheckPersonalInformation.new
+  end
+
+  def assessor_check_professional_standing_page
+    @assessor_check_professional_standing_page ||=
+      PageObjects::AssessorInterface::CheckProfessionalStanding.new
+  end
+
+  def assessor_check_qualifications_page
+    @assessor_check_qualifications_page ||=
+      PageObjects::AssessorInterface::CheckQualifications.new
+  end
+
+  def assessor_check_work_history_page
+    @assessor_check_work_history_page ||=
+      PageObjects::AssessorInterface::CheckWorkHistory.new
   end
 
   def assessor_edit_application_page
@@ -111,26 +131,6 @@ module PageHelpers
   def assessor_withdraw_application_page
     @assessor_withdraw_application_page ||=
       PageObjects::AssessorInterface::WithdrawApplication.new
-  end
-
-  def check_professional_standing_page
-    @check_professional_standing_page ||=
-      PageObjects::AssessorInterface::CheckProfessionalStanding.new
-  end
-
-  def check_qualifications_page
-    @check_qualifications_page ||=
-      PageObjects::AssessorInterface::CheckQualifications.new
-  end
-
-  def check_english_language_proficiency_page
-    @check_english_language_proficiency_page ||=
-      PageObjects::AssessorInterface::CheckEnglishLanguageProficiency.new
-  end
-
-  def check_work_history_page
-    @check_work_history_page ||=
-      PageObjects::AssessorInterface::CheckWorkHistory.new
   end
 
   def complete_assessment_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -148,30 +148,65 @@ module PageHelpers
       PageObjects::AssessorInterface::VerifyProfessionalStandingRequest.new
   end
 
+  def assessor_qualified_for_subject_page
+    @assessor_qualified_for_subject_page ||= PageObjects::AssessorInterface::CreateNote.new
+  end
+
   def assessor_withdraw_application_page
     @assessor_withdraw_application_page ||=
       PageObjects::AssessorInterface::WithdrawApplication.new
   end
 
-  def country_page
-    @country_page ||= PageObjects::EligibilityInterface::Country.new
+  def eligibility_country_page
+    @eligibility_country_page ||= PageObjects::EligibilityInterface::Country.new
   end
 
-  def create_note_page
-    @create_note_page ||= PageObjects::AssessorInterface::CreateNote.new
+  def eligibility_degree_page
+    @eligibility_degree_page ||= PageObjects::EligibilityInterface::Degree.new
   end
 
-  def degree_page
-    @degree_page ||= PageObjects::EligibilityInterface::Degree.new
+  def eligibility_eligible_page
+    @eligibility_eligible_page = PageObjects::EligibilityInterface::Eligible.new
   end
 
+  def eligibility_ineligible_page
+    @eligibility_ineligible_page = PageObjects::EligibilityInterface::Ineligible.new
+  end
+
+  def eligibility_misconduct_page
+    @eligibility_misconduct_page ||= PageObjects::EligibilityInterface::Misconduct.new
+  end
+
+  def eligibility_qualification_page
+    @eligibility_qualification_page ||= PageObjects::EligibilityInterface::Qualification.new
+  end
+
+  def eligibility_region_page
+    @eligibility_region_page ||= PageObjects::EligibilityInterface::Region.new
+  end
+
+  def eligibility_start_page
+    @eligibility_start_page ||= PageObjects::EligibilityInterface::Start.new
+  end
+
+  def eligibility_teach_children_page
+    @eligibility_teach_children_page ||=
+      PageObjects::EligibilityInterface::TeachChildren.new
+  end
+
+  def eligibility_qualified_for_subject_page
+    @eligibility_qualified_for_subject_page ||=
+      PageObjects::EligibilityInterface::QualifiedForSubject.new
+  end
+
+  def eligibility_work_experience_page
+    @eligibility_work_experience_page ||=
+      PageObjects::EligibilityInterface::WorkExperience.new
+  end
+  
   def edit_age_range_subjects_assessment_recommendation_award_page
     @edit_age_range_subjects_assessment_recommendation_award_page ||=
       PageObjects::AssessorInterface::EditAgeRangeSubjectsAssessmentRecommendationAward.new
-  end
-
-  def eligible_page
-    @eligible_page = PageObjects::EligibilityInterface::Eligible.new
   end
 
   def email_consent_letters_requests_assessment_recommendation_verify_page
@@ -194,17 +229,11 @@ module PageHelpers
       PageObjects::TeacherInterface::FurtherInformationRequired.new
   end
 
-  def ineligible_page
-    @ineligible_page = PageObjects::EligibilityInterface::Ineligible.new
-  end
-
   def login_page
     @login_page ||= PageObjects::AssessorInterface::Login.new
   end
 
-  def misconduct_page
-    @misconduct_page ||= PageObjects::EligibilityInterface::Misconduct.new
-  end
+  
 
   def performance_page
     @performance_page ||= PageObjects::Performance.new
@@ -228,11 +257,7 @@ module PageHelpers
     @preview_teacher_assessment_recommendation_award_page ||=
       PageObjects::AssessorInterface::PreviewTeacherAssessmentRecommendationAward.new
   end
-
-  def qualification_page
-    @qualification_page ||= PageObjects::EligibilityInterface::Qualification.new
-  end
-
+  
   def qualification_requests_assessment_recommendation_verify_page
     @qualification_requests_assessment_recommendation_verify_page ||=
       PageObjects::AssessorInterface::QualificationRequestsAssessmentRecommendationVerify.new
@@ -243,10 +268,6 @@ module PageHelpers
       PageObjects::AssessorInterface::ReferenceRequestsAssessmentRecommendationVerify.new
   end
 
-  def region_page
-    @region_page ||= PageObjects::EligibilityInterface::Region.new
-  end
-
   def review_further_information_request_page
     @review_further_information_request_page ||=
       PageObjects::AssessorInterface::ReviewFurtherInformationRequest.new
@@ -254,20 +275,6 @@ module PageHelpers
 
   def staff_signed_out_page
     @staff_signed_out_page ||= PageObjects::Staff::SignedOut.new
-  end
-
-  def start_page
-    @start_page ||= PageObjects::EligibilityInterface::Start.new
-  end
-
-  def teach_children_page
-    @teach_children_page ||=
-      PageObjects::EligibilityInterface::TeachChildren.new
-  end
-
-  def qualified_for_subject_page
-    @qualified_for_subject_page ||=
-      PageObjects::EligibilityInterface::QualifiedForSubject.new
   end
 
   def teacher_add_another_qualification_page
@@ -585,11 +592,6 @@ module PageHelpers
   def verify_professional_standing_assessment_recommendation_verify_page
     @verify_professional_standing_assessment_recommendation_verify_page ||=
       PageObjects::AssessorInterface::VerifyProfessionalStandingAssessmentRecommendationVerify.new
-  end
-
-  def work_experience_page
-    @work_experience_page ||=
-      PageObjects::EligibilityInterface::WorkExperience.new
   end
 
   def verify_qualifications_assessment_recommendation_verify_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -182,8 +182,7 @@ module PageHelpers
     @assessor_review_verifications_page ||=
       PageObjects::AssessorInterface::ReviewVerifications.new
   end
-
-
+  
   def assessor_timeline_page
     @assessor_timeline_page ||= PageObjects::AssessorInterface::Timeline.new
   end
@@ -264,21 +263,6 @@ module PageHelpers
       PageObjects::EligibilityInterface::WorkExperience.new
   end
 
-  def further_information_requested_page
-    @further_information_requested_page =
-      PageObjects::TeacherInterface::FurtherInformationRequested.new
-  end
-
-  def further_information_requested_start_page
-    @further_information_requested_start_page =
-      PageObjects::TeacherInterface::FurtherInformationRequestedStart.new
-  end
-
-  def further_information_required_page
-    @further_information_required_page =
-      PageObjects::TeacherInterface::FurtherInformationRequired.new
-  end
-
   def performance_page
     @performance_page ||= PageObjects::Performance.new
   end
@@ -348,6 +332,11 @@ module PageHelpers
       PageObjects::TeacherInterface::CheckQualifications.new
   end
 
+  def teacher_check_uploaded_files_page
+    @teacher_check_uploaded_files_page =
+      PageObjects::TeacherInterface::CheckUploadedFiles.new
+  end
+
   def teacher_check_reference_request_answers_page
     @teacher_check_reference_request_answers_page ||=
       PageObjects::TeacherInterface::CheckReferenceRequestAnswers.new
@@ -361,6 +350,17 @@ module PageHelpers
   def teacher_check_work_histories_page
     @teacher_check_work_histories_page ||=
       PageObjects::TeacherInterface::CheckWorkHistories.new
+  end
+
+
+  def teacher_check_your_answers_page
+    @teacher_check_your_answers_page =
+      PageObjects::TeacherInterface::CheckYourAnswers.new
+  end
+
+  def teacher_check_your_uploads_page
+    @teacher_check_your_uploads_page =
+      PageObjects::TeacherInterface::CheckYourUploads.new
   end
 
   def teacher_declined_application_page
@@ -468,6 +468,21 @@ module PageHelpers
       PageObjects::TeacherInterface::EnglishLanguageProviderReference.new
   end
 
+  def teacher_further_information_requested_page
+    @teacher_further_information_requested_page =
+      PageObjects::TeacherInterface::FurtherInformationRequested.new
+  end
+
+  def teacher_further_information_requested_start_page
+    @teacher_further_information_requested_start_page =
+      PageObjects::TeacherInterface::FurtherInformationRequestedStart.new
+  end
+
+  def teacher_further_information_required_page
+    @teacher_further_information_required_page =
+      PageObjects::TeacherInterface::FurtherInformationRequired.new
+  end
+
   def teacher_magic_link_page
     @teacher_magic_link_page = PageObjects::TeacherInterface::MagicLink.new
   end
@@ -497,6 +512,16 @@ module PageHelpers
       PageObjects::TeacherInterface::PartOfUniversityDegree.new
   end
 
+  def teacher_personal_information_summary_page
+    @teacher_personal_information_summary_page =
+      PageObjects::TeacherInterface::PersonalInformationSummary.new
+  end
+
+  def teacher_qualifications_form_page
+    @teacher_qualifications_form_page =
+      PageObjects::TeacherInterface::QualificationForm.new
+  end
+
   def teacher_reference_received_page
     @teacher_reference_received_page ||=
       PageObjects::TeacherInterface::ReferenceReceived.new
@@ -520,6 +545,11 @@ module PageHelpers
     @teacher_subjects_page = PageObjects::TeacherInterface::Subjects.new
   end
 
+  def teacher_submitted_application_page
+    @teacher_submitted_application_page =
+      PageObjects::TeacherInterface::SubmittedApplication.new
+  end
+
   def teacher_sign_in_page
     @teacher_sign_in_page = PageObjects::TeacherInterface::SignIn.new
   end
@@ -538,39 +568,9 @@ module PageHelpers
       PageObjects::TeacherInterface::UploadDocument.new
   end
 
-  def check_uploaded_files_page
-    @check_uploaded_files_page =
-      PageObjects::TeacherInterface::CheckUploadedFiles.new
-  end
-
-  def written_statement_page
-    @written_statement_page =
+  def teacher_written_statement_page
+    @teacher_written_statement_page =
       PageObjects::TeacherInterface::WrittenStatement.new
-  end
-
-  def personal_information_summary_page
-    @personal_information_summary_page =
-      PageObjects::TeacherInterface::PersonalInformationSummary.new
-  end
-
-  def qualifications_form_page
-    @qualifications_form_page =
-      PageObjects::TeacherInterface::QualificationForm.new
-  end
-
-  def check_your_answers_page
-    @check_your_answers_page =
-      PageObjects::TeacherInterface::CheckYourAnswers.new
-  end
-
-  def submitted_application_page
-    @submitted_application_page =
-      PageObjects::TeacherInterface::SubmittedApplication.new
-  end
-
-  def check_your_uploads_page
-    @check_your_uploads_page =
-      PageObjects::TeacherInterface::CheckYourUploads.new
   end
 
   def request_further_information_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -44,6 +44,11 @@ module PageHelpers
     @assessor_assign_reviewer_page ||= PageObjects::AssessorInterface::AssignReviewer.new
   end
 
+  def assessor_check_personal_information_page
+    @assessor_check_personal_information_page ||=
+      PageObjects::AssessorInterface::CheckPersonalInformation.new
+  end
+
   def assessor_edit_application_page
     @assessor_edit_application_page ||=
       PageObjects::AssessorInterface::EditApplication.new
@@ -106,11 +111,6 @@ module PageHelpers
   def assessor_withdraw_application_page
     @assessor_withdraw_application_page ||=
       PageObjects::AssessorInterface::WithdrawApplication.new
-  end
-
-  def check_personal_information_page
-    @check_personal_information_page ||=
-      PageObjects::AssessorInterface::CheckPersonalInformation.new
   end
 
   def check_professional_standing_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -119,6 +119,16 @@ module PageHelpers
       PageObjects::AssessorInterface::EmailConsentLettersAssessmentRecommendationVerify.new
   end
 
+  def assessor_further_information_request_page
+    @assessor_further_information_request_page ||=
+      PageObjects::AssessorInterface::FurtherInformationRequest.new
+  end
+
+  def assessor_further_information_request_preview_page
+    @assessor_further_information_request_preview_page ||=
+      PageObjects::AssessorInterface::FurtherInformationRequestPreview.new
+  end
+
   def assessor_locate_professional_standing_request_page
     @assessor_locate_professional_standing_request_page ||=
       PageObjects::AssessorInterface::LocateProfessionalStandingRequest.new
@@ -161,6 +171,11 @@ module PageHelpers
   def assessor_reference_requests_assessment_recommendation_verify_page
     @assessor_reference_requests_assessment_recommendation_verify_page ||=
       PageObjects::AssessorInterface::ReferenceRequestsAssessmentRecommendationVerify.new
+  end
+
+  def assessor_request_further_information_page
+    @request_further_information_form =
+      PageObjects::AssessorInterface::RequestFurtherInformation.new
   end
 
   def assessor_reverse_decision_page
@@ -571,21 +586,6 @@ module PageHelpers
   def teacher_written_statement_page
     @teacher_written_statement_page =
       PageObjects::TeacherInterface::WrittenStatement.new
-  end
-
-  def request_further_information_page
-    @request_further_information_form =
-      PageObjects::AssessorInterface::RequestFurtherInformation.new
-  end
-
-  def further_information_request_page
-    @further_information_request_page ||=
-      PageObjects::AssessorInterface::FurtherInformationRequest.new
-  end
-
-  def further_information_request_preview_page
-    @further_information_request_preview_page ||=
-      PageObjects::AssessorInterface::FurtherInformationRequestPreview.new
   end
 
   def support_edit_english_language_provider_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -82,6 +82,10 @@ module PageHelpers
       PageObjects::AssessorInterface::ReviewVerifications.new
   end
 
+  def assessor_timeline_page
+    @assessor_timeline_page ||= PageObjects::AssessorInterface::Timeline.new
+  end
+
   def assessor_verify_professional_standing_request_page
     @assessor_verify_professional_standing_request_page ||=
       PageObjects::AssessorInterface::VerifyProfessionalStandingRequest.new
@@ -493,10 +497,6 @@ module PageHelpers
 
   def teacher_subjects_page
     @teacher_subjects_page = PageObjects::TeacherInterface::Subjects.new
-  end
-
-  def timeline_page
-    @timeline_page ||= PageObjects::AssessorInterface::Timeline.new
   end
 
   def teacher_sign_in_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -17,7 +17,6 @@ module PageHelpers
       PageObjects::AssessorInterface::Application.new
   end
 
-
   def assessor_applications_page
     @assessor_applications_page ||= PageObjects::AssessorInterface::Applications.new
   end
@@ -32,9 +31,17 @@ module PageHelpers
       PageObjects::AssessorInterface::AssessmentRecommendationReview.new
   end
 
+  def assessor_assign_assessor_page
+    @assessor_assign_assessor_page ||= PageObjects::AssessorInterface::AssignAssessor.new
+  end
+
   def assessor_assessment_section_page
     @assessor_assessment_section_page ||=
       PageObjects::AssessorInterface::AssessmentSection.new
+  end
+  
+  def assessor_assign_reviewer_page
+    @assessor_assign_reviewer_page ||= PageObjects::AssessorInterface::AssignReviewer.new
   end
 
   def assessor_edit_application_page
@@ -99,14 +106,6 @@ module PageHelpers
   def assessor_withdraw_application_page
     @assessor_withdraw_application_page ||=
       PageObjects::AssessorInterface::WithdrawApplication.new
-  end
-
-  def assign_assessor_page
-    @assign_assessor_page ||= PageObjects::AssessorInterface::AssignAssessor.new
-  end
-
-  def assign_reviewer_page
-    @assign_reviewer_page ||= PageObjects::AssessorInterface::AssignReviewer.new
   end
 
   def check_further_information_request_answers_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -69,6 +69,26 @@ module PageHelpers
       PageObjects::AssessorInterface::CheckWorkHistory.new
   end
 
+  def assessor_complete_assessment_page
+    @assessor_complete_assessment_page ||=
+      PageObjects::AssessorInterface::CompleteAssessment.new
+  end
+
+  def assessor_confirm_assessment_recommendation_page
+    @assessor_confirm_assessment_recommendation_page ||=
+      PageObjects::AssessorInterface::ConfirmAssessmentRecommendation.new
+  end
+
+  def assessor_contact_professional_standing_assessment_recommendation_verify_page
+    @assessor_contact_professional_standing_assessment_recommendation_verify_page ||=
+      PageObjects::AssessorInterface::ContactProfessionalStandingAssessmentRecommendationVerify.new
+  end
+
+  def assessor_declare_assessment_recommendation_page
+    @assessor_declare_assessment_recommendation_page ||=
+      PageObjects::AssessorInterface::DeclareAssessmentRecommendation.new
+  end
+
   def assessor_edit_application_page
     @assessor_edit_application_page ||=
       PageObjects::AssessorInterface::EditApplication.new
@@ -131,26 +151,6 @@ module PageHelpers
   def assessor_withdraw_application_page
     @assessor_withdraw_application_page ||=
       PageObjects::AssessorInterface::WithdrawApplication.new
-  end
-
-  def complete_assessment_page
-    @complete_assessment_page ||=
-      PageObjects::AssessorInterface::CompleteAssessment.new
-  end
-
-  def confirm_assessment_recommendation_page
-    @confirm_assessment_recommendation_page ||=
-      PageObjects::AssessorInterface::ConfirmAssessmentRecommendation.new
-  end
-
-  def contact_professional_standing_assessment_recommendation_verify_page
-    @contact_professional_standing_assessment_recommendation_verify_page ||=
-      PageObjects::AssessorInterface::ContactProfessionalStandingAssessmentRecommendationVerify.new
-  end
-
-  def declare_assessment_recommendation_page
-    @declare_assessment_recommendation_page ||=
-      PageObjects::AssessorInterface::DeclareAssessmentRecommendation.new
   end
 
   def country_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -17,19 +17,24 @@ module PageHelpers
       PageObjects::AssessorInterface::Application.new
   end
 
-  def assessor_applications_page
-    @assessor_applications_page ||=
-      PageObjects::AssessorInterface::Applications.new
-  end
-
   def assessor_application_status_page
     @assessor_application_status_page ||=
       PageObjects::AssessorInterface::ApplicationStatus.new
   end
 
+  def assessor_applications_page
+    @assessor_applications_page ||=
+      PageObjects::AssessorInterface::Applications.new
+  end
+
   def assessor_assessment_recommendation_review_page
     @assessor_assessment_recommendation_review_page ||=
       PageObjects::AssessorInterface::AssessmentRecommendationReview.new
+  end
+
+  def assessor_assessment_section_page
+    @assessor_assessment_section_page ||=
+      PageObjects::AssessorInterface::AssessmentSection.new
   end
 
   def assessor_assign_assessor_page
@@ -40,11 +45,6 @@ module PageHelpers
   def assessor_assign_reviewer_page
     @assessor_assign_reviewer_page ||=
       PageObjects::AssessorInterface::AssignReviewer.new
-  end
-
-  def assessor_assessment_section_page
-    @assessor_assessment_section_page ||=
-      PageObjects::AssessorInterface::AssessmentSection.new
   end
 
   def assessor_check_english_language_proficiency_page
@@ -166,14 +166,14 @@ module PageHelpers
       PageObjects::AssessorInterface::QualificationRequests.new
   end
 
-  def assessor_reference_requests_page
-    @assessor_reference_requests_page ||=
-      PageObjects::AssessorInterface::ReferenceRequests.new
-  end
-
   def assessor_reference_requests_assessment_recommendation_verify_page
     @assessor_reference_requests_assessment_recommendation_verify_page ||=
       PageObjects::AssessorInterface::ReferenceRequestsAssessmentRecommendationVerify.new
+  end
+
+  def assessor_reference_requests_page
+    @assessor_reference_requests_page ||=
+      PageObjects::AssessorInterface::ReferenceRequests.new
   end
 
   def assessor_request_further_information_page
@@ -201,18 +201,13 @@ module PageHelpers
       PageObjects::AssessorInterface::ReviewVerifications.new
   end
 
-  def assessor_timeline_page
-    @assessor_timeline_page ||= PageObjects::AssessorInterface::Timeline.new
-  end
-
-  def assessor_verify_professional_standing_request_page
-    @assessor_verify_professional_standing_request_page ||=
-      PageObjects::AssessorInterface::VerifyProfessionalStandingRequest.new
-  end
-
   def assessor_qualified_for_subject_page
     @assessor_qualified_for_subject_page ||=
       PageObjects::AssessorInterface::CreateNote.new
+  end
+
+  def assessor_timeline_page
+    @assessor_timeline_page ||= PageObjects::AssessorInterface::Timeline.new
   end
 
   def assessor_verify_age_range_subjects_page
@@ -223,6 +218,11 @@ module PageHelpers
   def assessor_verify_professional_standing_assessment_recommendation_verify_page
     @assessor_verify_professional_standing_assessment_recommendation_verify_page ||=
       PageObjects::AssessorInterface::VerifyProfessionalStandingAssessmentRecommendationVerify.new
+  end
+
+  def assessor_verify_professional_standing_request_page
+    @assessor_verify_professional_standing_request_page ||=
+      PageObjects::AssessorInterface::VerifyProfessionalStandingRequest.new
   end
 
   def assessor_verify_qualifications_assessment_recommendation_verify_page
@@ -262,6 +262,11 @@ module PageHelpers
       PageObjects::EligibilityInterface::Qualification.new
   end
 
+  def eligibility_qualified_for_subject_page
+    @eligibility_qualified_for_subject_page ||=
+      PageObjects::EligibilityInterface::QualifiedForSubject.new
+  end
+
   def eligibility_region_page
     @eligibility_region_page ||= PageObjects::EligibilityInterface::Region.new
   end
@@ -273,11 +278,6 @@ module PageHelpers
   def eligibility_teach_children_page
     @eligibility_teach_children_page ||=
       PageObjects::EligibilityInterface::TeachChildren.new
-  end
-
-  def eligibility_qualified_for_subject_page
-    @eligibility_qualified_for_subject_page ||=
-      PageObjects::EligibilityInterface::QualifiedForSubject.new
   end
 
   def eligibility_work_experience_page
@@ -364,24 +364,24 @@ module PageHelpers
       PageObjects::TeacherInterface::CheckQualifications.new
   end
 
-  def teacher_check_uploaded_files_page
-    @teacher_check_uploaded_files_page =
-      PageObjects::TeacherInterface::CheckUploadedFiles.new
-  end
-
   def teacher_check_reference_request_answers_page
     @teacher_check_reference_request_answers_page ||=
       PageObjects::TeacherInterface::CheckReferenceRequestAnswers.new
   end
 
-  def teacher_check_work_history_page
-    @teacher_check_work_history_page ||=
-      PageObjects::TeacherInterface::CheckWorkHistory.new
+  def teacher_check_uploaded_files_page
+    @teacher_check_uploaded_files_page =
+      PageObjects::TeacherInterface::CheckUploadedFiles.new
   end
 
   def teacher_check_work_histories_page
     @teacher_check_work_histories_page ||=
       PageObjects::TeacherInterface::CheckWorkHistories.new
+  end
+
+  def teacher_check_work_history_page
+    @teacher_check_work_history_page ||=
+      PageObjects::TeacherInterface::CheckWorkHistory.new
   end
 
   def teacher_check_your_answers_page
@@ -572,15 +572,6 @@ module PageHelpers
     @teacher_signed_out_page = PageObjects::TeacherInterface::SignedOut.new
   end
 
-  def teacher_subjects_page
-    @teacher_subjects_page = PageObjects::TeacherInterface::Subjects.new
-  end
-
-  def teacher_submitted_application_page
-    @teacher_submitted_application_page =
-      PageObjects::TeacherInterface::SubmittedApplication.new
-  end
-
   def teacher_sign_in_page
     @teacher_sign_in_page = PageObjects::TeacherInterface::SignIn.new
   end
@@ -592,6 +583,15 @@ module PageHelpers
 
   def teacher_sign_up_page
     @teacher_sign_up_page = PageObjects::TeacherInterface::SignUp.new
+  end
+
+  def teacher_subjects_page
+    @teacher_subjects_page = PageObjects::TeacherInterface::Subjects.new
+  end
+
+  def teacher_submitted_application_page
+    @teacher_submitted_application_page =
+      PageObjects::TeacherInterface::SubmittedApplication.new
   end
 
   def teacher_upload_document_page

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -89,6 +89,11 @@ module PageHelpers
       PageObjects::AssessorInterface::DeclareAssessmentRecommendation.new
   end
 
+  def assessor_edit_age_range_subjects_assessment_recommendation_award_page
+    @assessor_edit_age_range_subjects_assessment_recommendation_award_page ||=
+      PageObjects::AssessorInterface::EditAgeRangeSubjectsAssessmentRecommendationAward.new
+  end
+
   def assessor_edit_application_page
     @assessor_edit_application_page ||=
       PageObjects::AssessorInterface::EditApplication.new
@@ -109,9 +114,38 @@ module PageHelpers
       PageObjects::AssessorInterface::EditWorkHistory.new
   end
 
+  def assessor_email_consent_letters_requests_assessment_recommendation_verify_page
+    @assessor_email_consent_letters_requests_assessment_recommendation_verify_page ||=
+      PageObjects::AssessorInterface::EmailConsentLettersAssessmentRecommendationVerify.new
+  end
+
   def assessor_locate_professional_standing_request_page
     @assessor_locate_professional_standing_request_page ||=
       PageObjects::AssessorInterface::LocateProfessionalStandingRequest.new
+  end
+
+  def assessor_login_page
+    @assessor_login_page ||= PageObjects::AssessorInterface::Login.new
+  end
+
+  def assessor_preview_assessment_recommendation_page
+    @assessor_preview_assessment_recommendation_page ||=
+      PageObjects::AssessorInterface::PreviewAssessmentRecommendation.new
+  end
+
+  def assessor_preview_referee_assessment_recommendation_award_page
+    @assessor_preview_referee_assessment_recommendation_award_page ||=
+      PageObjects::AssessorInterface::PreviewRefereeAssessmentRecommendationAward.new
+  end
+
+  def assessor_preview_teacher_assessment_recommendation_award_page
+    @assessor_preview_teacher_assessment_recommendation_award_page ||=
+      PageObjects::AssessorInterface::PreviewTeacherAssessmentRecommendationAward.new
+  end
+
+  def assessor_qualification_requests_assessment_recommendation_verify_page
+    @assessor_qualification_requests_assessment_recommendation_verify_page ||=
+      PageObjects::AssessorInterface::QualificationRequestsAssessmentRecommendationVerify.new
   end
 
   def assessor_qualification_requests_page
@@ -124,9 +158,19 @@ module PageHelpers
       PageObjects::AssessorInterface::ReferenceRequests.new
   end
 
+  def assessor_reference_requests_assessment_recommendation_verify_page
+    @assessor_reference_requests_assessment_recommendation_verify_page ||=
+      PageObjects::AssessorInterface::ReferenceRequestsAssessmentRecommendationVerify.new
+  end
+
   def assessor_reverse_decision_page
     @assessor_reverse_decision_page ||=
       PageObjects::AssessorInterface::ReverseDecision.new
+  end
+
+  def assessor_review_further_information_request_page
+    @assessor_review_further_information_request_page ||=
+      PageObjects::AssessorInterface::ReviewFurtherInformationRequest.new
   end
 
   def assessor_review_professional_standing_request_page
@@ -139,6 +183,7 @@ module PageHelpers
       PageObjects::AssessorInterface::ReviewVerifications.new
   end
 
+
   def assessor_timeline_page
     @assessor_timeline_page ||= PageObjects::AssessorInterface::Timeline.new
   end
@@ -150,6 +195,21 @@ module PageHelpers
 
   def assessor_qualified_for_subject_page
     @assessor_qualified_for_subject_page ||= PageObjects::AssessorInterface::CreateNote.new
+  end
+
+  def assessor_verify_age_range_subjects_page
+    @assessor_verify_age_range_subjects_page ||=
+      PageObjects::AssessorInterface::VerifyAgeRangeSubjectsPage.new
+  end
+
+  def assessor_verify_professional_standing_assessment_recommendation_verify_page
+    @assessor_verify_professional_standing_assessment_recommendation_verify_page ||=
+      PageObjects::AssessorInterface::VerifyProfessionalStandingAssessmentRecommendationVerify.new
+  end
+
+  def assessor_verify_qualifications_assessment_recommendation_verify_page
+    @assessor_verify_qualifications_assessment_recommendation_verify_page ||=
+      PageObjects::AssessorInterface::VerifyQualificationsAssessmentRecommendationVerify.new
   end
 
   def assessor_withdraw_application_page
@@ -203,16 +263,6 @@ module PageHelpers
     @eligibility_work_experience_page ||=
       PageObjects::EligibilityInterface::WorkExperience.new
   end
-  
-  def edit_age_range_subjects_assessment_recommendation_award_page
-    @edit_age_range_subjects_assessment_recommendation_award_page ||=
-      PageObjects::AssessorInterface::EditAgeRangeSubjectsAssessmentRecommendationAward.new
-  end
-
-  def email_consent_letters_requests_assessment_recommendation_verify_page
-    @email_consent_letters_requests_assessment_recommendation_verify_page ||=
-      PageObjects::AssessorInterface::EmailConsentLettersAssessmentRecommendationVerify.new
-  end
 
   def further_information_requested_page
     @further_information_requested_page =
@@ -229,48 +279,12 @@ module PageHelpers
       PageObjects::TeacherInterface::FurtherInformationRequired.new
   end
 
-  def login_page
-    @login_page ||= PageObjects::AssessorInterface::Login.new
-  end
-
-  
-
   def performance_page
     @performance_page ||= PageObjects::Performance.new
   end
 
   def personas_page
     @personas_page ||= PageObjects::Personas.new
-  end
-
-  def preview_assessment_recommendation_page
-    @preview_assessment_recommendation_page ||=
-      PageObjects::AssessorInterface::PreviewAssessmentRecommendation.new
-  end
-
-  def preview_referee_assessment_recommendation_award_page
-    @preview_referee_assessment_recommendation_award_page ||=
-      PageObjects::AssessorInterface::PreviewRefereeAssessmentRecommendationAward.new
-  end
-
-  def preview_teacher_assessment_recommendation_award_page
-    @preview_teacher_assessment_recommendation_award_page ||=
-      PageObjects::AssessorInterface::PreviewTeacherAssessmentRecommendationAward.new
-  end
-  
-  def qualification_requests_assessment_recommendation_verify_page
-    @qualification_requests_assessment_recommendation_verify_page ||=
-      PageObjects::AssessorInterface::QualificationRequestsAssessmentRecommendationVerify.new
-  end
-
-  def reference_requests_assessment_recommendation_verify_page
-    @reference_requests_assessment_recommendation_verify_page ||=
-      PageObjects::AssessorInterface::ReferenceRequestsAssessmentRecommendationVerify.new
-  end
-
-  def review_further_information_request_page
-    @review_further_information_request_page ||=
-      PageObjects::AssessorInterface::ReviewFurtherInformationRequest.new
   end
 
   def staff_signed_out_page
@@ -582,20 +596,5 @@ module PageHelpers
   def support_english_language_providers_index_page
     @support_english_language_providers_index_page ||=
       PageObjects::SupportInterface::EnglishLanguageProvidersIndex.new
-  end
-
-  def verify_age_range_subjects_page
-    @verify_age_range_subjects_page ||=
-      PageObjects::AssessorInterface::VerifyAgeRangeSubjectsPage.new
-  end
-
-  def verify_professional_standing_assessment_recommendation_verify_page
-    @verify_professional_standing_assessment_recommendation_verify_page ||=
-      PageObjects::AssessorInterface::VerifyProfessionalStandingAssessmentRecommendationVerify.new
-  end
-
-  def verify_qualifications_assessment_recommendation_verify_page
-    @verify_qualifications_assessment_recommendation_verify_page ||=
-      PageObjects::AssessorInterface::VerifyQualificationsAssessmentRecommendationVerify.new
   end
 end

--- a/spec/system/assessor_interface/assigning_assessor_spec.rb
+++ b/spec/system/assessor_interface/assigning_assessor_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe "Assigning an assessor", type: :system do
   it "assigns an assessor" do
     given_i_am_authorized_as_an_assessor_user
 
-    when_i_visit_the(:assessor_assign_assessor_page, application_id: application_form.id)
+    when_i_visit_the(
+      :assessor_assign_assessor_page,
+      application_id: application_form.id,
+    )
     and_i_select_an_assessor
     then_i_see_the(
       :assessor_application_page,
@@ -23,7 +26,10 @@ RSpec.describe "Assigning an assessor", type: :system do
   it "assigns a reviewer" do
     given_i_am_authorized_as_an_assessor_user
 
-    when_i_visit_the(:assessor_assign_reviewer_page, application_id: application_form.id)
+    when_i_visit_the(
+      :assessor_assign_reviewer_page,
+      application_id: application_form.id,
+    )
     and_i_select_a_reviewer
     then_i_see_the(
       :assessor_application_page,
@@ -35,7 +41,10 @@ RSpec.describe "Assigning an assessor", type: :system do
   it "requires permission" do
     given_i_am_authorized_as_a_support_user
 
-    when_i_visit_the(:assessor_assign_assessor_page, application_id: application_form.id)
+    when_i_visit_the(
+      :assessor_assign_assessor_page,
+      application_id: application_form.id,
+    )
     then_i_see_the_forbidden_page
   end
 

--- a/spec/system/assessor_interface/assigning_assessor_spec.rb
+++ b/spec/system/assessor_interface/assigning_assessor_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Assigning an assessor", type: :system do
   it "assigns an assessor" do
     given_i_am_authorized_as_an_assessor_user
 
-    when_i_visit_the(:assign_assessor_page, application_id: application_form.id)
+    when_i_visit_the(:assessor_assign_assessor_page, application_id: application_form.id)
     and_i_select_an_assessor
     then_i_see_the(
       :assessor_application_page,
@@ -23,7 +23,7 @@ RSpec.describe "Assigning an assessor", type: :system do
   it "assigns a reviewer" do
     given_i_am_authorized_as_an_assessor_user
 
-    when_i_visit_the(:assign_reviewer_page, application_id: application_form.id)
+    when_i_visit_the(:assessor_assign_reviewer_page, application_id: application_form.id)
     and_i_select_a_reviewer
     then_i_see_the(
       :assessor_application_page,
@@ -35,7 +35,7 @@ RSpec.describe "Assigning an assessor", type: :system do
   it "requires permission" do
     given_i_am_authorized_as_a_support_user
 
-    when_i_visit_the(:assign_assessor_page, application_id: application_form.id)
+    when_i_visit_the(:assessor_assign_assessor_page, application_id: application_form.id)
     then_i_see_the_forbidden_page
   end
 
@@ -46,8 +46,8 @@ RSpec.describe "Assigning an assessor", type: :system do
   end
 
   def and_i_select_an_assessor
-    assign_assessor_page.assessors.second.input.click
-    assign_assessor_page.continue_button.click
+    assessor_assign_assessor_page.assessors.second.input.click
+    assessor_assign_assessor_page.continue_button.click
   end
 
   def and_the_assessor_is_assigned_to_the_application_form
@@ -57,12 +57,12 @@ RSpec.describe "Assigning an assessor", type: :system do
   end
 
   def when_i_visit_the_assign_reviewer_page
-    assign_reviewer_page.load(application_id: application_form.id)
+    assessor_assign_reviewer_page.load(application_id: application_form.id)
   end
 
   def and_i_select_a_reviewer
-    assign_reviewer_page.reviewers.second.input.click
-    assign_reviewer_page.continue_button.click
+    assessor_assign_reviewer_page.reviewers.second.input.click
+    assessor_assign_reviewer_page.continue_button.click
   end
 
   def and_the_assessor_is_assigned_as_reviewer_to_the_application_form

--- a/spec/system/assessor_interface/authentication_spec.rb
+++ b/spec/system/assessor_interface/authentication_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Assessor authentication", type: :system do
     given_staff_exist
 
     when_i_visit_the(:assessor_applications_page)
-    then_i_see_the(:login_page)
+    then_i_see_the(:assessor_login_page)
 
     when_i_login
     then_i_see_the(:assessor_applications_page)
@@ -24,7 +24,7 @@ RSpec.describe "Assessor authentication", type: :system do
   end
 
   def when_i_login
-    login_page.submit(email: "staff@example.com", password: "password")
+    assessor_login_page.submit(email: "staff@example.com", password: "password")
   end
 
   def when_i_click_sign_out

--- a/spec/system/assessor_interface/authentication_spec.rb
+++ b/spec/system/assessor_interface/authentication_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe "Assessor authentication", type: :system do
     given_the_service_is_open
     given_staff_exist
 
-    when_i_visit_the(:applications_page)
+    when_i_visit_the(:assessor_applications_page)
     then_i_see_the(:login_page)
 
     when_i_login
-    then_i_see_the(:applications_page)
+    then_i_see_the(:assessor_applications_page)
 
     when_i_click_sign_out
     then_i_see_the(:staff_signed_out_page)
@@ -28,6 +28,6 @@ RSpec.describe "Assessor authentication", type: :system do
   end
 
   def when_i_click_sign_out
-    applications_page.header.sign_out_link.click
+    assessor_applications_page.header.sign_out_link.click
   end
 end

--- a/spec/system/assessor_interface/change_work_history_spec.rb
+++ b/spec/system/assessor_interface/change_work_history_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe "Assessor change work history", type: :system do
     given_i_am_authorized_as_a_user(manager)
 
     when_i_visit_the(
-      :check_work_history_page,
+      :assessor_check_work_history_page,
       application_id:,
       assessment_id:,
       section_id: assessment_section.id,
     )
-    then_i_see_the(:check_work_history_page)
+    then_i_see_the(:assessor_check_work_history_page)
 
     when_i_click_on_change_from_assessment
     then_i_see_the(
@@ -68,7 +68,7 @@ RSpec.describe "Assessor change work history", type: :system do
   end
 
   def when_i_click_on_change_from_assessment
-    check_work_history_page
+    assessor_check_work_history_page
       .cards
       .first
       .find_row(key: "Reference contact’s full name")

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -239,10 +239,16 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def then_i_see_the_personal_information
     expect(
-      assessor_check_personal_information_page.personal_information.given_names.text,
+      assessor_check_personal_information_page
+        .personal_information
+        .given_names
+        .text,
     ).to eq(application_form.given_names)
     expect(
-      assessor_check_personal_information_page.personal_information.family_name.text,
+      assessor_check_personal_information_page
+        .personal_information
+        .family_name
+        .text,
     ).to eq(application_form.family_name)
   end
 
@@ -281,9 +287,9 @@ RSpec.describe "Assessor check submitted details", type: :system do
   def then_i_see_the_qualifications
     teaching_qualification =
       application_form.qualifications.find(&:is_teaching_qualification?)
-    expect(assessor_check_qualifications_page.teaching_qualification.title.text).to eq(
-      teaching_qualification.title,
-    )
+    expect(
+      assessor_check_qualifications_page.teaching_qualification.title.text,
+    ).to eq(teaching_qualification.title)
   end
 
   def when_i_choose_check_qualifications_yes
@@ -313,18 +319,21 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def then_i_see_the_age_range_and_subjects
-    expect(assessor_verify_age_range_subjects_page.age_range.heading.text).to eq(
-      "Enter the age range you can teach",
-    )
+    expect(
+      assessor_verify_age_range_subjects_page.age_range.heading.text,
+    ).to eq("Enter the age range you can teach")
     expect(assessor_verify_age_range_subjects_page.subjects.heading.text).to eq(
       "Enter the subjects you can teach",
     )
   end
 
   def when_i_fill_in_age_range
-    assessor_verify_age_range_subjects_page.age_range_form.minimum.fill_in with: "7"
-    assessor_verify_age_range_subjects_page.age_range_form.maximum.fill_in with: "11"
-    assessor_verify_age_range_subjects_page.age_range_form.note.fill_in with: "A note."
+    assessor_verify_age_range_subjects_page.age_range_form.minimum.fill_in with:
+      "7"
+    assessor_verify_age_range_subjects_page.age_range_form.maximum.fill_in with:
+      "11"
+    assessor_verify_age_range_subjects_page.age_range_form.note.fill_in with:
+      "A note."
   end
 
   def and_i_fill_in_subjects
@@ -362,9 +371,9 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def then_i_see_the_work_history
     most_recent_role = application_form.work_histories.first
-    expect(assessor_check_work_history_page.most_recent_role.school_name.text).to eq(
-      most_recent_role.school_name,
-    )
+    expect(
+      assessor_check_work_history_page.most_recent_role.school_name.text,
+    ).to eq(most_recent_role.school_name)
   end
 
   def when_i_choose_check_work_history_yes

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   it "allows passing the personal information" do
     when_i_visit_the(
-      :check_personal_information_page,
+      :assessor_check_personal_information_page,
       application_id:,
       assessment_id:,
       section_id: section_id("personal_information"),
@@ -23,7 +23,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   it "allows failing the personal information" do
     when_i_visit_the(
-      :check_personal_information_page,
+      :assessor_check_personal_information_page,
       application_id:,
       assessment_id:,
       section_id: section_id("personal_information"),
@@ -38,7 +38,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   it "allows viewing personal information once submitted" do
     given_there_are_selected_failure_reasons("personal_information")
     when_i_visit_the(
-      :check_personal_information_page,
+      :assessor_check_personal_information_page,
       application_id:,
       assessment_id:,
       section_id: section_id("personal_information"),
@@ -239,16 +239,16 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def then_i_see_the_personal_information
     expect(
-      check_personal_information_page.personal_information.given_names.text,
+      assessor_check_personal_information_page.personal_information.given_names.text,
     ).to eq(application_form.given_names)
     expect(
-      check_personal_information_page.personal_information.family_name.text,
+      assessor_check_personal_information_page.personal_information.family_name.text,
     ).to eq(application_form.family_name)
   end
 
   def when_i_choose_check_personal_information_yes
-    check_personal_information_page.form.yes_radio_item.choose
-    check_personal_information_page.form.continue_button.click
+    assessor_check_personal_information_page.form.yes_radio_item.choose
+    assessor_check_personal_information_page.form.continue_button.click
   end
 
   def personal_information_task_item
@@ -264,18 +264,18 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def when_i_choose_check_personal_information_no
-    check_personal_information_page.form.no_radio_item.choose
-    check_personal_information_page
+    assessor_check_personal_information_page.form.no_radio_item.choose
+    assessor_check_personal_information_page
       .form
       .failure_reason_checkbox_items
       .first
       .checkbox
       .click
-    check_personal_information_page
+    assessor_check_personal_information_page
       .form
       .failure_reason_note_textareas
       .first.fill_in with: "Note."
-    check_personal_information_page.form.continue_button.click
+    assessor_check_personal_information_page.form.continue_button.click
   end
 
   def then_i_see_the_qualifications

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   it "allows passing the age range and subjects" do
     when_i_visit_the(
-      :verify_age_range_subjects_page,
+      :assessor_verify_age_range_subjects_page,
       application_id:,
       assessment_id:,
       section_id: section_id("age_range_subjects"),
@@ -103,7 +103,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   it "allows failing the age range and subjects" do
     when_i_visit_the(
-      :verify_age_range_subjects_page,
+      :assessor_verify_age_range_subjects_page,
       application_id:,
       assessment_id:,
       section_id: section_id("age_range_subjects"),
@@ -120,7 +120,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   it "allows viewing age_range_and_subjects once submitted" do
     given_there_are_selected_failure_reasons("age_range_subjects")
     when_i_visit_the(
-      :verify_age_range_subjects_page,
+      :assessor_verify_age_range_subjects_page,
       application_id:,
       assessment_id:,
       section_id: section_id("age_range_subjects"),
@@ -313,45 +313,45 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def then_i_see_the_age_range_and_subjects
-    expect(verify_age_range_subjects_page.age_range.heading.text).to eq(
+    expect(assessor_verify_age_range_subjects_page.age_range.heading.text).to eq(
       "Enter the age range you can teach",
     )
-    expect(verify_age_range_subjects_page.subjects.heading.text).to eq(
+    expect(assessor_verify_age_range_subjects_page.subjects.heading.text).to eq(
       "Enter the subjects you can teach",
     )
   end
 
   def when_i_fill_in_age_range
-    verify_age_range_subjects_page.age_range_form.minimum.fill_in with: "7"
-    verify_age_range_subjects_page.age_range_form.maximum.fill_in with: "11"
-    verify_age_range_subjects_page.age_range_form.note.fill_in with: "A note."
+    assessor_verify_age_range_subjects_page.age_range_form.minimum.fill_in with: "7"
+    assessor_verify_age_range_subjects_page.age_range_form.maximum.fill_in with: "11"
+    assessor_verify_age_range_subjects_page.age_range_form.note.fill_in with: "A note."
   end
 
   def and_i_fill_in_subjects
-    verify_age_range_subjects_page.subjects_form.first_field.fill_in with:
+    assessor_verify_age_range_subjects_page.subjects_form.first_field.fill_in with:
       "Physics"
-    verify_age_range_subjects_page.subjects_form.note_textarea.fill_in with:
+    assessor_verify_age_range_subjects_page.subjects_form.note_textarea.fill_in with:
       "Another note."
   end
 
   def and_i_choose_verify_age_range_subjects_yes
-    verify_age_range_subjects_page.form.yes_radio_item.choose
-    verify_age_range_subjects_page.form.continue_button.click
+    assessor_verify_age_range_subjects_page.form.yes_radio_item.choose
+    assessor_verify_age_range_subjects_page.form.continue_button.click
   end
 
   def and_i_choose_verify_age_range_subjects_no
-    verify_age_range_subjects_page.form.no_radio_item.choose
-    verify_age_range_subjects_page
+    assessor_verify_age_range_subjects_page.form.no_radio_item.choose
+    assessor_verify_age_range_subjects_page
       .form
       .failure_reason_checkbox_items
       .first
       .checkbox
       .click
-    verify_age_range_subjects_page
+    assessor_verify_age_range_subjects_page
       .form
       .failure_reason_note_textareas
       .first.fill_in with: "Note."
-    verify_age_range_subjects_page.form.continue_button.click
+    assessor_verify_age_range_subjects_page.form.continue_button.click
   end
 
   def and_i_see_verify_age_range_subjects_completed

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   it "allows passing the qualifications" do
     when_i_visit_the(
-      :check_qualifications_page,
+      :assessor_check_qualifications_page,
       application_id:,
       assessment_id:,
       section_id: section_id("qualifications"),
@@ -62,7 +62,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   it "allows failing the qualifications" do
     when_i_visit_the(
-      :check_qualifications_page,
+      :assessor_check_qualifications_page,
       application_id:,
       assessment_id:,
       section_id: section_id("qualifications"),
@@ -77,7 +77,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   it "allows viewing qualifications once submitted" do
     given_there_are_selected_failure_reasons("qualifications")
     when_i_visit_the(
-      :check_qualifications_page,
+      :assessor_check_qualifications_page,
       application_id:,
       assessment_id:,
       section_id: section_id("qualifications"),
@@ -130,7 +130,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   it "allows passing the work history" do
     when_i_visit_the(
-      :check_work_history_page,
+      :assessor_check_work_history_page,
       application_id:,
       assessment_id:,
       section_id: section_id("work_history"),
@@ -144,7 +144,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   it "allows failing the work history" do
     when_i_visit_the(
-      :check_work_history_page,
+      :assessor_check_work_history_page,
       application_id:,
       assessment_id:,
       section_id: section_id("work_history"),
@@ -159,7 +159,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   it "allows viewing work history once submitted" do
     given_there_are_selected_failure_reasons("work_history")
     when_i_visit_the(
-      :check_work_history_page,
+      :assessor_check_work_history_page,
       application_id:,
       assessment_id:,
       section_id: section_id("work_history"),
@@ -169,7 +169,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   it "allows passing the professional standing" do
     when_i_visit_the(
-      :check_professional_standing_page,
+      :assessor_check_professional_standing_page,
       application_id:,
       assessment_id:,
       section_id: section_id("professional_standing"),
@@ -183,7 +183,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   it "allows failing the professional standing" do
     when_i_visit_the(
-      :check_professional_standing_page,
+      :assessor_check_professional_standing_page,
       application_id:,
       assessment_id:,
       section_id: section_id("professional_standing"),
@@ -199,7 +199,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     given_application_form_doesnt_need_work_history
 
     when_i_visit_the(
-      :check_professional_standing_page,
+      :assessor_check_professional_standing_page,
       application_id:,
       assessment_id:,
       section_id: section_id("professional_standing"),
@@ -216,7 +216,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   it "allows viewing professional standing once submitted" do
     given_there_are_selected_failure_reasons("professional_standing")
     when_i_visit_the(
-      :check_professional_standing_page,
+      :assessor_check_professional_standing_page,
       application_id:,
       assessment_id:,
       section_id: section_id("professional_standing"),
@@ -281,29 +281,29 @@ RSpec.describe "Assessor check submitted details", type: :system do
   def then_i_see_the_qualifications
     teaching_qualification =
       application_form.qualifications.find(&:is_teaching_qualification?)
-    expect(check_qualifications_page.teaching_qualification.title.text).to eq(
+    expect(assessor_check_qualifications_page.teaching_qualification.title.text).to eq(
       teaching_qualification.title,
     )
   end
 
   def when_i_choose_check_qualifications_yes
-    check_qualifications_page.form.yes_radio_item.choose
-    check_qualifications_page.form.continue_button.click
+    assessor_check_qualifications_page.form.yes_radio_item.choose
+    assessor_check_qualifications_page.form.continue_button.click
   end
 
   def when_i_choose_check_qualifications_no
-    check_qualifications_page.form.no_radio_item.choose
-    check_qualifications_page
+    assessor_check_qualifications_page.form.no_radio_item.choose
+    assessor_check_qualifications_page
       .form
       .failure_reason_checkbox_items
       .first
       .checkbox
       .click
-    check_qualifications_page
+    assessor_check_qualifications_page
       .form
       .failure_reason_note_textareas
       .first.fill_in with: "Note."
-    check_qualifications_page.form.continue_button.click
+    assessor_check_qualifications_page.form.continue_button.click
   end
 
   def and_i_see_check_qualifications_completed
@@ -362,14 +362,14 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
   def then_i_see_the_work_history
     most_recent_role = application_form.work_histories.first
-    expect(check_work_history_page.most_recent_role.school_name.text).to eq(
+    expect(assessor_check_work_history_page.most_recent_role.school_name.text).to eq(
       most_recent_role.school_name,
     )
   end
 
   def when_i_choose_check_work_history_yes
-    check_work_history_page.form.yes_radio_item.choose
-    check_work_history_page.form.continue_button.click
+    assessor_check_work_history_page.form.yes_radio_item.choose
+    assessor_check_work_history_page.form.continue_button.click
   end
 
   def and_i_see_check_work_history_completed
@@ -379,24 +379,24 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def when_i_choose_check_work_history_no
-    check_work_history_page.form.no_radio_item.choose
-    check_work_history_page
+    assessor_check_work_history_page.form.no_radio_item.choose
+    assessor_check_work_history_page
       .form
       .failure_reason_checkbox_items
       .first
       .checkbox
       .click
-    check_work_history_page.school_checkbox_items.first.click
-    check_work_history_page
+    assessor_check_work_history_page.school_checkbox_items.first.click
+    assessor_check_work_history_page
       .form
       .failure_reason_note_textareas
       .first.fill_in with: "Note."
-    check_work_history_page.form.continue_button.click
+    assessor_check_work_history_page.form.continue_button.click
   end
 
   def then_i_see_the_professional_standing
     expect(
-      check_professional_standing_page
+      assessor_check_professional_standing_page
         .proof_of_recognition
         .registration_number
         .text,
@@ -404,22 +404,22 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def when_i_choose_check_professional_standing_yes
-    check_professional_standing_page.form.yes_radio_item.choose
-    check_professional_standing_page.form.continue_button.click
+    assessor_check_professional_standing_page.form.yes_radio_item.choose
+    assessor_check_professional_standing_page.form.continue_button.click
   end
 
   alias_method :and_i_choose_check_professional_standing_yes,
                :when_i_choose_check_professional_standing_yes
 
   def when_i_choose_full_registration
-    check_professional_standing_page
+    assessor_check_professional_standing_page
       .scotland_full_registration_form
       .yes_radio_item
       .choose
   end
 
   def and_i_choose_induction_not_required
-    check_professional_standing_page
+    assessor_check_professional_standing_page
       .induction_required_form
       .no_radio_item
       .choose
@@ -432,18 +432,18 @@ RSpec.describe "Assessor check submitted details", type: :system do
   end
 
   def when_i_choose_check_professional_standing_no
-    check_professional_standing_page.form.no_radio_item.choose
-    check_professional_standing_page
+    assessor_check_professional_standing_page.form.no_radio_item.choose
+    assessor_check_professional_standing_page
       .form
       .failure_reason_checkbox_items
       .first
       .checkbox
       .click
-    check_professional_standing_page
+    assessor_check_professional_standing_page
       .form
       .failure_reason_note_textareas
       .first.fill_in with: "Note."
-    check_professional_standing_page.form.continue_button.click
+    assessor_check_professional_standing_page.form.continue_button.click
   end
 
   def application_form

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
     )
 
     when_i_check_declaration
-    then_i_see_the(:age_range_subjects_assessment_recommendation_award_page)
+    then_i_see_the(:assessor_age_range_subjects_assessment_recommendation_award_page)
     and_i_see_the_age_range_subjects
 
     when_i_click_change_age_range_minimum
@@ -52,7 +52,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
     )
 
     when_i_click_continue
-    then_i_see_the(:age_range_subjects_assessment_recommendation_award_page)
+    then_i_see_the(:assessor_age_range_subjects_assessment_recommendation_award_page)
     and_i_continue_from_age_range_subjects
 
     then_i_see_the(
@@ -274,7 +274,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
   def and_i_see_the_age_range_subjects
     rows =
-      age_range_subjects_assessment_recommendation_award_page.summary_list.rows
+      assessor_age_range_subjects_assessment_recommendation_award_page.summary_list.rows
 
     expect(rows.count).to eq(3)
 
@@ -289,7 +289,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def when_i_click_change_age_range_minimum
-    age_range_subjects_assessment_recommendation_award_page
+    assessor_age_range_subjects_assessment_recommendation_award_page
       .summary_list
       .rows
       .first
@@ -299,7 +299,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def and_i_continue_from_age_range_subjects
-    age_range_subjects_assessment_recommendation_award_page.continue_button.click
+    assessor_age_range_subjects_assessment_recommendation_award_page.continue_button.click
   end
 
   def and_i_see_failure_reasons

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -27,7 +27,11 @@ RSpec.describe "Assessor completing assessment", type: :system do
     given_there_is_an_awardable_application_form(%i[old_regs])
     given_i_can_request_dqt_api
 
-    when_i_visit_the(:assessor_complete_assessment_page, application_id:, assessment_id:)
+    when_i_visit_the(
+      :assessor_complete_assessment_page,
+      application_id:,
+      assessment_id:,
+    )
 
     when_i_select_award_qts
     and_i_click_continue
@@ -78,7 +82,11 @@ RSpec.describe "Assessor completing assessment", type: :system do
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_awardable_application_form_under_new_regulations
 
-    when_i_visit_the(:assessor_complete_assessment_page, application_id:, assessment_id:)
+    when_i_visit_the(
+      :assessor_complete_assessment_page,
+      application_id:,
+      assessment_id:,
+    )
 
     when_i_select_award_qts
     and_i_click_continue
@@ -149,7 +157,11 @@ RSpec.describe "Assessor completing assessment", type: :system do
     given_i_am_authorized_as_an_assessor_user
     given_there_is_a_declinable_application_form
 
-    when_i_visit_the(:assessor_complete_assessment_page, application_id:, assessment_id:)
+    when_i_visit_the(
+      :assessor_complete_assessment_page,
+      application_id:,
+      assessment_id:,
+    )
 
     when_i_select_decline_qts
     and_i_click_continue
@@ -304,7 +316,10 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def when_i_check_declaration
-    assessor_declare_assessment_recommendation_page.form.declaration_checkbox.click
+    assessor_declare_assessment_recommendation_page
+      .form
+      .declaration_checkbox
+      .click
     assessor_declare_assessment_recommendation_page.form.submit_button.click
   end
 
@@ -365,7 +380,11 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def when_i_check_confirmation
-    assessor_confirm_assessment_recommendation_page.form.yes_radio_item.input.click
+    assessor_confirm_assessment_recommendation_page
+      .form
+      .yes_radio_item
+      .input
+      .click
     assessor_confirm_assessment_recommendation_page.form.continue_button.click
   end
 

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_click_change_age_range_minimum
     then_i_see_the(
-      :edit_age_range_subjects_assessment_recommendation_award_page,
+      :assessor_edit_age_range_subjects_assessment_recommendation_award_page,
     )
 
     when_i_click_continue
@@ -52,7 +52,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
     and_i_continue_from_age_range_subjects
 
     then_i_see_the(
-      :preview_assessment_recommendation_page,
+      :assessor_preview_assessment_recommendation_page,
       application_id:,
       assessment_id:,
       recommendation: "award",
@@ -83,28 +83,28 @@ RSpec.describe "Assessor completing assessment", type: :system do
     when_i_select_award_qts
     and_i_click_continue
     then_i_see_the(
-      :verify_qualifications_assessment_recommendation_verify_page,
+      :assessor_verify_qualifications_assessment_recommendation_verify_page,
       application_id:,
       assessment_id:,
     )
 
     when_i_select_yes_verify_qualifications
     then_i_see_the(
-      :qualification_requests_assessment_recommendation_verify_page,
+      :assessor_qualification_requests_assessment_recommendation_verify_page,
       application_id:,
       assessment_id:,
     )
 
     when_i_select_the_qualifications
     then_i_see_the(
-      :email_consent_letters_requests_assessment_recommendation_verify_page,
+      :assessor_email_consent_letters_requests_assessment_recommendation_verify_page,
       application_id:,
       assessment_id:,
     )
 
     when_i_click_continue_from_email_consent_letters
     then_i_see_the(
-      :verify_professional_standing_assessment_recommendation_verify_page,
+      :assessor_verify_professional_standing_assessment_recommendation_verify_page,
       application_id:,
       assessment_id:,
     )
@@ -118,21 +118,21 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_click_continue_from_contact_professional_standing
     then_i_see_the(
-      :reference_requests_assessment_recommendation_verify_page,
+      :assessor_reference_requests_assessment_recommendation_verify_page,
       application_id:,
       assessment_id:,
     )
 
     when_i_select_the_work_histories
     then_i_see_the(
-      :preview_referee_assessment_recommendation_award_page,
+      :assessor_preview_referee_assessment_recommendation_award_page,
       application_id:,
       assessment_id:,
     )
 
     when_i_send_the_referee_email
     then_i_see_the(
-      :preview_teacher_assessment_recommendation_award_page,
+      :assessor_preview_teacher_assessment_recommendation_award_page,
       application_id:,
       assessment_id:,
     )
@@ -163,7 +163,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_check_declaration
     then_i_see_the(
-      :preview_assessment_recommendation_page,
+      :assessor_preview_assessment_recommendation_page,
       application_id:,
       assessment_id:,
       recommendation: "decline",
@@ -309,33 +309,33 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def when_i_select_yes_verify_qualifications
-    verify_qualifications_assessment_recommendation_verify_page
+    assessor_verify_qualifications_assessment_recommendation_verify_page
       .form
       .yes_radio_item
       .choose
-    verify_qualifications_assessment_recommendation_verify_page
+    assessor_verify_qualifications_assessment_recommendation_verify_page
       .form
       .submit_button
       .click
   end
 
   def when_i_select_the_qualifications
-    qualification_requests_assessment_recommendation_verify_page
+    assessor_qualification_requests_assessment_recommendation_verify_page
       .form
       .submit_button
       .click
   end
 
   def when_i_click_continue_from_email_consent_letters
-    email_consent_letters_requests_assessment_recommendation_verify_page.continue_button.click
+    assessor_email_consent_letters_requests_assessment_recommendation_verify_page.continue_button.click
   end
 
   def when_i_select_yes_verify_professional_standing
-    verify_professional_standing_assessment_recommendation_verify_page
+    assessor_verify_professional_standing_assessment_recommendation_verify_page
       .form
       .yes_radio_item
       .choose
-    verify_professional_standing_assessment_recommendation_verify_page
+    assessor_verify_professional_standing_assessment_recommendation_verify_page
       .form
       .submit_button
       .click
@@ -346,22 +346,22 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def when_i_select_the_work_histories
-    reference_requests_assessment_recommendation_verify_page
+    assessor_reference_requests_assessment_recommendation_verify_page
       .form
       .submit_button
       .click
   end
 
   def when_i_send_the_referee_email
-    preview_referee_assessment_recommendation_award_page.send_button.click
+    assessor_preview_referee_assessment_recommendation_award_page.send_button.click
   end
 
   def when_i_send_the_teacher_email
-    preview_teacher_assessment_recommendation_award_page.send_button.click
+    assessor_preview_teacher_assessment_recommendation_award_page.send_button.click
   end
 
   def when_i_send_the_email
-    preview_assessment_recommendation_page.send_button.click
+    assessor_preview_assessment_recommendation_page.send_button.click
   end
 
   def when_i_check_confirmation

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe "Assessor completing assessment", type: :system do
     given_there_is_an_awardable_application_form(%i[old_regs])
     given_i_can_request_dqt_api
 
-    when_i_visit_the(:complete_assessment_page, application_id:, assessment_id:)
+    when_i_visit_the(:assessor_complete_assessment_page, application_id:, assessment_id:)
 
     when_i_select_award_qts
     and_i_click_continue
     then_i_see_the(
-      :declare_assessment_recommendation_page,
+      :assessor_declare_assessment_recommendation_page,
       application_id:,
       assessment_id:,
       recommendation: "award",
@@ -60,7 +60,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_send_the_email
     then_i_see_the(
-      :confirm_assessment_recommendation_page,
+      :assessor_confirm_assessment_recommendation_page,
       application_id:,
       assessment_id:,
       recommendation: "award",
@@ -78,7 +78,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_awardable_application_form_under_new_regulations
 
-    when_i_visit_the(:complete_assessment_page, application_id:, assessment_id:)
+    when_i_visit_the(:assessor_complete_assessment_page, application_id:, assessment_id:)
 
     when_i_select_award_qts
     and_i_click_continue
@@ -111,7 +111,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_select_yes_verify_professional_standing
     then_i_see_the(
-      :contact_professional_standing_assessment_recommendation_verify_page,
+      :assessor_contact_professional_standing_assessment_recommendation_verify_page,
       application_id:,
       assessment_id:,
     )
@@ -149,12 +149,12 @@ RSpec.describe "Assessor completing assessment", type: :system do
     given_i_am_authorized_as_an_assessor_user
     given_there_is_a_declinable_application_form
 
-    when_i_visit_the(:complete_assessment_page, application_id:, assessment_id:)
+    when_i_visit_the(:assessor_complete_assessment_page, application_id:, assessment_id:)
 
     when_i_select_decline_qts
     and_i_click_continue
     then_i_see_the(
-      :declare_assessment_recommendation_page,
+      :assessor_declare_assessment_recommendation_page,
       application_id:,
       assessment_id:,
       recommendation: "decline",
@@ -171,7 +171,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_send_the_email
     then_i_see_the(
-      :confirm_assessment_recommendation_page,
+      :assessor_confirm_assessment_recommendation_page,
       application_id:,
       assessment_id:,
       recommendation: "decline",
@@ -253,11 +253,11 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def when_i_select_award_qts
-    complete_assessment_page.award_qts.input.choose
+    assessor_complete_assessment_page.award_qts.input.choose
   end
 
   def when_i_select_decline_qts
-    complete_assessment_page.decline_qts.input.choose
+    assessor_complete_assessment_page.decline_qts.input.choose
   end
 
   def and_i_see_the_age_range_subjects
@@ -292,7 +292,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
   def and_i_see_failure_reasons
     failure_reason_item =
-      declare_assessment_recommendation_page
+      assessor_declare_assessment_recommendation_page
         .failure_reason_lists
         .first
         .items
@@ -304,8 +304,8 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def when_i_check_declaration
-    declare_assessment_recommendation_page.form.declaration_checkbox.click
-    declare_assessment_recommendation_page.form.submit_button.click
+    assessor_declare_assessment_recommendation_page.form.declaration_checkbox.click
+    assessor_declare_assessment_recommendation_page.form.submit_button.click
   end
 
   def when_i_select_yes_verify_qualifications
@@ -342,7 +342,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def when_i_click_continue_from_contact_professional_standing
-    contact_professional_standing_assessment_recommendation_verify_page.continue_button.click
+    assessor_contact_professional_standing_assessment_recommendation_verify_page.continue_button.click
   end
 
   def when_i_select_the_work_histories
@@ -365,8 +365,8 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   def when_i_check_confirmation
-    confirm_assessment_recommendation_page.form.yes_radio_item.input.click
-    confirm_assessment_recommendation_page.form.continue_button.click
+    assessor_confirm_assessment_recommendation_page.form.yes_radio_item.input.click
+    assessor_confirm_assessment_recommendation_page.form.continue_button.click
   end
 
   def when_i_click_on_overview_button

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -43,7 +43,9 @@ RSpec.describe "Assessor completing assessment", type: :system do
     )
 
     when_i_check_declaration
-    then_i_see_the(:assessor_age_range_subjects_assessment_recommendation_award_page)
+    then_i_see_the(
+      :assessor_age_range_subjects_assessment_recommendation_award_page,
+    )
     and_i_see_the_age_range_subjects
 
     when_i_click_change_age_range_minimum
@@ -52,7 +54,9 @@ RSpec.describe "Assessor completing assessment", type: :system do
     )
 
     when_i_click_continue
-    then_i_see_the(:assessor_age_range_subjects_assessment_recommendation_award_page)
+    then_i_see_the(
+      :assessor_age_range_subjects_assessment_recommendation_award_page,
+    )
     and_i_continue_from_age_range_subjects
 
     then_i_see_the(

--- a/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
+++ b/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     then_i_see_the_application
 
     when_i_visit_the(
-      :check_english_language_proficiency_page,
+      :assessor_check_english_language_proficiency_page,
       application_id:,
       assessment_id:,
       section_id: section_id("english_language_proficiency"),
@@ -44,7 +44,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     then_i_see_the_application
 
     when_i_visit_the(
-      :check_english_language_proficiency_page,
+      :assessor_check_english_language_proficiency_page,
       application_id:,
       assessment_id:,
       section_id: section_id("english_language_proficiency"),
@@ -52,17 +52,17 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     then_i_am_asked_to_confirm_english_language_proficiency_in_the_qualifications_section
 
     when_i_visit_the(
-      :check_qualifications_page,
+      :assessor_check_qualifications_page,
       application_id:,
       assessment_id:,
       section_id: section_id("qualifications"),
     )
     then_i_can_see_failure_reasons_if_i_do_not_wish_to_confirm(
-      check_qualifications_page,
+      assessor_check_qualifications_page,
       "english_language_exemption_by_qualification_not_confirmed",
     )
-    and_i_confirm_english_language_exemption(check_qualifications_page)
-    and_i_confirm_the_section_as_complete(check_qualifications_page)
+    and_i_confirm_english_language_exemption(assessor_check_qualifications_page)
+    and_i_confirm_the_section_as_complete(assessor_check_qualifications_page)
     then_i_see_the_qualifications_section_is_complete
     and_the_english_language_section_is_complete
   end
@@ -73,7 +73,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     and_the_application_english_language_proof_method_is_provider
     given_i_am_authorized_as_an_assessor_user
     when_i_visit_the(
-      :check_english_language_proficiency_page,
+      :assessor_check_english_language_proficiency_page,
       application_id:,
       assessment_id:,
       section_id: section_id("english_language_proficiency"),
@@ -81,7 +81,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     then_i_am_asked_to_confirm_english_language_proficiency_by_provider
     and_i_can_see_provider_failure_reasons_if_i_do_not_wish_to_confirm
     and_i_confirm_the_section_as_complete(
-      check_english_language_proficiency_page,
+      assessor_check_english_language_proficiency_page,
     )
     then_the_english_language_section_is_complete
   end
@@ -92,7 +92,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     and_the_application_english_language_proof_method_is_moi
     given_i_am_authorized_as_an_assessor_user
     when_i_visit_the(
-      :check_english_language_proficiency_page,
+      :assessor_check_english_language_proficiency_page,
       application_id:,
       assessment_id:,
       section_id: section_id("english_language_proficiency"),
@@ -100,7 +100,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     then_i_am_asked_to_confirm_english_language_proficiency_by_moi
     and_i_can_see_moi_failure_reasons_if_i_do_not_wish_to_confirm
     and_i_confirm_the_section_as_complete(
-      check_english_language_proficiency_page,
+      assessor_check_english_language_proficiency_page,
     )
     then_the_english_language_section_is_complete
   end
@@ -173,33 +173,33 @@ RSpec.describe "Assessor confirms English language section", type: :system do
   end
 
   def then_i_am_asked_to_confirm_english_language_proficiency_in_the_personal_information_section
-    expect(check_english_language_proficiency_page.heading.text).to eq(
+    expect(assessor_check_english_language_proficiency_page.heading.text).to eq(
       "Check English language proficiency",
     )
-    expect(check_english_language_proficiency_page.h2s.last.text).to eq(
+    expect(assessor_check_english_language_proficiency_page.h2s.last.text).to eq(
       "English language exemption by birth/citizenship",
     )
-    check_english_language_proficiency_page.return_button.click
+    assessor_check_english_language_proficiency_page.return_button.click
   end
 
   def then_i_am_asked_to_confirm_english_language_proficiency_in_the_qualifications_section
-    expect(check_english_language_proficiency_page.heading.text).to eq(
+    expect(assessor_check_english_language_proficiency_page.heading.text).to eq(
       "Check English language proficiency",
     )
-    expect(check_english_language_proficiency_page.h2s.last.text).to eq(
+    expect(assessor_check_english_language_proficiency_page.h2s.last.text).to eq(
       "English language exemption by country of study",
     )
-    check_english_language_proficiency_page.return_button.click
+    assessor_check_english_language_proficiency_page.return_button.click
   end
 
   def then_i_am_asked_to_confirm_english_language_proficiency_by_provider
-    expect(check_english_language_proficiency_page.heading.text).to eq(
+    expect(assessor_check_english_language_proficiency_page.heading.text).to eq(
       "Check English language proficiency",
     )
     expect(
-      check_english_language_proficiency_page.cards.first.heading.text,
+      assessor_check_english_language_proficiency_page.cards.first.heading.text,
     ).to eq("Verify your English language proficiency")
-    expect(check_english_language_proficiency_page.lists.last.text).to eq(
+    expect(assessor_check_english_language_proficiency_page.lists.last.text).to eq(
       I18n.t(
         "assessor_interface.assessment_sections.checks.english_language_valid_provider",
       ),
@@ -207,14 +207,14 @@ RSpec.describe "Assessor confirms English language section", type: :system do
   end
 
   def then_i_am_asked_to_confirm_english_language_proficiency_by_moi
-    expect(check_english_language_proficiency_page.heading.text).to eq(
+    expect(assessor_check_english_language_proficiency_page.heading.text).to eq(
       "Check English language proficiency",
     )
     expect(
-      check_english_language_proficiency_page.cards.first.heading.text,
+      assessor_check_english_language_proficiency_page.cards.first.heading.text,
     ).to eq("Verify your English language proficiency")
 
-    expect(check_english_language_proficiency_page.lists.last.text).to eq(
+    expect(assessor_check_english_language_proficiency_page.lists.last.text).to eq(
       I18n.t(
         "assessor_interface.assessment_sections.checks.english_language_valid_moi",
       ),
@@ -223,14 +223,14 @@ RSpec.describe "Assessor confirms English language section", type: :system do
 
   def and_i_can_see_provider_failure_reasons_if_i_do_not_wish_to_confirm
     then_i_can_see_failure_reasons_if_i_do_not_wish_to_confirm(
-      check_english_language_proficiency_page,
+      assessor_check_english_language_proficiency_page,
       "english_language_qualification_invalid",
     )
   end
 
   def and_i_can_see_moi_failure_reasons_if_i_do_not_wish_to_confirm
     then_i_can_see_failure_reasons_if_i_do_not_wish_to_confirm(
-      check_english_language_proficiency_page,
+      assessor_check_english_language_proficiency_page,
       "english_language_moi_invalid_format",
     )
   end

--- a/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
+++ b/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
@@ -19,17 +19,17 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     then_i_am_asked_to_confirm_english_language_proficiency_in_the_personal_information_section
 
     when_i_visit_the(
-      :check_personal_information_page,
+      :assessor_check_personal_information_page,
       application_id:,
       assessment_id:,
       section_id: section_id("personal_information"),
     )
     then_i_can_see_failure_reasons_if_i_do_not_wish_to_confirm(
-      check_personal_information_page,
+      assessor_check_personal_information_page,
       "english_language_exemption_by_citizenship_not_confirmed",
     )
-    and_i_confirm_english_language_exemption(check_personal_information_page)
-    and_i_confirm_the_section_as_complete(check_personal_information_page)
+    and_i_confirm_english_language_exemption(assessor_check_personal_information_page)
+    and_i_confirm_the_section_as_complete(assessor_check_personal_information_page)
     then_i_see_the_personal_information_section_is_complete
     and_the_english_language_section_is_complete
   end

--- a/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
+++ b/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
@@ -28,8 +28,12 @@ RSpec.describe "Assessor confirms English language section", type: :system do
       assessor_check_personal_information_page,
       "english_language_exemption_by_citizenship_not_confirmed",
     )
-    and_i_confirm_english_language_exemption(assessor_check_personal_information_page)
-    and_i_confirm_the_section_as_complete(assessor_check_personal_information_page)
+    and_i_confirm_english_language_exemption(
+      assessor_check_personal_information_page,
+    )
+    and_i_confirm_the_section_as_complete(
+      assessor_check_personal_information_page,
+    )
     then_i_see_the_personal_information_section_is_complete
     and_the_english_language_section_is_complete
   end
@@ -176,9 +180,9 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     expect(assessor_check_english_language_proficiency_page.heading.text).to eq(
       "Check English language proficiency",
     )
-    expect(assessor_check_english_language_proficiency_page.h2s.last.text).to eq(
-      "English language exemption by birth/citizenship",
-    )
+    expect(
+      assessor_check_english_language_proficiency_page.h2s.last.text,
+    ).to eq("English language exemption by birth/citizenship")
     assessor_check_english_language_proficiency_page.return_button.click
   end
 
@@ -186,9 +190,9 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     expect(assessor_check_english_language_proficiency_page.heading.text).to eq(
       "Check English language proficiency",
     )
-    expect(assessor_check_english_language_proficiency_page.h2s.last.text).to eq(
-      "English language exemption by country of study",
-    )
+    expect(
+      assessor_check_english_language_proficiency_page.h2s.last.text,
+    ).to eq("English language exemption by country of study")
     assessor_check_english_language_proficiency_page.return_button.click
   end
 
@@ -199,7 +203,9 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     expect(
       assessor_check_english_language_proficiency_page.cards.first.heading.text,
     ).to eq("Verify your English language proficiency")
-    expect(assessor_check_english_language_proficiency_page.lists.last.text).to eq(
+    expect(
+      assessor_check_english_language_proficiency_page.lists.last.text,
+    ).to eq(
       I18n.t(
         "assessor_interface.assessment_sections.checks.english_language_valid_provider",
       ),
@@ -214,7 +220,9 @@ RSpec.describe "Assessor confirms English language section", type: :system do
       assessor_check_english_language_proficiency_page.cards.first.heading.text,
     ).to eq("Verify your English language proficiency")
 
-    expect(assessor_check_english_language_proficiency_page.lists.last.text).to eq(
+    expect(
+      assessor_check_english_language_proficiency_page.lists.last.text,
+    ).to eq(
       I18n.t(
         "assessor_interface.assessment_sections.checks.english_language_valid_moi",
       ),

--- a/spec/system/assessor_interface/creating_note_spec.rb
+++ b/spec/system/assessor_interface/creating_note_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe "Creating a note", type: :system do
       application_id: application_form.id,
     )
 
-    when_i_visit_the(:timeline_page, application_id: application_form.id)
-    then_i_see_the(:timeline_page, application_id: application_form.id)
+    when_i_visit_the(:assessor_timeline_page, application_id: application_form.id)
+    then_i_see_the(:assessor_timeline_page, application_id: application_form.id)
     and_i_see_the_note_timeline_event
   end
 
@@ -42,7 +42,7 @@ RSpec.describe "Creating a note", type: :system do
   end
 
   def and_i_see_the_note_timeline_event
-    timeline_item = timeline_page.timeline_items.first
+    timeline_item = assessor_timeline_page.timeline_items.first
 
     expect(timeline_item.title).to have_content("Note created")
 

--- a/spec/system/assessor_interface/creating_note_spec.rb
+++ b/spec/system/assessor_interface/creating_note_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Creating a note", type: :system do
       application_id: application_form.id,
     )
     and_i_click_add_note
-    then_i_see_the(:create_note_page, application_id: application_form.id)
+    then_i_see_the(:assessor_qualified_for_subject_page, application_id: application_form.id)
 
     when_i_create_a_note
     then_i_see_the(
@@ -37,8 +37,8 @@ RSpec.describe "Creating a note", type: :system do
   end
 
   def when_i_create_a_note
-    create_note_page.form.text_textarea.fill_in with: "A note."
-    create_note_page.form.submit_button.click
+    assessor_qualified_for_subject_page.form.text_textarea.fill_in with: "A note."
+    assessor_qualified_for_subject_page.form.submit_button.click
   end
 
   def and_i_see_the_note_timeline_event

--- a/spec/system/assessor_interface/creating_note_spec.rb
+++ b/spec/system/assessor_interface/creating_note_spec.rb
@@ -13,7 +13,10 @@ RSpec.describe "Creating a note", type: :system do
       application_id: application_form.id,
     )
     and_i_click_add_note
-    then_i_see_the(:assessor_qualified_for_subject_page, application_id: application_form.id)
+    then_i_see_the(
+      :assessor_qualified_for_subject_page,
+      application_id: application_form.id,
+    )
 
     when_i_create_a_note
     then_i_see_the(
@@ -21,7 +24,10 @@ RSpec.describe "Creating a note", type: :system do
       application_id: application_form.id,
     )
 
-    when_i_visit_the(:assessor_timeline_page, application_id: application_form.id)
+    when_i_visit_the(
+      :assessor_timeline_page,
+      application_id: application_form.id,
+    )
     then_i_see_the(:assessor_timeline_page, application_id: application_form.id)
     and_i_see_the_note_timeline_event
   end
@@ -37,7 +43,8 @@ RSpec.describe "Creating a note", type: :system do
   end
 
   def when_i_create_a_note
-    assessor_qualified_for_subject_page.form.text_textarea.fill_in with: "A note."
+    assessor_qualified_for_subject_page.form.text_textarea.fill_in with:
+      "A note."
     assessor_qualified_for_subject_page.form.submit_button.click
   end
 

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Assessor filtering application forms", type: :system do
   end
 
   it "applies the filters" do
-    when_i_visit_the(:applications_page)
+    when_i_visit_the(:assessor_applications_page)
 
     when_i_clear_the_filters
     and_i_apply_the_assessor_filter
@@ -56,110 +56,110 @@ RSpec.describe "Assessor filtering application forms", type: :system do
   end
 
   def when_i_clear_the_filters
-    applications_page.clear_filters.click
+    assessor_applications_page.clear_filters.click
   end
 
   def and_i_apply_the_assessor_filter
-    expect(applications_page.assessor_filter.assessors.count).to eq(4)
-    applications_page.assessor_filter.assessors.second.checkbox.click
-    applications_page.apply_filters.click
+    expect(assessor_applications_page.assessor_filter.assessors.count).to eq(4)
+    assessor_applications_page.assessor_filter.assessors.second.checkbox.click
+    assessor_applications_page.apply_filters.click
   end
 
   def then_i_see_a_list_of_applications_filtered_by_assessor
-    expect(applications_page.search_results.count).to eq(1)
-    expect(applications_page.search_results.first.name.text).to eq(
+    expect(assessor_applications_page.search_results.count).to eq(1)
+    expect(assessor_applications_page.search_results.first.name.text).to eq(
       "Arnold Drummond",
     )
   end
 
   def and_i_apply_the_country_filter
-    applications_page.country_filter.country.set("France")
-    applications_page.apply_filters.click
+    assessor_applications_page.country_filter.country.set("France")
+    assessor_applications_page.apply_filters.click
   end
 
   def then_i_see_a_list_of_applications_filtered_by_country
-    expect(applications_page.search_results.count).to eq(1)
-    expect(applications_page.search_results.first.name.text).to eq(
+    expect(assessor_applications_page.search_results.count).to eq(1)
+    expect(assessor_applications_page.search_results.first.name.text).to eq(
       "Emma Dubois",
     )
   end
 
   def and_i_apply_the_reference_filter
-    applications_page.reference_filter.reference.set("CHER")
-    applications_page.apply_filters.click
+    assessor_applications_page.reference_filter.reference.set("CHER")
+    assessor_applications_page.apply_filters.click
   end
 
   def then_i_see_a_list_of_applications_filtered_by_reference
-    expect(applications_page.search_results.count).to eq(1)
-    expect(applications_page.search_results.first.name.text).to eq("Cher Bert")
+    expect(assessor_applications_page.search_results.count).to eq(1)
+    expect(assessor_applications_page.search_results.first.name.text).to eq("Cher Bert")
   end
 
   def and_i_apply_the_name_filter
-    applications_page.name_filter.name.set("cher")
-    applications_page.apply_filters.click
+    assessor_applications_page.name_filter.name.set("cher")
+    assessor_applications_page.apply_filters.click
   end
 
   def then_i_see_a_list_of_applications_filtered_by_name
-    expect(applications_page.search_results.count).to eq(1)
-    expect(applications_page.search_results.first.name.text).to eq("Cher Bert")
+    expect(assessor_applications_page.search_results.count).to eq(1)
+    expect(assessor_applications_page.search_results.first.name.text).to eq("Cher Bert")
   end
 
   def and_i_apply_the_email_filter
-    applications_page.email_filter.email.set("emma.dubois@example.org")
-    applications_page.apply_filters.click
+    assessor_applications_page.email_filter.email.set("emma.dubois@example.org")
+    assessor_applications_page.apply_filters.click
   end
 
   def then_i_see_a_list_of_applications_filtered_by_email
-    expect(applications_page.search_results.count).to eq(1)
-    expect(applications_page.search_results.first.name.text).to eq(
+    expect(assessor_applications_page.search_results.count).to eq(1)
+    expect(assessor_applications_page.search_results.first.name.text).to eq(
       "Emma Dubois",
     )
   end
 
   def and_i_apply_the_submitted_at_filter
-    applications_page.submitted_at_filter.start_day.set(1)
-    applications_page.submitted_at_filter.start_month.set(1)
-    applications_page.submitted_at_filter.start_year.set(2020)
-    applications_page.apply_filters.click
+    assessor_applications_page.submitted_at_filter.start_day.set(1)
+    assessor_applications_page.submitted_at_filter.start_month.set(1)
+    assessor_applications_page.submitted_at_filter.start_year.set(2020)
+    assessor_applications_page.apply_filters.click
   end
 
   def then_i_see_a_list_of_applications_filtered_by_submitted_at
-    expect(applications_page.search_results.count).to eq(1)
-    expect(applications_page.search_results.first.name.text).to eq("John Smith")
+    expect(assessor_applications_page.search_results.count).to eq(1)
+    expect(assessor_applications_page.search_results.first.name.text).to eq("John Smith")
   end
 
   def and_i_apply_the_action_required_by_filter
     admin_action_item =
-      applications_page.action_required_by_filter.items.find do |item|
+      assessor_applications_page.action_required_by_filter.items.find do |item|
         item.label.text == "Admin (1)"
       rescue Capybara::ElementNotFound
         false
       end
     admin_action_item.checkbox.click
-    applications_page.apply_filters.click
+    assessor_applications_page.apply_filters.click
   end
 
   def then_i_see_a_list_of_applications_filtered_by_action_required_by
-    expect(applications_page.search_results.count).to eq(1)
-    expect(applications_page.search_results.first.name.text).to eq(
+    expect(assessor_applications_page.search_results.count).to eq(1)
+    expect(assessor_applications_page.search_results.first.name.text).to eq(
       "Emma Dubois",
     )
   end
 
   def and_i_apply_the_stage_filter
     completed_item =
-      applications_page.stage_filter.items.find do |item|
+      assessor_applications_page.stage_filter.items.find do |item|
         item.label.text == "Completed (1)"
       rescue Capybara::ElementNotFound
         false
       end
     completed_item.checkbox.click
-    applications_page.apply_filters.click
+    assessor_applications_page.apply_filters.click
   end
 
   def then_i_see_a_list_of_applications_filtered_by_stage
-    expect(applications_page.search_results.count).to eq(1)
-    expect(applications_page.search_results.first.name.text).to eq("John Smith")
+    expect(assessor_applications_page.search_results.count).to eq(1)
+    expect(assessor_applications_page.search_results.first.name.text).to eq("John Smith")
   end
 
   def application_forms

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -91,7 +91,9 @@ RSpec.describe "Assessor filtering application forms", type: :system do
 
   def then_i_see_a_list_of_applications_filtered_by_reference
     expect(assessor_applications_page.search_results.count).to eq(1)
-    expect(assessor_applications_page.search_results.first.name.text).to eq("Cher Bert")
+    expect(assessor_applications_page.search_results.first.name.text).to eq(
+      "Cher Bert",
+    )
   end
 
   def and_i_apply_the_name_filter
@@ -101,7 +103,9 @@ RSpec.describe "Assessor filtering application forms", type: :system do
 
   def then_i_see_a_list_of_applications_filtered_by_name
     expect(assessor_applications_page.search_results.count).to eq(1)
-    expect(assessor_applications_page.search_results.first.name.text).to eq("Cher Bert")
+    expect(assessor_applications_page.search_results.first.name.text).to eq(
+      "Cher Bert",
+    )
   end
 
   def and_i_apply_the_email_filter
@@ -125,7 +129,9 @@ RSpec.describe "Assessor filtering application forms", type: :system do
 
   def then_i_see_a_list_of_applications_filtered_by_submitted_at
     expect(assessor_applications_page.search_results.count).to eq(1)
-    expect(assessor_applications_page.search_results.first.name.text).to eq("John Smith")
+    expect(assessor_applications_page.search_results.first.name.text).to eq(
+      "John Smith",
+    )
   end
 
   def and_i_apply_the_action_required_by_filter
@@ -159,7 +165,9 @@ RSpec.describe "Assessor filtering application forms", type: :system do
 
   def then_i_see_a_list_of_applications_filtered_by_stage
     expect(assessor_applications_page.search_results.count).to eq(1)
-    expect(assessor_applications_page.search_results.first.name.text).to eq("John Smith")
+    expect(assessor_applications_page.search_results.first.name.text).to eq(
+      "John Smith",
+    )
   end
 
   def application_forms

--- a/spec/system/assessor_interface/listing_application_forms_spec.rb
+++ b/spec/system/assessor_interface/listing_application_forms_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe "Assessor listing application forms", type: :system do
   end
 
   it "displays a list of applications" do
-    when_i_visit_the(:applications_page)
+    when_i_visit_the(:assessor_applications_page)
     then_i_see_a_list_of_applications
   end
 
   it "paginates the results" do
-    when_i_visit_the(:applications_page)
+    when_i_visit_the(:assessor_applications_page)
     then_i_see_the_pagination_controls
 
     when_i_click_on_next
@@ -29,7 +29,7 @@ RSpec.describe "Assessor listing application forms", type: :system do
   end
 
   def when_i_click_on_next
-    applications_page.pagination.next.click
+    assessor_applications_page.pagination.next.click
   end
 
   def then_i_see_a_list_of_applications
@@ -42,7 +42,7 @@ RSpec.describe "Assessor listing application forms", type: :system do
   end
 
   def then_i_see_the_pagination_controls
-    expect(applications_page.pagination).to be_visible
+    expect(assessor_applications_page.pagination).to be_visible
   end
 
   def then_i_see_the_next_page_of_applications
@@ -55,7 +55,7 @@ RSpec.describe "Assessor listing application forms", type: :system do
   end
 
   def visible_names
-    applications_page.search_results.map { |result| result.name.text }
+    assessor_applications_page.search_results.map { |result| result.name.text }
   end
 
   def application_forms

--- a/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
+++ b/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
@@ -31,11 +31,11 @@ RSpec.describe "Assessor pre-assessment tasks", type: :system do
 
     when_i_click_on_the_preliminary_check_task
     and_i_choose_no_to_both_questions
-    then_i_see_the(:complete_assessment_page, application_id:)
+    then_i_see_the(:assessor_complete_assessment_page, application_id:)
 
     when_i_select_decline_qts
     then_i_see_the(
-      :declare_assessment_recommendation_page,
+      :assessor_declare_assessment_recommendation_page,
       application_id:,
       recommendation: "decline",
     )
@@ -87,14 +87,14 @@ RSpec.describe "Assessor pre-assessment tasks", type: :system do
   end
 
   def when_i_select_decline_qts
-    expect(complete_assessment_page.new_states.count).to eq(1)
-    complete_assessment_page.decline_qts.input.choose
-    complete_assessment_page.continue_button.click
+    expect(assessor_complete_assessment_page.new_states.count).to eq(1)
+    assessor_complete_assessment_page.decline_qts.input.choose
+    assessor_complete_assessment_page.continue_button.click
   end
 
   def and_i_see_the_failure_reasons
     failure_reason_items =
-      declare_assessment_recommendation_page.failure_reason_lists.first.items
+      assessor_declare_assessment_recommendation_page.failure_reason_lists.first.items
 
     expect(failure_reason_items.first.text).to eq(
       "The teaching qualifications do not meet the required academic level (level 6).",

--- a/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
+++ b/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
@@ -94,7 +94,10 @@ RSpec.describe "Assessor pre-assessment tasks", type: :system do
 
   def and_i_see_the_failure_reasons
     failure_reason_items =
-      assessor_declare_assessment_recommendation_page.failure_reason_lists.first.items
+      assessor_declare_assessment_recommendation_page
+        .failure_reason_lists
+        .first
+        .items
 
     expect(failure_reason_items.first.text).to eq(
       "The teaching qualifications do not meet the required academic level (level 6).",

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -26,7 +26,11 @@ RSpec.describe "Assessor requesting further information", type: :system do
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_application_form_with_failure_reasons
 
-    when_i_visit_the(:assessor_complete_assessment_page, application_id:, assessment_id:)
+    when_i_visit_the(
+      :assessor_complete_assessment_page,
+      application_id:,
+      assessment_id:,
+    )
 
     when_i_select_request_further_information
     and_i_click_continue
@@ -71,12 +75,14 @@ RSpec.describe "Assessor requesting further information", type: :system do
 
   def and_i_see_the_further_information_request_items
     expect(assessor_request_further_information_page.items.count).to eq(1)
-    expect(assessor_request_further_information_page.items.first.heading.text).to eq(
+    expect(
+      assessor_request_further_information_page.items.first.heading.text,
+    ).to eq(
       "Subjects entered are acceptable for QTS, but the uploaded qualifications do not match them.",
     )
-    expect(assessor_request_further_information_page.items.first.feedback.text).to eq(
-      "A note.",
-    )
+    expect(
+      assessor_request_further_information_page.items.first.feedback.text,
+    ).to eq("A note.")
   end
 
   def when_i_click_continue_to_email_button
@@ -90,7 +96,10 @@ RSpec.describe "Assessor requesting further information", type: :system do
   end
 
   def when_i_click_send_to_applicant
-    assessor_further_information_request_preview_page.form.send_to_applicant_button.click
+    assessor_further_information_request_preview_page
+      .form
+      .send_to_applicant_button
+      .click
   end
 
   def and_i_receive_a_further_information_requested_email

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_application_form_with_failure_reasons
 
-    when_i_visit_the(:complete_assessment_page, application_id:, assessment_id:)
+    when_i_visit_the(:assessor_complete_assessment_page, application_id:, assessment_id:)
 
     when_i_select_request_further_information
     and_i_click_continue
@@ -66,7 +66,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
   end
 
   def when_i_select_request_further_information
-    complete_assessment_page.request_further_information.input.choose
+    assessor_complete_assessment_page.request_further_information.input.choose
   end
 
   def and_i_see_the_further_information_request_items

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
     when_i_select_request_further_information
     and_i_click_continue
     then_i_see_the(
-      :request_further_information_page,
+      :assessor_request_further_information_page,
       application_id:,
       assessment_id:,
     )
@@ -39,7 +39,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
 
     when_i_click_continue_to_email_button
     then_i_see_the(
-      :further_information_request_preview_page,
+      :assessor_further_information_request_preview_page,
       application_id:,
       assessment_id:,
     )
@@ -47,7 +47,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
 
     when_i_click_send_to_applicant
     then_i_see_the(
-      :further_information_request_page,
+      :assessor_further_information_request_page,
       application_id:,
       assessment_id:,
       further_information_request_id:,
@@ -70,27 +70,27 @@ RSpec.describe "Assessor requesting further information", type: :system do
   end
 
   def and_i_see_the_further_information_request_items
-    expect(request_further_information_page.items.count).to eq(1)
-    expect(request_further_information_page.items.first.heading.text).to eq(
+    expect(assessor_request_further_information_page.items.count).to eq(1)
+    expect(assessor_request_further_information_page.items.first.heading.text).to eq(
       "Subjects entered are acceptable for QTS, but the uploaded qualifications do not match them.",
     )
-    expect(request_further_information_page.items.first.feedback.text).to eq(
+    expect(assessor_request_further_information_page.items.first.feedback.text).to eq(
       "A note.",
     )
   end
 
   def when_i_click_continue_to_email_button
-    request_further_information_page.continue_button.click
+    assessor_request_further_information_page.continue_button.click
   end
 
   def and_i_see_the_email_preview
     expect(
-      further_information_request_preview_page.email_preview,
+      assessor_further_information_request_preview_page.email_preview,
     ).to have_content("I am an email")
   end
 
   def when_i_click_send_to_applicant
-    further_information_request_preview_page.form.send_to_applicant_button.click
+    assessor_further_information_request_preview_page.form.send_to_applicant_button.click
   end
 
   def and_i_receive_a_further_information_requested_email

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     when_i_visit_the(:assessor_application_page, application_id:)
     and_i_click_review_requested_information
     then_i_see_the(
-      :review_further_information_request_page,
+      :assessor_review_further_information_request_page,
       application_id:,
       assessment_id:,
       further_information_request_id:,
@@ -30,7 +30,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     when_i_visit_the(:assessor_application_page, application_id:)
     and_i_click_review_requested_information
     then_i_see_the(
-      :review_further_information_request_page,
+      :assessor_review_further_information_request_page,
       application_id:,
       assessment_id:,
       further_information_request_id:,
@@ -49,7 +49,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     when_i_visit_the(:assessor_application_page, application_id:)
     and_i_click_review_requested_information
     then_i_see_the(
-      :review_further_information_request_page,
+      :assessor_review_further_information_request_page,
       application_id:,
       assessment_id:,
       further_information_request_id:,
@@ -74,7 +74,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
 
   def and_i_see_the_check_your_answers_items
     rows =
-      review_further_information_request_page.summary_lists.flat_map(&:rows)
+      assessor_review_further_information_request_page.summary_lists.flat_map(&:rows)
 
     expect(rows.count).to eq(8)
 
@@ -86,8 +86,8 @@ RSpec.describe "Assessor reviewing further information", type: :system do
   end
 
   def when_i_mark_the_section_as_complete
-    review_further_information_request_page.form.yes_radio_item.input.click
-    review_further_information_request_page.form.continue_button.click
+    assessor_review_further_information_request_page.form.yes_radio_item.input.click
+    assessor_review_further_information_request_page.form.continue_button.click
   end
 
   def and_i_see_an_award_qts_option
@@ -95,10 +95,10 @@ RSpec.describe "Assessor reviewing further information", type: :system do
   end
 
   def when_i_mark_the_section_as_incomplete
-    review_further_information_request_page.form.no_radio_item.input.click
-    review_further_information_request_page.form.failure_reason_textarea.fill_in with:
+    assessor_review_further_information_request_page.form.no_radio_item.input.click
+    assessor_review_further_information_request_page.form.failure_reason_textarea.fill_in with:
       "Failure reason"
-    review_further_information_request_page.form.continue_button.click
+    assessor_review_further_information_request_page.form.continue_button.click
   end
 
   def and_i_see_a_decline_qts_option
@@ -106,7 +106,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
   end
 
   def and_i_do_not_see_the_review_further_information_form
-    expect(review_further_information_request_page).not_to have_form
+    expect(assessor_review_further_information_request_page).not_to have_form
   end
 
   def application_form

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -74,7 +74,9 @@ RSpec.describe "Assessor reviewing further information", type: :system do
 
   def and_i_see_the_check_your_answers_items
     rows =
-      assessor_review_further_information_request_page.summary_lists.flat_map(&:rows)
+      assessor_review_further_information_request_page.summary_lists.flat_map(
+        &:rows
+      )
 
     expect(rows.count).to eq(8)
 
@@ -86,7 +88,11 @@ RSpec.describe "Assessor reviewing further information", type: :system do
   end
 
   def when_i_mark_the_section_as_complete
-    assessor_review_further_information_request_page.form.yes_radio_item.input.click
+    assessor_review_further_information_request_page
+      .form
+      .yes_radio_item
+      .input
+      .click
     assessor_review_further_information_request_page.form.continue_button.click
   end
 
@@ -95,7 +101,11 @@ RSpec.describe "Assessor reviewing further information", type: :system do
   end
 
   def when_i_mark_the_section_as_incomplete
-    assessor_review_further_information_request_page.form.no_radio_item.input.click
+    assessor_review_further_information_request_page
+      .form
+      .no_radio_item
+      .input
+      .click
     assessor_review_further_information_request_page.form.failure_reason_textarea.fill_in with:
       "Failure reason"
     assessor_review_further_information_request_page.form.continue_button.click

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     and_i_see_the_check_your_answers_items
 
     when_i_mark_the_section_as_complete
-    then_i_see_the(:complete_assessment_page, application_id:)
+    then_i_see_the(:assessor_complete_assessment_page, application_id:)
     and_i_see_an_award_qts_option
   end
 
@@ -38,7 +38,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     and_i_see_the_check_your_answers_items
 
     when_i_mark_the_section_as_incomplete
-    then_i_see_the(:complete_assessment_page, application_id:)
+    then_i_see_the(:assessor_complete_assessment_page, application_id:)
     and_i_see_a_decline_qts_option
   end
 
@@ -91,7 +91,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
   end
 
   def and_i_see_an_award_qts_option
-    expect(complete_assessment_page.award_qts).to_not be_nil
+    expect(assessor_complete_assessment_page.award_qts).to_not be_nil
   end
 
   def when_i_mark_the_section_as_incomplete
@@ -102,7 +102,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
   end
 
   def and_i_see_a_decline_qts_option
-    expect(complete_assessment_page.decline_qts).to_not be_nil
+    expect(assessor_complete_assessment_page.decline_qts).to_not be_nil
   end
 
   def and_i_do_not_see_the_review_further_information_form

--- a/spec/system/assessor_interface/reviewing_verifications_spec.rb
+++ b/spec/system/assessor_interface/reviewing_verifications_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Assessor reviewing verifications", type: :system do
 
     when_i_click_on_assessment_decision
     then_i_see_the(
-      :complete_assessment_page,
+      :assessor_complete_assessment_page,
       application_id: application_form_id,
       assessment_id:,
     )

--- a/spec/system/assessor_interface/view_application_form_spec.rb
+++ b/spec/system/assessor_interface/view_application_form_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Assessor view application form", type: :system do
     and_i_see_the_assessment_tasks
 
     when_i_click_back_link
-    then_i_see_the(:applications_page)
+    then_i_see_the(:assessor_applications_page)
   end
 
   private

--- a/spec/system/assessor_interface/view_timeline_events_spec.rb
+++ b/spec/system/assessor_interface/view_timeline_events_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe "Assessor view timeline events", type: :system do
 
   def then_i_see_the_timeline
     expect(assessor_timeline_page).to have_heading
-    expect(assessor_timeline_page.heading).to have_content("Application history")
+    expect(assessor_timeline_page.heading).to have_content(
+      "Application history",
+    )
 
     expect(assessor_timeline_page).to have_timeline_items
     expect(assessor_timeline_page.timeline_items.first.title).to have_content(

--- a/spec/system/assessor_interface/view_timeline_events_spec.rb
+++ b/spec/system/assessor_interface/view_timeline_events_spec.rb
@@ -31,17 +31,17 @@ RSpec.describe "Assessor view timeline events", type: :system do
   end
 
   def then_i_see_the_timeline
-    expect(timeline_page).to have_heading
-    expect(timeline_page.heading).to have_content("Application history")
+    expect(assessor_timeline_page).to have_heading
+    expect(assessor_timeline_page.heading).to have_content("Application history")
 
-    expect(timeline_page).to have_timeline_items
-    expect(timeline_page.timeline_items.first.title).to have_content(
+    expect(assessor_timeline_page).to have_timeline_items
+    expect(assessor_timeline_page.timeline_items.first.title).to have_content(
       "Note created",
     )
-    expect(timeline_page.timeline_items.second.title).to have_content(
+    expect(assessor_timeline_page.timeline_items.second.title).to have_content(
       "Status changed",
     )
-    expect(timeline_page.timeline_items.third.title).to have_content(
+    expect(assessor_timeline_page.timeline_items.third.title).to have_content(
       "Assessor assigned",
     )
   end

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -9,62 +9,62 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   it "happy path" do
-    when_i_visit_the(:start_page)
-    then_i_see_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
+    then_i_see_the(:eligibility_start_page)
 
     when_i_press_start_now
-    then_i_see_the(:country_page)
+    then_i_see_the(:eligibility_country_page)
 
     when_i_select_an_eligible_country
-    then_i_see_the(:qualification_page)
+    then_i_see_the(:eligibility_qualification_page)
 
     when_i_have_a_qualification
-    then_i_see_the(:degree_page)
+    then_i_see_the(:eligibility_degree_page)
 
     when_i_have_a_degree
-    then_i_see_the(:teach_children_page)
+    then_i_see_the(:eligibility_teach_children_page)
 
     when_i_can_teach_children
-    then_i_see_the(:work_experience_page)
+    then_i_see_the(:eligibility_work_experience_page)
 
     when_i_have_more_than_20_months_work_experience
-    then_i_see_the(:misconduct_page)
+    then_i_see_the(:eligibility_misconduct_page)
 
     when_i_dont_have_a_misconduct_record
-    then_i_see_the(:eligible_page)
+    then_i_see_the(:eligibility_eligible_page)
 
-    when_i_visit_the(:start_page)
-    then_i_see_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
+    then_i_see_the(:eligibility_start_page)
     when_i_press_start_now
     then_i_have_two_eligibility_checks
   end
 
   it "ineligible paths" do
-    when_i_visit_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
 
     when_i_press_start_now
     when_i_select_an_ineligible_country
-    then_i_see_the(:ineligible_page)
+    then_i_see_the(:eligibility_ineligible_page)
     and_i_see_the_ineligible_country_text
 
     when_i_press_back
     when_i_select_an_eligible_country
-    then_i_see_the(:qualification_page)
+    then_i_see_the(:eligibility_qualification_page)
 
     when_i_dont_have_a_qualification
-    then_i_see_the(:degree_page)
+    then_i_see_the(:eligibility_degree_page)
 
     when_i_dont_have_a_degree
-    then_i_see_the(:teach_children_page)
+    then_i_see_the(:eligibility_teach_children_page)
 
     when_i_cant_teach_children
-    then_i_see_the(:work_experience_page)
+    then_i_see_the(:eligibility_work_experience_page)
 
     when_i_have_under_9_months_work_experience
-    then_i_see_the(:misconduct_page)
+    then_i_see_the(:eligibility_misconduct_page)
 
     when_i_have_a_misconduct_record
-    then_i_see_the(:ineligible_page)
+    then_i_see_the(:eligibility_ineligible_page)
     and_i_see_the_ineligible_degree_text
     and_i_see_the_ineligible_qualification_text_with_eligible_country
     and_i_see_the_ineligible_teach_children_text
@@ -73,107 +73,107 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   it "ineligible countries" do
-    when_i_visit_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
 
     when_i_press_start_now
     when_i_select_england
-    then_i_see_the(:ineligible_page)
+    then_i_see_the(:eligibility_ineligible_page)
     and_i_see_the_ineligible_england_or_wales_text
 
     when_i_press_back
     when_i_select_wales
-    then_i_see_the(:ineligible_page)
+    then_i_see_the(:eligibility_ineligible_page)
     and_i_see_the_ineligible_england_or_wales_text
 
     when_i_press_back
     when_i_select_nigeria
-    then_i_see_the(:ineligible_page)
+    then_i_see_the(:eligibility_ineligible_page)
   end
 
   it "trying to skip steps" do
-    when_i_visit_the(:start_page)
-    then_i_see_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
+    then_i_see_the(:eligibility_start_page)
 
-    when_i_visit_the(:eligible_page)
-    then_i_see_the(:start_page)
+    when_i_visit_the(:eligibility_eligible_page)
+    then_i_see_the(:eligibility_start_page)
 
-    when_i_visit_the(:ineligible_page)
-    then_i_see_the(:start_page)
+    when_i_visit_the(:eligibility_ineligible_page)
+    then_i_see_the(:eligibility_start_page)
 
     when_i_press_start_now
-    then_i_see_the(:country_page)
+    then_i_see_the(:eligibility_country_page)
 
-    when_i_visit_the(:region_page)
-    then_i_see_the(:country_page)
+    when_i_visit_the(:eligibility_region_page)
+    then_i_see_the(:eligibility_country_page)
 
     when_i_select_an_eligible_country
-    then_i_see_the(:qualification_page)
+    then_i_see_the(:eligibility_qualification_page)
 
-    when_i_visit_the(:degree_page)
-    then_i_see_the(:qualification_page)
+    when_i_visit_the(:eligibility_degree_page)
+    then_i_see_the(:eligibility_qualification_page)
 
     when_i_have_a_qualification
-    then_i_see_the(:degree_page)
+    then_i_see_the(:eligibility_degree_page)
 
-    when_i_visit_the(:teach_children_page)
-    then_i_see_the(:degree_page)
+    when_i_visit_the(:eligibility_teach_children_page)
+    then_i_see_the(:eligibility_degree_page)
 
     when_i_have_a_degree
-    then_i_see_the(:teach_children_page)
+    then_i_see_the(:eligibility_teach_children_page)
 
-    when_i_visit_the(:work_experience_page)
-    then_i_see_the(:teach_children_page)
+    when_i_visit_the(:eligibility_work_experience_page)
+    then_i_see_the(:eligibility_teach_children_page)
 
     when_i_can_teach_children
-    then_i_see_the(:work_experience_page)
+    then_i_see_the(:eligibility_work_experience_page)
 
-    when_i_visit_the(:misconduct_page)
-    then_i_see_the(:work_experience_page)
+    when_i_visit_the(:eligibility_misconduct_page)
+    then_i_see_the(:eligibility_work_experience_page)
 
     when_i_have_more_than_20_months_work_experience
-    then_i_see_the(:misconduct_page)
+    then_i_see_the(:eligibility_misconduct_page)
   end
 
   it "handles the country picker error" do
-    when_i_visit_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
     when_i_press_start_now
     when_i_dont_select_a_country
     then_i_see_the_country_error_message
 
     when_i_select_an_eligible_country
-    then_i_see_the(:qualification_page)
+    then_i_see_the(:eligibility_qualification_page)
   end
 
   it "can skip questions with qualification" do
-    when_i_visit_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
     when_i_press_start_now
     when_i_select_a_skip_questions_country
-    then_i_see_the(:qualification_page)
+    then_i_see_the(:eligibility_qualification_page)
 
     when_i_have_a_qualification
-    then_i_see_the(:eligible_page)
+    then_i_see_the(:eligibility_eligible_page)
   end
 
   it "can skip questions without qualification" do
-    when_i_visit_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
     when_i_press_start_now
     when_i_select_a_skip_questions_country
-    then_i_see_the(:qualification_page)
+    then_i_see_the(:eligibility_qualification_page)
 
     when_i_dont_have_a_qualification
-    then_i_see_the(:degree_page)
+    then_i_see_the(:eligibility_degree_page)
 
     when_i_dont_have_a_degree
-    then_i_see_the(:teach_children_page)
+    then_i_see_the(:eligibility_teach_children_page)
 
     when_i_cant_teach_children
-    then_i_see_the(:work_experience_page)
+    then_i_see_the(:eligibility_work_experience_page)
 
     when_i_have_under_9_months_work_experience
-    then_i_see_the(:misconduct_page)
+    then_i_see_the(:eligibility_misconduct_page)
 
     when_i_have_a_misconduct_record
-    then_i_see_the(:ineligible_page)
+    then_i_see_the(:eligibility_ineligible_page)
     and_i_see_the_ineligible_degree_text
     and_i_see_the_ineligible_qualification_text_with_skip_questions_country
     and_i_see_the_ineligible_degree_text
@@ -183,132 +183,132 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   it "handles countries with multiple regions" do
-    when_i_visit_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
     when_i_press_start_now
     when_i_select_a_multiple_region_country
     then_i_see_the_region_page
 
     when_i_select_a_region
-    then_i_see_the(:qualification_page)
+    then_i_see_the(:eligibility_qualification_page)
   end
 
   it "service is closed" do
     given_the_service_is_closed
-    when_i_visit_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
     then_access_is_denied
 
     given_the_service_is_open
     given_i_am_authorized_as_a_support_user
-    when_i_visit_the(:start_page)
-    then_i_see_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
+    then_i_see_the(:eligibility_start_page)
 
     when_i_press_start_now
-    then_i_see_the(:country_page)
+    then_i_see_the(:eligibility_country_page)
 
     when_i_select_an_eligible_country
-    then_i_see_the(:qualification_page)
+    then_i_see_the(:eligibility_qualification_page)
   end
 
   it "test user is disabled" do
     given_the_service_is_closed
-    when_i_visit_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
     then_access_is_denied
 
     when_i_am_authorized_as_a_test_user
-    when_i_visit_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
     then_access_is_denied
 
     given_the_test_user_is_enabled
     when_i_am_authorized_as_a_test_user
-    when_i_visit_the(:start_page)
-    then_i_see_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
+    then_i_see_the(:eligibility_start_page)
   end
 
   it "happy path when filtering by country requiring qualification for subject" do
-    when_i_visit_the(:start_page)
-    then_i_see_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
+    then_i_see_the(:eligibility_start_page)
 
     when_i_press_start_now
-    then_i_see_the(:country_page)
+    then_i_see_the(:eligibility_country_page)
 
     when_i_select_a_qualified_for_subject_country
-    then_i_see_the(:qualification_page)
+    then_i_see_the(:eligibility_qualification_page)
 
     when_i_have_a_qualification
-    then_i_see_the(:degree_page)
+    then_i_see_the(:eligibility_degree_page)
 
     when_i_have_a_degree
-    then_i_see_the(:teach_children_page)
+    then_i_see_the(:eligibility_teach_children_page)
 
     when_i_can_teach_children
-    then_i_see_the(:qualified_for_subject_page)
+    then_i_see_the(:eligibility_qualified_for_subject_page)
 
     when_i_am_qualified_to_teach_a_relevant_subject
-    then_i_see_the(:work_experience_page)
+    then_i_see_the(:eligibility_work_experience_page)
 
     when_i_have_more_than_20_months_work_experience
-    then_i_see_the(:misconduct_page)
+    then_i_see_the(:eligibility_misconduct_page)
 
     when_i_dont_have_a_misconduct_record
-    then_i_see_the(:eligible_page)
+    then_i_see_the(:eligibility_eligible_page)
   end
 
   it "ineligible path when filtering by country, not qualified for UK secondary" do
-    when_i_visit_the(:start_page)
-    then_i_see_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
+    then_i_see_the(:eligibility_start_page)
 
     when_i_press_start_now
-    then_i_see_the(:country_page)
+    then_i_see_the(:eligibility_country_page)
 
     when_i_select_a_qualified_for_subject_country
-    then_i_see_the(:qualification_page)
+    then_i_see_the(:eligibility_qualification_page)
 
     when_i_have_a_qualification
-    then_i_see_the(:degree_page)
+    then_i_see_the(:eligibility_degree_page)
 
     when_i_have_a_degree
-    then_i_see_the(:teach_children_page)
+    then_i_see_the(:eligibility_teach_children_page)
 
     when_i_cant_teach_children
-    then_i_see_the(:qualified_for_subject_page)
+    then_i_see_the(:eligibility_qualified_for_subject_page)
 
     when_i_am_qualified_to_teach_a_relevant_subject
-    then_i_see_the(:work_experience_page)
+    then_i_see_the(:eligibility_work_experience_page)
 
     when_i_have_more_than_20_months_work_experience
-    then_i_see_the(:misconduct_page)
+    then_i_see_the(:eligibility_misconduct_page)
 
     when_i_dont_have_a_misconduct_record
-    then_i_see_the(:ineligible_page)
+    then_i_see_the(:eligibility_ineligible_page)
   end
 
   it "ineligible path when filtering by country, not qualified in relevant subject" do
-    when_i_visit_the(:start_page)
-    then_i_see_the(:start_page)
+    when_i_visit_the(:eligibility_start_page)
+    then_i_see_the(:eligibility_start_page)
 
     when_i_press_start_now
-    then_i_see_the(:country_page)
+    then_i_see_the(:eligibility_country_page)
 
     when_i_select_a_qualified_for_subject_country
-    then_i_see_the(:qualification_page)
+    then_i_see_the(:eligibility_qualification_page)
 
     when_i_have_a_qualification
-    then_i_see_the(:degree_page)
+    then_i_see_the(:eligibility_degree_page)
 
     when_i_have_a_degree
-    then_i_see_the(:teach_children_page)
+    then_i_see_the(:eligibility_teach_children_page)
 
     when_i_can_teach_children
-    then_i_see_the(:qualified_for_subject_page)
+    then_i_see_the(:eligibility_qualified_for_subject_page)
 
     when_i_am_not_qualified_to_teach_a_relevant_subject
-    then_i_see_the(:work_experience_page)
+    then_i_see_the(:eligibility_work_experience_page)
 
     when_i_have_more_than_20_months_work_experience
-    then_i_see_the(:misconduct_page)
+    then_i_see_the(:eligibility_misconduct_page)
 
     when_i_dont_have_a_misconduct_record
-    then_i_see_the(:ineligible_page)
+    then_i_see_the(:eligibility_ineligible_page)
   end
 
   private
@@ -333,177 +333,177 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def then_i_do_not_see_the_start_page
-    expect(start_page).not_to be_displayed
+    expect(eligibility_start_page).not_to be_displayed
   end
 
   def when_i_press_start_now
-    start_page.start_button.click
+    eligibility_start_page.start_button.click
   end
 
   def when_i_select_an_eligible_country
-    country_page.submit(country: "Scotland")
+    eligibility_country_page.submit(country: "Scotland")
   end
 
   def when_i_select_an_ineligible_country
-    country_page.submit(country: "Spain")
+    eligibility_country_page.submit(country: "Spain")
   end
 
   def when_i_select_a_skip_questions_country
-    country_page.submit(country: "Portugal")
+    eligibility_country_page.submit(country: "Portugal")
   end
 
   def when_i_select_a_multiple_region_country
-    country_page.submit(country: "Italy")
+    eligibility_country_page.submit(country: "Italy")
   end
 
   def when_i_select_england
-    country_page.submit(country: "England")
+    eligibility_country_page.submit(country: "England")
   end
 
   def when_i_select_wales
-    country_page.submit(country: "Wales")
+    eligibility_country_page.submit(country: "Wales")
   end
 
   def when_i_select_nigeria
-    country_page.submit(country: "Nigeria")
+    eligibility_country_page.submit(country: "Nigeria")
   end
 
   def when_i_select_laos
-    country_page.submit(country: "Laos")
+    eligibility_country_page.submit(country: "Laos")
   end
 
   def when_i_dont_select_a_country
-    country_page.form.continue_button.click
+    eligibility_country_page.form.continue_button.click
   end
 
   def when_i_select_a_qualified_for_subject_country
-    country_page.submit(country: "Jamaica")
+    eligibility_country_page.submit(country: "Jamaica")
   end
 
   def then_i_see_the_country_error_message
-    expect(country_page).to have_error_summary
-    expect(country_page.error_summary.body).to have_content(
+    expect(eligibility_country_page).to have_error_summary
+    expect(eligibility_country_page.error_summary.body).to have_content(
       "Tell us where you’re currently recognised as a teacher",
     )
   end
 
   def then_i_see_the_region_page
-    expect(region_page).to have_title(
+    expect(eligibility_region_page).to have_title(
       "In which state/territory are you currently recognised as a teacher?",
     )
-    expect(region_page.heading).to have_content(
+    expect(eligibility_region_page.heading).to have_content(
       "In which state/territory are you currently recognised as a teacher?",
     )
   end
 
   def when_i_select_a_region
-    region_page.submit(region: "Region")
+    eligibility_region_page.submit(region: "Region")
   end
 
   def when_i_have_a_qualification
-    qualification_page.submit_yes
+    eligibility_qualification_page.submit_yes
   end
 
   def when_i_dont_have_a_qualification
-    qualification_page.submit_no
+    eligibility_qualification_page.submit_no
   end
 
   def when_i_have_a_degree
-    degree_page.submit_yes
+    eligibility_degree_page.submit_yes
   end
 
   def when_i_dont_have_a_degree
-    degree_page.submit_no
+    eligibility_degree_page.submit_no
   end
 
   def when_i_can_teach_children
-    teach_children_page.submit_yes
+    eligibility_teach_children_page.submit_yes
   end
 
   def when_i_cant_teach_children
-    teach_children_page.submit_no
+    eligibility_teach_children_page.submit_no
   end
 
   def when_i_am_qualified_to_teach_a_relevant_subject
-    qualified_for_subject_page.submit_yes
+    eligibility_qualified_for_subject_page.submit_yes
   end
 
   def when_i_am_not_qualified_to_teach_a_relevant_subject
-    qualified_for_subject_page.submit_no
+    eligibility_qualified_for_subject_page.submit_no
   end
 
   def when_i_have_more_than_20_months_work_experience
-    work_experience_page.submit_over_20_months
+    eligibility_work_experience_page.submit_over_20_months
   end
 
   def when_i_have_under_9_months_work_experience
-    work_experience_page.submit_under_9_months
+    eligibility_work_experience_page.submit_under_9_months
   end
 
   def when_i_have_a_misconduct_record
-    misconduct_page.submit_yes
+    eligibility_misconduct_page.submit_yes
   end
 
   def when_i_dont_have_a_misconduct_record
-    misconduct_page.submit_no
+    eligibility_misconduct_page.submit_no
   end
 
   def when_i_press_apply
-    eligible_page.apply_button.click
+    eligibility_eligible_page.apply_button.click
   end
 
   def and_i_see_the_ineligible_country_text
-    expect(ineligible_page.heading.text).to eq(
+    expect(eligibility_ineligible_page.heading.text).to eq(
       "You’re not eligible to apply for qualified teacher status (QTS) in England",
     )
-    expect(ineligible_page.body).to have_content(
+    expect(eligibility_ineligible_page.body).to have_content(
       "If you are recognised as a teacher in Spain you are not currently eligible to use this service.",
     )
   end
 
   def and_i_see_the_ineligible_england_or_wales_text
-    expect(ineligible_page.heading.text).to eq(
+    expect(eligibility_ineligible_page.heading.text).to eq(
       "You’re not eligible to apply for qualified teacher status (QTS) in England",
     )
-    expect(ineligible_page.body).to have_content(
+    expect(eligibility_ineligible_page.body).to have_content(
       "This service is for qualified teachers who trained to teach outside of England",
     )
   end
 
   def and_i_see_the_ineligible_misconduct_text
-    expect(ineligible_page.reasons).to have_content(
+    expect(eligibility_ineligible_page.reasons).to have_content(
       "To teach in England, you must not have any findings of misconduct or restrictions on your employment record.",
     )
   end
 
   def and_i_see_the_ineligible_teach_children_text
-    expect(ineligible_page.reasons).to have_content(
+    expect(eligibility_ineligible_page.reasons).to have_content(
       "You are not qualified to teach children who are aged somewhere between 5 and 16 years.",
     )
   end
 
   def and_i_see_the_ineligible_work_experience_text
-    expect(ineligible_page.reasons).to have_content(
+    expect(eligibility_ineligible_page.reasons).to have_content(
       "You do not have sufficient work experience as a teacher.",
     )
   end
 
   def and_i_see_the_ineligible_qualification_text_with_eligible_country
-    expect(ineligible_page.reasons).to have_content(
+    expect(eligibility_ineligible_page.reasons).to have_content(
       "You have not completed a formal teaching qualification in Scotland, for example, an undergraduate teaching " \
         "degree or postgraduate teaching qualification.",
     )
   end
 
   def and_i_see_the_ineligible_qualification_text_with_skip_questions_country
-    expect(ineligible_page.reasons).to have_content(
+    expect(eligibility_ineligible_page.reasons).to have_content(
       "You have not completed a formal teaching qualification in Portugal, for example, an undergraduate teaching " \
         "degree or postgraduate teaching qualification.",
     )
   end
 
   def and_i_see_the_ineligible_degree_text
-    expect(ineligible_page.reasons).to have_content("You do not have a degree.")
+    expect(eligibility_ineligible_page.reasons).to have_content("You do not have a degree.")
   end
 
   def when_i_press_back

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -503,7 +503,9 @@ RSpec.describe "Eligibility check", type: :system do
   end
 
   def and_i_see_the_ineligible_degree_text
-    expect(eligibility_ineligible_page.reasons).to have_content("You do not have a degree.")
+    expect(eligibility_ineligible_page.reasons).to have_content(
+      "You do not have a degree.",
+    )
   end
 
   def when_i_press_back

--- a/spec/system/personas_spec.rb
+++ b/spec/system/personas_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Personas", type: :system do
       when_i_visit_the(:personas_page)
 
       when_i_sign_in_as_an_eligible_persona
-      then_i_see_the(:eligible_page)
+      then_i_see_the(:eligibility_eligible_page)
 
       when_i_visit_the(:personas_page)
 
@@ -42,7 +42,7 @@ RSpec.describe "Personas", type: :system do
     given_personas_are_deactivated
 
     when_i_visit_the(:personas_page)
-    then_i_see_the(:start_page)
+    then_i_see_the(:eligibility_start_page)
     and_i_see_the_feature_disabled_message
   end
 

--- a/spec/system/personas_spec.rb
+++ b/spec/system/personas_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Personas", type: :system do
       and_i_see_some_personas
 
       when_i_sign_in_as_a_staff_persona
-      then_i_see_the(:applications_page)
+      then_i_see_the(:assessor_applications_page)
 
       when_i_visit_the(:personas_page)
 

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -48,7 +48,7 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
   end
 
   def and_i_click_the_start_button
-    start_page.start_button.click
+    eligibility_start_page.start_button.click
   end
 
   def and_i_need_to_check_my_eligibility
@@ -61,23 +61,23 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
   end
 
   def and_i_enter_a_country
-    country_page.submit(country: "Canada")
+    eligibility_country_page.submit(country: "Canada")
   end
 
   def and_i_select_a_state
-    region_page.submit(region: "Ontario")
+    eligibility_region_page.submit(region: "Ontario")
   end
 
   def and_i_have_a_teaching_qualification
-    qualification_page.submit_yes
+    eligibility_qualification_page.submit_yes
   end
 
   def and_i_have_a_university_degree
-    degree_page.submit_yes
+    eligibility_degree_page.submit_yes
   end
 
   def and_i_am_qualified_to_teach_children
-    teach_children_page.submit_yes
+    eligibility_teach_children_page.submit_yes
   end
 
   def and_i_have_work_experience
@@ -86,53 +86,53 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
     if page.has_content?(
          "How long have you been employed as a recognised teacher?",
        )
-      work_experience_page.submit_over_20_months
+      eligibility_work_experience_page.submit_over_20_months
     end
   end
 
   def and_i_dont_have_sanctions
-    misconduct_page.submit_no
+    eligibility_misconduct_page.submit_no
   end
 
   def then_i_should_be_eligible_to_apply
-    expect(eligible_page).to have_content("You’re eligible to apply")
+    expect(eligibility_eligible_page).to have_content("You’re eligible to apply")
   end
 
-  def start_page
-    @start_page ||= PageObjects::EligibilityInterface::Start.new
+  def eligibility_start_page
+    @eligibility_start_page ||= PageObjects::EligibilityInterface::Start.new
   end
 
-  def country_page
-    @country_page ||= PageObjects::EligibilityInterface::Country.new
+  def eligibility_country_page
+    @eligibility_country_page ||= PageObjects::EligibilityInterface::Country.new
   end
 
-  def region_page
-    @region_page ||= PageObjects::EligibilityInterface::Region.new
+  def eligibility_region_page
+    @eligibility_region_page ||= PageObjects::EligibilityInterface::Region.new
   end
 
-  def qualification_page
-    @qualification_page ||= PageObjects::EligibilityInterface::Qualification.new
+  def eligibility_qualification_page
+    @eligibility_qualification_page ||= PageObjects::EligibilityInterface::Qualification.new
   end
 
-  def degree_page
-    @degree_page ||= PageObjects::EligibilityInterface::Degree.new
+  def eligibility_degree_page
+    @eligibility_degree_page ||= PageObjects::EligibilityInterface::Degree.new
   end
 
-  def teach_children_page
-    @teach_children_page ||=
+  def eligibility_teach_children_page
+    @eligibility_teach_children_page ||=
       PageObjects::EligibilityInterface::TeachChildren.new
   end
 
-  def work_experience_page
-    @work_experience_page ||=
+  def eligibility_work_experience_page
+    @eligibility_work_experience_page ||=
       PageObjects::EligibilityInterface::WorkExperience.new
   end
 
-  def misconduct_page
-    @misconduct_page ||= PageObjects::EligibilityInterface::Misconduct.new
+  def eligibility_misconduct_page
+    @eligibility_misconduct_page ||= PageObjects::EligibilityInterface::Misconduct.new
   end
 
-  def eligible_page
-    @eligible_page ||= PageObjects::EligibilityInterface::Eligible.new
+  def eligibility_eligible_page
+    @eligibility_eligible_page ||= PageObjects::EligibilityInterface::Eligible.new
   end
 end

--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -95,7 +95,9 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
   end
 
   def then_i_should_be_eligible_to_apply
-    expect(eligibility_eligible_page).to have_content("You’re eligible to apply")
+    expect(eligibility_eligible_page).to have_content(
+      "You’re eligible to apply",
+    )
   end
 
   def eligibility_start_page
@@ -111,7 +113,8 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
   end
 
   def eligibility_qualification_page
-    @eligibility_qualification_page ||= PageObjects::EligibilityInterface::Qualification.new
+    @eligibility_qualification_page ||=
+      PageObjects::EligibilityInterface::Qualification.new
   end
 
   def eligibility_degree_page
@@ -129,10 +132,12 @@ describe "Smoke test", type: :system, js: true, smoke_test: true do
   end
 
   def eligibility_misconduct_page
-    @eligibility_misconduct_page ||= PageObjects::EligibilityInterface::Misconduct.new
+    @eligibility_misconduct_page ||=
+      PageObjects::EligibilityInterface::Misconduct.new
   end
 
   def eligibility_eligible_page
-    @eligibility_eligible_page ||= PageObjects::EligibilityInterface::Eligible.new
+    @eligibility_eligible_page ||=
+      PageObjects::EligibilityInterface::Eligible.new
   end
 end

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -182,7 +182,7 @@ RSpec.describe "Teacher authentication", type: :system do
   end
 
   def when_i_select_a_country
-    country_page.submit(country: "Scotland")
+    eligibility_country_page.submit(country: "Scotland")
   end
 
   def when_i_click_sign_out

--- a/spec/system/teacher_interface/check_answers_spec.rb
+++ b/spec/system/teacher_interface/check_answers_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe "Teacher application check answers", type: :system do
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
 
-    when_i_visit_the(:check_your_answers_page, application_id:)
+    when_i_visit_the(:teacher_check_your_answers_page, application_id:)
   end
 
   it "about you section" do
     when_i_click_change_links(:about_you, :personal_information) do
       and_i_click_continue
-      then_i_see_the(:check_your_answers_page)
+      then_i_see_the(:teacher_check_your_answers_page)
     end
 
     when_i_click_change_links(:about_you, :identification_document) do
       and_i_dont_need_to_upload_another_file
-      then_i_see_the(:check_your_answers_page)
+      then_i_see_the(:teacher_check_your_answers_page)
     end
   end
 
@@ -29,17 +29,17 @@ RSpec.describe "Teacher application check answers", type: :system do
         and_i_click_continue
       end
 
-      then_i_see_the(:check_your_answers_page)
+      then_i_see_the(:teacher_check_your_answers_page)
     end
 
     when_i_click_change_links(:who_you_can_teach, :age_range) do
       and_i_click_continue
-      then_i_see_the(:check_your_answers_page)
+      then_i_see_the(:teacher_check_your_answers_page)
     end
 
     when_i_click_change_links(:who_you_can_teach, :subjects) do
       and_i_click_continue
-      then_i_see_the(:check_your_answers_page)
+      then_i_see_the(:teacher_check_your_answers_page)
     end
   end
 
@@ -51,43 +51,43 @@ RSpec.describe "Teacher application check answers", type: :system do
         and_i_click_continue
       end
 
-      then_i_see_the(:check_your_answers_page)
+      then_i_see_the(:teacher_check_your_answers_page)
     end
   end
 
   it "proof of recognition section" do
     when_i_click_change_links(:proof_of_recognition, :registration_number) do
       and_i_click_continue
-      then_i_see_the(:check_your_answers_page)
+      then_i_see_the(:teacher_check_your_answers_page)
     end
 
     when_i_click_change_links(:proof_of_recognition, :written_statement) do
       and_i_dont_need_to_upload_another_file
-      then_i_see_the(:check_your_answers_page)
+      then_i_see_the(:teacher_check_your_answers_page)
     end
   end
 
   it "display application form work history before qualifications banner" do
     #should display the banner
-    when_i_visit_the(:check_your_answers_page, application_id:) do
+    when_i_visit_the(:teacher_check_your_answers_page, application_id:) do
       and_i_have_early_work_history
       then_i_see_the_banner
     end
 
     #should not display the banner
-    when_i_visit_the(:check_your_answers_page, application_id:) do
+    when_i_visit_the(:teacher_check_your_answers_page, application_id:) do
       and_i_have_later_work_history
       then_i_do_not_see_the_banner
     end
 
     #should not display the banner
-    when_i_visit_the(:check_your_answers_page, application_id:) do
+    when_i_visit_the(:teacher_check_your_answers_page, application_id:) do
       and_i_have_no_work_history
       then_i_do_not_see_the_banner
     end
 
     #should not display the banner
-    when_i_visit_the(:check_your_answers_page, application_id:) do
+    when_i_visit_the(:teacher_check_your_answers_page, application_id:) do
       and_i_have_no_qualifications
       then_i_do_not_see_the_banner
     end
@@ -139,7 +139,7 @@ RSpec.describe "Teacher application check answers", type: :system do
     index = 0
     while (
             row =
-              check_your_answers_page
+              teacher_check_your_answers_page
                 .send(section)
                 .send("#{summary_list}_summary_list")
                 .rows[

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -75,7 +75,9 @@ RSpec.describe "Teacher documents", type: :system do
   end
 
   def then_i_see_the_check_your_uploaded_files_page
-    expect(teacher_check_uploaded_files_page).to have_title("Check your uploaded files")
+    expect(teacher_check_uploaded_files_page).to have_title(
+      "Check your uploaded files",
+    )
     expect(teacher_check_uploaded_files_page.heading.text).to eq(
       "Check your uploaded files – written statement document",
     )

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -75,21 +75,21 @@ RSpec.describe "Teacher documents", type: :system do
   end
 
   def then_i_see_the_check_your_uploaded_files_page
-    expect(check_uploaded_files_page).to have_title("Check your uploaded files")
-    expect(check_uploaded_files_page.heading.text).to eq(
+    expect(teacher_check_uploaded_files_page).to have_title("Check your uploaded files")
+    expect(teacher_check_uploaded_files_page.heading.text).to eq(
       "Check your uploaded files – written statement document",
     )
-    expect(check_uploaded_files_page.files).to have_content(
+    expect(teacher_check_uploaded_files_page.files).to have_content(
       "File 1\tupload.pdf (opens in a new tab)\tDelete",
     )
-    expect(check_uploaded_files_page.files).to have_content(
+    expect(teacher_check_uploaded_files_page.files).to have_content(
       "File 2\tupload.pdf (opens in a new tab)\tDelete",
     )
   end
 
   def then_i_see_the_check_your_uploaded_files_page_with_three_files
     then_i_see_the_check_your_uploaded_files_page
-    expect(check_uploaded_files_page.files).to have_content(
+    expect(teacher_check_uploaded_files_page.files).to have_content(
       "File 3\tupload.pdf (opens in a new tab)\tDelete",
     )
   end

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   it "save and sign out" do
-    when_i_visit_the(:further_information_requested_start_page)
-    then_i_see_the(:further_information_requested_start_page)
+    when_i_visit_the(:teacher_further_information_requested_start_page)
+    then_i_see_the(:teacher_further_information_requested_start_page)
 
     when_i_click_the_start_button
-    then_i_see_the(:further_information_requested_page)
+    then_i_see_the(:teacher_further_information_requested_page)
     and_i_see_the_text_task_list_item
     and_i_see_the_document_task_list_item
 
@@ -23,20 +23,20 @@ RSpec.describe "Teacher further information", type: :system do
 
   it "check your answers" do
     when_i_visit_the(
-      :further_information_requested_page,
+      :teacher_further_information_requested_page,
       request_id: further_information_request.id,
     )
 
     when_i_click_the_text_task_list_item
-    then_i_see_the(:further_information_required_page)
+    then_i_see_the(:teacher_further_information_required_page)
 
     when_i_fill_in_the_response
     and_i_click_continue
-    then_i_see_the(:further_information_requested_page)
+    then_i_see_the(:teacher_further_information_requested_page)
     and_i_see_a_completed_text_task_list_item
 
     when_i_click_the_document_task_list_item
-    then_i_see_the(:further_information_required_page)
+    then_i_see_the(:teacher_further_information_required_page)
     and_i_click_continue
     then_i_see_the(:teacher_upload_document_page)
 
@@ -44,11 +44,11 @@ RSpec.describe "Teacher further information", type: :system do
     then_i_see_the(:teacher_check_document_page)
 
     when_i_dont_need_to_upload_another_file
-    then_i_see_the(:further_information_requested_page)
+    then_i_see_the(:teacher_further_information_requested_page)
     and_i_see_a_completed_document_task_list_item
 
     when_i_click_the_work_history_contact_task_list_item
-    then_i_see_the(:further_information_required_page)
+    then_i_see_the(:teacher_further_information_required_page)
     when_i_fill_in_the_work_history_contact_response
     and_i_click_continue
     and_i_see_the_completed_work_history_contact_list_item
@@ -67,7 +67,7 @@ RSpec.describe "Teacher further information", type: :system do
     then_i_see_the(:teacher_check_further_information_request_answers_page)
 
     when_i_submit_the_further_information
-    then_i_see_the(:submitted_application_page)
+    then_i_see_the(:teacher_submitted_application_page)
     and_i_see_the_further_information_received_information
     and_i_receive_a_further_information_received_email
   end
@@ -77,7 +77,7 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def when_i_click_the_start_button
-    further_information_requested_start_page.start_button.click
+    teacher_further_information_requested_start_page.start_button.click
   end
 
   def and_i_see_the_text_task_list_item
@@ -113,14 +113,14 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def when_i_fill_in_the_response
-    further_information_required_page.form.response_textarea.fill_in with:
+    teacher_further_information_required_page.form.response_textarea.fill_in with:
       "Response"
   end
 
   def when_i_fill_in_the_work_history_contact_response
-    further_information_required_page.form.contact_name.fill_in with: "James"
-    further_information_required_page.form.contact_job.fill_in with: "Carpenter"
-    further_information_required_page.form.contact_email.fill_in with:
+    teacher_further_information_required_page.form.contact_name.fill_in with: "James"
+    teacher_further_information_required_page.form.contact_job.fill_in with: "Carpenter"
+    teacher_further_information_required_page.form.contact_email.fill_in with:
       "jamescarpenter@sample.com"
   end
 
@@ -137,15 +137,15 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def and_i_click_continue
-    further_information_required_page.form.continue_button.click
+    teacher_further_information_required_page.form.continue_button.click
   end
 
   def when_i_click_the_save_and_sign_out_button
-    further_information_requested_page.save_and_sign_out_button.click
+    teacher_further_information_requested_page.save_and_sign_out_button.click
   end
 
   def when_i_click_the_check_your_answers_button
-    further_information_requested_page.check_your_answers_button.click
+    teacher_further_information_requested_page.check_your_answers_button.click
   end
 
   def and_i_see_the_check_your_answers_items
@@ -176,10 +176,10 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def and_i_see_the_further_information_received_information
-    expect(submitted_application_page.panel.title.text).to eq(
+    expect(teacher_submitted_application_page.panel.title.text).to eq(
       "Further information successfully submitted",
     )
-    expect(submitted_application_page.panel.body.text).to eq(
+    expect(teacher_submitted_application_page.panel.body.text).to eq(
       "Your application reference number\n#{@application_form.reference}",
     )
   end
@@ -216,7 +216,7 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def text_task_list_item
-    further_information_requested_page.task_list.find_item(
+    teacher_further_information_requested_page.task_list.find_item(
       "Tell us more about the subjects you can teach",
     )
   end
@@ -226,13 +226,13 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def work_history_task_list_item
-    further_information_requested_page.task_list.find_item(
+    teacher_further_information_requested_page.task_list.find_item(
       "Add your work history contact’s details",
     )
   end
 
   def document_task_list_item
-    further_information_requested_page.task_list.find_item(
+    teacher_further_information_requested_page.task_list.find_item(
       "Upload your identity document",
     )
   end

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -54,17 +54,17 @@ RSpec.describe "Teacher further information", type: :system do
     and_i_see_the_completed_work_history_contact_list_item
 
     when_i_click_the_check_your_answers_button
-    then_i_see_the(:check_further_information_request_answers_page)
+    then_i_see_the(:teacher_check_further_information_request_answers_page)
     and_i_see_the_check_your_answers_items
 
     when_i_click_the_text_check_your_answers_item
     and_i_click_continue
-    then_i_see_the(:check_further_information_request_answers_page)
+    then_i_see_the(:teacher_check_further_information_request_answers_page)
 
     when_i_click_the_document_check_your_answers_item
     and_i_click_continue
     when_i_dont_need_to_upload_another_file
-    then_i_see_the(:check_further_information_request_answers_page)
+    then_i_see_the(:teacher_check_further_information_request_answers_page)
 
     when_i_submit_the_further_information
     then_i_see_the(:submitted_application_page)
@@ -149,7 +149,7 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def and_i_see_the_check_your_answers_items
-    rows = check_further_information_request_answers_page.summary_list.rows
+    rows = teacher_check_further_information_request_answers_page.summary_list.rows
 
     expect(rows.count).to eq(3)
 
@@ -172,7 +172,7 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def when_i_submit_the_further_information
-    check_further_information_request_answers_page.submit_button.click
+    teacher_check_further_information_request_answers_page.submit_button.click
   end
 
   def and_i_see_the_further_information_received_information
@@ -222,7 +222,7 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def text_check_answers_item
-    check_further_information_request_answers_page.summary_list.rows.first
+    teacher_check_further_information_request_answers_page.summary_list.rows.first
   end
 
   def work_history_task_list_item
@@ -238,6 +238,6 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def document_check_answers_item
-    check_further_information_request_answers_page.summary_list.rows.last
+    teacher_check_further_information_request_answers_page.summary_list.rows.last
   end
 end

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -118,8 +118,10 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def when_i_fill_in_the_work_history_contact_response
-    teacher_further_information_required_page.form.contact_name.fill_in with: "James"
-    teacher_further_information_required_page.form.contact_job.fill_in with: "Carpenter"
+    teacher_further_information_required_page.form.contact_name.fill_in with:
+      "James"
+    teacher_further_information_required_page.form.contact_job.fill_in with:
+      "Carpenter"
     teacher_further_information_required_page.form.contact_email.fill_in with:
       "jamescarpenter@sample.com"
   end
@@ -149,7 +151,8 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def and_i_see_the_check_your_answers_items
-    rows = teacher_check_further_information_request_answers_page.summary_list.rows
+    rows =
+      teacher_check_further_information_request_answers_page.summary_list.rows
 
     expect(rows.count).to eq(3)
 
@@ -222,7 +225,10 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def text_check_answers_item
-    teacher_check_further_information_request_answers_page.summary_list.rows.first
+    teacher_check_further_information_request_answers_page
+      .summary_list
+      .rows
+      .first
   end
 
   def work_history_task_list_item
@@ -238,6 +244,9 @@ RSpec.describe "Teacher further information", type: :system do
   end
 
   def document_check_answers_item
-    teacher_check_further_information_request_answers_page.summary_list.rows.last
+    teacher_check_further_information_request_answers_page
+      .summary_list
+      .rows
+      .last
   end
 end

--- a/spec/system/teacher_interface/malware_scanning_spec.rb
+++ b/spec/system/teacher_interface/malware_scanning_spec.rb
@@ -53,17 +53,17 @@ RSpec.describe "Malware scanning", type: :system do
   end
 
   def then_i_see_the_check_your_uploaded_files_page
-    expect(check_uploaded_files_page).to have_title("Check your uploaded files")
-    expect(check_uploaded_files_page.heading.text).to eq(
+    expect(teacher_check_uploaded_files_page).to have_title("Check your uploaded files")
+    expect(teacher_check_uploaded_files_page.heading.text).to eq(
       "Check your uploaded files – written statement document",
     )
   end
 
   def and_the_uploaded_files_have_been_marked_as_malware
-    expect(check_uploaded_files_page.files).to have_content(
+    expect(teacher_check_uploaded_files_page.files).to have_content(
       "File 1\tFile upload error\nThere’s a problem with this file",
     )
-    expect(check_uploaded_files_page.files).to have_content(
+    expect(teacher_check_uploaded_files_page.files).to have_content(
       "File 2\tFile upload error\nThere’s a problem with this file",
     )
   end
@@ -90,7 +90,7 @@ RSpec.describe "Malware scanning", type: :system do
   end
 
   def then_i_see_the_check_your_uploaded_files_page
-    expect(check_uploaded_files_page).to have_title("Check your uploaded files")
+    expect(teacher_check_uploaded_files_page).to have_title("Check your uploaded files")
   end
 
   def teacher

--- a/spec/system/teacher_interface/malware_scanning_spec.rb
+++ b/spec/system/teacher_interface/malware_scanning_spec.rb
@@ -53,7 +53,9 @@ RSpec.describe "Malware scanning", type: :system do
   end
 
   def then_i_see_the_check_your_uploaded_files_page
-    expect(teacher_check_uploaded_files_page).to have_title("Check your uploaded files")
+    expect(teacher_check_uploaded_files_page).to have_title(
+      "Check your uploaded files",
+    )
     expect(teacher_check_uploaded_files_page.heading.text).to eq(
       "Check your uploaded files – written statement document",
     )
@@ -90,7 +92,9 @@ RSpec.describe "Malware scanning", type: :system do
   end
 
   def then_i_see_the_check_your_uploaded_files_page
-    expect(teacher_check_uploaded_files_page).to have_title("Check your uploaded files")
+    expect(teacher_check_uploaded_files_page).to have_title(
+      "Check your uploaded files",
+    )
   end
 
   def teacher

--- a/spec/system/teacher_interface/submitting_spec.rb
+++ b/spec/system/teacher_interface/submitting_spec.rb
@@ -42,7 +42,11 @@ RSpec.describe "Teacher submitting", type: :system do
       .confirm_no_sanctions
       .click
 
-    teacher_check_your_answers_page.submission_declaration.form.submit_button.click
+    teacher_check_your_answers_page
+      .submission_declaration
+      .form
+      .submit_button
+      .click
   end
 
   def and_i_see_the_submitted_application_information

--- a/spec/system/teacher_interface/submitting_spec.rb
+++ b/spec/system/teacher_interface/submitting_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe "Teacher submitting", type: :system do
     then_i_see_the(:teacher_application_page)
 
     when_i_click_check_your_answers
-    then_i_see_the(:check_your_answers_page)
+    then_i_see_the(:teacher_check_your_answers_page)
 
     when_i_confirm_i_have_no_sanctions
-    then_i_see_the(:submitted_application_page)
+    then_i_see_the(:teacher_submitted_application_page)
     and_i_see_the_submitted_application_information
     and_i_receive_an_application_email
   end
@@ -36,20 +36,20 @@ RSpec.describe "Teacher submitting", type: :system do
       reverse_name: true,
     ).and_return([])
 
-    check_your_answers_page
+    teacher_check_your_answers_page
       .submission_declaration
       .form
       .confirm_no_sanctions
       .click
 
-    check_your_answers_page.submission_declaration.form.submit_button.click
+    teacher_check_your_answers_page.submission_declaration.form.submit_button.click
   end
 
   def and_i_see_the_submitted_application_information
-    expect(submitted_application_page.panel.title.text).to eq(
+    expect(teacher_submitted_application_page.panel.title.text).to eq(
       "Application complete",
     )
-    expect(submitted_application_page.panel.body.text).to eq(
+    expect(teacher_submitted_application_page.panel.body.text).to eq(
       "Your application reference number\n#{application_form.reference}",
     )
   end


### PR DESCRIPTION
We use page objects in our system tests (https://github.com/DFE-Digital/apply-for-qualified-teacher-status/tree/main/spec/support/autoload/page_objects ) and they’re all in modules according to which part of the service they refer to.

We access these helpers from a file which constructs them, but in that file we don’t use the module names in the naming of the methods: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/spec/support/page_helpers.rb

This has lead to a number of confusingly named methods and it means we’ve started adding prefixes to some, but not all of them, and in some cases it’s hard to know which page is being tested.

We should refactor this file to make sure every method is prefixed with an appropriate namespace.