### PR TITLE
Change title of send for review page

### DIFF
--- a/app/views/assessor_interface/professional_standing_requests/edit_verify_failed.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_verify_failed.html.erb
@@ -1,10 +1,10 @@
-<% content_for :page_title, "#{"Error: " if @form.errors.any?}Record LoPS response" %>
+<% content_for :page_title, "#{"Error: " if @form.errors.any?}Send for review" %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
 <%= form_with model: @form, url: [:verify_failed, :assessor_interface, @application_form, @assessment, :professional_standing_request] do |f| %>
   <%= f.govuk_error_summary %>
 
-  <h1 class="govuk-heading-xl">Record LoPS response</h1>
+  <h1 class="govuk-heading-xl">Send for review</h1>
 
   <p class="govuk-body">You have opted to send this LoPS for review.</p>
 


### PR DESCRIPTION
We've decided to change the title of this page so it will match the wording for work history and qualifications.