### PR TITLE
2366 create link with dynamic name

### DIFF
--- a/app/controllers/assessor_interface/review_verifications_controller.rb
+++ b/app/controllers/assessor_interface/review_verifications_controller.rb
@@ -13,11 +13,11 @@ module AssessorInterface
 
       @region = @assessment.application_form.region
 
-      if @region.teaching_authority_name.present?
-        @teaching_authority_name = @region.teaching_authority_name
-      else
-        @teaching_authority_name = "Contact relevant competent authority"
-      end      
+      @teaching_authority_name =
+        (
+          @region.teaching_authority_name.presence ||
+            "Contact relevant competent authority"
+        )
 
       render layout: "full_from_desktop"
     end

--- a/app/controllers/assessor_interface/review_verifications_controller.rb
+++ b/app/controllers/assessor_interface/review_verifications_controller.rb
@@ -11,6 +11,14 @@ module AssessorInterface
       @professional_standing_request =
         assessment.professional_standing_request if assessment.professional_standing_request.verify_failed?
 
+      @region = @assessment.application_form.region
+
+      if @region.teaching_authority_name.present?
+        @teaching_authority_name = @region.teaching_authority_name
+      else
+        @teaching_authority_name = "Contact relevant competent authority"
+      end      
+
       render layout: "full_from_desktop"
     end
 

--- a/app/views/assessor_interface/review_verifications/index.html.erb
+++ b/app/views/assessor_interface/review_verifications/index.html.erb
@@ -7,17 +7,20 @@
   The following verification tasks have been flagged for review:
 </p>
 
-<%= govuk_table do |table|
-  if @professional_standing_request.present?
-    table.with_caption(text: "LoPS")
-    table.with_body do |body|
-      body.with_row do |row|
-        row.with_cell { govuk_link_to region_certificate_name(@application_form.region), [:review, :assessor_interface, @application_form, @assessment, :professional_standing_request] }
-        row.with_cell { render(StatusTag::Component.new(@professional_standing_request.review_status)) }
-      end
-    end
-  end
-end %>
+<%= render(TaskList::Component.new(
+  [
+    {
+      title: "LoPS",
+      items: [
+        {
+          name: @teaching_authority_name,
+          link: [:review, :assessor_interface, @application_form, @assessment, :professional_standing_request],
+          status: @professional_standing_request.review_status,
+        }
+      ],
+    }
+  ]
+)) %>
 
 <div class="govuk-!-padding-top-3">
   <%= govuk_button_link_to "Back to overview", [:assessor_interface, @application_form] %>

--- a/spec/system/assessor_interface/reviewing_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/reviewing_professional_standing_spec.rb
@@ -94,8 +94,9 @@ RSpec.describe "Assessor reviewing verifications", type: :system do
   end
 
   def when_i_click_on_lops
-    assessor_review_verifications_page.rows.first.link.click
+    find(".govuk-link").click
   end
+  
 
   def when_i_fill_in_the_review_lops_form
     form = assessor_review_professional_standing_request_page.form
@@ -109,15 +110,13 @@ RSpec.describe "Assessor reviewing verifications", type: :system do
   end
 
   def and_i_see_the_lops_not_started
-    expect(assessor_review_verifications_page.rows.first.tag.text).to eq(
-      "NOT STARTED",
-    )
+    status_text = find(".govuk-tag.govuk-tag--grey.app-task-list__tag").text
+    expect(status_text).to eq("NOT STARTED")
   end
 
   def and_i_see_the_lops_accepted
-    expect(assessor_review_verifications_page.rows.first.tag.text).to eq(
-      "ACCEPTED",
-    )
+    status_text = find('strong.govuk-tag.govuk-tag--green.app-task-list__tag').text
+    expect(status_text).to eq("ACCEPTED")
   end
 
   def application_form


### PR DESCRIPTION
LoPS link on Review verifications page has been made dynamic to pull through the name of the competent authority

https://trello.com/c/FfuC3FAK/2366-create-link-with-dynamic-name