### PR TITLE
Improve assessor work history duration calculation

### DIFF
--- a/app/controllers/teacher_interface/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/work_histories_controller.rb
@@ -261,7 +261,6 @@ module TeacherInterface
       @years_count, @months_count =
         WorkHistoryDuration.for_application_form(
           application_form,
-          consider_teaching_qualification: true,
         ).count_years_and_months
     end
 

--- a/app/forms/teacher_interface/qualification_form.rb
+++ b/app/forms/teacher_interface/qualification_form.rb
@@ -79,10 +79,9 @@ module TeacherInterface
     end
 
     def create_work_history_duration
-      WorkHistoryDuration.for_application_form(
-        application_form,
-        consider_teaching_qualification: true,
-      ).tap(&:count_months)
+      WorkHistoryDuration.for_application_form(application_form).tap(
+        &:count_months
+      )
     end
 
     def changed_work_history_duration?(old_duration, new_duration)

--- a/app/forms/teacher_interface/work_history_school_form.rb
+++ b/app/forms/teacher_interface/work_history_school_form.rb
@@ -72,7 +72,6 @@ module TeacherInterface
     def has_enough_work_history_for_submission?
       WorkHistoryDuration.for_application_form(
         application_form.reload,
-        consider_teaching_qualification: true,
       ).enough_for_submission?
     end
   end

--- a/app/lib/application_form_section_status_updater.rb
+++ b/app/lib/application_form_section_status_updater.rb
@@ -145,7 +145,6 @@ class ApplicationFormSectionStatusUpdater
       enough_for_submission =
         WorkHistoryDuration.for_application_form(
           application_form,
-          consider_teaching_qualification: true,
         ).enough_for_submission?
 
       enough_for_submission ? :completed : :in_progress

--- a/app/lib/work_history_duration.rb
+++ b/app/lib/work_history_duration.rb
@@ -1,46 +1,28 @@
 # frozen_string_literal: true
 
 class WorkHistoryDuration
-  def initialize(
-    application_form:,
-    relation:,
-    consider_teaching_qualification: false
-  )
+  def initialize(application_form:, relation:)
     @application_form = application_form
     @relation =
       relation.where.not(start_date: nil).where.not(hours_per_week: nil)
-    @consider_teaching_qualification = consider_teaching_qualification
   end
 
-  def self.for_application_form(
-    application_form,
-    consider_teaching_qualification: false
-  )
+  def self.for_application_form(application_form)
     WorkHistoryDuration.new(
       application_form:,
       relation: application_form.work_histories,
-      consider_teaching_qualification:,
     )
   end
 
-  def self.for_ids(
-    ids,
-    application_form:,
-    consider_teaching_qualification: false
-  )
+  def self.for_ids(ids, application_form:)
     WorkHistoryDuration.new(
       application_form:,
       relation: application_form.work_histories.where(id: ids),
-      consider_teaching_qualification:,
     )
   end
 
-  def self.for_record(record, consider_teaching_qualification: false)
-    for_ids(
-      [record.id],
-      application_form: record.application_form,
-      consider_teaching_qualification:,
-    )
+  def self.for_record(record)
+    for_ids([record.id], application_form: record.application_form)
   end
 
   def count_months
@@ -77,7 +59,7 @@ class WorkHistoryDuration
   AVERAGE_WEEKS_PER_MONTH = 4.34
   HOURS_PER_FULL_TIME_MONTH = 130.0
 
-  attr_reader :application_form, :relation, :consider_teaching_qualification
+  attr_reader :application_form, :relation
 
   def work_histories
     @work_histories ||=
@@ -89,10 +71,7 @@ class WorkHistoryDuration
   end
 
   def teaching_qualification
-    @teaching_qualification ||=
-      if consider_teaching_qualification
-        application_form.teaching_qualification
-      end
+    @teaching_qualification ||= application_form.teaching_qualification
   end
 
   def work_history_full_time_months(work_history)

--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -250,9 +250,6 @@ class TeacherInterface::ApplicationFormViewObject
 
   def work_history_duration
     @work_history_duration ||=
-      WorkHistoryDuration.for_application_form(
-        application_form,
-        consider_teaching_qualification: true,
-      )
+      WorkHistoryDuration.for_application_form(application_form)
   end
 end

--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -34,47 +34,4 @@ namespace :application_forms do
         puts "#{application_form.reference}: #{application_form.action_required_by} - #{application_form.status}"
       end
   end
-
-  desc "Decline applications with less than 9 months of work experience."
-  task :decline_work_history_duration,
-       %i[staff_email] => :environment do |_task, args|
-    user = Staff.find_by!(email: args[:staff_email])
-    zimbabwe = Country.find_by!(code: "ZW").regions.first
-
-    ApplicationForm
-      .not_started_stage
-      .where.not(region: zimbabwe)
-      .where(needs_work_history: true)
-      .each do |application_form|
-        if WorkHistoryDuration.for_application_form(
-             application_form,
-             consider_teaching_qualification: true,
-           ).enough_for_submission?
-          next
-        end
-
-        assessment = application_form.assessment
-
-        assessment_section = assessment.sections.find_by!(key: "work_history")
-        assessment_section.selected_failure_reasons.create!(
-          key: FailureReasons::WORK_HISTORY_DURATION,
-          assessor_feedback:
-            "You have added at least one teaching role that started before you " \
-              "qualified as a teacher. We do not accept teaching work experience " \
-              "that was gained before you qualified as a teacher. This means you " \
-              "have less than 9 months eligible teaching work history and are not " \
-              "eligible for QTS.\n\nYou can reapply for QTS once you have gained " \
-              "more teaching work experience. If you have this experience already, " \
-              "you can reapply and provide evidence of this as part of your new " \
-              "application.",
-        )
-        assessment_section.update!(passed: false)
-
-        application_form.reload
-
-        DeclineQTS.call(application_form:, user:)
-
-        puts application_form.reference
-      end
-  end
 end

--- a/spec/lib/work_history_duration_spec.rb
+++ b/spec/lib/work_history_duration_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe WorkHistoryDuration do
   let(:application_form) { create(:application_form) }
   let(:today) { Date.new(2021, 1, 15) }
 
-  shared_examples "month counter" do |consider_teaching_qualification|
+  shared_examples "month counter" do
     subject(:count_months) do
       travel_to(today) { work_history_duration.count_months }
     end
@@ -32,7 +32,7 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
-      it { is_expected.to eq(consider_teaching_qualification ? 6 : 12) }
+      it { is_expected.to eq(6) }
     end
 
     context "with a finished full time work history with extra hours" do
@@ -46,7 +46,7 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
-      it { is_expected.to eq(consider_teaching_qualification ? 6 : 12) }
+      it { is_expected.to eq(6) }
     end
 
     context "with a finished part time work history" do
@@ -60,7 +60,7 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
-      it { is_expected.to eq(consider_teaching_qualification ? 3 : 6) }
+      it { is_expected.to eq(3) }
     end
 
     context "with an ongoing full time work history" do
@@ -73,7 +73,7 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
-      it { is_expected.to eq(consider_teaching_qualification ? 7 : 13) }
+      it { is_expected.to eq(7) }
     end
 
     context "with an ongoing part time work history" do
@@ -86,7 +86,7 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
-      it { is_expected.to eq(consider_teaching_qualification ? 4 : 7) }
+      it { is_expected.to eq(4) }
     end
 
     context "with a full time and a part time work history" do
@@ -107,7 +107,7 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
-      it { is_expected.to eq(consider_teaching_qualification ? 3 : 10) }
+      it { is_expected.to eq(3) }
     end
 
     context "with work history before the teaching qualification" do
@@ -121,80 +121,39 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
-      it { is_expected.to eq(consider_teaching_qualification ? 0 : 12) }
+      it { is_expected.to eq(0) }
     end
   end
 
   describe "#count_months" do
     context "passing an application form" do
-      context "when not considering the teaching qualification" do
-        subject(:work_history_duration) do
-          described_class.for_application_form(application_form)
-        end
-
-        it_behaves_like "month counter", false
+      subject(:work_history_duration) do
+        described_class.for_application_form(application_form)
       end
 
-      context "when considering the teaching qualification" do
-        subject(:work_history_duration) do
-          described_class.for_application_form(
-            application_form,
-            consider_teaching_qualification: true,
-          )
-        end
-
-        it_behaves_like "month counter", true
-      end
+      it_behaves_like "month counter"
     end
 
     context "passing a work history relation" do
-      context "when not considering the teaching qualification" do
-        subject(:work_history_duration) do
-          described_class.new(
-            application_form:,
-            relation: application_form.work_histories,
-          )
-        end
-
-        it_behaves_like "month counter", false
+      subject(:work_history_duration) do
+        described_class.new(
+          application_form:,
+          relation: application_form.work_histories,
+        )
       end
 
-      context "when considering the teaching qualification" do
-        subject(:work_history_duration) do
-          described_class.new(
-            application_form:,
-            relation: application_form.work_histories,
-            consider_teaching_qualification: true,
-          )
-        end
-
-        it_behaves_like "month counter", true
-      end
+      it_behaves_like "month counter"
     end
 
     context "passing work history IDs" do
-      context "when not considering the teaching qualification" do
-        subject(:work_history_duration) do
-          described_class.for_ids(
-            application_form.work_histories.pluck(:id),
-            application_form:,
-          )
-        end
-
-        it_behaves_like "month counter", false
+      subject(:work_history_duration) do
+        described_class.for_ids(
+          application_form.work_histories.pluck(:id),
+          application_form:,
+        )
       end
 
-      context "when considering the teaching qualification" do
-        subject(:work_history_duration) do
-          described_class.for_ids(
-            application_form.work_histories.pluck(:id),
-            application_form:,
-            consider_teaching_qualification: true,
-          )
-        end
-
-        it_behaves_like "month counter", true
-      end
+      it_behaves_like "month counter"
     end
 
     context "passing a work history record" do
@@ -216,22 +175,11 @@ RSpec.describe WorkHistoryDuration do
         )
       end
 
+      let(:work_history_duration) { described_class.for_record(work_history) }
+
       subject(:count) { work_history_duration.count_months }
 
-      context "when not considering the teaching qualification" do
-        let(:work_history_duration) { described_class.for_record(work_history) }
-        it { is_expected.to eq(12) }
-      end
-
-      context "when considering the teaching qualification" do
-        let(:work_history_duration) do
-          described_class.for_record(
-            work_history,
-            consider_teaching_qualification: true,
-          )
-        end
-        it { is_expected.to eq(6) }
-      end
+      it { is_expected.to eq(6) }
     end
   end
 end


### PR DESCRIPTION
This improves the work history duration calculation for assessors by considering the certificate of the teaching qualification when compared to the start date of the work history.