### PR TITLE
Consider qualification when calculating work history duration

### DIFF
--- a/app/controllers/teacher_interface/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/work_histories_controller.rb
@@ -257,7 +257,8 @@ module TeacherInterface
     end
 
     def load_months_count
-      @months_count = WorkHistoryDuration.new(application_form:).count_months
+      @months_count =
+        WorkHistoryDuration.for_application_form(application_form).count_months
     end
 
     def check_member_identifier

--- a/app/forms/assessor_interface/select_work_histories_form.rb
+++ b/app/forms/assessor_interface/select_work_histories_form.rb
@@ -38,12 +38,6 @@ class AssessorInterface::SelectWorkHistoriesForm
   end
 
   def work_history_duration
-    WorkHistoryDuration.new(
-      work_history_relation:
-        WorkHistory.where(
-          application_form_id: application_form.id,
-          id: work_history_ids,
-        ),
-    )
+    WorkHistoryDuration.for_ids(work_history_ids, application_form:)
   end
 end

--- a/app/helpers/work_history_helper.rb
+++ b/app/helpers/work_history_helper.rb
@@ -14,8 +14,7 @@ module WorkHistoryHelper
   end
 
   def work_history_name_and_duration(work_history, most_recent: false)
-    months =
-      WorkHistoryDuration.new(work_history_record: work_history).count_months
+    months = WorkHistoryDuration.for_record(work_history).count_months
 
     result = "#{work_history.school_name} (#{months} months)"
     result.concat(" ", most_recent_tag) if most_recent

--- a/app/lib/application_form_section_status_updater.rb
+++ b/app/lib/application_form_section_status_updater.rb
@@ -142,7 +142,8 @@ class ApplicationFormSectionStatusUpdater
       return :not_started if work_histories.empty?
       return :in_progress unless all_work_histories_complete
 
-      months_count = WorkHistoryDuration.new(application_form:).count_months
+      months_count =
+        WorkHistoryDuration.for_application_form(application_form).count_months
       return :in_progress unless months_count >= 9
 
       :completed

--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -95,11 +95,9 @@ class ApplicationFormStatusUpdater
     received_requests = reference_requests.filter(&:received?)
 
     months_count =
-      WorkHistoryDuration.new(
-        work_history_relation:
-          application_form.work_histories.where(
-            id: received_requests.map(&:work_history_id),
-          ),
+      WorkHistoryDuration.for_ids(
+        received_requests.map(&:work_history_id),
+        application_form:,
       ).count_months
 
     most_recent_reference_request =

--- a/app/lib/work_history_duration.rb
+++ b/app/lib/work_history_duration.rb
@@ -1,24 +1,28 @@
 # frozen_string_literal: true
 
 class WorkHistoryDuration
-  def initialize(
-    application_form: nil,
-    work_history_relation: nil,
-    work_history_record: nil
-  )
-    if !application_form.nil? && work_history_relation.nil?
-      @work_history_relation =
-        application_form
-          .work_histories
-          .where.not(start_date: nil)
-          .where.not(hours_per_week: nil)
-    elsif !work_history_relation.nil? && application_form.nil?
-      @work_history_relation = work_history_relation
-    elsif !work_history_record.nil?
-      @work_histories = [work_history_record]
-    else
-      raise "Pass only an application_form or a work_history_relation."
-    end
+  def initialize(application_form:, relation:)
+    @application_form = application_form
+    @relation =
+      relation.where.not(start_date: nil).where.not(hours_per_week: nil)
+  end
+
+  def self.for_application_form(application_form)
+    WorkHistoryDuration.new(
+      application_form:,
+      relation: application_form.work_histories,
+    )
+  end
+
+  def self.for_ids(ids, application_form:)
+    WorkHistoryDuration.new(
+      application_form:,
+      relation: application_form.work_histories.where(id: ids),
+    )
+  end
+
+  def self.for_record(record)
+    for_ids([record.id], application_form: record.application_form)
   end
 
   def count_months
@@ -33,11 +37,11 @@ class WorkHistoryDuration
   AVERAGE_WEEKS_PER_MONTH = 4.34
   HOURS_PER_FULL_TIME_MONTH = 130.0
 
-  attr_reader :work_history_relation
+  attr_reader :application_form, :relation
 
   def work_histories
     @work_histories ||=
-      work_history_relation.order(:start_date).select(
+      relation.order(:start_date).select(
         :start_date,
         :end_date,
         :hours_per_week,

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -247,14 +247,9 @@ class Assessment < ApplicationRecord
     return false unless references_verified
 
     months_count =
-      WorkHistoryDuration.new(
-        work_history_relation:
-          application_form.work_histories.where(
-            id:
-              reference_requests.where(review_passed: true).map(
-                &:work_history_id
-              ),
-          ),
+      WorkHistoryDuration.for_ids(
+        reference_requests.where(review_passed: true).pluck(:work_history_id),
+        application_form:,
       ).count_months
 
     months_count >= 9

--- a/app/services/update_assessment_induction_required.rb
+++ b/app/services/update_assessment_induction_required.rb
@@ -25,7 +25,10 @@ class UpdateAssessmentInductionRequired
 
   def passed_months_count
     @passed_months_count ||=
-      WorkHistoryDuration.new(work_history_relation:).count_months
+      WorkHistoryDuration.new(
+        application_form:,
+        relation: work_history_relation,
+      ).count_months
   end
 
   def work_history_relation

--- a/app/views/assessor_interface/assessment_sections/_work_history_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_work_history_summary.html.erb
@@ -13,7 +13,7 @@
 
 <% if application_form.created_under_new_regulations? %>
   <%
-    months_count = WorkHistoryDuration.new(application_form:).count_months
+    months_count = WorkHistoryDuration.for_application_form(application_form).count_months
     years_count = (months_count / 12).floor
     remaining_months_count = months_count - years_count * 12
   %>

--- a/app/views/assessor_interface/reference_requests/edit.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit.html.erb
@@ -21,7 +21,7 @@
 
     summary_list.with_row do |row|
       row.with_key { "Number of months" }
-      row.with_value { WorkHistoryDuration.new(work_history_record: work_history).count_months.to_s }
+      row.with_value { WorkHistoryDuration.for_record(work_history).count_months.to_s }
     end
 
     summary_list.with_row do |row|

--- a/spec/lib/work_history_duration_spec.rb
+++ b/spec/lib/work_history_duration_spec.rb
@@ -105,7 +105,9 @@ RSpec.describe WorkHistoryDuration do
 
   describe "#count_months" do
     context "passing an application form" do
-      subject(:work_history_duration) { described_class.new(application_form:) }
+      subject(:work_history_duration) do
+        described_class.for_application_form(application_form)
+      end
 
       it_behaves_like "month counter"
     end
@@ -113,7 +115,19 @@ RSpec.describe WorkHistoryDuration do
     context "passing a work history relation" do
       subject(:work_history_duration) do
         described_class.new(
-          work_history_relation: application_form.work_histories,
+          application_form:,
+          relation: application_form.work_histories,
+        )
+      end
+
+      it_behaves_like "month counter"
+    end
+
+    context "passing work history IDs" do
+      subject(:work_history_duration) do
+        described_class.for_ids(
+          application_form.work_histories.pluck(:id),
+          application_form:,
         )
       end
 
@@ -131,34 +145,11 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
-      let(:work_history_duration) do
-        described_class.new(work_history_record: work_history)
-      end
+      let(:work_history_duration) { described_class.for_record(work_history) }
 
       subject(:count) { work_history_duration.count_months }
 
       it { is_expected.to eq(12) }
-    end
-
-    context "passing nothing" do
-      subject(:work_history_duration) { described_class.new }
-
-      it "raises an error" do
-        expect { work_history_duration }.to raise_error(/only/)
-      end
-    end
-
-    context "passing both" do
-      subject(:work_history_duration) do
-        described_class.new(
-          application_form:,
-          work_history_relation: application_form.work_histories,
-        )
-      end
-
-      it "raises an error" do
-        expect { work_history_duration }.to raise_error(/only/)
-      end
     end
   end
 end

--- a/spec/lib/work_history_duration_spec.rb
+++ b/spec/lib/work_history_duration_spec.rb
@@ -4,11 +4,19 @@ require "rails_helper"
 
 RSpec.describe WorkHistoryDuration do
   let(:application_form) { create(:application_form) }
-  let(:today) { Date.new(2023, 1, 15) }
+  let(:today) { Date.new(2021, 1, 15) }
 
-  shared_examples "month counter" do
+  shared_examples "month counter" do |consider_teaching_qualification|
     subject(:count_months) do
       travel_to(today) { work_history_duration.count_months }
+    end
+
+    before do
+      create(
+        :qualification,
+        application_form:,
+        certificate_date: Date.new(2020, 7, 1),
+      )
     end
 
     it { is_expected.to eq(0) }
@@ -24,7 +32,7 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
-      it { is_expected.to eq(12) }
+      it { is_expected.to eq(consider_teaching_qualification ? 6 : 12) }
     end
 
     context "with a finished full time work history with extra hours" do
@@ -38,7 +46,7 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
-      it { is_expected.to eq(12) }
+      it { is_expected.to eq(consider_teaching_qualification ? 6 : 12) }
     end
 
     context "with a finished part time work history" do
@@ -52,7 +60,7 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
-      it { is_expected.to eq(6) }
+      it { is_expected.to eq(consider_teaching_qualification ? 3 : 6) }
     end
 
     context "with an ongoing full time work history" do
@@ -60,12 +68,12 @@ RSpec.describe WorkHistoryDuration do
         create(
           :work_history,
           application_form:,
-          start_date: Date.new(2022, 1, 1),
+          start_date: Date.new(2020, 1, 1),
           hours_per_week: 30,
         )
       end
 
-      it { is_expected.to eq(13) }
+      it { is_expected.to eq(consider_teaching_qualification ? 7 : 13) }
     end
 
     context "with an ongoing part time work history" do
@@ -73,12 +81,12 @@ RSpec.describe WorkHistoryDuration do
         create(
           :work_history,
           application_form:,
-          start_date: Date.new(2022, 1, 1),
+          start_date: Date.new(2020, 1, 1),
           hours_per_week: 15,
         )
       end
 
-      it { is_expected.to eq(7) }
+      it { is_expected.to eq(consider_teaching_qualification ? 4 : 7) }
     end
 
     context "with a full time and a part time work history" do
@@ -99,42 +107,105 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
-      it { is_expected.to eq(10) }
+      it { is_expected.to eq(consider_teaching_qualification ? 3 : 10) }
+    end
+
+    context "with work history before the teaching qualification" do
+      before do
+        create(
+          :work_history,
+          application_form:,
+          start_date: Date.new(2019, 1, 1),
+          end_date: Date.new(2019, 12, 31),
+          hours_per_week: 30,
+        )
+      end
+
+      it { is_expected.to eq(consider_teaching_qualification ? 0 : 12) }
     end
   end
 
   describe "#count_months" do
     context "passing an application form" do
-      subject(:work_history_duration) do
-        described_class.for_application_form(application_form)
+      context "when not considering the teaching qualification" do
+        subject(:work_history_duration) do
+          described_class.for_application_form(application_form)
+        end
+
+        it_behaves_like "month counter", false
       end
 
-      it_behaves_like "month counter"
+      context "when considering the teaching qualification" do
+        subject(:work_history_duration) do
+          described_class.for_application_form(
+            application_form,
+            consider_teaching_qualification: true,
+          )
+        end
+
+        it_behaves_like "month counter", true
+      end
     end
 
     context "passing a work history relation" do
-      subject(:work_history_duration) do
-        described_class.new(
-          application_form:,
-          relation: application_form.work_histories,
-        )
+      context "when not considering the teaching qualification" do
+        subject(:work_history_duration) do
+          described_class.new(
+            application_form:,
+            relation: application_form.work_histories,
+          )
+        end
+
+        it_behaves_like "month counter", false
       end
 
-      it_behaves_like "month counter"
+      context "when considering the teaching qualification" do
+        subject(:work_history_duration) do
+          described_class.new(
+            application_form:,
+            relation: application_form.work_histories,
+            consider_teaching_qualification: true,
+          )
+        end
+
+        it_behaves_like "month counter", true
+      end
     end
 
     context "passing work history IDs" do
-      subject(:work_history_duration) do
-        described_class.for_ids(
-          application_form.work_histories.pluck(:id),
-          application_form:,
-        )
+      context "when not considering the teaching qualification" do
+        subject(:work_history_duration) do
+          described_class.for_ids(
+            application_form.work_histories.pluck(:id),
+            application_form:,
+          )
+        end
+
+        it_behaves_like "month counter", false
       end
 
-      it_behaves_like "month counter"
+      context "when considering the teaching qualification" do
+        subject(:work_history_duration) do
+          described_class.for_ids(
+            application_form.work_histories.pluck(:id),
+            application_form:,
+            consider_teaching_qualification: true,
+          )
+        end
+
+        it_behaves_like "month counter", true
+      end
     end
 
     context "passing a work history record" do
+      before do
+        create(
+          :qualification,
+          application_form:,
+          certificate_date: Date.new(2022, 7, 1),
+        )
+      end
+
       let(:work_history) do
         create(
           :work_history,
@@ -145,11 +216,22 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
-      let(:work_history_duration) { described_class.for_record(work_history) }
-
       subject(:count) { work_history_duration.count_months }
 
-      it { is_expected.to eq(12) }
+      context "when not considering the teaching qualification" do
+        let(:work_history_duration) { described_class.for_record(work_history) }
+        it { is_expected.to eq(12) }
+      end
+
+      context "when considering the teaching qualification" do
+        let(:work_history_duration) do
+          described_class.for_record(
+            work_history,
+            consider_teaching_qualification: true,
+          )
+        end
+        it { is_expected.to eq(6) }
+      end
     end
   end
 end


### PR DESCRIPTION
This updates the calculation to (optionally) include the teaching qualification, which is currently missing from the calculation. Effectively, this will disregard any months of work history that are prior to the qualification certificate date.

This is currently behind a flag as we want to do some analyse on the number of applications which will be affected by this change, with the intention to eventually change the calculation to use this in all cases.

I've also refactored the `WorkHistoryDuration` initializer to require the necessary arguments and then provides some convenience methods which handles the specific cases. This removes the need to raise runtime exceptions when invalid arguments are passed in, and allows us to test the method is called correctly.
