### PR TITLE
Remove line about new application status

### DIFF
--- a/app/views/assessor_interface/application_forms/status.html.erb
+++ b/app/views/assessor_interface/application_forms/status.html.erb
@@ -9,10 +9,6 @@
   <%= govuk_panel(title_text: "QTS application #{@view_object.application_form.reference} has been #{@view_object.status.downcase}") %>
 <% end %>
 
-<% unless @view_object.application_form.waiting_on? %>
-  <p class="govuk-body">The status of this application has been changed to ’<%= @view_object.status %>‘.</p>
-<% end %>
-
 <% if @view_object.assessment.review? %>
   <p class="govuk-body">An assessor will now review the application and make a decision on awarding or declining QTS.</p>
 <% elsif @view_object.application_form.declined? %>


### PR DESCRIPTION
This isn't in the design, and it's not accurate any more as applications don't have a single status.