### PR TITLE
Fix logic on which reference requests to send emails for

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -332,6 +332,7 @@ class ApplicationForm < ApplicationRecord
     ReferenceRequest
       .joins(:work_history)
       .where(work_histories: { application_form_id: id })
+      .where.not(requested_at: nil)
       .where(received_at: nil, verify_passed: nil, review_passed: nil)
   end
 end


### PR DESCRIPTION
We only want to send emails for reference requests which are remindable themselves.

This should fix: https://dfe-teacher-services.sentry.io/issues/4641187399/events/2d5da30941ef48dc81a73bf5e25df4b4/