### PR TITLE
Add QualificationRequestPolicy

### DIFF
--- a/app/controllers/assessor_interface/qualification_requests_controller.rb
+++ b/app/controllers/assessor_interface/qualification_requests_controller.rb
@@ -2,10 +2,15 @@
 
 module AssessorInterface
   class QualificationRequestsController < BaseController
-    before_action :authorize_assessor
     before_action :set_variables, except: :index
 
+    before_action except: :index do
+      authorize [:assessor_interface, qualification_request]
+    end
+
     def index
+      authorize %i[assessor_interface qualification_request]
+
       @qualification_requests = qualification_requests
       @application_form = qualification_requests.first.application_form
       @assessment = @application_form.assessment

--- a/app/policies/assessor_interface/qualification_request_policy.rb
+++ b/app/policies/assessor_interface/qualification_request_policy.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AssessorInterface::QualificationRequestPolicy < ApplicationPolicy
+  def index?
+    user.assess_permission || user.verify_permission
+  end
+
+  def update?
+    user.assess_permission || user.verify_permission
+  end
+end

--- a/spec/policies/assessor_interface/qualification_request_policy_spec.rb
+++ b/spec/policies/assessor_interface/qualification_request_policy_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::QualificationRequestPolicy do
+  it_behaves_like "a policy"
+
+  let(:user) { nil }
+  let(:record) { nil }
+
+  subject(:policy) { described_class.new(user, record) }
+
+  describe "#index?" do
+    subject(:index?) { policy.index? }
+    it_behaves_like "a policy method requiring the assess permission"
+    it_behaves_like "a policy method requiring the verify permission"
+  end
+
+  describe "#show?" do
+    subject(:show?) { policy.show? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+
+  describe "#create?" do
+    subject(:create?) { policy.create? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+
+  describe "#new?" do
+    subject(:new?) { policy.new? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+
+  describe "#update?" do
+    subject(:update?) { policy.update? }
+    it_behaves_like "a policy method requiring the assess permission"
+    it_behaves_like "a policy method requiring the verify permission"
+  end
+
+  describe "#edit?" do
+    subject(:edit?) { policy.edit? }
+    it_behaves_like "a policy method requiring the assess permission"
+    it_behaves_like "a policy method requiring the verify permission"
+  end
+
+  describe "#destroy?" do
+    subject(:destroy?) { policy.destroy? }
+
+    let(:user) { create(:staff, :confirmed) }
+    it { is_expected.to be false }
+  end
+end


### PR DESCRIPTION
This refactors how we handle permissions for qualification requests in preparation for the new verification journey.