### PR TITLE
Reload after requesting a requestable

### DIFF
--- a/app/forms/assessor_interface/requestable_request_form.rb
+++ b/app/forms/assessor_interface/requestable_request_form.rb
@@ -17,6 +17,7 @@ class AssessorInterface::RequestableRequestForm
 
     if passed && !requestable.requested?
       RequestRequestable.call(requestable:, user:)
+      application_form.reload
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end
 

--- a/app/services/create_further_information_request.rb
+++ b/app/services/create_further_information_request.rb
@@ -22,6 +22,8 @@ class CreateFurtherInformationRequest
 
         RequestRequestable.call(requestable:, user:)
 
+        application_form.reload
+
         ApplicationFormStatusUpdater.call(application_form:, user:)
 
         requestable

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -27,6 +27,8 @@ class SubmitApplicationForm
 
       create_professional_standing_request(assessment)
 
+      application_form.reload
+
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end
 

--- a/app/services/verify_assessment.rb
+++ b/app/services/verify_assessment.rb
@@ -28,6 +28,8 @@ class VerifyAssessment
         create_qualification_requests
         reference_requests = create_reference_requests
 
+        application_form.reload
+
         ApplicationFormStatusUpdater.call(application_form:, user:)
 
         reference_requests


### PR DESCRIPTION
This should ensure that when we then update the status of the application, it's fully up to date with what we would expect.

[Trello Card](https://trello.com/c/iD0Y1JEx/2395-investigate-applications-showing-at-incorrect-status)