### PR TITLE
Add teacher facing failure reasons

### DIFF
--- a/app/views/teacher_interface/application_forms/show/_declined.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_declined.html.erb
@@ -3,12 +3,12 @@
 <h3 class="govuk-heading-m">Why your application was declined</h3>
 
 <% if view_object.show_further_information_request_expired_content? %>
-  <%= govuk_inset_text(text: t(".further_information_request_expired")) %>
+  <%= govuk_inset_text(text: t(".failure_reasons.further_information_request_expired")) %>
 <% end %>
 
 <% if view_object.show_professional_standing_request_expired_content? %>
   <%= govuk_inset_text(text: t(
-    ".professional_standing_request_expired",
+    ".failure_reasons.professional_standing_request_expired",
     certificate_name: region_certificate_name(view_object.region),
     teaching_authority_name: region_teaching_authority_name(view_object.region)
   )) %>
@@ -18,13 +18,11 @@
   <h4 class="govuk-heading-s">Notes from the assessor:</h4>
 
   <% sections.each do |section| %>
-    <h5 class="govuk-heading-s"><%= t(".assessment_section.#{section[:assessment_section_key]}") %></h5>
+    <h5 class="govuk-heading-s"><%= section[:assessment_section_key].humanize %></h5>
     <ul class="govuk-list">
       <% section[:failure_reasons].each do |failure_reason| %>
         <li>
-          <h6 class="govuk-body">
-            <%= t(failure_reason[:key], scope: %i[assessor_interface assessment_sections failure_reasons as_statement]) %>
-          </h6>
+          <h6 class="govuk-body"><%= t(".failure_reasons.#{failure_reason[:key]}") %></h6>
 
           <% if (text = failure_reason[:assessor_feedback]).present? %>
             <%= govuk_inset_text { simple_format text } %>

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -1,14 +1,15 @@
 <% content_for :page_title, "#{"Error: " if @form&.errors&.any?}Further information required" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
 
-<h1 class="govuk-heading-l">Further information required</h1>
-<h3 class="govuk-heading-s">Notes from the assessor</h3>
+<%= form_with model: @form, url: [:teacher_interface, :application_form, @further_information_request, @further_information_request_item], method: :put do |f| %>
+  <h1 class="govuk-heading-l">Further information required</h1>
 
-<%= govuk_inset_text do %>
-  <%= simple_format @further_information_request_item.failure_reason_assessor_feedback %>
-<% end %>
+  <h2 class="govuk-heading-s">Notes from the assessor</h2>
 
-<%= form_with model: @form, url: teacher_interface_application_form_further_information_request_further_information_request_item_path, method: :put do |f| %>
+  <%= govuk_inset_text do %>
+    <%= simple_format @further_information_request_item.failure_reason_assessor_feedback %>
+  <% end %>
+
   <% if @further_information_request_item.text? %>
     <%= f.govuk_text_area :response, label: { size: "s" } %>
   <% end %>

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -3,8 +3,58 @@ en:
     application_forms:
       show:
         declined:
-          further_information_request_expired: Your application has been declined as you did not respond to the assessor’s request for further information within the specified time.
-          professional_standing_request_expired: Your application has been declined as we did not receive your %{certificate_name} from %{teaching_authority_name} within 180 days.
+          failure_reasons:
+            additional_degree_certificate_illegible: Your additional degree certificate (or translation) is illegible or in a format that we cannot accept.
+            additional_degree_transcript_illegible: Your additional degree transcript (or translation) is illegible or in a format that we cannot accept.
+            age_range: The age range you are qualified to teach does not fall within the requirements of QTS.
+            applicant_already_dqt: There’s a potential duplicate of your application. We need to ask for an additional identifier.
+            applicant_already_qts: You already hold QTS and induction exemption.
+            application_and_qualification_names_do_not_match: The name on the online application form is different from 1 or more qualification documents, but no evidence of change of name was provided.
+            authorisation_to_teach: Sanctions or restrictions were detected on your professional record.
+            confirm_age_range_subjects: We were not provided with sufficient evidence to confirm qualification to teach the age ranges and subjects entered on the online application form.
+            degree_certificate_illegible: Your university degree certificate (or translation) is illegible or in a format that we cannot accept.
+            degree_transcript_illegible: Your university degree transcript (or translation) is illegible or in a format that we cannot accept.
+            duplicate_application: You already have an application in-flight.
+            english_language_exemption_by_citizenship_not_confirmed: Your ID does not confirm English language exemption by birth or citizenship.
+            english_language_exemption_by_qualification_not_confirmed: Your qualification documents do not confirm English language exemption by country of study.
+            english_language_moi_invalid_format: Your Medium of instruction (MOI) document is illegible or in a format that we cannot accept.
+            english_language_moi_not_taught_in_english: Your MOI does not show that you were taught exclusively in English.
+            english_language_not_achieved_b2: You provided evidence of a SELT that has not achieved B2 level.
+            english_language_proficiency_document_illegible: Your English language proficiency test document is illegible or in a format that we cannot accept.
+            english_language_qualification_invalid: Your English language qualification is not from one of the approved providers.
+            english_language_selt_expired: You have provided evidence of a SELT but the test was not completed within the last 2 years.
+            english_language_unverifiable_reference_number: We were unable to verify the reference number that you have provided.
+            full_professional_status: Your recognition level as a teacher does not match the required level, or has outstanding conditions.
+            further_information_request_expired: Your application has been declined as you did not respond to the assessor’s request for further information within the specified time.
+            identification_document_expired: Your ID document has expired.
+            identification_document_illegible: Your ID document is illegible or in a format that we cannot accept.
+            identification_document_mismatch: Your name on the online application form is different from the ID document, but no evidence of change of name was provided.
+            name_change_document_illegible: The evidence for your name change is illegible or in a format we cannot accept.
+            not_qualified_to_teach_mainstream: You are not qualified to teach in mainstream education.
+            professional_standing_request_expired: Your application has been declined as we did not receive your %{certificate_name} from %{teaching_authority_name} within 180 days.
+            qualifications_dont_match_other_details: Your uploaded qualifications do not match other details entered, for example, name of qualification, name of institution or dates.
+            qualifications_dont_match_subjects: The subjects you entered are acceptable for QTS, but the uploaded qualifications do not match them.
+            qualified_to_teach: We were not provided with sufficient evidence to confirm qualification to teach at state or government schools.
+            qualified_to_teach_children_11_to_16: You are not qualified to teach children aged 11-16.
+            registration_number: We could not find your reference number, or the number was in the wrong format. You will need to supply the number again.
+            registration_number_alternative: We could not find your reference number. You will need to upload written proof of recognition as a teacher instead.
+            satisfactory_evidence_work_history: The information you provided on work history is not sufficient to award QTS.
+            school_details_cannot_be_verified: We could not verify the school details you provided.
+            teaching_certificate_illegible: Your teaching qualification certificate (or translation) is illegible or in a format that we cannot accept.
+            teaching_hours_not_fulfilled: The required teaching hours have not been fulfilled.
+            teaching_qualification: We were not provided with sufficient evidence to verify the teaching qualification provided.
+            teaching_qualification_1_year: Your teacher training course qualification did not last at least 1 academic year.
+            teaching_qualification_pedagogy: Your teaching qualification did not have enough focus on pedagogy.
+            teaching_qualification_subjects_criteria: You are not qualified to teach one of the subjects that we currently accept (Maths, Science, Biology, Chemistry, Physics, French, German, Italian, Japanese, Latin, Mandarin, Russian, Spanish).
+            teaching_qualifications_from_ineligible_country: Your teaching qualifications were completed in an ineligible country.
+            teaching_qualifications_not_at_required_level: Your teaching qualifications do not meet the required academic level (level 6).
+            teaching_transcript_illegible: Your teaching qualification transcript (or translation) is illegible or in a format that we cannot accept.
+            unrecognised_references: Your application contained one or more references that cannot be considered.
+            work_history_break: There is an unexplained break in your work history.
+            work_history_duration: Your work experience does not meet the minimum duration requirements.
+            written_statement_illegible: Your letter is illegible or in a format that we cannot accept.
+            written_statement_information: Your letter is missing information.
+            written_statement_recent: Your letter was not issued within the last 6 months.
         draft:
           check: Check your application
           save: Save and sign out

--- a/lib/tasks/example_data.rake
+++ b/lib/tasks/example_data.rake
@@ -163,7 +163,18 @@ def create_application_forms
 
       assessment = AssessmentFactory.call(application_form:)
 
-      if application_form.waiting_on?
+      if application_form.declined?
+        FactoryBot.create(
+          :selected_failure_reason,
+          :fi_requestable,
+          assessment_section: assessment.sections.first,
+        )
+        FactoryBot.create(
+          :selected_failure_reason,
+          :declinable,
+          assessment_section: assessment.sections.second,
+        )
+      elsif application_form.waiting_on?
         if application_form.teaching_authority_provides_written_statement
           FactoryBot.create(
             :professional_standing_request,


### PR DESCRIPTION
This adds content for failures reasons show to teachers, as opposed to the current ones we show which are for the assessors.

[Trello Card](https://trello.com/c/ZgVtLWdj/2392-review-fi-decline-reasons-so-that-they-speak-directly-to-the-applicant)