### PR TITLE
Improve decline email and view content

### DIFF
--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -13,7 +13,7 @@ module TeacherInterface
     define_history_check :edit
 
     def new
-      existing_application_form = current_teacher.application_form
+      existing_application_form = application_form
 
       @already_applied = existing_application_form.present?
       @needs_region = false
@@ -26,7 +26,7 @@ module TeacherInterface
     end
 
     def create
-      @already_applied = current_teacher.application_form.present?
+      @already_applied = application_form.present?
 
       @country_region_form =
         CountryRegionForm.new(
@@ -44,15 +44,15 @@ module TeacherInterface
     end
 
     def show
-      @view_object = ApplicationFormShowViewObject.new(current_teacher:)
-
-      if @view_object.application_form.nil?
+      if application_form.nil?
         redirect_to %i[new teacher_interface application_form]
       end
+
+      @view_object = ApplicationFormViewObject.new(application_form:)
     end
 
     def edit
-      @view_object = ApplicationFormShowViewObject.new(current_teacher:)
+      @view_object = ApplicationFormViewObject.new(application_form:)
 
       @sanction_confirmation_form =
         SanctionConfirmationForm.new(
@@ -62,7 +62,7 @@ module TeacherInterface
     end
 
     def update
-      @view_object = ApplicationFormShowViewObject.new(current_teacher:)
+      @view_object = ApplicationFormViewObject.new(application_form:)
 
       if (
            @sanction_confirmation_form =

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -19,6 +19,9 @@ class TeacherMailer < ApplicationMailer
   end
 
   def application_declined
+    @view_object =
+      TeacherInterface::ApplicationFormViewObject.new(application_form:)
+
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
       to: teacher.email,

--- a/app/views/assessor_interface/assessment_recommendation_decline/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_decline/edit.html.erb
@@ -32,21 +32,21 @@
     <% @assessment.sections.not_preliminary.each do |section| %>
       <% if (selected_failure_reasons = section.selected_failure_reasons).present? %>
         <h3 class="govuk-heading-m"><%= t(".assessment_section.#{section.key}") %></h3>
-        <ul class="govuk-list">
+        <ul class="govuk-list govuk-list--bullet">
           <% selected_failure_reasons.each do |failure_reason| %>
             <li>
               <h4 class="govuk-heading-s">
                 <%= t(failure_reason.key, scope: %i[assessor_interface assessment_sections failure_reasons as_statement]) %>
               </h4>
 
-              <% if FailureReasons.decline?(failure_reason: failure_reason.key) %>
-                <p class="govuk-body govuk-!-margin-bottom-2">Your note to the applicant:</p>
-              <% else %>
-                <p class="govuk-body govuk-!-margin-bottom-2">Your note (the applicant won’t see this):</p>
-              <% end %>
+              <% if (assessor_feedback = failure_reason.assessor_feedback).present? %>
+                <% if FailureReasons.decline?(failure_reason: failure_reason.key) %>
+                  <p class="govuk-body govuk-!-margin-bottom-2">Your note to the applicant:</p>
+                <% else %>
+                  <p class="govuk-body govuk-!-margin-bottom-2">Your note (the applicant won’t see this):</p>
+                <% end %>
 
-              <%= govuk_inset_text do %>
-                <%= simple_format failure_reason.assessor_feedback %>
+                <%= govuk_inset_text { simple_format assessor_feedback } %>
               <% end %>
             </li>
           <% end %>

--- a/app/views/shared/teacher_mailer/_reference_number.text.erb
+++ b/app/views/shared/teacher_mailer/_reference_number.text.erb
@@ -1,3 +1,1 @@
-Your application reference number is:
-
-<%= @application_form.reference %>
+Application reference number: <%= @application_form.reference %>

--- a/app/views/teacher_interface/application_forms/show/_declined.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_declined.html.erb
@@ -1,50 +1,35 @@
 <h2 class="govuk-heading-l">Your QTS application has been declined</h2>
 
-<h3 class="govuk-heading-m">Why your application was declined</h3>
+<p class="govuk-body">Thank you for applying for qualified teacher status (QTS) and for your patience while we reviewed your application.</p>
 
-<% if (declined_reasons = view_object.declined_reasons).present? %>
-  <% declined_reasons.each do |title, reasons| %>
-    <% if title.present? %>
-      <h4 class="govuk-heading-s"><%= title %></h4>
-    <% end %>
+<h3 class="govuk-heading-m">Reason for decline</h3>
 
-    <ul class="govuk-list">
-      <% reasons.each do |reason| %>
-        <li><%= simple_format reason %></li>
-      <% end %>
-    </ul>
+<% view_object.declined_reasons.each do |title, reasons| %>
+  <% if title.present? %>
+    <h4 class="govuk-heading-s"><%= title %></h4>
   <% end %>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <% reasons.each do |reason| %>
+      <li><%= simple_format reason %></li>
+    <% end %>
+  </ul>
 <% end %>
 
 <% unless view_object.declined_cannot_reapply? %>
-  <h3 class="govuk-heading-m">What you can do next</h3>
+  <h2 class="govuk-heading-l">What you can do next</h2>
 
-  <p class="govuk-body">While your QTS application was declined this time, you can make a new application in future, if you’re able to address the decline reasons we’ve set out.</p>
+  <p class="govuk-body">You’ll be able to make a new application for QTS once you've addressed the decline reasons we've given. If you reapply for QTS, you’ll not be able to review the details of your previous application.</p>
 
-  <p class="govuk-body">If you reapply for QTS, you will not be able to review the details of your previous application.</p>
+  <p class="govuk-body"><%= govuk_button_link_to "Apply again", %i[new teacher_interface application_form] %></p>
 
-  <p class="govuk-body"><%= govuk_button_link_to "Apply again", new_teacher_interface_application_form_path %></p>
-
-  <h3 class="govuk-heading-m">Other routes to teaching in England</h3>
-
-  <p class="govuk-body">You may want to explore other routes to teaching in England. QTS is not a requirement to teach in independent (private) schools, academies, free schools and in the further education (FE) sector in England.</p>
-
-  <p class="govuk-body">You can find out more about working in these sectors from:</p>
-
-  <ul class="govuk-list">
-    <li><%= govuk_link_to "Independent Schools Council", "http://www.isc.co.uk/" %></li>
-    <li><%= govuk_link_to "The Education & Training Foundation", "http://www.et-foundation.co.uk/" %></li>
-    <li><%= govuk_link_to "Academies and Free Schools", "https://www.gov.uk/types-of-school" %></li>
-  </ul>
-
-  <p class="govuk-body">For further information on other routes to gaining QTS visit <%= govuk_link_to "Get Into Teaching", "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas" %>.</p>
-  <p class="govuk-body">You can also learn more about <%= govuk_link_to "training to teach in England", "https://getintoteaching.education.gov.uk/non-uk-teachers/train-to-teach-in-england-as-an-international-student" %>.</p>
+  <p class="govuk-body">You may want to <%= govuk_link_to "explore other routes to getting QTS", "https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk" %>.</p>
 <% end %>
 
-<h3 class="govuk-heading-m">Decision review</h3>
+<h2 class="govuk-heading-l">Decision review</h2>
 
 <p class="govuk-body">Applicants who have been declined for QTS are entitled to a review of the decline decision by a Casework Manager.</p>
-<p class="govuk-body">If you would like to request a decision review, you will need to provide:</p>
+<p class="govuk-body">If you would like to request a decision review, you’ll need to provide:</p>
 
 <ul class="govuk-list govuk-list--bullet">
   <li>formal evidence and reasoning as to how you meet the required assessment criteria</li>
@@ -52,7 +37,5 @@
 </ul>
 
 <p class="govuk-body">Your request for review must be received within 28 days of receipt of the decision to decline QTS.</p>
-
 <p class="govuk-body">Email your request for review, including the information required as above, to <%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %>.</p>
-
 <p class="govuk-body">If you are not satisfied with the outcome of the decision review, you can request a final formal appeal to a senior Teacher Qualification Manager.</p>

--- a/app/views/teacher_interface/application_forms/show/_declined.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_declined.html.erb
@@ -2,39 +2,18 @@
 
 <h3 class="govuk-heading-m">Why your application was declined</h3>
 
-<% if view_object.show_further_information_request_expired_content? %>
-  <%= govuk_inset_text(text: t(".failure_reasons.further_information_request_expired")) %>
-<% end %>
+<% if (declined_reasons = view_object.declined_reasons).present? %>
+  <% declined_reasons.each do |title, reasons| %>
+    <% if title.present? %>
+      <h4 class="govuk-heading-s"><%= title %></h4>
+    <% end %>
 
-<% if view_object.show_professional_standing_request_expired_content? %>
-  <%= govuk_inset_text(text: t(
-    ".failure_reasons.professional_standing_request_expired",
-    certificate_name: region_certificate_name(view_object.region),
-    teaching_authority_name: region_teaching_authority_name(view_object.region)
-  )) %>
-<% end %>
-
-<% if (sections = view_object.notes_from_assessors).present? %>
-  <h4 class="govuk-heading-s">Notes from the assessor:</h4>
-
-  <% sections.each do |section| %>
-    <h5 class="govuk-heading-s"><%= section[:assessment_section_key].humanize %></h5>
     <ul class="govuk-list">
-      <% section[:failure_reasons].each do |failure_reason| %>
-        <li>
-          <h6 class="govuk-body"><%= t(".failure_reasons.#{failure_reason[:key]}") %></h6>
-
-          <% if (text = failure_reason[:assessor_feedback]).present? %>
-            <%= govuk_inset_text { simple_format text } %>
-          <% end %>
-        </li>
+      <% reasons.each do |reason| %>
+        <li><%= simple_format reason %></li>
       <% end %>
     </ul>
   <% end %>
-<% end %>
-
-<% if (recommendation_assessor_note = view_object.assessment.recommendation_assessor_note).present? %>
-  <%= govuk_inset_text { simple_format recommendation_assessor_note } %>
 <% end %>
 
 <% unless view_object.declined_cannot_reapply? %>

--- a/app/views/teacher_mailer/application_declined.text.erb
+++ b/app/views/teacher_mailer/application_declined.text.erb
@@ -1,25 +1,43 @@
 Dear <%= application_form_full_name(@application_form) %>
 
-# Your QTS application has been declined
-
 <%= render "shared/teacher_mailer/reference_number" %>
 
-Thank you for applying for qualified teacher status (QTS) and for your patience while we reviewed your application.
+Thank you for applying for QTS in England. Unfortunately, your application has been declined.
 
-Unfortunately, we’re unable to award QTS status.
+# Reason for decline
 
-<%- if @further_information_requested -%>
+<% @view_object.declined_reasons.each do |title, reasons| %>
+<% if title.present? %>
+## <%= title %>
+
+<% end %>
+<% reasons.each do |reason| %>
+- <%= reason.gsub("\n\n", "\n").gsub("\n", "\n  ") %>
+<% end %>
+
+<% end %>
+<% unless @view_object.declined_cannot_reapply? %>
 # What you can do next
 
-You can sign in to find out why your application was declined:
-<%- else -%>
-# Why your QTS application was declined
+You’ll be able to make a new application for QTS once you've addressed the decline reasons we've given. If you reapply for QTS, you’ll not be able to review the details of your previous application.
 
-You can sign in to find out why your application was declined:
-<%- end -%>
+[Apply again](<%= new_teacher_interface_application_form_url %>)
 
-<%= new_teacher_session_url %>
+You may want to [explore other routes to getting QTS](https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk).
 
-<%= render "shared/teacher_mailer/help_us_to_improve_this_service" %>
+<% end %>
+# Decision review
+
+Applicants who have been declined for QTS are entitled to a review of the decline decision by a Casework Manager.
+If you would like to request a decision review, you’ll need to provide:
+
+- formal evidence and reasoning as to how you meet the required assessment criteria
+- additional information not included in your original application that would support your decision review
+
+Your request for review must be received within 28 days of receipt of the decision to decline QTS. Email your request for review, including the information required as above, to <%= t("service.email.enquiries") %>.
+
+If you are not satisfied with the outcome of the decision review, you can request a final formal appeal to a senior Teacher Qualification Manager.
+
+[Sign in](<%= new_teacher_session_url %>) to review the outcome of your application.
 
 <%= render "shared/teacher_mailer/footer" %>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Date::DATE_FORMATS[:long_ordinal_uk] = "%-d %B %Y"
-
-Time::DATE_FORMATS[:date_and_time] = "%e %B %Y at %l:%M %P"
-
 Date::DATE_FORMATS[:month_and_year] = "%B %Y"
+
+Time::DATE_FORMATS[:date] = "%e %B %Y"
+Time::DATE_FORMATS[:date_and_time] = "%e %B %Y at %l:%M %P"

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -9,7 +9,7 @@ en:
       application_awarded:
         subject: Your QTS application was successful
       application_declined:
-        subject: Your QTS application has been declined
+        subject: Your QTS application was unsuccessful
       application_not_submitted:
         subject:
           0: Your draft QTS application will be deleted in 2 weeks

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe TeacherMailer, type: :mailer do
     describe "#subject" do
       subject(:subject) { mail.subject }
 
-      it { is_expected.to eq("Your QTS application has been declined") }
+      it { is_expected.to eq("Your QTS application was unsuccessful") }
     end
 
     describe "#to" do
@@ -72,30 +72,10 @@ RSpec.describe TeacherMailer, type: :mailer do
 
       it { is_expected.to include("Dear First Last") }
       it { is_expected.to include("abc") }
-      it do
-        is_expected.to include(
-          "You can sign in to find out why your application was declined:",
-        )
-      end
+      it { is_expected.to include("Reason for decline") }
     end
 
     it_behaves_like "an observable mailer", "application_declined"
-
-    context "further information requested" do
-      let(:assessment) do
-        create(:assessment, :with_further_information_request)
-      end
-
-      describe "#body" do
-        subject(:body) { mail.body.encoded }
-
-        it do
-          is_expected.to include(
-            "You can sign in to find out why your application was declined:",
-          )
-        end
-      end
-    end
   end
 
   describe "#application_not_submitted" do

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
       end
 
       it { is_expected.to match(/Your QTS application has been declined/) }
-      it { is_expected.to match(/Why your application was declined/) }
-      it { is_expected.to match(/you can make a new application in future/) }
+      it { is_expected.to match(/Reason for decline/) }
+      it { is_expected.to match(/You’ll be able to make a new application/) }
     end
 
     context "and a further information request" do
@@ -62,7 +62,7 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
       end
 
       it { is_expected.to match(/Your QTS application has been declined/) }
-      it { is_expected.to match(/you can make a new application in future/) }
+      it { is_expected.to match(/You’ll be able to make a new application/) }
 
       it "does not show the assessor notes to the applicant" do
         expect(subject).not_to match(/A note/)

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
   before do
     assign(
       :view_object,
-      TeacherInterface::ApplicationFormShowViewObject.new(
-        current_teacher: application_form.teacher,
-      ),
+      TeacherInterface::ApplicationFormViewObject.new(application_form:),
     )
   end
 
@@ -46,7 +44,7 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
       end
 
       it { is_expected.to match(/Your QTS application has been declined/) }
-      it { is_expected.to match(/Notes/) }
+      it { is_expected.to match(/Why your application was declined/) }
       it { is_expected.to match(/you can make a new application in future/) }
     end
 


### PR DESCRIPTION
This updates the content on the decline email and view as requested by our content designers. I've also refactored the view object to make it easy to use in the mailer and the view.

[Trello Card](https://trello.com/c/qMirmba8/2364-update-the-decline-email-with-design-changes)

## Screenshots

<img width="681" alt="Screenshot 2023-11-09 at 17 11 35" src="https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/031a989d-77bd-4044-aa99-a29d96343da9">
