### PR TITLE
Update status if references not yet verified

### DIFF
--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -137,6 +137,11 @@ class ApplicationFormStatusUpdater
     waiting_on?(requestables: reference_requests)
   end
 
+  def needs_references_verified?
+    reference_requests.present? && !waiting_on_reference &&
+      references_verified != true
+  end
+
   def status
     @status ||=
       if dqt_trn_request&.potential_duplicate?
@@ -178,7 +183,8 @@ class ApplicationFormStatusUpdater
       elsif dqt_trn_request.present? || assessment_in_review? ||
             overdue_further_information || overdue_qualification ||
             overdue_reference || received_further_information ||
-            received_qualification || received_reference
+            received_qualification || received_reference ||
+            needs_references_verified?
         "assessor"
       elsif preliminary_check? || need_to_request_lops? || overdue_lops ||
             received_lops
@@ -207,7 +213,8 @@ class ApplicationFormStatusUpdater
       elsif assessment_in_verify? || need_to_request_lops? || overdue_lops ||
             overdue_qualification || overdue_reference || received_lops ||
             received_qualification || received_reference || waiting_on_lops ||
-            waiting_on_qualification || waiting_on_reference
+            waiting_on_qualification || waiting_on_reference ||
+            needs_references_verified?
         "verification"
       elsif overdue_further_information || received_further_information ||
             waiting_on_further_information ||

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -309,7 +309,10 @@ class AssessorInterface::ApplicationFormsShowViewObject
           if assessment.references_verified
             :completed
           else
-            requestables_task_item_status(reference_requests)
+            requestables_task_item_status(
+              reference_requests,
+              default: :in_progress,
+            )
           end
         ),
     }
@@ -452,11 +455,11 @@ class AssessorInterface::ApplicationFormsShowViewObject
     !assessment.unknown? && !request_further_information_unfinished?
   end
 
-  def requestables_task_item_status(requestables)
+  def requestables_task_item_status(requestables, default: :completed)
     unreviewed_requests = requestables.reject(&:reviewed?)
 
     if unreviewed_requests.empty?
-      :completed
+      default
     elsif unreviewed_requests.any?(&:expired?)
       :overdue
     elsif unreviewed_requests.any?(&:received?)


### PR DESCRIPTION
To proceed assessors have to select a radio item recording whether they have happy with the number of references that have been received, but we're not considering the status of this field anywhere.