### PR TITLE
Stop recording status changed timeline events

### DIFF
--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -25,14 +25,7 @@ class ApplicationFormStatusUpdater
         waiting_on_reference:,
       )
 
-      if (old_status = application_form.status) != status
-        application_form.update!(status:)
-        create_timeline_event(
-          event_type: "status_changed",
-          old_value: old_status,
-          new_value: status,
-        )
-      end
+      application_form.update!(status:) if application_form.status != status
 
       if (old_action_required_by = application_form.action_required_by) !=
            action_required_by

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
   end
 
-  context "state changed" do
+  context "status changed" do
     let(:timeline_event) do
       create(
         :timeline_event,

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -187,11 +187,11 @@ FactoryBot.define do
       after(:create) do |application_form, _evaluator|
         create(
           :timeline_event,
-          :status_changed,
+          :stage_changed,
           application_form:,
           creator: application_form.teacher,
           old_value: "draft",
-          new_value: "submitted",
+          new_value: "not_started",
         )
       end
     end

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -66,16 +66,6 @@ RSpec.describe ApplicationFormStatusUpdater do
     it "changes status to #{new_status}" do
       expect { call }.to change(application_form, :status).to(new_status)
     end
-
-    it "records a timeline event" do
-      expect { call }.to have_recorded_timeline_event(
-        :status_changed,
-        creator: user,
-        application_form:,
-        old_value: "draft",
-        new_value: new_status,
-      )
-    end
   end
 
   describe "#call" do
@@ -479,10 +469,6 @@ RSpec.describe ApplicationFormStatusUpdater do
     context "when status is unchanged" do
       it "doesn't change the status from draft" do
         expect { call }.to_not change(application_form, :status).from("draft")
-      end
-
-      it "doesn't record a timeline event" do
-        expect { call }.to_not have_recorded_timeline_event(:status_changed)
       end
 
       include_examples "doesn't change action required by"

--- a/spec/services/rollback_assessment_spec.rb
+++ b/spec/services/rollback_assessment_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe RollbackAssessment do
       end
 
       it "reverts application form status" do
-        expect { call }.to change(application_form, :status).to("waiting_on")
+        expect { call }.to change(application_form, :stage).to("verification")
       end
 
       it "records a timeline event" do
         expect { call }.to have_recorded_timeline_event(
-          :status_changed,
+          :stage_changed,
           creator: user,
         )
       end
@@ -40,12 +40,12 @@ RSpec.describe RollbackAssessment do
       end
 
       it "reverts application form status" do
-        expect { call }.to change(application_form, :status).to("waiting_on")
+        expect { call }.to change(application_form, :stage).to("assessment")
       end
 
       it "records a timeline event" do
         expect { call }.to have_recorded_timeline_event(
-          :status_changed,
+          :stage_changed,
           creator: user,
         )
       end
@@ -57,12 +57,12 @@ RSpec.describe RollbackAssessment do
       end
 
       it "reverts application form status" do
-        expect { call }.to change(application_form, :status).to("submitted")
+        expect { call }.to change(application_form, :stage).to("not_started")
       end
 
       it "records a timeline event" do
         expect { call }.to have_recorded_timeline_event(
-          :status_changed,
+          :stage_changed,
           creator: user,
         )
       end
@@ -81,12 +81,12 @@ RSpec.describe RollbackAssessment do
       end
 
       it "reverts application form status" do
-        expect { call }.to change(application_form, :status).to("waiting_on")
+        expect { call }.to change(application_form, :stage).to("verification")
       end
 
       it "records a timeline event" do
         expect { call }.to have_recorded_timeline_event(
-          :status_changed,
+          :stage_changed,
           creator: user,
         )
       end
@@ -102,12 +102,12 @@ RSpec.describe RollbackAssessment do
       end
 
       it "reverts application form status" do
-        expect { call }.to change(application_form, :status).to("waiting_on")
+        expect { call }.to change(application_form, :stage).to("assessment")
       end
 
       it "records a timeline event" do
         expect { call }.to have_recorded_timeline_event(
-          :status_changed,
+          :stage_changed,
           creator: user,
         )
       end
@@ -119,12 +119,12 @@ RSpec.describe RollbackAssessment do
       end
 
       it "reverts application form status" do
-        expect { call }.to change(application_form, :status).to("submitted")
+        expect { call }.to change(application_form, :stage).to("not_started")
       end
 
       it "records a timeline event" do
         expect { call }.to have_recorded_timeline_event(
-          :status_changed,
+          :stage_changed,
           creator: user,
         )
       end
@@ -164,12 +164,12 @@ RSpec.describe RollbackAssessment do
     end
 
     it "reverts application form status" do
-      expect { call }.to change(application_form, :status).to("submitted")
+      expect { call }.to change(application_form, :stage).to("not_started")
     end
 
     it "records a timeline event" do
       expect { call }.to have_recorded_timeline_event(
-        :status_changed,
+        :stage_changed,
         creator: user,
       )
     end

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -9,29 +9,19 @@ RSpec.describe SubmitApplicationForm do
 
   subject(:call) { described_class.call(application_form:, user:) }
 
-  describe "application form submitted status" do
-    subject(:submitted?) { application_form.submitted? }
-
-    it { is_expected.to be false }
-
-    context "when calling the service" do
-      before { call }
-
-      it { is_expected.to be true }
-    end
+  it "changes stage to not started" do
+    expect { call }.to change(application_form, :stage).from("draft").to(
+      "not_started",
+    )
   end
 
-  describe "application form preliminary check status" do
-    subject(:submitted?) { application_form.preliminary_check? }
+  context "when region requires preliminary check" do
+    let(:region) { create(:region, :requires_preliminary_check) }
 
-    it { is_expected.to be false }
-
-    context "when calling the service" do
-      let(:region) { create(:region, :requires_preliminary_check) }
-
-      before { call }
-
-      it { is_expected.to be true }
+    it "changes stage to pre-assessment" do
+      expect { call }.to change(application_form, :stage).from("draft").to(
+        "pre_assessment",
+      )
     end
   end
 
@@ -75,11 +65,11 @@ RSpec.describe SubmitApplicationForm do
 
   it "records a timeline event" do
     expect { call }.to have_recorded_timeline_event(
-      :status_changed,
+      :stage_changed,
       creator: user,
       application_form:,
       old_value: "draft",
-      new_value: "submitted",
+      new_value: "not_started",
     )
   end
 

--- a/spec/system/assessor_interface/view_timeline_events_spec.rb
+++ b/spec/system/assessor_interface/view_timeline_events_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Assessor view timeline events", type: :system do
       "Note created",
     )
     expect(assessor_timeline_page.timeline_items.second.title).to have_content(
-      "Status changed",
+      "Stage changed",
     )
     expect(assessor_timeline_page.timeline_items.third.title).to have_content(
       "Assessor assigned",
@@ -54,7 +54,7 @@ RSpec.describe "Assessor view timeline events", type: :system do
         application_form =
           create(:application_form, :submitted, :with_assessment)
         create(:timeline_event, :assessor_assigned, application_form:)
-        create(:timeline_event, :status_changed, application_form:)
+        create(:timeline_event, :stage_changed, application_form:)
         create(:timeline_event, :note_created, application_form:)
         application_form
       end


### PR DESCRIPTION
We're going to be shortly removing this event anyway and it clutters up the timeline events view with information that's not shown anywhere else, so we can safely remove this.