### PR TITLE
Changes made to titles and Management integrated into task list

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -59,8 +59,8 @@ class AssessorInterface::ApplicationFormsShowViewObject
            assessment,
          ).rollback?
         {
-          title: "Reverse decision",
-          path: [:rollback, :assessor_interface, application_form, assessment],
+          name: "Reverse decision",
+          link: [:rollback, :assessor_interface, application_form, assessment],
         }
       end,
       if AssessorInterface::ApplicationFormPolicy.new(
@@ -68,8 +68,8 @@ class AssessorInterface::ApplicationFormsShowViewObject
            application_form,
          ).withdraw?
         {
-          title: "Withdraw",
-          path: [:withdraw, :assessor_interface, application_form],
+          name: "Withdraw",
+          link: [:withdraw, :assessor_interface, application_form],
         }
       end,
     ].compact
@@ -96,10 +96,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
 
     {
       title: "Management",
-      items:
-        management_tasks.map do |task|
-          { name: task[:title], link: task[:path] }
-        end,
+      items: management_tasks,
     }
   end
 

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -94,10 +94,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
   def management_task_list_section
     return nil if management_tasks.blank?
 
-    {
-      title: "Management",
-      items: management_tasks,
-    }
+    { title: "Management", items: management_tasks }
   end
 
   def pre_assessment_task_list_section

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -24,6 +24,7 @@ class AssessorInterface::ApplicationFormsShowViewObject
       assessment_task_list_section,
       verification_task_list_section,
       review_task_list_section,
+      management_task_list_section,
     ].compact
   end
 
@@ -89,6 +90,18 @@ class AssessorInterface::ApplicationFormsShowViewObject
            :reference_requests,
            to: :assessment
   delegate :canonical_email, to: :teacher
+
+  def management_task_list_section
+    return nil if management_tasks.blank?
+
+    {
+      title: "Management",
+      items:
+        management_tasks.map do |task|
+          { name: task[:title], link: task[:path] }
+        end,
+    }
+  end
 
   def pre_assessment_task_list_section
     {

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -28,17 +28,6 @@
   application_form, current_staff:, highlight_email: @view_object.highlight_email?
 )) %>
 
-<h2 class="govuk-heading-l govuk-!-margin-top-9">Assessment</h2>
+<h2 class="govuk-heading-l govuk-!-margin-top-9">Task list</h2>
 
 <%= render(TaskList::Component.new(@view_object.task_list_sections)) %>
-
-<% if (management_tasks = @view_object.management_tasks).present? %>
-  <%= govuk_warning_text do %>
-    <h2 class="govuk-heading-s">Management tasks</h2>
-    <ul class="govuk-list govuk-list--bullet">
-      <% management_tasks.each do |task| %>
-        <li><%= govuk_link_to task[:title], task[:path] %></li>
-      <% end %>
-    </ul>
-  <% end %>
-<% end %>

--- a/spec/system/assessor_interface/reverse_decision_spec.rb
+++ b/spec/system/assessor_interface/reverse_decision_spec.rb
@@ -43,11 +43,13 @@ RSpec.describe "Assessor reverse decision", type: :system do
   end
 
   def and_i_see_the_reverse_decision_link
-    expect(assessor_application_page.management_tasks).to be_visible
+    expect(assessor_application_page.task_list).to have_content(
+      "Reverse decision",
+    )
   end
 
   def when_i_click_on_reverse_decision
-    assessor_application_page.management_tasks.links.first.click
+    assessor_application_page.task_list.click_on("Reverse decision")
   end
 
   def when_i_confirm_the_reversal

--- a/spec/system/assessor_interface/withdraw_application_spec.rb
+++ b/spec/system/assessor_interface/withdraw_application_spec.rb
@@ -39,11 +39,11 @@ RSpec.describe "Assessor withdraw application", type: :system do
   end
 
   def and_i_see_the_withdraw_link
-    expect(assessor_application_page.management_tasks).to be_visible
+    expect(assessor_application_page.task_list).to have_content("Withdraw")
   end
 
   def when_i_click_on_withdraw
-    assessor_application_page.management_tasks.links.first.click
+    assessor_application_page.task_list.click_on("Withdraw")
   end
 
   def when_i_confirm_the_withdrawal

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -598,8 +598,8 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
         is_expected.to eq(
           [
             {
-              title: "Reverse decision",
-              path: [
+              name: "Reverse decision",
+              link: [
                 :rollback,
                 :assessor_interface,
                 application_form,
@@ -607,8 +607,8 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
               ],
             },
             {
-              title: "Withdraw",
-              path: [:withdraw, :assessor_interface, application_form],
+              name: "Withdraw",
+              link: [:withdraw, :assessor_interface, application_form],
             },
           ],
         )


### PR DESCRIPTION
https://trello.com/c/znCe7eOH/2342-rename-application-overview-assessment-title

Assessment header changed to Tasklist
Management tasks change to Management
Management links integrated into task list

![Screenshot 2023-10-23 at 03 50 16](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/23318757/6391c1ec-80b7-45f1-a2f4-5c8ad6bf435c)
