### PR TITLE
Refactor WorkHistoryHelper

### DIFF
--- a/app/helpers/work_history_helper.rb
+++ b/app/helpers/work_history_helper.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module WorkHistoryHelper
-  def work_history_title(work_history)
+  def work_history_name(work_history)
     work_history.school_name.presence || work_history.city.presence ||
       work_history.country_name.presence || work_history.job.presence ||
       I18n.t(
@@ -13,15 +15,16 @@ module WorkHistoryHelper
       )
   end
 
-  def work_history_name_and_duration(work_history, most_recent: false)
+  def work_history_name_and_duration(work_history)
     months = WorkHistoryDuration.for_record(work_history).count_months
 
-    result = "#{work_history.school_name} (#{months} months)"
-    result.concat(" ", most_recent_tag) if most_recent
-    result.html_safe
-  end
-
-  def most_recent_tag
-    tag.span("MOST RECENT", class: "govuk-!-font-weight-bold")
+    [
+      "#{work_history_name(work_history)} — #{months} months",
+      (
+        if work_history.current_or_most_recent_role?
+          tag.span("(MOST RECENT)", class: "govuk-!-font-weight-bold")
+        end
+      ),
+    ].compact_blank.join(" ").html_safe
   end
 end

--- a/app/views/assessor_interface/reference_requests/index.html.erb
+++ b/app/views/assessor_interface/reference_requests/index.html.erb
@@ -18,9 +18,9 @@
           {
             title: "Work references",
             indentation: false,
-            items: @reference_requests.each_with_index.map do |reference_request, index|
+            items: @reference_requests.map do |reference_request|
               {
-                name: work_history_name_and_duration(reference_request.work_history, most_recent: index.zero?),
+                name: work_history_name_and_duration(reference_request.work_history),
                 link: [:edit, :assessor_interface, @application_form, @assessment, reference_request],
                 status: reference_request.status
               }

--- a/app/views/assessor_interface/work_histories/edit.html.erb
+++ b/app/views/assessor_interface/work_histories/edit.html.erb
@@ -1,4 +1,4 @@
-<% title = "Change details for ‘#{work_history_title(@work_history)}’" %>
+<% title = "Change details for ‘#{work_history_name(@work_history)}’" %>
 <% application_form = @work_history.application_form %>
 
 <% content_for :page_title, "#{"Error: " if @form.errors.any?}#{title}" %>

--- a/app/views/teacher_interface/work_histories/delete.html.erb
+++ b/app/views/teacher_interface/work_histories/delete.html.erb
@@ -8,7 +8,7 @@
                                        [OpenStruct.new(value: :true), OpenStruct.new(value: :false)],
                                        :value,
                                        inline: true,
-                                       legend: { text: "Are you sure you want to delete #{work_history_title(@work_history)}?", size: "l", tag: "h1" } %>
+                                       legend: { text: "Are you sure you want to delete #{work_history_name(@work_history)}?", size: "l", tag: "h1" } %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/spec/helpers/work_history_spec.rb
+++ b/spec/helpers/work_history_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe WorkHistoryHelper do
-  describe "#work_history_title" do
-    subject(:title) { work_history_title(work_history) }
+  describe "#work_history_name" do
+    subject(:name) { work_history_name(work_history) }
 
     let(:work_history) { build(:work_history) }
 
@@ -34,9 +34,12 @@ RSpec.describe WorkHistoryHelper do
   end
 
   describe "#work_history_name_and_duration" do
+    let(:application_form) { create(:application_form) }
+
     let(:work_history) do
       create(
         :work_history,
+        application_form:,
         school_name: "School of Rock",
         start_date: Date.new(2022, 1, 1),
         end_date: Date.new(2022, 12, 22),
@@ -46,16 +49,16 @@ RSpec.describe WorkHistoryHelper do
 
     subject(:name_and_duration) { work_history_name_and_duration(work_history) }
 
-    it { is_expected.to eq("School of Rock (12 months)") }
+    context "when it is not the most recent" do
+      before { create(:work_history, application_form:) }
 
-    context "when work history is most recent" do
-      subject(:name_and_duration) do
-        work_history_name_and_duration(work_history, most_recent: true)
-      end
+      it { is_expected.to eq("School of Rock — 12 months") }
+    end
 
+    context "when it is the most recent" do
       it do
         is_expected.to eq(
-          %(School of Rock (12 months) <span class="govuk-!-font-weight-bold">MOST RECENT</span>),
+          %(School of Rock — 12 months <span class="govuk-!-font-weight-bold">(MOST RECENT)</span>),
         )
       end
     end


### PR DESCRIPTION
This changes the content shown for each work history to match the new designs, and removes the need to pass in an index.