### PR TITLE
Remove unused Rake task

### DIFF
--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -35,42 +35,9 @@ namespace :application_forms do
       end
   end
 
-  desc "Update work history duration."
-  task update_work_history_duration: :environment do |_task, _args|
-    ApplicationForm.draft_stage.each do |application_form|
-      old_work_history_duration =
-        WorkHistoryDuration.for_application_form(application_form)
-
-      new_work_history_duration =
-        WorkHistoryDuration.for_application_form(
-          application_form,
-          consider_teaching_qualification: true,
-        )
-
-      unless (
-               old_work_history_duration.enough_for_submission? &&
-                 !new_work_history_duration.enough_for_submission?
-             ) ||
-               (
-                 old_work_history_duration.enough_to_skip_induction? &&
-                   !new_work_history_duration.enough_to_skip_induction?
-               )
-        next
-      end
-
-      application_form.update!(
-        qualification_changed_work_history_duration: true,
-      )
-
-      ApplicationFormSectionStatusUpdater.call(application_form:)
-
-      puts application_form.reference
-    end
-  end
-
   desc "Decline applications with less than 9 months of work experience."
   task :decline_work_history_duration,
-       %i[staff_email] => :environment do |_task, _args|
+       %i[staff_email] => :environment do |_task, args|
     user = Staff.find_by!(email: args[:staff_email])
     zimbabwe = Country.find_by!(code: "ZW").regions.first
 


### PR DESCRIPTION
This removes the `update_work_history_duration` Rake task which has now be run in production.

I've also fixed a typo in the `decline_work_history_duration` Rake task.