### PR TITLE
Don't send reminders for reviewed reference requests

### DIFF
--- a/app/views/assessor_interface/application_forms/status.html.erb
+++ b/app/views/assessor_interface/application_forms/status.html.erb
@@ -1,5 +1,5 @@
 <% title = if @view_object.assessment.review?
-             "An assessor will now review the application and make a decision on awarding or declining QTS."
+             "Application sent for review"
            elsif @view_object.application_form.waiting_on?
              "Reference requests sent successfully"
            elsif @view_object.application_form.awarded?


### PR DESCRIPTION
This changes the logic on when to send reminder emails to applicants to avoid sending them if the reference request has been reviewed (presumably rejected if it's not been received).