### PR TITLE
Show email previews without an API key

### DIFF
--- a/app/lib/mailer_preview.rb
+++ b/app/lib/mailer_preview.rb
@@ -26,7 +26,11 @@ class MailerPreview
   attr_reader :mailer_class, :params
 
   def client
-    @client ||= Notifications::Client.new(ENV.fetch("GOVUK_NOTIFY_API_KEY"))
+    @client ||=
+      begin
+        api_key = ENV["GOVUK_NOTIFY_API_KEY"]
+        Notifications::Client.new(api_key) if api_key.present?
+      end
   end
 
   def mailer
@@ -34,6 +38,8 @@ class MailerPreview
   end
 
   def generate_preview(mail)
+    return "<p>Missing GOV.UK Notify API key.</p>" if client.nil?
+
     client.generate_template_preview(
       ApplicationMailer::GOVUK_NOTIFY_TEMPLATE_ID,
       personalisation: {


### PR DESCRIPTION
We often don't have a GOV.UK Notify API key available when running the application locally, and if we're not testing the previews specifically it can be a significant overhead to get one. I've changed the mailer preview to handle this case gracefully.

In production we already require an API key in the ActionMailer initialiser so this doesn't introduce the ability to run in production without an API key.