### PR TITLE
Ensure the work history section is not passed

### DIFF
--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -68,6 +68,7 @@ namespace :application_forms do
               "you can reapply and provide evidence of this as part of your new " \
               "application.",
         )
+        assessment_section.update!(passed: false)
 
         application_form.reload
 


### PR DESCRIPTION
This isn't necessary to decline, but it helps to show what status the application is in.