### PR TITLE
Remove references to application_id

### DIFF
--- a/spec/support/autoload/page_objects/assessor_interface/age_range_subjects_assessment_recommendation_award.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/age_range_subjects_assessment_recommendation_award.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class AgeRangeSubjectsAssessmentRecommendationAward < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/recommendation/award/age-range-subjects"
 
       element :heading, "h1"

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class Application < SitePrism::Page
-      set_url "/assessor/applications/{application_id}"
+      set_url "/assessor/applications/{application_form_id}"
 
       element :back_link, "a", text: "Back"
 

--- a/spec/support/autoload/page_objects/assessor_interface/application_status.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application_status.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module AssessorInterface
     class ApplicationStatus < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/status"
+      set_url "/assessor/applications/{application_form_id}/status"
 
       element :back_link, "a", text: "Back"
 

--- a/spec/support/autoload/page_objects/assessor_interface/assessment_section.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/assessment_section.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module AssessorInterface
     class AssessmentSection < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/{section_id}"
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}/sections/{section_id}"
 
       element :heading, "h1"
 

--- a/spec/support/autoload/page_objects/assessor_interface/assign_assessor.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/assign_assessor.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module AssessorInterface
     class AssignAssessor < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assign-assessor"
+      set_url "/assessor/applications/{application_form_id}/assign-assessor"
 
       element :heading, "h1"
       sections :assessors, PageObjects::GovukRadioItem, ".govuk-radios__item"

--- a/spec/support/autoload/page_objects/assessor_interface/assign_reviewer.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/assign_reviewer.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module AssessorInterface
     class AssignReviewer < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assign-reviewer"
+      set_url "/assessor/applications/{application_form_id}/assign-reviewer"
 
       element :heading, "h1"
       sections :reviewers, PageObjects::GovukRadioItem, ".govuk-radios__item"

--- a/spec/support/autoload/page_objects/assessor_interface/check_english_language_proficiency.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_english_language_proficiency.rb
@@ -5,7 +5,7 @@ module PageObjects
     end
 
     class CheckEnglishLanguageProficiency < AssessmentSection
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/{section_id}"
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}/sections/{section_id}"
 
       sections :cards, EnglishLanguageProficiencyCard, ".govuk-summary-card"
 

--- a/spec/support/autoload/page_objects/assessor_interface/check_personal_information.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_personal_information.rb
@@ -9,7 +9,7 @@ module PageObjects
     end
 
     class CheckPersonalInformation < AssessmentSection
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/{section_id}"
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}/sections/{section_id}"
 
       sections :cards, PersonalInformationCard, ".govuk-summary-card"
 

--- a/spec/support/autoload/page_objects/assessor_interface/check_professional_standing.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_professional_standing.rb
@@ -7,7 +7,7 @@ module PageObjects
     end
 
     class CheckProfessionalStanding < AssessmentSection
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/{section_id}"
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}/sections/{section_id}"
 
       sections :cards, ProfessionalStandingCard, ".govuk-summary-card"
 

--- a/spec/support/autoload/page_objects/assessor_interface/check_qualifications.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_qualifications.rb
@@ -7,7 +7,7 @@ module PageObjects
     end
 
     class CheckQualifications < AssessmentSection
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/{section_id}"
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}/sections/{section_id}"
 
       sections :cards, QualificationCard, ".govuk-summary-card"
 

--- a/spec/support/autoload/page_objects/assessor_interface/check_work_history.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/check_work_history.rb
@@ -7,7 +7,7 @@ module PageObjects
     end
 
     class CheckWorkHistory < AssessmentSection
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/{section_id}"
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}/sections/{section_id}"
 
       sections :cards, WorkHistoryCard, ".govuk-summary-card"
 

--- a/spec/support/autoload/page_objects/assessor_interface/complete_assessment.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/complete_assessment.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module AssessorInterface
     class CompleteAssessment < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/edit"
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}/edit"
 
       element :heading, "h1"
       sections :new_states, GovukRadioItem, ".govuk-radios__item"

--- a/spec/support/autoload/page_objects/assessor_interface/confirm_assessment_recommendation.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/confirm_assessment_recommendation.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module AssessorInterface
     class ConfirmAssessmentRecommendation < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/recommendation/{recommendation}/confirm"
 
       element :heading, "h1"

--- a/spec/support/autoload/page_objects/assessor_interface/contact_professional_standing_assessment_recommendation_verify.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/contact_professional_standing_assessment_recommendation_verify.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class ContactProfessionalStandingAssessmentRecommendationVerify < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/recommendation/verify/contact-professional-standing"
 
       element :heading, "h1"

--- a/spec/support/autoload/page_objects/assessor_interface/create_note.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/create_note.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module AssessorInterface
     class CreateNote < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/notes/new"
+      set_url "/assessor/applications/{application_form_id}/notes/new"
 
       element :heading, "h1"
 

--- a/spec/support/autoload/page_objects/assessor_interface/declare_assessment_recommendation.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/declare_assessment_recommendation.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module AssessorInterface
     class DeclareAssessmentRecommendation < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/recommendation/{recommendation}/edit"
 
       element :heading, "h1"

--- a/spec/support/autoload/page_objects/assessor_interface/edit_age_range_subjects_assessment_recommendation_award.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/edit_age_range_subjects_assessment_recommendation_award.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class EditAgeRangeSubjectsAssessmentRecommendationAward < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/recommendation/award/age-range-subjects/edit"
 
       element :heading, "h1"

--- a/spec/support/autoload/page_objects/assessor_interface/edit_qualification_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/edit_qualification_request.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class EditQualificationRequest < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/qualification-requests/{id}/edit"
 
       section :form, "form" do

--- a/spec/support/autoload/page_objects/assessor_interface/edit_reference_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/edit_reference_request.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class EditReferenceRequest < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/reference-requests/{id}/edit"
 
       section :summary_list, GovukSummaryList, "#reference-details-summary-list"

--- a/spec/support/autoload/page_objects/assessor_interface/email_consent_letters_assessment_recommendation_verify.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/email_consent_letters_assessment_recommendation_verify.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class EmailConsentLettersAssessmentRecommendationVerify < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/recommendation/verify/email-consent-letters"
 
       element :heading, "h1"

--- a/spec/support/autoload/page_objects/assessor_interface/further_information_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/further_information_request.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module AssessorInterface
     class FurtherInformationRequest < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/further-information-requests/{further_information_request_id}"
     end
   end

--- a/spec/support/autoload/page_objects/assessor_interface/further_information_request_preview.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/further_information_request_preview.rb
@@ -1,7 +1,8 @@
 module PageObjects
   module AssessorInterface
     class FurtherInformationRequestPreview < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/further-information-requests/new"
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
+                "/further-information-requests/new"
 
       element :email_preview, "div.app-email-preview"
 

--- a/spec/support/autoload/page_objects/assessor_interface/preview_assessment_recommendation.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/preview_assessment_recommendation.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module AssessorInterface
     class PreviewAssessmentRecommendation < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/recommendation/{recommendation}/preview"
 
       element :heading, "h1"

--- a/spec/support/autoload/page_objects/assessor_interface/preview_referee_assessment_recommendation_award.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/preview_referee_assessment_recommendation_award.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class PreviewRefereeAssessmentRecommendationAward < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/recommendation/verify/preview-referee"
 
       element :heading, "h1"

--- a/spec/support/autoload/page_objects/assessor_interface/preview_teacher_assessment_recommendation_award.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/preview_teacher_assessment_recommendation_award.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class PreviewTeacherAssessmentRecommendationAward < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/recommendation/verify/preview-teacher"
 
       element :heading, "h1"

--- a/spec/support/autoload/page_objects/assessor_interface/qualification_requests.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/qualification_requests.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class QualificationRequests < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/qualification-requests"
 
       section :task_list, ".app-task-list__item" do

--- a/spec/support/autoload/page_objects/assessor_interface/qualification_requests_assessment_recommendation_verify.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/qualification_requests_assessment_recommendation_verify.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class QualificationRequestsAssessmentRecommendationVerify < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/recommendation/verify/qualification-requests"
 
       element :heading, "h1"

--- a/spec/support/autoload/page_objects/assessor_interface/reference_requests.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/reference_requests.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class ReferenceRequests < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/reference-requests"
 
       section :task_list, ".app-task-list__item" do

--- a/spec/support/autoload/page_objects/assessor_interface/reference_requests_assessment_recommendation_verify.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/reference_requests_assessment_recommendation_verify.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class ReferenceRequestsAssessmentRecommendationVerify < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/recommendation/verify/reference-requests"
 
       element :heading, "h1"

--- a/spec/support/autoload/page_objects/assessor_interface/request_further_information.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/request_further_information.rb
@@ -1,7 +1,8 @@
 module PageObjects
   module AssessorInterface
     class RequestFurtherInformation < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/further-information-requests/preview"
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
+                "/further-information-requests/preview"
 
       sections :items, ".app-further-information-request-item" do
         element :heading, ".govuk-heading-s"

--- a/spec/support/autoload/page_objects/assessor_interface/review_further_information_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/review_further_information_request.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module AssessorInterface
     class ReviewFurtherInformationRequest < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/further-information-requests/{further_information_request_id}/edit"
 
       element :heading, ".govuk-heading-xl"

--- a/spec/support/autoload/page_objects/assessor_interface/timeline.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/timeline.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module AssessorInterface
     class Timeline < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/timeline_events"
+      set_url "/assessor/applications/{application_form_id}/timeline_events"
 
       element :heading, "h1"
       sections :timeline_items, MojTimelineItem, ".moj-timeline__item"

--- a/spec/support/autoload/page_objects/assessor_interface/verify_age_range_subjects_page.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/verify_age_range_subjects_page.rb
@@ -7,7 +7,7 @@ module PageObjects
     end
 
     class VerifyAgeRangeSubjectsPage < AssessmentSection
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}/sections/{section_id}"
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}/sections/{section_id}"
 
       sections :cards, AgeRangeSubjectCard, ".govuk-summary-card"
 

--- a/spec/support/autoload/page_objects/assessor_interface/verify_professional_standing_assessment_recommendation_verify.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/verify_professional_standing_assessment_recommendation_verify.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class VerifyProfessionalStandingAssessmentRecommendationVerify < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/recommendation/verify/verify-professional-standing"
 
       element :heading, "h1"

--- a/spec/support/autoload/page_objects/assessor_interface/verify_qualifications_assessment_recommendation_verify.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/verify_qualifications_assessment_recommendation_verify.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module AssessorInterface
     class VerifyQualificationsAssessmentRecommendationVerify < SitePrism::Page
-      set_url "/assessor/applications/{application_id}/assessments/{assessment_id}" \
+      set_url "/assessor/applications/{application_form_id}/assessments/{assessment_id}" \
                 "/recommendation/verify/verify-qualifications"
 
       element :heading, "h1"

--- a/spec/support/autoload/page_objects/teacher_interface/check_uploaded_files.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/check_uploaded_files.rb
@@ -1,7 +1,7 @@
 module PageObjects
   module TeacherInterface
     class CheckUploadedFiles < SitePrism::Page
-      set_url "/teacher/application/documents/{application_id}/edit"
+      set_url "/teacher/application/documents/{application_form_id}/edit"
 
       element :heading, "h1"
       element :files, ".govuk-grid-row .govuk-grid-column-two-thirds"

--- a/spec/support/autoload/page_objects/teacher_interface/document_available.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/document_available.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module TeacherInterface
     class DocumentAvailable < SitePrism::Page
-      set_url "/teacher/application/documents/{application_id}/edit"
+      set_url "/teacher/application/documents/{application_form_id}/edit"
 
       element :heading, "h1"
 

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -87,6 +87,11 @@ module PageHelpers
       PageObjects::AssessorInterface::ContactProfessionalStandingAssessmentRecommendationVerify.new
   end
 
+  def assessor_create_note_page
+    @assessor_create_note_page ||=
+      PageObjects::AssessorInterface::CreateNote.new
+  end
+
   def assessor_declare_assessment_recommendation_page
     @assessor_declare_assessment_recommendation_page ||=
       PageObjects::AssessorInterface::DeclareAssessmentRecommendation.new
@@ -199,11 +204,6 @@ module PageHelpers
   def assessor_review_verifications_page
     @assessor_review_verifications_page ||=
       PageObjects::AssessorInterface::ReviewVerifications.new
-  end
-
-  def assessor_qualified_for_subject_page
-    @assessor_qualified_for_subject_page ||=
-      PageObjects::AssessorInterface::CreateNote.new
   end
 
   def assessor_timeline_page

--- a/spec/system/assessor_interface/assigning_assessor_spec.rb
+++ b/spec/system/assessor_interface/assigning_assessor_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe "Assigning an assessor", type: :system do
 
     when_i_visit_the(
       :assessor_assign_assessor_page,
-      application_id: application_form.id,
+      application_form_id: application_form.id,
     )
     and_i_select_an_assessor
     then_i_see_the(
       :assessor_application_page,
-      application_id: application_form.id,
+      application_form_id: application_form.id,
     )
     and_the_assessor_is_assigned_to_the_application_form
   end
@@ -28,12 +28,12 @@ RSpec.describe "Assigning an assessor", type: :system do
 
     when_i_visit_the(
       :assessor_assign_reviewer_page,
-      application_id: application_form.id,
+      application_form_id: application_form.id,
     )
     and_i_select_a_reviewer
     then_i_see_the(
       :assessor_application_page,
-      application_id: application_form.id,
+      application_form_id: application_form.id,
     )
     and_the_assessor_is_assigned_as_reviewer_to_the_application_form
   end
@@ -43,7 +43,7 @@ RSpec.describe "Assigning an assessor", type: :system do
 
     when_i_visit_the(
       :assessor_assign_assessor_page,
-      application_id: application_form.id,
+      application_form_id: application_form.id,
     )
     then_i_see_the_forbidden_page
   end
@@ -66,7 +66,7 @@ RSpec.describe "Assigning an assessor", type: :system do
   end
 
   def when_i_visit_the_assign_reviewer_page
-    assessor_assign_reviewer_page.load(application_id: application_form.id)
+    assessor_assign_reviewer_page.load(application_form_id: application_form.id)
   end
 
   def and_i_select_a_reviewer

--- a/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
@@ -77,7 +77,5 @@ RSpec.describe "Assessor awaiting professional standing", type: :system do
       )
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 end

--- a/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/awaiting_professional_standing_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Assessor awaiting professional standing", type: :system do
   end
 
   it "review complete" do
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     and_i_see_a_waiting_on_status
     and_i_click_awaiting_professional_standing
     then_i_see_the(
@@ -19,7 +19,7 @@ RSpec.describe "Assessor awaiting professional standing", type: :system do
     )
 
     when_i_fill_in_the_form
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_a_not_started_status
     and_the_teacher_receives_a_professional_standing_received_email
   end
@@ -80,6 +80,4 @@ RSpec.describe "Assessor awaiting professional standing", type: :system do
   def application_form_id
     application_form.id
   end
-
-  alias_method :application_id, :application_form_id
 end

--- a/spec/system/assessor_interface/change_application_form_name_spec.rb
+++ b/spec/system/assessor_interface/change_application_form_name_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe "Assessor change application form name", type: :system do
   it "allows changing application form name" do
     given_i_am_authorized_as_a_user(manager)
 
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     then_i_see_the(:assessor_application_page)
 
     when_i_click_on_change_name
     then_i_see_the(:assessor_edit_application_page, application_form_id:)
 
     when_i_fill_in_the_name
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
   end
 
   def given_there_is_an_application_form
@@ -60,7 +60,6 @@ RSpec.describe "Assessor change application form name", type: :system do
   end
 
   delegate :id, to: :application_form, prefix: true
-  alias_method :application_id, :application_form_id
 
   def assessor
     create(:staff, :confirmed, :with_assess_permission)

--- a/spec/system/assessor_interface/change_work_history_spec.rb
+++ b/spec/system/assessor_interface/change_work_history_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Assessor change work history", type: :system do
 
     when_i_visit_the(
       :assessor_check_work_history_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: assessment_section.id,
     )
@@ -38,7 +38,7 @@ RSpec.describe "Assessor change work history", type: :system do
     )
 
     when_i_fill_in_the_contact_information
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
   end
 
   it "allows changing work history from verification" do
@@ -46,7 +46,7 @@ RSpec.describe "Assessor change work history", type: :system do
 
     when_i_visit_the(
       :assessor_edit_reference_request_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       id: reference_request.id,
     )
@@ -60,7 +60,7 @@ RSpec.describe "Assessor change work history", type: :system do
     )
 
     when_i_fill_in_the_contact_information
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
   end
 
   def given_there_is_an_application_form
@@ -100,7 +100,6 @@ RSpec.describe "Assessor change work history", type: :system do
   end
 
   delegate :id, to: :application_form, prefix: true
-  alias_method :application_id, :application_form_id
 
   def assessment
     @assessment ||= create(:assessment, application_form:)

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -10,28 +10,28 @@ RSpec.describe "Assessor check submitted details", type: :system do
   it "allows passing the personal information" do
     when_i_visit_the(
       :assessor_check_personal_information_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("personal_information"),
     )
     then_i_see_the_personal_information
 
     when_i_choose_check_personal_information_yes
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_check_personal_information_completed
   end
 
   it "allows failing the personal information" do
     when_i_visit_the(
       :assessor_check_personal_information_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("personal_information"),
     )
     then_i_see_the_personal_information
 
     when_i_choose_check_personal_information_no
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_check_personal_information_completed
   end
 
@@ -39,7 +39,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     given_there_are_selected_failure_reasons("personal_information")
     when_i_visit_the(
       :assessor_check_personal_information_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("personal_information"),
     )
@@ -49,28 +49,28 @@ RSpec.describe "Assessor check submitted details", type: :system do
   it "allows passing the qualifications" do
     when_i_visit_the(
       :assessor_check_qualifications_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("qualifications"),
     )
     then_i_see_the_qualifications
 
     when_i_choose_check_qualifications_yes
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_check_qualifications_completed
   end
 
   it "allows failing the qualifications" do
     when_i_visit_the(
       :assessor_check_qualifications_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("qualifications"),
     )
     then_i_see_the_qualifications
 
     when_i_choose_check_qualifications_no
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_check_qualifications_completed
   end
 
@@ -78,7 +78,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     given_there_are_selected_failure_reasons("qualifications")
     when_i_visit_the(
       :assessor_check_qualifications_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("qualifications"),
     )
@@ -88,7 +88,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
   it "allows passing the age range and subjects" do
     when_i_visit_the(
       :assessor_verify_age_range_subjects_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("age_range_subjects"),
     )
@@ -97,14 +97,14 @@ RSpec.describe "Assessor check submitted details", type: :system do
     when_i_fill_in_age_range
     and_i_fill_in_subjects
     and_i_choose_verify_age_range_subjects_yes
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_verify_age_range_subjects_completed
   end
 
   it "allows failing the age range and subjects" do
     when_i_visit_the(
       :assessor_verify_age_range_subjects_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("age_range_subjects"),
     )
@@ -113,7 +113,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     when_i_fill_in_age_range
     and_i_fill_in_subjects
     and_i_choose_verify_age_range_subjects_no
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_verify_age_range_subjects_completed
   end
 
@@ -121,7 +121,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     given_there_are_selected_failure_reasons("age_range_subjects")
     when_i_visit_the(
       :assessor_verify_age_range_subjects_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("age_range_subjects"),
     )
@@ -131,28 +131,28 @@ RSpec.describe "Assessor check submitted details", type: :system do
   it "allows passing the work history" do
     when_i_visit_the(
       :assessor_check_work_history_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("work_history"),
     )
     then_i_see_the_work_history
 
     when_i_choose_check_work_history_yes
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_check_work_history_completed
   end
 
   it "allows failing the work history" do
     when_i_visit_the(
       :assessor_check_work_history_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("work_history"),
     )
     then_i_see_the_work_history
 
     when_i_choose_check_work_history_no
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_check_work_history_completed
   end
 
@@ -160,7 +160,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     given_there_are_selected_failure_reasons("work_history")
     when_i_visit_the(
       :assessor_check_work_history_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("work_history"),
     )
@@ -170,28 +170,28 @@ RSpec.describe "Assessor check submitted details", type: :system do
   it "allows passing the professional standing" do
     when_i_visit_the(
       :assessor_check_professional_standing_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("professional_standing"),
     )
     then_i_see_the_professional_standing
 
     when_i_choose_check_professional_standing_yes
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_check_professional_standing_completed
   end
 
   it "allows failing the professional standing" do
     when_i_visit_the(
       :assessor_check_professional_standing_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("professional_standing"),
     )
     then_i_see_the_professional_standing
 
     when_i_choose_check_professional_standing_no
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_check_professional_standing_completed
   end
 
@@ -200,7 +200,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
 
     when_i_visit_the(
       :assessor_check_professional_standing_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("professional_standing"),
     )
@@ -209,7 +209,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     when_i_choose_full_registration
     and_i_choose_induction_not_required
     and_i_choose_check_professional_standing_yes
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_check_professional_standing_completed
   end
 
@@ -217,7 +217,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
     given_there_are_selected_failure_reasons("professional_standing")
     when_i_visit_the(
       :assessor_check_professional_standing_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("professional_standing"),
     )
@@ -509,7 +509,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
       end
   end
 
-  def application_id
+  def application_form_id
     application_form.id
   end
 

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -509,9 +509,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
       end
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 
   def assessment_id
     application_form.assessment.id

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -414,9 +414,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
     )
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 
   def assessment_id
     application_form.assessment.id

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_visit_the(
       :assessor_complete_assessment_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
 
@@ -37,7 +37,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
     and_i_click_continue
     then_i_see_the(
       :assessor_declare_assessment_recommendation_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       recommendation: "award",
     )
@@ -61,7 +61,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     then_i_see_the(
       :assessor_preview_assessment_recommendation_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       recommendation: "award",
     )
@@ -69,13 +69,13 @@ RSpec.describe "Assessor completing assessment", type: :system do
     when_i_send_the_email
     then_i_see_the(
       :assessor_confirm_assessment_recommendation_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       recommendation: "award",
     )
 
     when_i_check_confirmation
-    then_i_see_the(:assessor_application_status_page, application_id:)
+    then_i_see_the(:assessor_application_status_page, application_form_id:)
 
     when_i_click_on_overview_button
     then_the_application_form_is_awarded
@@ -88,7 +88,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_visit_the(
       :assessor_complete_assessment_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
 
@@ -96,61 +96,61 @@ RSpec.describe "Assessor completing assessment", type: :system do
     and_i_click_continue
     then_i_see_the(
       :assessor_verify_qualifications_assessment_recommendation_verify_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
 
     when_i_select_yes_verify_qualifications
     then_i_see_the(
       :assessor_qualification_requests_assessment_recommendation_verify_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
 
     when_i_select_the_qualifications
     then_i_see_the(
       :assessor_email_consent_letters_requests_assessment_recommendation_verify_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
 
     when_i_click_continue_from_email_consent_letters
     then_i_see_the(
       :assessor_verify_professional_standing_assessment_recommendation_verify_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
 
     when_i_select_yes_verify_professional_standing
     then_i_see_the(
       :assessor_contact_professional_standing_assessment_recommendation_verify_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
 
     when_i_click_continue_from_contact_professional_standing
     then_i_see_the(
       :assessor_reference_requests_assessment_recommendation_verify_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
 
     when_i_select_the_work_histories
     then_i_see_the(
       :assessor_preview_referee_assessment_recommendation_award_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
 
     when_i_send_the_referee_email
     then_i_see_the(
       :assessor_preview_teacher_assessment_recommendation_award_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
 
     when_i_send_the_teacher_email
-    then_i_see_the(:assessor_application_status_page, application_id:)
+    then_i_see_the(:assessor_application_status_page, application_form_id:)
 
     when_i_click_on_overview_button
     then_the_application_form_is_waiting_on
@@ -163,7 +163,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_visit_the(
       :assessor_complete_assessment_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
 
@@ -171,7 +171,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
     and_i_click_continue
     then_i_see_the(
       :assessor_declare_assessment_recommendation_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       recommendation: "decline",
     )
@@ -180,7 +180,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
     when_i_check_declaration
     then_i_see_the(
       :assessor_preview_assessment_recommendation_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       recommendation: "decline",
     )
@@ -188,13 +188,13 @@ RSpec.describe "Assessor completing assessment", type: :system do
     when_i_send_the_email
     then_i_see_the(
       :assessor_confirm_assessment_recommendation_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       recommendation: "decline",
     )
 
     when_i_check_confirmation
-    then_i_see_the(:assessor_application_status_page, application_id:)
+    then_i_see_the(:assessor_application_status_page, application_form_id:)
 
     when_i_click_on_overview_button
     then_the_application_form_is_declined
@@ -414,7 +414,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
     )
   end
 
-  def application_id
+  def application_form_id
     application_form.id
   end
 

--- a/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
+++ b/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
@@ -7,12 +7,12 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     and_the_application_states_english_language_exemption_by_citizenship
     given_i_am_authorized_as_an_assessor_user
 
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     then_i_see_the_application
 
     when_i_visit_the(
       :assessor_check_english_language_proficiency_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("english_language_proficiency"),
     )
@@ -20,7 +20,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
 
     when_i_visit_the(
       :assessor_check_personal_information_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("personal_information"),
     )
@@ -44,12 +44,12 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     and_the_application_states_english_language_exemption_by_qualification
     given_i_am_authorized_as_an_assessor_user
 
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     then_i_see_the_application
 
     when_i_visit_the(
       :assessor_check_english_language_proficiency_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("english_language_proficiency"),
     )
@@ -57,7 +57,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
 
     when_i_visit_the(
       :assessor_check_qualifications_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("qualifications"),
     )
@@ -78,7 +78,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     given_i_am_authorized_as_an_assessor_user
     when_i_visit_the(
       :assessor_check_english_language_proficiency_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("english_language_proficiency"),
     )
@@ -97,7 +97,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
     given_i_am_authorized_as_an_assessor_user
     when_i_visit_the(
       :assessor_check_english_language_proficiency_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       section_id: section_id("english_language_proficiency"),
     )
@@ -320,7 +320,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
       end
   end
 
-  def application_id
+  def application_form_id
     application_form.id
   end
 

--- a/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
+++ b/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
@@ -320,9 +320,7 @@ RSpec.describe "Assessor confirms English language section", type: :system do
       end
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 
   def assessment_id
     application_form.assessment.id

--- a/spec/system/assessor_interface/creating_note_spec.rb
+++ b/spec/system/assessor_interface/creating_note_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Creating a note", type: :system do
     )
     and_i_click_add_note
     then_i_see_the(
-      :assessor_qualified_for_subject_page,
+      :assessor_create_note_page,
       application_form_id: application_form.id,
     )
 
@@ -46,9 +46,8 @@ RSpec.describe "Creating a note", type: :system do
   end
 
   def when_i_create_a_note
-    assessor_qualified_for_subject_page.form.text_textarea.fill_in with:
-      "A note."
-    assessor_qualified_for_subject_page.form.submit_button.click
+    assessor_create_note_page.form.text_textarea.fill_in with: "A note."
+    assessor_create_note_page.form.submit_button.click
   end
 
   def and_i_see_the_note_timeline_event

--- a/spec/system/assessor_interface/creating_note_spec.rb
+++ b/spec/system/assessor_interface/creating_note_spec.rb
@@ -10,25 +10,28 @@ RSpec.describe "Creating a note", type: :system do
 
     when_i_visit_the(
       :assessor_application_page,
-      application_id: application_form.id,
+      application_form_id: application_form.id,
     )
     and_i_click_add_note
     then_i_see_the(
       :assessor_qualified_for_subject_page,
-      application_id: application_form.id,
+      application_form_id: application_form.id,
     )
 
     when_i_create_a_note
     then_i_see_the(
       :assessor_application_page,
-      application_id: application_form.id,
+      application_form_id: application_form.id,
     )
 
     when_i_visit_the(
       :assessor_timeline_page,
-      application_id: application_form.id,
+      application_form_id: application_form.id,
     )
-    then_i_see_the(:assessor_timeline_page, application_id: application_form.id)
+    then_i_see_the(
+      :assessor_timeline_page,
+      application_form_id: application_form.id,
+    )
     and_i_see_the_note_timeline_event
   end
 

--- a/spec/system/assessor_interface/duplicate_applicant_application_form_spec.rb
+++ b/spec/system/assessor_interface/duplicate_applicant_application_form_spec.rb
@@ -61,9 +61,7 @@ RSpec.describe "Assessor views duplicate applicant's application form",
       end
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 
   def dqt_match
     {

--- a/spec/system/assessor_interface/duplicate_applicant_application_form_spec.rb
+++ b/spec/system/assessor_interface/duplicate_applicant_application_form_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Assessor views duplicate applicant's application form",
     given_there_is_an_application_form
     and_the_applicant_matches_a_record_in_dqt
 
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     then_i_see_the_application
     and_i_see_the_warning_of_an_existing_record_in_dqt
   end
@@ -61,7 +61,7 @@ RSpec.describe "Assessor views duplicate applicant's application form",
       end
   end
 
-  def application_id
+  def application_form_id
     application_form.id
   end
 

--- a/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
+++ b/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
@@ -10,33 +10,33 @@ RSpec.describe "Assessor pre-assessment tasks", type: :system do
   end
 
   it "passes preliminary check" do
-    when_i_visit_the(:assessor_application_page, application_id:)
-    then_i_see_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_a_waiting_on_status
     and_i_see_an_unstarted_preliminary_check_task
 
     when_i_click_on_the_preliminary_check_task
     and_i_choose_yes_to_both_questions
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_a_completed_preliminary_check_task
     and_an_email_has_been_sent_to_the_teacher
     and_the_assessor_is_unassigned
   end
 
   it "fails preliminary check" do
-    when_i_visit_the(:assessor_application_page, application_id:)
-    then_i_see_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_a_waiting_on_status
     and_i_see_an_unstarted_preliminary_check_task
 
     when_i_click_on_the_preliminary_check_task
     and_i_choose_no_to_both_questions
-    then_i_see_the(:assessor_complete_assessment_page, application_id:)
+    then_i_see_the(:assessor_complete_assessment_page, application_form_id:)
 
     when_i_select_decline_qts
     then_i_see_the(
       :assessor_declare_assessment_recommendation_page,
-      application_id:,
+      application_form_id:,
       recommendation: "decline",
     )
     and_i_see_the_failure_reasons
@@ -153,7 +153,7 @@ RSpec.describe "Assessor pre-assessment tasks", type: :system do
       end
   end
 
-  def application_id
+  def application_form_id
     application_form.id
   end
 end

--- a/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
+++ b/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
@@ -153,7 +153,5 @@ RSpec.describe "Assessor pre-assessment tasks", type: :system do
       end
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 end

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -163,9 +163,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
       end
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 
   def assessment_id
     application_form.assessment.id

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
 
     when_i_visit_the(
       :assessor_complete_assessment_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
 
@@ -36,7 +36,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
     and_i_click_continue
     then_i_see_the(
       :assessor_request_further_information_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
     and_i_see_the_further_information_request_items
@@ -44,7 +44,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
     when_i_click_continue_to_email_button
     then_i_see_the(
       :assessor_further_information_request_preview_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
     )
     and_i_see_the_email_preview
@@ -52,7 +52,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
     when_i_click_send_to_applicant
     then_i_see_the(
       :assessor_further_information_request_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       further_information_request_id:,
     )
@@ -163,7 +163,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
       end
   end
 
-  def application_id
+  def application_form_id
     application_form.id
   end
 

--- a/spec/system/assessor_interface/reverse_decision_spec.rb
+++ b/spec/system/assessor_interface/reverse_decision_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Assessor reverse decision", type: :system do
   it "allows reversing a decision" do
     given_i_am_authorized_as_a_user(manager)
 
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     then_i_see_the(:assessor_application_page)
     and_i_see_the_reverse_decision_link
 
@@ -34,7 +34,7 @@ RSpec.describe "Assessor reverse decision", type: :system do
     )
 
     when_i_confirm_the_reversal
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
   end
 
   def given_there_is_an_application_form
@@ -60,7 +60,6 @@ RSpec.describe "Assessor reverse decision", type: :system do
   end
 
   delegate :id, to: :application_form, prefix: true
-  alias_method :application_id, :application_form_id
 
   def assessment
     @assessment ||= create(:assessment, :decline, application_form:)

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -11,34 +11,34 @@ RSpec.describe "Assessor reviewing further information", type: :system do
   end
 
   it "review complete" do
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     and_i_click_review_requested_information
     then_i_see_the(
       :assessor_review_further_information_request_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       further_information_request_id:,
     )
     and_i_see_the_check_your_answers_items
 
     when_i_mark_the_section_as_complete
-    then_i_see_the(:assessor_complete_assessment_page, application_id:)
+    then_i_see_the(:assessor_complete_assessment_page, application_form_id:)
     and_i_see_an_award_qts_option
   end
 
   it "review incomplete" do
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     and_i_click_review_requested_information
     then_i_see_the(
       :assessor_review_further_information_request_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       further_information_request_id:,
     )
     and_i_see_the_check_your_answers_items
 
     when_i_mark_the_section_as_incomplete
-    then_i_see_the(:assessor_complete_assessment_page, application_id:)
+    then_i_see_the(:assessor_complete_assessment_page, application_form_id:)
     and_i_see_a_decline_qts_option
   end
 
@@ -46,11 +46,11 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     further_information_request.update!(review_passed: true)
     further_information_request.assessment.award!
 
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     and_i_click_review_requested_information
     then_i_see_the(
       :assessor_review_further_information_request_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       further_information_request_id:,
     )
@@ -142,7 +142,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
       )
   end
 
-  def application_id
+  def application_form_id
     application_form.id
   end
 

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -142,9 +142,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
       )
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 
   def assessment_id
     application_form.assessment.id

--- a/spec/system/assessor_interface/reviewing_verifications_spec.rb
+++ b/spec/system/assessor_interface/reviewing_verifications_spec.rb
@@ -10,20 +10,11 @@ RSpec.describe "Assessor reviewing verifications", type: :system do
   end
 
   it "sends for review" do
-    when_i_visit_the(
-      :assessor_application_page,
-      application_id: application_form_id,
-    )
-    then_i_see_the(
-      :assessor_application_page,
-      application_id: application_form_id,
-    )
+    when_i_visit_the(:assessor_application_page, application_form_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
 
     when_i_click_on_verification_decision
-    then_i_see_the(
-      :assessor_application_page,
-      application_id: application_form_id,
-    )
+    then_i_see_the(:assessor_application_page, application_form_id:)
 
     when_i_click_on_review_verifications
     then_i_see_the(
@@ -49,15 +40,12 @@ RSpec.describe "Assessor reviewing verifications", type: :system do
     and_i_see_the_lops_accepted
 
     when_i_click_on_back_to_overview
-    then_i_see_the(
-      :assessor_application_page,
-      application_id: application_form_id,
-    )
+    then_i_see_the(:assessor_application_page, application_form_id:)
 
     when_i_click_on_assessment_decision
     then_i_see_the(
       :assessor_complete_assessment_page,
-      application_id: application_form_id,
+      application_form_id:,
       assessment_id:,
     )
   end
@@ -75,10 +63,7 @@ RSpec.describe "Assessor reviewing verifications", type: :system do
     application_form.assessment.review!
 
     # TODO: reload the page
-    when_i_visit_the(
-      :assessor_application_page,
-      application_id: application_form_id,
-    )
+    when_i_visit_the(:assessor_application_page, application_form_id:)
   end
 
   def when_i_click_on_review_verifications

--- a/spec/system/assessor_interface/reviewing_verifications_spec.rb
+++ b/spec/system/assessor_interface/reviewing_verifications_spec.rb
@@ -120,9 +120,7 @@ RSpec.describe "Assessor reviewing verifications", type: :system do
       end
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 
   def assessment_id
     application_form.assessment.id

--- a/spec/system/assessor_interface/verifying_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/verifying_professional_standing_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
   end
 
   it "record location and review" do
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     and_i_see_a_waiting_on_status
     and_i_click_record_professional_standing_task
     then_i_see_the(
@@ -19,7 +19,7 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
     )
 
     when_i_fill_in_the_location_form
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
     and_i_see_a_received_status
 
     when_i_click_review_professional_standing_task
@@ -29,7 +29,7 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
     )
 
     when_i_fill_in_the_review_form
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
   end
 
   private
@@ -95,9 +95,7 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
       end
   end
 
-  def application_id
+  def application_form_id
     application_form.id
   end
-
-  alias_method :application_form_id, :application_id
 end

--- a/spec/system/assessor_interface/verifying_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/verifying_professional_standing_spec.rb
@@ -95,7 +95,5 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
       end
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 end

--- a/spec/system/assessor_interface/verifying_qualifications_spec.rb
+++ b/spec/system/assessor_interface/verifying_qualifications_spec.rb
@@ -10,64 +10,76 @@ RSpec.describe "Assessor verifying qualifications", type: :system do
   end
 
   it "received and passed" do
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     and_i_see_a_waiting_on_status
     and_i_click_record_qualifications_task
-    then_i_see_the(:assessor_qualification_requests_page, application_id:)
+    then_i_see_the(:assessor_qualification_requests_page, application_form_id:)
 
     when_i_select_the_first_qualification_request
-    then_i_see_the(:assessor_edit_qualification_request_page, application_id:)
+    then_i_see_the(
+      :assessor_edit_qualification_request_page,
+      application_form_id:,
+    )
 
     when_the_request_is_received_and_passed
-    then_i_see_the(:assessor_qualification_requests_page, application_id:)
+    then_i_see_the(:assessor_qualification_requests_page, application_form_id:)
 
     when_i_go_back_to_overview
     and_i_see_an_in_progress_status
   end
 
   it "received and not passed" do
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     and_i_see_a_waiting_on_status
     and_i_click_record_qualifications_task
-    then_i_see_the(:assessor_qualification_requests_page, application_id:)
+    then_i_see_the(:assessor_qualification_requests_page, application_form_id:)
 
     when_i_select_the_first_qualification_request
-    then_i_see_the(:assessor_edit_qualification_request_page, application_id:)
+    then_i_see_the(
+      :assessor_edit_qualification_request_page,
+      application_form_id:,
+    )
 
     when_the_request_is_received_and_not_passed
-    then_i_see_the(:assessor_qualification_requests_page, application_id:)
+    then_i_see_the(:assessor_qualification_requests_page, application_form_id:)
 
     when_i_go_back_to_overview
     and_i_see_an_in_progress_status
   end
 
   it "not received and failed" do
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     and_i_see_a_waiting_on_status
     and_i_click_record_qualifications_task
-    then_i_see_the(:assessor_qualification_requests_page, application_id:)
+    then_i_see_the(:assessor_qualification_requests_page, application_form_id:)
 
     when_i_select_the_first_qualification_request
-    then_i_see_the(:assessor_edit_qualification_request_page, application_id:)
+    then_i_see_the(
+      :assessor_edit_qualification_request_page,
+      application_form_id:,
+    )
 
     when_the_request_is_not_received_and_failed
-    then_i_see_the(:assessor_qualification_requests_page, application_id:)
+    then_i_see_the(:assessor_qualification_requests_page, application_form_id:)
 
     when_i_go_back_to_overview
     and_i_see_an_in_progress_status
   end
 
   it "not received and not failed" do
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     and_i_see_a_waiting_on_status
     and_i_click_record_qualifications_task
-    then_i_see_the(:assessor_qualification_requests_page, application_id:)
+    then_i_see_the(:assessor_qualification_requests_page, application_form_id:)
 
     when_i_select_the_first_qualification_request
-    then_i_see_the(:assessor_edit_qualification_request_page, application_id:)
+    then_i_see_the(
+      :assessor_edit_qualification_request_page,
+      application_form_id:,
+    )
 
     when_the_request_is_not_received_and_not_failed
-    then_i_see_the(:assessor_qualification_requests_page, application_id:)
+    then_i_see_the(:assessor_qualification_requests_page, application_form_id:)
 
     when_i_go_back_to_overview
     and_i_see_a_waiting_on_status
@@ -162,7 +174,7 @@ RSpec.describe "Assessor verifying qualifications", type: :system do
       end
   end
 
-  def application_id
+  def application_form_id
     application_form.id
   end
 end

--- a/spec/system/assessor_interface/verifying_qualifications_spec.rb
+++ b/spec/system/assessor_interface/verifying_qualifications_spec.rb
@@ -174,7 +174,5 @@ RSpec.describe "Assessor verifying qualifications", type: :system do
       end
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 end

--- a/spec/system/assessor_interface/verifying_references_spec.rb
+++ b/spec/system/assessor_interface/verifying_references_spec.rb
@@ -167,9 +167,7 @@ RSpec.describe "Assessor verifying references", type: :system do
       end
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 
   def assessment_id
     application_form.assessment.id

--- a/spec/system/assessor_interface/verifying_references_spec.rb
+++ b/spec/system/assessor_interface/verifying_references_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe "Assessor verifying references", type: :system do
   end
 
   it "Verify accepted references" do
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     and_i_see_a_waiting_on_status
     and_i_click_verify_references
-    then_i_see_the(:assessor_reference_requests_page, application_id:)
+    then_i_see_the(:assessor_reference_requests_page, application_form_id:)
 
     when_i_click_on_a_reference_request
     then_i_see_the(
       :assessor_edit_reference_request_page,
-      application_id:,
+      application_form_id:,
       assessment_id:,
       id: reference_request.id,
     )
@@ -167,7 +167,7 @@ RSpec.describe "Assessor verifying references", type: :system do
       end
   end
 
-  def application_id
+  def application_form_id
     application_form.id
   end
 

--- a/spec/system/assessor_interface/view_application_form_spec.rb
+++ b/spec/system/assessor_interface/view_application_form_spec.rb
@@ -74,7 +74,5 @@ RSpec.describe "Assessor view application form", type: :system do
       end
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 end

--- a/spec/system/assessor_interface/view_application_form_spec.rb
+++ b/spec/system/assessor_interface/view_application_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Assessor view application form", type: :system do
     given_there_is_an_application_form
     given_i_am_authorized_as_an_assessor_user
 
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     then_i_see_the_application
     and_i_see_the_assessment_tasks
 
@@ -74,7 +74,7 @@ RSpec.describe "Assessor view application form", type: :system do
       end
   end
 
-  def application_id
+  def application_form_id
     application_form.id
   end
 end

--- a/spec/system/assessor_interface/view_timeline_events_spec.rb
+++ b/spec/system/assessor_interface/view_timeline_events_spec.rb
@@ -60,9 +60,7 @@ RSpec.describe "Assessor view timeline events", type: :system do
       end
   end
 
-  def application_form_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 
   def assessor
     @assessor ||= create(:staff, :confirmed)

--- a/spec/system/assessor_interface/view_timeline_events_spec.rb
+++ b/spec/system/assessor_interface/view_timeline_events_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Assessor view timeline events", type: :system do
   end
 
   it "displays the timeline events" do
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     and_i_click_view_timeline
     then_i_see_the_timeline
   end
@@ -60,7 +60,7 @@ RSpec.describe "Assessor view timeline events", type: :system do
       end
   end
 
-  def application_id
+  def application_form_id
     application_form.id
   end
 

--- a/spec/system/assessor_interface/withdraw_application_spec.rb
+++ b/spec/system/assessor_interface/withdraw_application_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Assessor withdraw application", type: :system do
   it "allows withdrawing an application" do
     given_i_am_authorized_as_a_user(manager)
 
-    when_i_visit_the(:assessor_application_page, application_id:)
+    when_i_visit_the(:assessor_application_page, application_form_id:)
     then_i_see_the(:assessor_application_page)
     and_i_see_the_withdraw_link
 
@@ -30,7 +30,7 @@ RSpec.describe "Assessor withdraw application", type: :system do
     then_i_see_the(:assessor_withdraw_application_page, application_form_id:)
 
     when_i_confirm_the_withdrawal
-    then_i_see_the(:assessor_application_page, application_id:)
+    then_i_see_the(:assessor_application_page, application_form_id:)
   end
 
   def given_there_is_an_application_form
@@ -56,7 +56,6 @@ RSpec.describe "Assessor withdraw application", type: :system do
   end
 
   delegate :id, to: :application_form, prefix: true
-  alias_method :application_id, :application_form_id
 
   def assessment
     @assessment ||= create(:assessment, :decline, application_form:)

--- a/spec/system/teacher_interface/check_answers_spec.rb
+++ b/spec/system/teacher_interface/check_answers_spec.rb
@@ -68,25 +68,21 @@ RSpec.describe "Teacher application check answers", type: :system do
   end
 
   it "display application form work history before qualifications banner" do
-    #should display the banner
     when_i_visit_the(:teacher_check_your_answers_page, application_form_id:) do
       and_i_have_early_work_history
       then_i_see_the_banner
     end
 
-    #should not display the banner
     when_i_visit_the(:teacher_check_your_answers_page, application_form_id:) do
       and_i_have_later_work_history
       then_i_do_not_see_the_banner
     end
 
-    #should not display the banner
     when_i_visit_the(:teacher_check_your_answers_page, application_form_id:) do
       and_i_have_no_work_history
       then_i_do_not_see_the_banner
     end
 
-    #should not display the banner
     when_i_visit_the(:teacher_check_your_answers_page, application_form_id:) do
       and_i_have_no_qualifications
       then_i_do_not_see_the_banner

--- a/spec/system/teacher_interface/check_answers_spec.rb
+++ b/spec/system/teacher_interface/check_answers_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Teacher application check answers", type: :system do
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
 
-    when_i_visit_the(:teacher_check_your_answers_page, application_id:)
+    when_i_visit_the(:teacher_check_your_answers_page, application_form_id:)
   end
 
   it "about you section" do
@@ -69,25 +69,25 @@ RSpec.describe "Teacher application check answers", type: :system do
 
   it "display application form work history before qualifications banner" do
     #should display the banner
-    when_i_visit_the(:teacher_check_your_answers_page, application_id:) do
+    when_i_visit_the(:teacher_check_your_answers_page, application_form_id:) do
       and_i_have_early_work_history
       then_i_see_the_banner
     end
 
     #should not display the banner
-    when_i_visit_the(:teacher_check_your_answers_page, application_id:) do
+    when_i_visit_the(:teacher_check_your_answers_page, application_form_id:) do
       and_i_have_later_work_history
       then_i_do_not_see_the_banner
     end
 
     #should not display the banner
-    when_i_visit_the(:teacher_check_your_answers_page, application_id:) do
+    when_i_visit_the(:teacher_check_your_answers_page, application_form_id:) do
       and_i_have_no_work_history
       then_i_do_not_see_the_banner
     end
 
     #should not display the banner
-    when_i_visit_the(:teacher_check_your_answers_page, application_id:) do
+    when_i_visit_the(:teacher_check_your_answers_page, application_form_id:) do
       and_i_have_no_qualifications
       then_i_do_not_see_the_banner
     end
@@ -177,7 +177,5 @@ RSpec.describe "Teacher application check answers", type: :system do
       )
   end
 
-  def application_id
-    application_form.id
-  end
+  delegate :id, to: :application_form, prefix: true
 end


### PR DESCRIPTION
I've renamed them to `application_form_id` to be consistent with the name of the model, which is `ApplicationForm`. This makes things clearer by using consistent naming across the codebase.