### PR TITLE
Reduce duplicate status changes

### DIFF
--- a/app/forms/assessor_interface/requestable_request_form.rb
+++ b/app/forms/assessor_interface/requestable_request_form.rb
@@ -17,6 +17,7 @@ class AssessorInterface::RequestableRequestForm
 
     if passed && !requestable.requested?
       RequestRequestable.call(requestable:, user:)
+      ApplicationFormStatusUpdater.call(application_form:, user:)
     end
 
     true

--- a/app/services/request_requestable.rb
+++ b/app/services/request_requestable.rb
@@ -14,7 +14,6 @@ class RequestRequestable
     ActiveRecord::Base.transaction do
       requestable.requested!
       create_timeline_event
-      ApplicationFormStatusUpdater.call(application_form:, user:)
     end
 
     requestable.after_requested(user:)

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -69,8 +69,8 @@ class SubmitApplicationForm
   def create_professional_standing_request(assessment)
     return unless application_form.teaching_authority_provides_written_statement
 
-    requestable = ProfessionalStandingRequest.create!(assessment:)
-
-    RequestRequestable.call(requestable:, user:)
+    ProfessionalStandingRequest
+      .create!(assessment:)
+      .tap { |requestable| RequestRequestable.call(requestable:, user:) }
   end
 end


### PR DESCRIPTION
This reduces the number of times we update the status from the `RequestRequestable` service class to remove duplicate timeline events. Everywhere that uses this class now calls the status updater anyway as part of normal operation, so we don't need it here.