### PR TITLE
Add overdue professional standing interface

### DIFF
--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -95,6 +95,8 @@ module AssessorInterface
           requestable:,
           user: current_staff,
           passed: requestable.verify_passed,
+          received:
+            requestable.verify_passed == false ? requestable.received? : nil,
         )
     end
 
@@ -191,7 +193,7 @@ module AssessorInterface
       @professional_standing_request ||=
         ProfessionalStandingRequest.joins(
           assessment: :application_form,
-        ).find_by(
+        ).find_by!(
           assessment_id: params[:assessment_id],
           application_form: {
             reference: params[:application_form_reference],

--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -177,6 +177,7 @@ module AssessorInterface
     def verify_passed_form_params
       params.require(:assessor_interface_requestable_verify_passed_form).permit(
         :passed,
+        :received,
       )
     end
 

--- a/app/forms/assessor_interface/requestable_verify_passed_form.rb
+++ b/app/forms/assessor_interface/requestable_verify_passed_form.rb
@@ -10,10 +10,17 @@ class AssessorInterface::RequestableVerifyPassedForm
   attribute :passed, :boolean
   validates :passed, inclusion: [true, false]
 
+  attribute :received, :boolean
+  validates :received, inclusion: [nil, true, false]
+
   def save
     return false if invalid?
 
-    ReceiveRequestable.call(requestable:, user:) unless requestable.received?
+    if (passed || received) && !requestable.received?
+      ReceiveRequestable.call(requestable:, user:)
+    elsif received == false && requestable.received?
+      UnreceiveRequestable.call(requestable:, user:)
+    end
 
     VerifyRequestable.call(requestable:, user:, passed:, note: "") if passed
 

--- a/app/services/unreceive_requestable.rb
+++ b/app/services/unreceive_requestable.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class UnreceiveRequestable
+  include ServicePattern
+
+  def initialize(requestable:, user:)
+    @requestable = requestable
+    @user = user
+  end
+
+  def call
+    raise NotReceived unless requestable.received?
+
+    ActiveRecord::Base.transaction do
+      requestable.update!(received_at: nil)
+      delete_timeline_events
+      ApplicationFormStatusUpdater.call(application_form:, user:)
+    end
+  end
+
+  class NotReceived < StandardError
+  end
+
+  private
+
+  attr_reader :requestable, :user
+
+  delegate :application_form, to: :requestable
+
+  def delete_timeline_events
+    TimelineEvent.where(
+      application_form:,
+      event_type: "requestable_received",
+      requestable:,
+    ).delete_all
+  end
+end

--- a/app/views/assessor_interface/professional_standing_requests/edit_verify.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_verify.html.erb
@@ -25,7 +25,18 @@
                 "After following the steps above, have you received a valid response?" :
                 "Does the response confirm that the LoPS is valid?" %>
 
-  <%= f.govuk_collection_radio_buttons :passed, %i[true false], :itself, legend: { text: legend } %>
+  <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: legend, size: "s" } do %>
+    <%= f.govuk_radio_button :passed, :true, link_errors: true %>
+
+    <% if @professional_standing_request.expired? %>
+      <%= f.govuk_radio_button :passed, :false do %>
+        <%= f.govuk_radio_button :received, :true %>
+        <%= f.govuk_radio_button :received, :false %>
+      <% end %>
+    <% else %>
+      <%= f.govuk_radio_button :passed, :false %>
+    <% end %>
+  <% end %>
 
   <%= f.govuk_submit do %>
     <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>

--- a/app/views/assessor_interface/professional_standing_requests/edit_verify.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_verify.html.erb
@@ -6,8 +6,26 @@
 
   <h1 class="govuk-heading-xl">Record LoPS response</h1>
 
-  <%= f.govuk_collection_radio_buttons :passed, %i[true false], :itself,
-                                       legend: { text: "Does the response confirm that the LoPS is valid?" } %>
+  <% if @professional_standing_request.expired? %>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text govuk-!-font-size-27"><span class="govuk-warning-text__assistive">Warning</span>This LoPS response is overdue</strong>
+    </div>
+
+    <h2 class="govuk-heading-s">Please follow these steps:</h2>
+
+    <ul class="govuk-list govuk-list--number govuk-!-margin-bottom-8">
+      <li>In Zendesk use macro ‘PR - 1st verification of LoPS’ to email the competent authority to remind them.</li>
+      <li>If no response, use macro ‘PR - 1st verification of LoPS’ to email the applicant and the competent authority to remind them.</li>
+      <li>If no response, escalate to an EO.</li>
+    </ul>
+  <% end %>
+
+  <% legend = @professional_standing_request.expired? ?
+                "After following the steps above, have you received a valid response?" :
+                "Does the response confirm that the LoPS is valid?" %>
+
+  <%= f.govuk_collection_radio_buttons :passed, %i[true false], :itself, legend: { text: legend } %>
 
   <%= f.govuk_submit do %>
     <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>

--- a/app/views/assessor_interface/professional_standing_requests/edit_verify_failed.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_verify_failed.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Send for review", error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, verify_assessor_interface_application_form_assessment_professional_standing_request_path(@application_form, @assessment) %>
 
 <%= form_with model: @form, url: [:verify_failed, :assessor_interface, @application_form, @assessment, :professional_standing_request] do |f| %>
   <%= f.govuk_error_summary %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -391,13 +391,13 @@ en:
         assessor_interface/requestable_verify_failed_form:
           attributes:
             note:
-              blank: Enter why you are not satisfied
+              blank: Add a note explaining why you are sending this for review
         assessor_interface/requestable_verify_passed_form:
           attributes:
             passed:
-              inclusion: Select whether you are satisfied with the request
+              inclusion: Tell us if you have received a valid response
             received:
-              inclusion: Select whether you have received the request
+              inclusion: Tell us if you have received a response that's not valid, or if you have not received a response
         assessor_interface/select_qualifications_form:
           attributes:
             qualification_ids:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -396,6 +396,8 @@ en:
           attributes:
             passed:
               inclusion: Select whether you are satisfied with the request
+            received:
+              inclusion: Select whether you have received the request
         assessor_interface/select_qualifications_form:
           attributes:
             qualification_ids:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -121,8 +121,11 @@ en:
           false: "No"
       assessor_interface_requestable_verify_passed_form:
         passed_options:
-          true: "Yes, mark as completed"
-          false: "No, send for review"
+          true: Yes, mark as completed
+          false: No, send for review
+        received_options:
+          true: Response received and not valid
+          false: Response not received
       assessor_interface_verify_professional_standing_form:
         verify_professional_standing_options:
           true: Yes, verify LoPS

--- a/spec/services/unreceive_requestable_spec.rb
+++ b/spec/services/unreceive_requestable_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UnreceiveRequestable do
+  let(:application_form) do
+    create(:application_form, :submitted, statuses: %w[received_qualification])
+  end
+  let(:requestable) do
+    create(
+      :qualification_request,
+      :received,
+      :receivable,
+      assessment: create(:assessment, application_form:),
+    )
+  end
+  let!(:timeline_event) do
+    create(
+      :timeline_event,
+      :requestable_received,
+      requestable:,
+      application_form:,
+    )
+  end
+  let(:user) { "John Smith" }
+
+  subject(:call) { described_class.call(requestable:, user:) }
+
+  context "with an already not received requestable" do
+    before { requestable.update!(received_at: nil) }
+
+    it "raises an error" do
+      expect { call }.to raise_error(UnreceiveRequestable::NotReceived)
+    end
+  end
+
+  it "changes the requestable state from received" do
+    expect { call }.to change(requestable, :received?).from(true).to(false)
+  end
+
+  it "changes the application form status" do
+    expect { call }.to change { application_form.reload.statuses }.to(
+      %w[assessment_not_started],
+    )
+  end
+
+  it "changes the requestable received at" do
+    expect { call }.to change(requestable, :received_at).to(nil)
+  end
+
+  it "deletes the requestable received timeline event" do
+    expect { call }.to change(TimelineEvent, :count).by(-1)
+    expect { timeline_event.reload }.to raise_error(
+      ActiveRecord::RecordNotFound,
+    )
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/verify_professional_standing_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/verify_professional_standing_request.rb
@@ -7,22 +7,35 @@ module PageObjects
                 "/professional-standing-request/verify"
 
       section :form, "form" do
-        section :true_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(1)"
-        section :false_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(2)"
+        element :passed_true_radio_item,
+                "#assessor-interface-requestable-verify-passed-form-passed-true-field",
+                visible: false
+        element :passed_false_radio_item,
+                "#assessor-interface-requestable-verify-passed-form-passed-false-field",
+                visible: false
+        element :received_true_radio_item,
+                "#assessor-interface-requestable-verify-passed-form-received-true-field",
+                visible: false
+        element :received_false_radio_item,
+                "#assessor-interface-requestable-verify-passed-form-received-false-field",
+                visible: false
         element :submit_button, ".govuk-button"
       end
 
       def submit_yes
-        form.true_radio_item.choose
+        form.passed_true_radio_item.choose
         form.submit_button.click
       end
 
-      def submit_no
-        form.false_radio_item.choose
+      def submit_no(received: nil)
+        form.passed_false_radio_item.choose
+
+        if received
+          form.received_true_radio_item.choose
+        elsif received == false
+          form.received_false_radio_item.choose
+        end
+
         form.submit_button.click
       end
     end

--- a/spec/system/assessor_interface/verifying_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/verifying_professional_standing_spec.rb
@@ -94,6 +94,56 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
     and_the_record_lops_response_status_is("REVIEW")
   end
 
+  it "record after overdue" do
+    given_the_professional_standing_request_has_been_requested
+    given_the_professional_standing_request_has_expired
+
+    when_i_visit_the(:assessor_application_page, reference:)
+    and_i_click_professional_standing_task
+    then_i_see_the(
+      :assessor_professional_standing_request_page,
+      reference:,
+      assessment_id:,
+    )
+    and_the_request_lops_verification_status_is("COMPLETED")
+    and_the_record_lops_response_status_is("OVERDUE")
+
+    when_i_click_record_lops_response
+    then_i_see_the(
+      :assessor_verify_professional_standing_request_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_see_the_overdue_content
+    and_i_submit_yes_on_the_verify_form
+    then_i_see_the(
+      :assessor_professional_standing_request_page,
+      reference:,
+      assessment_id:,
+    )
+    and_the_record_lops_response_status_is("COMPLETED")
+
+    when_i_click_record_lops_response
+    then_i_see_the(
+      :assessor_verify_professional_standing_request_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_submit_no_on_the_verify_form
+    then_i_see_the(
+      :assessor_verify_failed_professional_standing_request_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_submit_an_internal_note
+    then_i_see_the(
+      :assessor_professional_standing_request_page,
+      reference:,
+      assessment_id:,
+    )
+    and_the_record_lops_response_status_is("REVIEW")
+  end
+
   private
 
   def given_there_is_an_application_form_with_professional_standing_request
@@ -102,6 +152,10 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
 
   def given_the_professional_standing_request_has_been_requested
     application_form.assessment.professional_standing_request.requested!
+  end
+
+  def given_the_professional_standing_request_has_expired
+    application_form.assessment.professional_standing_request.expired!
   end
 
   def and_i_click_professional_standing_task
@@ -140,6 +194,12 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
 
   def and_i_submit_unchecked_on_the_request_form
     assessor_request_professional_standing_request_page.submit_unchecked
+  end
+
+  def and_i_see_the_overdue_content
+    expect(assessor_verify_professional_standing_request_page).to have_content(
+      "This LoPS response is overdue",
+    )
   end
 
   def and_i_submit_yes_on_the_verify_form

--- a/spec/system/assessor_interface/verifying_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/verifying_professional_standing_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
     given_there_is_an_application_form_with_professional_standing_request
   end
 
-  it "verify" do
+  it "request" do
     when_i_visit_the(:assessor_application_page, reference:)
     and_i_click_professional_standing_task
     then_i_see_the(
@@ -37,6 +37,20 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
 
     when_i_click_request_lops_verification
     and_i_submit_checked_on_the_request_form
+    then_i_see_the(
+      :assessor_professional_standing_request_page,
+      reference:,
+      assessment_id:,
+    )
+    and_the_request_lops_verification_status_is("COMPLETED")
+    and_the_record_lops_response_status_is("WAITING ON")
+  end
+
+  it "record" do
+    given_the_professional_standing_request_has_been_requested
+
+    when_i_visit_the(:assessor_application_page, reference:)
+    and_i_click_professional_standing_task
     then_i_see_the(
       :assessor_professional_standing_request_page,
       reference:,
@@ -84,6 +98,10 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
 
   def given_there_is_an_application_form_with_professional_standing_request
     application_form
+  end
+
+  def given_the_professional_standing_request_has_been_requested
+    application_form.assessment.professional_standing_request.requested!
   end
 
   def and_i_click_professional_standing_task
@@ -142,7 +160,7 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
     @application_form ||=
       begin
         application_form =
-          create(:application_form, :submitted, statuses: %w[waiting_on_lops])
+          create(:application_form, :submitted, :verification_stage)
         create(
           :assessment,
           :with_professional_standing_request,

--- a/spec/system/assessor_interface/verifying_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/verifying_professional_standing_spec.rb
@@ -129,7 +129,27 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
       reference:,
       assessment_id:,
     )
-    and_i_submit_no_on_the_verify_form
+    and_i_submit_no_and_not_received_on_the_verify_form
+    then_i_see_the(
+      :assessor_verify_failed_professional_standing_request_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_submit_an_internal_note
+    then_i_see_the(
+      :assessor_professional_standing_request_page,
+      reference:,
+      assessment_id:,
+    )
+    and_the_record_lops_response_status_is("REVIEW")
+
+    when_i_click_record_lops_response
+    then_i_see_the(
+      :assessor_verify_professional_standing_request_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_submit_no_and_received_on_the_verify_form
     then_i_see_the(
       :assessor_verify_failed_professional_standing_request_page,
       reference:,
@@ -208,6 +228,16 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
 
   def and_i_submit_no_on_the_verify_form
     assessor_verify_professional_standing_request_page.submit_no
+  end
+
+  def and_i_submit_no_and_received_on_the_verify_form
+    assessor_verify_professional_standing_request_page.submit_no(received: true)
+  end
+
+  def and_i_submit_no_and_not_received_on_the_verify_form
+    assessor_verify_professional_standing_request_page.submit_no(
+      received: false,
+    )
   end
 
   def and_i_submit_an_internal_note


### PR DESCRIPTION
This builds the overdue professional standing user journey which allows admins to better respond to overdue professional standing.

[Jira Issue](https://dfedigital.atlassian.net/browse/AQTS-39)

## Screenshots

![Screenshot 2023-12-01 at 11 44 04](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/8b2a675e-db63-4185-a9b5-8ab913f252c6)

![Screenshot 2023-12-01 at 11 44 08](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/0ee17453-234d-4f43-b366-215dffb8ebe6)


![Screenshot 2023-12-01 at 11 42 28](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/da131e9a-e8aa-4434-8093-b5ce6b4c94fd)
