### PR TITLE
Hide some applications from assessment

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -24,6 +24,7 @@
 #  given_names                                   :text             default(""), not null
 #  has_alternative_name                          :boolean
 #  has_work_history                              :boolean
+#  hidden_from_assessment                        :boolean          default(FALSE), not null
 #  identification_document_status                :string           default("not_started"), not null
 #  needs_registration_number                     :boolean          not null
 #  needs_work_history                            :boolean          not null

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -200,16 +200,14 @@ class ApplicationForm < ApplicationRecord
 
   scope :active,
         -> do
-          joins(region: :country)
-            .where.not(countries: { code: "ZW" })
-            .merge(
-              assessable
-                .or(awarded_pending_checks)
-                .or(potential_duplicate_in_dqt)
-                .or(awarded.where("awarded_at >= ?", 90.days.ago))
-                .or(declined.where("declined_at >= ?", 90.days.ago))
-                .or(withdrawn.where("withdrawn_at >= ?", 90.days.ago)),
-            )
+          where(hidden_from_assessment: false).merge(
+            assessable
+              .or(awarded_pending_checks)
+              .or(potential_duplicate_in_dqt)
+              .or(awarded.where("awarded_at >= ?", 90.days.ago))
+              .or(declined.where("declined_at >= ?", 90.days.ago))
+              .or(withdrawn.where("withdrawn_at >= ?", 90.days.ago)),
+          )
         end
 
   scope :destroyable,

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -21,6 +21,8 @@
     - record_id
     - blob_id
     - created_at
+  :application_forms:
+    - hidden_from_assessment
   :sessions:
     - id
     - session_id

--- a/db/migrate/20231120105534_add_hidden_from_assessment_to_application_forms.rb
+++ b/db/migrate/20231120105534_add_hidden_from_assessment_to_application_forms.rb
@@ -1,0 +1,9 @@
+class AddHiddenFromAssessmentToApplicationForms < ActiveRecord::Migration[7.1]
+  def change
+    add_column :application_forms,
+               :hidden_from_assessment,
+               :boolean,
+               null: false,
+               default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_14_102513) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_20_105534) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -108,6 +108,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_14_102513) do
     t.string "action_required_by", default: "none", null: false
     t.string "stage", default: "draft", null: false
     t.string "statuses", default: ["draft"], null: false, array: true
+    t.boolean "hidden_from_assessment", default: false, null: false
     t.index ["action_required_by"], name: "index_application_forms_on_action_required_by"
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["english_language_provider_id"], name: "index_application_forms_on_english_language_provider_id"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -24,6 +24,7 @@
 #  given_names                                   :text             default(""), not null
 #  has_alternative_name                          :boolean
 #  has_work_history                              :boolean
+#  hidden_from_assessment                        :boolean          default(FALSE), not null
 #  identification_document_status                :string           default("not_started"), not null
 #  needs_registration_number                     :boolean          not null
 #  needs_work_history                            :boolean          not null

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -24,6 +24,7 @@
 #  given_names                                   :text             default(""), not null
 #  has_alternative_name                          :boolean
 #  has_work_history                              :boolean
+#  hidden_from_assessment                        :boolean          default(FALSE), not null
 #  identification_document_status                :string           default("not_started"), not null
 #  needs_registration_number                     :boolean          not null
 #  needs_work_history                            :boolean          not null

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -353,6 +353,14 @@ RSpec.describe ApplicationForm, type: :model do
 
         it { is_expected.to eq([application_form]) }
       end
+
+      context "when hidden from assessment" do
+        before do
+          create(:application_form, :submitted, hidden_from_assessment: true)
+        end
+
+        it { is_expected.to be_empty }
+      end
     end
 
     describe "#destroyable" do

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -25,6 +25,64 @@ RSpec.describe SubmitApplicationForm do
     end
   end
 
+  describe "hidden_from_assessment column" do
+    context "when country is not Zimbabwe and work history is above 9 months" do
+      let(:region) { create(:region, :in_country, country_code: "FR") }
+
+      before do
+        create(
+          :qualification,
+          application_form:,
+          certificate_date: Date.new(2019, 1, 1),
+        )
+        create(
+          :work_history,
+          application_form:,
+          start_date: Date.new(2019, 1, 1),
+          end_date: Date.new(2020, 1, 1),
+          hours_per_week: 38,
+        )
+      end
+
+      it "doesn't hide the application form" do
+        expect { call }.to_not change(application_form, :hidden_from_assessment)
+      end
+    end
+
+    context "when country is Zimbabwe" do
+      let(:region) { create(:region, :in_country, country_code: "ZW") }
+
+      it "hides the application form" do
+        expect { call }.to change(application_form, :hidden_from_assessment).to(
+          true,
+        )
+      end
+    end
+
+    context "when work history considering qualification is less than 9 months" do
+      before do
+        create(
+          :qualification,
+          application_form:,
+          certificate_date: Date.new(2020, 1, 1),
+        )
+        create(
+          :work_history,
+          application_form:,
+          start_date: Date.new(2019, 1, 1),
+          end_date: Date.new(2020, 1, 1),
+          hours_per_week: 38,
+        )
+      end
+
+      it "hides the application form" do
+        expect { call }.to change(application_form, :hidden_from_assessment).to(
+          true,
+        )
+      end
+    end
+  end
+
   describe "compacting blank subjects" do
     subject(:subjects) { application_form.subjects }
 


### PR DESCRIPTION
We want the ability to hide some applications from assessors when they shouldn't yet be picked up. This PR introduces a field for capturing whether that is the case, and applies our existing logic on the new field. I've then added some additional logic that we want to capture related to the work history duration.

[Jira Issue](https://dfedigital.atlassian.net/browse/AQTS-24)