### PR TITLE
Don't send ActiveStorage to analytics

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,26 +1,5 @@
 ---
 :shared:
-  :active_storage_variant_records:
-    - id
-    - blob_id
-    - variation_digest
-  :active_storage_blobs:
-    - id
-    - key
-    - filename
-    - content_type
-    - metadata
-    - service_name
-    - byte_size
-    - checksum
-    - created_at
-  :active_storage_attachments:
-    - id
-    - name
-    - record_type
-    - record_id
-    - blob_id
-    - created_at
   :application_forms:
     - action_required_by
     - age_range_max

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -1,5 +1,26 @@
 ---
 :shared:
+  :active_storage_variant_records:
+    - id
+    - blob_id
+    - variation_digest
+  :active_storage_blobs:
+    - id
+    - key
+    - filename
+    - content_type
+    - metadata
+    - service_name
+    - byte_size
+    - checksum
+    - created_at
+  :active_storage_attachments:
+    - id
+    - name
+    - record_type
+    - record_id
+    - blob_id
+    - created_at
   :sessions:
     - id
     - session_id


### PR DESCRIPTION
This isn't used anywhere in the analytics and it's a lot of unnecessary data that we send to BigQuery.