### PR TITLE
2322-send-referee-reminders-to-applicants

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
@@ -207,7 +207,6 @@ module AssessorInterface
 
     def preview_referee
       authorize %i[assessor_interface assessment_recommendation], :edit?
-      @reference_requests = assessment.reference_requests
     end
 
     def preview_teacher

--- a/app/mailers/referee_mailer.rb
+++ b/app/mailers/referee_mailer.rb
@@ -8,12 +8,14 @@ class RefereeMailer < ApplicationMailer
   helper :application_form
 
   def reference_reminder
+    @number_of_reminders_sent = params[:number_of_reminders_sent]
+
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
       to: work_history.contact_email,
       subject:
         I18n.t(
-          "mailer.referee.reference_reminder.subject",
+          "mailer.referee.reference_reminder.subject.#{@number_of_reminders_sent}",
           name: application_form_full_name(application_form),
         ),
     )

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -109,6 +109,8 @@ class TeacherMailer < ApplicationMailer
   end
 
   def references_requested
+    @reference_requests = params[:reference_requests]
+
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
       to: teacher.email,

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -94,6 +94,20 @@ class TeacherMailer < ApplicationMailer
     )
   end
 
+  def references_reminder
+    @number_of_reminders_sent = params[:number_of_reminders_sent]
+    @reference_requests = params[:reference_requests]
+
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: teacher.email,
+      subject:
+        I18n.t(
+          "mailer.teacher.references_reminder.subject.#{@number_of_reminders_sent}",
+        ),
+    )
+  end
+
   def references_requested
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -220,7 +220,12 @@ class ApplicationForm < ApplicationRecord
             .or(withdrawn.where("withdrawn_at < ?", 5.years.ago))
         end
 
-  scope :remindable, -> { draft.where("created_at < ?", 5.months.ago) }
+  scope :remindable,
+        -> do
+          verification_stage.or(
+            draft_stage.where("created_at < ?", 5.months.ago),
+          )
+        end
 
   def to_param
     reference
@@ -262,18 +267,46 @@ class ApplicationForm < ApplicationRecord
     created_at >= Date.parse(ENV.fetch("NEW_REGS_DATE", "2023-02-01"))
   end
 
-  def should_send_reminder_email?(_name, number_of_reminders_sent)
-    return false if days_until_expired.nil? || teacher.application_form != self
-
-    (days_until_expired <= 14 && number_of_reminders_sent.zero?) ||
-      (days_until_expired <= 7 && number_of_reminders_sent == 1)
+  def reminder_email_names
+    %w[expiration references]
   end
 
-  def send_reminder_email(_name, number_of_reminders_sent)
-    TeacherMailer
-      .with(teacher:, number_of_reminders_sent:)
-      .application_not_submitted
-      .deliver_later
+  def should_send_reminder_email?(name, number_of_reminders_sent)
+    return false if teacher.application_form != self
+
+    case name
+    when "expiration"
+      return false if days_until_expired.nil?
+
+      (days_until_expired <= 14 && number_of_reminders_sent.zero?) ||
+        (days_until_expired <= 7 && number_of_reminders_sent == 1)
+    when "references"
+      unreviewed_reference_requests.any? do |reference_request|
+        reference_request.should_send_reminder_email?(
+          "expiration",
+          number_of_reminders_sent,
+        )
+      end
+    end
+  end
+
+  def send_reminder_email(name, number_of_reminders_sent)
+    case name
+    when "expiration"
+      TeacherMailer
+        .with(teacher:, number_of_reminders_sent:)
+        .application_not_submitted
+        .deliver_later
+    when "references"
+      TeacherMailer
+        .with(
+          teacher:,
+          number_of_reminders_sent:,
+          reference_requests: unreviewed_reference_requests.to_a,
+        )
+        .references_reminder
+        .deliver_later
+    end
   end
 
   def expires_after
@@ -292,5 +325,12 @@ class ApplicationForm < ApplicationRecord
     documents.build(document_type: :medium_of_instruction)
     documents.build(document_type: :english_language_proficiency)
     documents.build(document_type: :written_statement)
+  end
+
+  def unreviewed_reference_requests
+    ReferenceRequest
+      .joins(:work_history)
+      .where(work_histories: { application_form_id: id })
+      .where(received_at: nil, expired_at: nil)
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -91,6 +91,7 @@
 #  fk_rails_...  (teacher_id => teachers.id)
 #
 class ApplicationForm < ApplicationRecord
+  include Expirable
   include Remindable
 
   belongs_to :teacher
@@ -261,8 +262,8 @@ class ApplicationForm < ApplicationRecord
     created_at >= Date.parse(ENV.fetch("NEW_REGS_DATE", "2023-02-01"))
   end
 
-  def should_send_reminder_email?(days_until_expired, number_of_reminders_sent)
-    return false if teacher.application_form != self
+  def should_send_reminder_email?(number_of_reminders_sent)
+    return false if days_until_expired.nil? || teacher.application_form != self
 
     (days_until_expired <= 14 && number_of_reminders_sent.zero?) ||
       (days_until_expired <= 7 && number_of_reminders_sent == 1)

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -262,14 +262,14 @@ class ApplicationForm < ApplicationRecord
     created_at >= Date.parse(ENV.fetch("NEW_REGS_DATE", "2023-02-01"))
   end
 
-  def should_send_reminder_email?(number_of_reminders_sent)
+  def should_send_reminder_email?(_name, number_of_reminders_sent)
     return false if days_until_expired.nil? || teacher.application_form != self
 
     (days_until_expired <= 14 && number_of_reminders_sent.zero?) ||
       (days_until_expired <= 7 && number_of_reminders_sent == 1)
   end
 
-  def send_reminder_email(number_of_reminders_sent)
+  def send_reminder_email(_name, number_of_reminders_sent)
     TeacherMailer
       .with(teacher:, number_of_reminders_sent:)
       .application_not_submitted

--- a/app/models/concerns/expirable.rb
+++ b/app/models/concerns/expirable.rb
@@ -9,6 +9,11 @@ module Expirable
     requested_at + expires_after
   end
 
+  def days_until_expired
+    return nil if expires_at.nil?
+    (expires_at.to_date - Time.zone.today).to_i
+  end
+
   def expired!
     update!(expired_at: Time.zone.now)
   end

--- a/app/models/concerns/remindable.rb
+++ b/app/models/concerns/remindable.rb
@@ -5,11 +5,15 @@ module Remindable
 
   included { has_many :reminder_emails, as: :remindable }
 
-  def should_send_reminder_email?(number_of_reminders_sent)
+  def reminder_email_names
+    %w[expiration]
+  end
+
+  def should_send_reminder_email?(type, number_of_reminders_sent)
     # whether to send a reminder email at this point
   end
 
-  def send_reminder_email(number_of_reminders_sent)
+  def send_reminder_email(type, number_of_reminders_sent)
     # send a suitable reminder email for this object
   end
 end

--- a/app/models/concerns/remindable.rb
+++ b/app/models/concerns/remindable.rb
@@ -3,11 +3,9 @@
 module Remindable
   extend ActiveSupport::Concern
 
-  include Expirable
-
   included { has_many :reminder_emails, as: :remindable }
 
-  def should_send_reminder_email?(days_until_expired, number_of_reminders_sent)
+  def should_send_reminder_email?(number_of_reminders_sent)
     # whether to send a reminder email at this point
   end
 

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -40,7 +40,7 @@ class FurtherInformationRequest < ApplicationRecord
 
   FOUR_WEEK_COUNTRY_CODES = %w[AU CA GI NZ US].freeze
 
-  def should_send_reminder_email?(days_until_expired, number_of_reminders_sent)
+  def should_send_reminder_email?(number_of_reminders_sent)
     (days_until_expired <= 14 && number_of_reminders_sent.zero?) ||
       (days_until_expired <= 7 && number_of_reminders_sent == 1) ||
       (days_until_expired <= 2 && number_of_reminders_sent == 2)

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -40,13 +40,13 @@ class FurtherInformationRequest < ApplicationRecord
 
   FOUR_WEEK_COUNTRY_CODES = %w[AU CA GI NZ US].freeze
 
-  def should_send_reminder_email?(number_of_reminders_sent)
+  def should_send_reminder_email?(_name, number_of_reminders_sent)
     (days_until_expired <= 14 && number_of_reminders_sent.zero?) ||
       (days_until_expired <= 7 && number_of_reminders_sent == 1) ||
       (days_until_expired <= 2 && number_of_reminders_sent == 2)
   end
 
-  def send_reminder_email(_number_of_reminders_sent)
+  def send_reminder_email(_name, _number_of_reminders_sent)
     TeacherMailer
       .with(teacher:, further_information_request: self)
       .further_information_reminder

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -93,7 +93,7 @@ class ReferenceRequest < ApplicationRecord
     ].none?(&:nil?)
   end
 
-  def should_send_reminder_email?(days_until_expired, number_of_reminders_sent)
+  def should_send_reminder_email?(number_of_reminders_sent)
     (days_until_expired <= 28 && number_of_reminders_sent.zero?) ||
       (days_until_expired <= 14 && number_of_reminders_sent == 1)
   end

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -98,8 +98,11 @@ class ReferenceRequest < ApplicationRecord
       (days_until_expired <= 14 && number_of_reminders_sent == 1)
   end
 
-  def send_reminder_email(_name, _number_of_reminders_sent)
-    RefereeMailer.with(reference_request: self).reference_reminder.deliver_later
+  def send_reminder_email(_name, number_of_reminders_sent)
+    RefereeMailer
+      .with(reference_request: self, number_of_reminders_sent:)
+      .reference_reminder
+      .deliver_later
   end
 
   def expires_after

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -93,12 +93,12 @@ class ReferenceRequest < ApplicationRecord
     ].none?(&:nil?)
   end
 
-  def should_send_reminder_email?(number_of_reminders_sent)
+  def should_send_reminder_email?(_name, number_of_reminders_sent)
     (days_until_expired <= 28 && number_of_reminders_sent.zero?) ||
       (days_until_expired <= 14 && number_of_reminders_sent == 1)
   end
 
-  def send_reminder_email(_number_of_reminders_sent)
+  def send_reminder_email(_name, _number_of_reminders_sent)
     RefereeMailer.with(reference_request: self).reference_reminder.deliver_later
   end
 

--- a/app/models/reminder_email.rb
+++ b/app/models/reminder_email.rb
@@ -5,6 +5,7 @@
 # Table name: reminder_emails
 #
 #  id              :bigint           not null, primary key
+#  name            :string           default("expiration"), not null
 #  remindable_type :string           default(""), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null

--- a/app/services/send_reminder_email.rb
+++ b/app/services/send_reminder_email.rb
@@ -19,21 +19,11 @@ class SendReminderEmail
   attr_reader :remindable
 
   def send_reminder?
-    return false unless remindable.expires_at
-
-    remindable.should_send_reminder_email?(
-      days_until_expired,
-      number_of_reminders_sent,
-    )
+    remindable.should_send_reminder_email?(number_of_reminders_sent)
   end
 
   def number_of_reminders_sent
     remindable.reminder_emails.count
-  end
-
-  def days_until_expired
-    today = Time.zone.today
-    (remindable.expires_at.to_date - today).to_i
   end
 
   def send_email

--- a/app/services/send_reminder_email.rb
+++ b/app/services/send_reminder_email.rb
@@ -8,9 +8,11 @@ class SendReminderEmail
   end
 
   def call
-    if send_reminder?
-      send_email
-      record_reminder
+    remindable.reminder_email_names.each do |name|
+      if send_reminder?(name)
+        send_email(name)
+        record_reminder(name)
+      end
     end
   end
 
@@ -18,19 +20,19 @@ class SendReminderEmail
 
   attr_reader :remindable
 
-  def send_reminder?
-    remindable.should_send_reminder_email?(number_of_reminders_sent)
+  def send_reminder?(name)
+    remindable.should_send_reminder_email?(name, number_of_reminders_sent(name))
   end
 
-  def number_of_reminders_sent
-    remindable.reminder_emails.count
+  def number_of_reminders_sent(name)
+    remindable.reminder_emails.where(name:).count
   end
 
-  def send_email
-    remindable.send_reminder_email(number_of_reminders_sent)
+  def send_email(name)
+    remindable.send_reminder_email(name, number_of_reminders_sent(name))
   end
 
-  def record_reminder
-    remindable.reminder_emails.create!
+  def record_reminder(name)
+    remindable.reminder_emails.create!(name:)
   end
 end

--- a/app/services/update_work_history_contact.rb
+++ b/app/services/update_work_history_contact.rb
@@ -27,7 +27,10 @@ class UpdateWorkHistoryContact
 
     if email.present? && (reference_request = work_history.reference_request)
       RefereeMailer.with(reference_request:).reference_requested.deliver_later
-      TeacherMailer.with(teacher:).references_requested.deliver_later
+      TeacherMailer
+        .with(teacher:, reference_requests: [reference_request])
+        .references_requested
+        .deliver_later
     end
   end
 

--- a/app/services/verify_assessment.rb
+++ b/app/services/verify_assessment.rb
@@ -83,6 +83,9 @@ class VerifyAssessment
       RefereeMailer.with(reference_request:).reference_requested.deliver_later
     end
 
-    TeacherMailer.with(teacher:).references_requested.deliver_later
+    TeacherMailer
+      .with(teacher:, reference_requests:)
+      .references_requested
+      .deliver_later
   end
 end

--- a/app/views/assessor_interface/assessment_recommendation_verify/preview_teacher.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/preview_teacher.html.erb
@@ -11,6 +11,9 @@
   mailer_class: TeacherMailer,
   name: :references_requested,
   teacher: @application_form.teacher,
+  reference_requests: [OpenStruct.new(
+    expires_at: Time.zone.now + 6.weeks,
+  )],
 )) %>
 
 <div class="govuk-button-group">

--- a/app/views/referee_mailer/reference_reminder.text.erb
+++ b/app/views/referee_mailer/reference_reminder.text.erb
@@ -1,14 +1,35 @@
 Dear <%= @work_history.contact_name %>
 
-We still need you to confirm some information about <%= application_form_full_name(@application_form) %> as part of their application for qualified teacher status (QTS) in England.
+<% if @number_of_reminders_sent == 1 %>
+You have just 2 weeks to complete the reference request for <%= application_form_full_name(@application_form) %>.
+<% end %>
 
-We recently contacted you to ask you to help us confirm that the information <%= application_form_full_name(@application_form) %> has provided about their work history and experience is accurate.
+<%= application_form_full_name(@application_form) %> has applied for qualified teacher status (QTS) in England.
 
-Please follow the link below and answer the questions by <%= @reference_request.expires_at.to_date.to_fs(:long_ordinal_uk) %>. If we do not receive your response by this date, it could affect the outcome for the applicant.
+<% if @number_of_reminders_sent == 0 %>
+We recently asked you to confirm the information they’ve provided about their work history and experience. We have not yet received a response from you. The applicant may not be awarded QTS if we cannot confirm the information they have provided.
+<% elsif @number_of_reminders_sent == 1 %>
+They have given us your name and email address to confirm the information they’ve provided about their work history and experience.
+
+The applicant may not be awarded QTS if we cannot confirm the information they have provided.
+<% end %>
+
+# What you need to do
+
+You need to answer a few questions about <%= application_form_full_name(@application_form) %> by <%= @reference_request.expires_at.to_date.to_fs(:long_ordinal_uk) %>. This should take no longer than 5 minutes.
+
+Follow the link below to start.
 
 <%= teacher_interface_reference_request_url(@reference_request.slug) %>
 
-It should take no longer than 5 minutes.
+# About QTS
+
+QTS is a legal requirement to teach in many English schools, and most schools prefer their teachers to have it.
+
+<%= application_form_full_name(@application_form) %> has not applied for a job. Having QTS does not guarantee a job or give someone the right to work in England.
+
+The QTS application allows us to assess a person’s teacher training and experience to understand if they have the skills and qualifications needed to gain QTS in England.
 
 Kind regards,
-The Teacher Qualifications Team (part of the Teaching Regulation Agency)
+Teaching Regulation Authority (TRA)
+(an executive agency sponsored by the Department for Education, England)

--- a/app/views/referee_mailer/reference_requested.text.erb
+++ b/app/views/referee_mailer/reference_requested.text.erb
@@ -1,22 +1,26 @@
 Dear <%= @work_history.contact_name %>
 
-We need you to confirm some information about <%= application_form_full_name(@application_form) %> as part of their application for qualified teacher status (QTS) in England.
+<%= application_form_full_name(@application_form) %> has applied for qualified teacher status (QTS) in England.
 
-As part of the QTS application process, our assessors need to understand each applicant’s work history and experience.
+They have given us your name and email address to confirm the information they’ve provided about their work history and experience.
 
-<%= application_form_full_name(@application_form) %> has given us your name and email address to help us confirm that the information they’ve provided about their work history and experience is accurate.
+# What you need to do
 
-# About QTS
+You need to answer a few questions about <%= application_form_full_name(@application_form) %> by <%= @reference_request.expires_at.to_date.to_fs(:long_ordinal_uk) %>. This should take no longer than 5 minutes.
 
-<%= application_form_full_name(@application_form) %> is NOT applying for a job – their QTS application just allows us to assess their qualifications and teaching experience to understand whether they can teach in England.
-
-# What we need you to do
-
-Please follow the link below and answer the questions by <%= @reference_request.expires_at.to_date.to_fs(:long_ordinal_uk) %>.
+Follow the link below to start.
 
 <%= teacher_interface_reference_request_url(@reference_request.slug) %>
 
-It should take no longer than 5 minutes.
+Please complete the reference by the due date. The applicant may not be awarded QTS if we cannot confirm the information they have provided.
+
+# About QTS
+
+QTS is a legal requirement to teach in many English schools, and most schools prefer their teachers to have it.
+
+<%= application_form_full_name(@application_form) %> has not applied for a job. Having QTS does not guarantee a job or give someone the right to work in England.
+
+The QTS application allows us to assess a person’s teacher training and experience to understand if they have the skills and qualifications needed to gain QTS in England.
 
 Kind regards,
 Teaching Regulation Authority (TRA)

--- a/app/views/shared/teacher_mailer/_any_questions_contact.text.erb
+++ b/app/views/shared/teacher_mailer/_any_questions_contact.text.erb
@@ -1,1 +1,1 @@
-If you have any questions, contact: <%= t("service.email.enquiries") %>
+If you have any questions, contact: [<%= t("service.email.enquiries") %>](mailto:<%= t("service.email.enquiries") %>)

--- a/app/views/teacher_mailer/application_declined.text.erb
+++ b/app/views/teacher_mailer/application_declined.text.erb
@@ -34,7 +34,7 @@ If you would like to request a decision review, you’ll need to provide:
 - formal evidence and reasoning as to how you meet the required assessment criteria
 - additional information not included in your original application that would support your decision review
 
-Your request for review must be received within 28 days of receipt of the decision to decline QTS. Email your request for review, including the information required as above, to <%= t("service.email.enquiries") %>.
+Your request for review must be received within 28 days of receipt of the decision to decline QTS. Email your request for review, including the information required as above, to [<%= t("service.email.enquiries") %>](mailto:<%= t("service.email.enquiries") %>).
 
 If you are not satisfied with the outcome of the decision review, you can request a final formal appeal to a senior Teacher Qualification Manager.
 

--- a/app/views/teacher_mailer/initial_checks_passed.text.erb
+++ b/app/views/teacher_mailer/initial_checks_passed.text.erb
@@ -4,7 +4,7 @@ Dear <%= application_form_full_name(@application_form) %>
 
 <%= render "shared/teacher_mailer/reference_number" %>
 
-You should now request your <%= region_certificate_name(@application_form.region) %> from <%= region_teaching_authority_name(@application_form.region) %>. Contact them directly and instruct them to send the document to <%= t("service.email.verification") %>.
+You should now request your <%= region_certificate_name(@application_form.region) %> from <%= region_teaching_authority_name(@application_form.region) %>. Contact them directly and instruct them to send the document to [<%= t("service.email.verification") %>](mailto:<%= t("service.email.verification") %>).
 
 Once we receive the document, we’ll begin the full assessment of your application.
 

--- a/app/views/teacher_mailer/references_reminder.text.erb
+++ b/app/views/teacher_mailer/references_reminder.text.erb
@@ -1,0 +1,17 @@
+Dear <%= application_form_full_name(@application_form) %>
+
+## We’re still waiting for a response from one or more of the references you provided to verify your work history.
+
+<% if @number_of_reminders_sent == 0 %>
+We contacted your references on <%= @reference_requests.first.requested_at.to_date.to_fs(:long_ordinal_uk) %> but have not received a response from:
+<% elsif @number_of_reminders_sent == 1 %>
+The following references have just 2 weeks to respond to the reference request.
+<% end %>
+
+<% @reference_requests.each do |reference_request| %>
+- <%= reference_request.work_history.contact_name %> — <%= reference_request.work_history.school_name %>
+<% end %>
+
+They need to respond by <%= @reference_requests.first.expires_at.to_date.to_fs(:long_ordinal_uk) %>. If your references do not respond, and, as a result, we cannot verify your work history, we may not be able to award you QTS. You should contact your reference to remind them about the request.
+
+<%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/references_requested.text.erb
+++ b/app/views/teacher_mailer/references_requested.text.erb
@@ -6,6 +6,6 @@ They need to respond by <%= @reference_requests.first.expires_at.to_date.to_fs(:
 
 Contact them to make sure they have received the request. They may need to check their junk email folder.
 
-If they have not received the request, email QTS.Enquiries@education.gov.uk
+If they have not received the request, email [<%= t("service.email.enquiries") %>](mailto:<%= t("service.email.enquiries") %>).
 
 <%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/references_requested.text.erb
+++ b/app/views/teacher_mailer/references_requested.text.erb
@@ -1,9 +1,11 @@
 Dear <%= application_form_full_name(@application_form) %>
 
-# We’ve contacted the references you provided to verify your work history
+We’ve contacted the references you provided to verify the work history information you gave as part of your QTS application.
 
-As part of your QTS application we’ve contacted the references that you provided.
+They need to respond by <%= @reference_requests.first.expires_at.to_date.to_fs(:long_ordinal_uk) %>. If your references do not respond, and, as a result, we cannot verify your work history, we may not be able to award you QTS.
 
-Once they reply, we’ll review the references and proceed with assessing your application.
+Contact them to make sure they have received the request. They may need to check their junk email folder.
+
+If they have not received the request, email QTS.Enquiries@education.gov.uk
 
 <%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teaching_authority_mailer/application_submitted.text.erb
+++ b/app/views/teaching_authority_mailer/application_submitted.text.erb
@@ -17,7 +17,7 @@ They’ve told us that they’re qualified to teach children <%= @application_fo
 
 We’d be grateful if you could provide written evidence of their professional standing as a teacher in <%= CountryName.from_region(@region, with_definite_article: true) %>, and email it to us at:
 
-<%= t("service.email.verification") %>
+[<%= t("service.email.verification") %>](mailto:<%= t("service.email.verification") %>)
 
 Please include their QTS application reference number <%= @application_form.reference %>.
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -294,11 +294,12 @@
     - updated_at
     - written_statement_optional
   :reminder_emails:
-    - id
     - created_at
-    - updated_at
+    - id
+    - name
     - remindable_id
     - remindable_type
+    - updated_at
   :selected_failure_reasons:
     - id
     - created_at

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -28,6 +28,10 @@ en:
         subject: Your qualified teacher status application – we’ve received your %{certificate}
       references_requested:
         subject: Your qualified teacher status application – we’ve contacted your references
+      references_reminder:
+        subject:
+          0: Waiting on references – QTS application
+          1: Your references only have two weeks left to respond
     teaching_authority:
       application_submitted:
         subject: "%{name} has made an application for qualified teacher status (QTS) in England"

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -2,9 +2,11 @@ en:
   mailer:
     referee:
       reference_reminder:
-        subject: We still need you to verify %{name}’s application for qualified teacher status (QTS)
+        subject:
+          0: Waiting on reference request for %{name}’s application for QTS
+          1: Please complete reference request for %{name}’s application for QTS
       reference_requested:
-        subject: Please help us to verify %{name}’s application for qualified teacher status (QTS)
+        subject: Reference request for %{name}’s application for qualified teacher status (QTS)
     teacher:
       application_awarded:
         subject: Your QTS application was successful
@@ -27,7 +29,7 @@ en:
       professional_standing_received:
         subject: Your qualified teacher status application – we’ve received your %{certificate}
       references_requested:
-        subject: Your qualified teacher status application – we’ve contacted your references
+        subject: We’ve contacted your references – QTS application
       references_reminder:
         subject:
           0: Waiting on references – QTS application

--- a/db/migrate/20231114102513_add_name_to_reminder_emails.rb
+++ b/db/migrate/20231114102513_add_name_to_reminder_emails.rb
@@ -1,0 +1,9 @@
+class AddNameToReminderEmails < ActiveRecord::Migration[7.1]
+  def change
+    add_column :reminder_emails,
+               :name,
+               :string,
+               null: false,
+               default: "expiration"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_11_121802) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_14_102513) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -391,6 +391,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_11_121802) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "remindable_type", default: "", null: false
+    t.string "name", default: "expiration", null: false
     t.index ["remindable_type", "remindable_id"], name: "index_reminder_emails_on_remindable_type_and_remindable_id"
   end
 

--- a/spec/mailers/referee_mailer_spec.rb
+++ b/spec/mailers/referee_mailer_spec.rb
@@ -23,7 +23,10 @@ RSpec.describe RefereeMailer, type: :mailer do
 
   describe "#reference_reminder" do
     subject(:mail) do
-      described_class.with(reference_request:).reference_reminder
+      described_class.with(
+        reference_request:,
+        number_of_reminders_sent: 0,
+      ).reference_reminder
     end
 
     describe "#subject" do
@@ -31,7 +34,7 @@ RSpec.describe RefereeMailer, type: :mailer do
 
       it do
         is_expected.to eq(
-          "We still need you to verify First Last’s application for qualified teacher status (QTS)",
+          "Waiting on reference request for First Last’s application for QTS",
         )
       end
     end
@@ -48,7 +51,7 @@ RSpec.describe RefereeMailer, type: :mailer do
       it { is_expected.to include("Dear Contact Name") }
       it do
         is_expected.to include(
-          "We still need you to confirm some information about First Last",
+          "You need to answer a few questions about First Last",
         )
       end
       it do
@@ -71,7 +74,7 @@ RSpec.describe RefereeMailer, type: :mailer do
 
       it do
         is_expected.to eq(
-          "Please help us to verify First Last’s application for qualified teacher status (QTS)",
+          "Reference request for First Last’s application for qualified teacher status (QTS)",
         )
       end
     end
@@ -88,7 +91,7 @@ RSpec.describe RefereeMailer, type: :mailer do
       it { is_expected.to include("Dear Contact Name") }
       it do
         is_expected.to include(
-          "We need you to confirm some information about First Last",
+          "You need to answer a few questions about First Last",
         )
       end
       it do

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -442,15 +442,18 @@ RSpec.describe TeacherMailer, type: :mailer do
   end
 
   describe "#references_requested" do
-    subject(:mail) { described_class.with(teacher:).references_requested }
+    subject(:mail) do
+      described_class.with(
+        teacher:,
+        reference_requests: [create(:reference_request, :requested)],
+      ).references_requested
+    end
 
     describe "#subject" do
       subject(:subject) { mail.subject }
 
       it do
-        is_expected.to eq(
-          "Your qualified teacher status application – we’ve contacted your references",
-        )
+        is_expected.to eq("We’ve contacted your references – QTS application")
       end
     end
 
@@ -466,7 +469,7 @@ RSpec.describe TeacherMailer, type: :mailer do
       it { is_expected.to include("Dear First Last") }
       it do
         is_expected.to include(
-          "We’ve contacted the references you provided to verify your work history",
+          "We’ve contacted the references you provided to verify the work history",
         )
       end
     end

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -366,6 +366,81 @@ RSpec.describe TeacherMailer, type: :mailer do
     it_behaves_like "an observable mailer", "professional_standing_received"
   end
 
+  describe "#references_reminder" do
+    let(:reference_request) do
+      create(
+        :reference_request,
+        requested_at: Date.new(2020, 1, 1),
+        work_history:
+          create(
+            :work_history,
+            school_name: "St Smith School",
+            contact_name: "John Smith",
+          ),
+        assessment:,
+      )
+    end
+    let(:number_of_reminders_sent) { nil }
+    subject(:mail) do
+      described_class.with(
+        teacher:,
+        number_of_reminders_sent:,
+        reference_requests: [reference_request],
+      ).references_reminder
+    end
+
+    describe "#subject" do
+      subject(:subject) { mail.subject }
+
+      context "with no reminder emails" do
+        let(:number_of_reminders_sent) { 0 }
+        it { is_expected.to eq("Waiting on references – QTS application") }
+      end
+
+      context "with one reminder email" do
+        let(:number_of_reminders_sent) { 1 }
+        it do
+          is_expected.to eq(
+            "Your references only have two weeks left to respond",
+          )
+        end
+      end
+    end
+
+    describe "#to" do
+      subject(:to) { mail.to }
+
+      it { is_expected.to eq(["teacher@example.com"]) }
+    end
+
+    describe "#body" do
+      subject(:body) { mail.body.encoded }
+
+      let(:number_of_reminders_sent) { 0 }
+
+      it { is_expected.to include("Dear First Last") }
+      it do
+        is_expected.to include(
+          "We’re still waiting for a response from one or more of the " \
+            "references you provided to verify your work history.",
+        )
+      end
+      it { is_expected.to include("John Smith — St Smith School") }
+
+      context "when the second reminder email" do
+        let(:number_of_reminders_sent) { 1 }
+
+        it do
+          is_expected.to include(
+            "The following references have just 2 weeks to respond to the reference request.",
+          )
+        end
+      end
+    end
+
+    it_behaves_like "an observable mailer", "references_reminder"
+  end
+
   describe "#references_requested" do
     subject(:mail) { described_class.with(teacher:).references_requested }
 

--- a/spec/mailers/teaching_authority_mailer_spec.rb
+++ b/spec/mailers/teaching_authority_mailer_spec.rb
@@ -81,7 +81,7 @@ They’ve told us that they’re qualified to teach children Maths and French fr
 
 We’d be grateful if you could provide written evidence of their professional standing as a teacher in Region Name, and email it to us at:
 
-ApplyQTS.Verification@education.gov.uk
+[ApplyQTS.Verification@education.gov.uk](mailto:ApplyQTS.Verification@education.gov.uk)
 
 Please include their QTS application reference number abc.
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe ApplicationForm, type: :model do
     )
   end
 
+  it_behaves_like "an expirable"
   it_behaves_like "a remindable"
 
   describe "columns" do

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -27,7 +27,12 @@ require "rails_helper"
 RSpec.describe FurtherInformationRequest do
   subject(:further_information_request) { create(:further_information_request) }
 
-  it_behaves_like "a remindable"
+  it_behaves_like "an expirable"
+
+  it_behaves_like "a remindable" do
+    subject { create(:further_information_request, :requested) }
+  end
+
   it_behaves_like "a requestable"
 
   describe "scopes" do

--- a/spec/models/reference_request_spec.rb
+++ b/spec/models/reference_request_spec.rb
@@ -55,7 +55,11 @@ require "rails_helper"
 RSpec.describe ReferenceRequest do
   subject(:reference_request) { create(:reference_request) }
 
-  it_behaves_like "a remindable"
+  it_behaves_like "an expirable"
+
+  it_behaves_like "a remindable" do
+    subject { create(:reference_request, :requested) }
+  end
 
   it_behaves_like "a requestable" do
     subject { create(:reference_request, :receivable) }

--- a/spec/services/send_reminder_email_spec.rb
+++ b/spec/services/send_reminder_email_spec.rb
@@ -48,7 +48,13 @@ RSpec.describe SendReminderEmail do
         expect { subject }.to have_enqueued_mail(
           RefereeMailer,
           :reference_reminder,
-        ).with(params: { reference_request: remindable }, args: [])
+        ).with(
+          params: {
+            reference_request: remindable,
+            number_of_reminders_sent: a_kind_of(Integer),
+          },
+          args: [],
+        )
       end
     end
 

--- a/spec/services/send_reminder_email_spec.rb
+++ b/spec/services/send_reminder_email_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe SendReminderEmail do
 
     shared_examples "sends an email" do
       it "logs an email" do
-        expect { call }.to change { ReminderEmail.where(remindable:).count }.by(
-          1,
-        )
+        expect { call }.to change {
+          ReminderEmail.where(remindable:, name: "expiration").count
+        }.by(1)
       end
     end
 
@@ -75,12 +75,14 @@ RSpec.describe SendReminderEmail do
       end
 
       context "when a previous reminder has been sent" do
-        before { remindable.reminder_emails.create }
+        before { remindable.reminder_emails.create!(name: "expiration") }
         include_examples "doesn't send an email"
       end
 
       context "when two previous reminders have been sent" do
-        before { 2.times { remindable.reminder_emails.create } }
+        before do
+          2.times { remindable.reminder_emails.create!(name: "expiration") }
+        end
         include_examples "doesn't send an email"
       end
     end
@@ -91,12 +93,14 @@ RSpec.describe SendReminderEmail do
       end
 
       context "when one previous reminder has been sent" do
-        before { remindable.reminder_emails.create }
+        before { remindable.reminder_emails.create!(name: "expiration") }
         include_examples shared_example
       end
 
       context "when two previous reminders have been sent" do
-        before { 2.times { remindable.reminder_emails.create } }
+        before do
+          2.times { remindable.reminder_emails.create!(name: "expiration") }
+        end
         include_examples "doesn't send an email"
       end
     end
@@ -107,12 +111,14 @@ RSpec.describe SendReminderEmail do
       end
 
       context "when one previous reminder has been sent" do
-        before { remindable.reminder_emails.create }
+        before { remindable.reminder_emails.create!(name: "expiration") }
         include_examples shared_example
       end
 
       context "when two previous reminders have been sent" do
-        before { 2.times { remindable.reminder_emails.create } }
+        before do
+          2.times { remindable.reminder_emails.create!(name: "expiration") }
+        end
         include_examples shared_example
       end
     end

--- a/spec/support/shared_examples/remindable.rb
+++ b/spec/support/shared_examples/remindable.rb
@@ -13,9 +13,7 @@ RSpec.shared_examples "a remindable" do
   end
 
   describe "#should_send_reminder_email?" do
-    let(:should_send_reminder_email?) do
-      subject.should_send_reminder_email?(0, 0)
-    end
+    let(:should_send_reminder_email?) { subject.should_send_reminder_email?(0) }
 
     it "returns a boolean" do
       expect(should_send_reminder_email?).to be_in([true, false])
@@ -29,6 +27,4 @@ RSpec.shared_examples "a remindable" do
       expect { send_reminder_email }.to have_enqueued_mail
     end
   end
-
-  include_examples "an expirable"
 end

--- a/spec/support/shared_examples/remindable.rb
+++ b/spec/support/shared_examples/remindable.rb
@@ -14,7 +14,7 @@ RSpec.shared_examples "a remindable" do
 
   describe "#should_send_reminder_email?" do
     let(:should_send_reminder_email?) do
-      subject.should_send_reminder_email?("type", 0)
+      subject.should_send_reminder_email?("expiration", 0)
     end
 
     it "returns a boolean" do
@@ -23,7 +23,7 @@ RSpec.shared_examples "a remindable" do
   end
 
   describe "#send_reminder_email" do
-    let(:send_reminder_email) { subject.send_reminder_email("type", 0) }
+    let(:send_reminder_email) { subject.send_reminder_email("expiration", 0) }
 
     it "enqueues an email" do
       expect { send_reminder_email }.to have_enqueued_mail

--- a/spec/support/shared_examples/remindable.rb
+++ b/spec/support/shared_examples/remindable.rb
@@ -13,7 +13,9 @@ RSpec.shared_examples "a remindable" do
   end
 
   describe "#should_send_reminder_email?" do
-    let(:should_send_reminder_email?) { subject.should_send_reminder_email?(0) }
+    let(:should_send_reminder_email?) do
+      subject.should_send_reminder_email?("type", 0)
+    end
 
     it "returns a boolean" do
       expect(should_send_reminder_email?).to be_in([true, false])
@@ -21,7 +23,7 @@ RSpec.shared_examples "a remindable" do
   end
 
   describe "#send_reminder_email" do
-    let(:send_reminder_email) { subject.send_reminder_email(0) }
+    let(:send_reminder_email) { subject.send_reminder_email("type", 0) }
 
     it "enqueues an email" do
       expect { send_reminder_email }.to have_enqueued_mail


### PR DESCRIPTION
When reference request reminder emails are sent to referees the associated teacher will be notified. They will be contacted when their referees have 28 and 14 days to respond.
