### PR TITLE
Don't allow reapplying for ineligible countries

### DIFF
--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -96,6 +96,8 @@ class TeacherInterface::ApplicationFormViewObject
   def declined_cannot_reapply?
     return false if assessment.nil?
 
+    return true unless region.country.eligibility_enabled
+
     assessment.sections.any? do |section|
       section.selected_failure_reasons.any? do |failure_reason|
         %w[authorisation_to_teach applicant_already_qts].include?(

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -26,6 +26,10 @@ FactoryBot.define do
       subject_limited { true }
     end
 
+    trait :ineligible do
+      eligibility_enabled { false }
+    end
+
     trait :with_national_region do
       after(:create) do |country, _evaluator|
         create(:region, :national, country:)

--- a/spec/view_objects/teacher_interface/application_form_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_view_object_spec.rb
@@ -284,8 +284,8 @@ RSpec.describe TeacherInterface::ApplicationFormViewObject do
 
     it { is_expected.to be false }
 
-    context "with failure reasons" do
-      let(:assessment) { create(:assessment, application_form:) }
+    context "with an assessment" do
+      let!(:assessment) { create(:assessment, application_form:) }
 
       context "with sanctions" do
         let!(:assessment_section) do
@@ -308,6 +308,15 @@ RSpec.describe TeacherInterface::ApplicationFormViewObject do
             :declines_with_already_qts,
             assessment:,
           )
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context "with an ineligible country" do
+        let(:country) { create(:country, :ineligible) }
+        let(:application_form) do
+          create(:application_form, region: create(:region, country:))
         end
 
         it { is_expected.to be true }


### PR DESCRIPTION
If a country has become ineligible then we shouldn't allow applicants to reapply again so easily.