### PR TITLE
Only show assessors who are assigned to applications

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -22,7 +22,12 @@ class AssessorInterface::ApplicationFormsIndexViewObject
   end
 
   def assessor_filter_options
-    Staff.assessors.order(:name) +
+    ApplicationForm
+      .active
+      .joins(:assessor)
+      .pluck(Arel.sql("DISTINCT ON(assessor_id) assessor_id"), "staff.name")
+      .sort_by { |_id, name| name }
+      .map { |id, name| OpenStruct.new(id:, name:) } +
       [OpenStruct.new(id: "null", name: "Not assigned")]
   end
 

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe "Assessor filtering application forms", type: :system do
   end
 
   def and_i_apply_the_assessor_filter
-    expect(assessor_applications_page.assessor_filter.assessors.count).to eq(4)
-    assessor_applications_page.assessor_filter.assessors.second.checkbox.click
+    expect(assessor_applications_page.assessor_filter.assessors.count).to eq(3)
+    assessor_applications_page.assessor_filter.assessors.first.checkbox.click
     assessor_applications_page.apply_filters.click
   end
 

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -128,15 +128,23 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
     end
 
     context "with an assessor user" do
-      let!(:staff) { create(:staff, :with_assess_permission) }
+      let!(:staff) { create(:staff) }
 
-      it { is_expected.to include(staff) }
+      before { create(:application_form, :submitted, assessor: staff) }
+
+      it do
+        is_expected.to include(OpenStruct.new(id: staff.id, name: staff.name))
+      end
     end
 
     context "with an non-assessor user" do
       let!(:staff) { create(:staff) }
 
-      it { is_expected.not_to include(staff) }
+      it do
+        is_expected.to_not include(
+          OpenStruct.new(id: staff.id, name: staff.name),
+        )
+      end
     end
   end
 


### PR DESCRIPTION
This will reduce the number of assessors shown in the list, and it also means we can take away the assess permission from staff who have left without them disappearing from this list.