### PR TITLE
Review qualifications and references

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
@@ -21,7 +21,19 @@ module AssessorInterface
 
     def edit
       @professional_standing_request =
-        assessment.professional_standing_request if assessment.professional_standing_request.verify_failed?
+        assessment.professional_standing_request if assessment.professional_standing_request&.verify_failed?
+
+      @qualification_requests =
+        assessment
+          .qualification_requests
+          .includes(:qualification)
+          .where(verify_passed: false)
+
+      @reference_requests =
+        assessment
+          .reference_requests
+          .includes(:work_history)
+          .where(verify_passed: false)
 
       render layout: "full_from_desktop"
     end

--- a/app/controllers/assessor_interface/assessments_controller.rb
+++ b/app/controllers/assessor_interface/assessments_controller.rb
@@ -14,7 +14,19 @@ module AssessorInterface
 
     def review
       @professional_standing_request =
-        assessment.professional_standing_request if assessment.professional_standing_request.verify_failed?
+        assessment.professional_standing_request if assessment.professional_standing_request&.verify_failed?
+
+      @qualification_requests =
+        assessment
+          .qualification_requests
+          .includes(:qualification)
+          .where(verify_passed: false)
+
+      @reference_requests =
+        assessment
+          .reference_requests
+          .includes(:work_history)
+          .where(verify_passed: false)
 
       render layout: "full_from_desktop"
     end

--- a/app/controllers/assessor_interface/qualification_requests_controller.rb
+++ b/app/controllers/assessor_interface/qualification_requests_controller.rb
@@ -13,7 +13,7 @@ module AssessorInterface
 
       @qualification_requests = qualification_requests
       @application_form = qualification_requests.first.application_form
-      @assessment = @application_form.assessment
+      @assessment = qualification_requests.first.assessment
 
       render layout: "application"
     end
@@ -67,6 +67,25 @@ module AssessorInterface
       end
     end
 
+    def edit_review
+      @form = RequestableReviewForm.new(requestable:)
+    end
+
+    def update_review
+      @form =
+        RequestableReviewForm.new(
+          requestable:,
+          user: current_staff,
+          **requestable_review_form_params,
+        )
+
+      if @form.save
+        redirect_to [:review, :assessor_interface, application_form, assessment]
+      else
+        render :edit_review, status: :unprocessable_entity
+      end
+    end
+
     private
 
     def set_variables
@@ -81,6 +100,13 @@ module AssessorInterface
         :passed,
         :note,
         :failed,
+      )
+    end
+
+    def requestable_review_form_params
+      params.require(:assessor_interface_requestable_review_form).permit(
+        :passed,
+        :note,
       )
     end
 
@@ -101,6 +127,8 @@ module AssessorInterface
     def qualification_request
       @qualification_request ||= qualification_requests.find(params[:id])
     end
+
+    delegate :application_form, :assessment, to: :qualification_request
 
     alias_method :requestable, :qualification_request
   end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -157,9 +157,15 @@ class Assessment < ApplicationRecord
     return false unless verify?
     return false if skip_verification?
 
-    enough_reference_requests_reviewed? &&
-      all_qualification_requests_reviewed? &&
-      professional_standing_request_verify_failed?
+    (
+      enough_reference_requests_reviewed? &&
+        all_qualification_requests_reviewed?
+    ) &&
+      (
+        any_qualification_requests_verify_failed? ||
+          any_reference_requests_verify_failed? ||
+          professional_standing_request_verify_failed?
+      )
   end
 
   def can_verify?
@@ -252,6 +258,10 @@ class Assessment < ApplicationRecord
     ).enough_for_submission?
   end
 
+  def any_reference_requests_verify_failed?
+    reference_requests.any?(&:verify_failed?)
+  end
+
   def all_qualification_requests_reviewed?
     qualification_requests.all?(&:reviewed?)
   end
@@ -262,6 +272,10 @@ class Assessment < ApplicationRecord
 
   def any_qualification_requests_review_failed?
     qualification_requests.any?(&:review_failed?)
+  end
+
+  def any_qualification_requests_verify_failed?
+    qualification_requests.any?(&:verify_failed?)
   end
 
   def professional_standing_request_reviewed?

--- a/app/policies/assessor_interface/qualification_request_policy.rb
+++ b/app/policies/assessor_interface/qualification_request_policy.rb
@@ -8,4 +8,10 @@ class AssessorInterface::QualificationRequestPolicy < ApplicationPolicy
   def update?
     user.assess_permission
   end
+
+  def update_review?
+    user.assess_permission
+  end
+
+  alias_method :edit_review?, :update_review?
 end

--- a/app/policies/assessor_interface/reference_request_policy.rb
+++ b/app/policies/assessor_interface/reference_request_policy.rb
@@ -16,4 +16,10 @@ class AssessorInterface::ReferenceRequestPolicy < ApplicationPolicy
   def edit?
     user.assess_permission || user.change_work_history_permission
   end
+
+  def update_review?
+    user.assess_permission
+  end
+
+  alias_method :edit_review?, :update_review?
 end

--- a/app/views/assessor_interface/assessment_recommendation_review/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_review/edit.html.erb
@@ -29,4 +29,56 @@
   </table>
 <% end %>
 
+<% if @qualification_requests.present? %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">References</th>
+        <th scope="col" class="govuk-table__header"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @qualification_requests.each do |qualification_request| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <p><%= qualification_title(qualification_request.qualification) %></p>
+            <h3 class="govuk-heading-s">Internal note</h3>
+            <%= simple_format qualification_request.verify_note %>
+          </td>
+
+          <td class="govuk-table__cell app-table__center_right govuk-!-padding-right-1">
+            <%= render(StatusTag::Component.new(qualification_request.status)) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
+<% if @reference_requests.present? %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th class="govuk-table__header">References</th>
+        <th scope="col" class="govuk-table__header"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @reference_requests.each do |reference_request| %>
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell">
+            <p><%= work_history_name(reference_request.work_history) %></p>
+            <h3 class="govuk-heading-s">Internal note</h3>
+            <%= simple_format reference_request.verify_note %>
+          </td>
+
+          <td class="govuk-table__cell app-table__center_right govuk-!-padding-right-1">
+            <%= render(StatusTag::Component.new(reference_request.status)) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>
+
 <%= govuk_button_to "Continue", [:assessor_interface, @application_form, @assessment, :assessment_recommendation_review], method: :put %>

--- a/app/views/assessor_interface/assessments/review.html.erb
+++ b/app/views/assessor_interface/assessments/review.html.erb
@@ -7,23 +7,47 @@
   The following verification tasks have been flagged for review:
 </p>
 
-<%= render(TaskList::Component.new(
+<%= render(TaskList::Component.new([
   if @professional_standing_request.present?
-    [
-      {
-        title: "LoPS",
-        indentation: false,
-        items: [
-          {
-            name: region_teaching_authority_name(@application_form.region, context: :assessor).upcase_first,
-            link: [:review, :assessor_interface, @application_form, @assessment, :professional_standing_request],
-            status: @professional_standing_request.review_status,
-          }
-        ],
-      }
-    ]
+    {
+      title: "LoPS",
+      indentation: false,
+      items: [
+        {
+          name: region_teaching_authority_name(@application_form.region, context: :assessor).upcase_first,
+          link: [:review, :assessor_interface, @application_form, @assessment, :professional_standing_request],
+          status: @professional_standing_request.review_status,
+        }
+      ],
+    }
+  end,
+  if @qualification_requests.present?
+    {
+      title: "Qualifications",
+      indentation: false,
+      items: @qualification_requests.map do |qualification_request|
+        {
+          name: qualification_title(qualification_request.qualification),
+          link: [:review, :assessor_interface, @application_form, @assessment, qualification_request],
+          status: qualification_request.review_status,
+        }
+      end
+    }
+  end,
+  if @reference_requests.present?
+    {
+      title: "References",
+      indentation: false,
+      items: @reference_requests.map do |reference_request|
+        {
+          name: work_history_name(reference_request.work_history),
+          link: [:review, :assessor_interface, @application_form, @assessment, reference_request],
+          status: reference_request.review_status,
+        }
+      end
+    }
   end
-)) %>
+].compact)) %>
 
 <div class="govuk-!-padding-top-3">
   <%= govuk_button_link_to "Back to overview", [:assessor_interface, @application_form] %>

--- a/app/views/assessor_interface/professional_standing_requests/edit_review.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_review.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Review LoPS", error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, review_assessor_interface_application_form_assessment_path(@application_form, @assessment) %>
 
 <%= form_with model: @form, url: [:review, :assessor_interface, @application_form, @assessment, :professional_standing_request] do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/assessor_interface/qualification_requests/edit_review.html.erb
+++ b/app/views/assessor_interface/qualification_requests/edit_review.html.erb
@@ -1,0 +1,28 @@
+<% content_for :page_title, title_with_error_prefix("Review qualification", error: @form.errors.any?) %>
+<% content_for :back_link_url, review_assessor_interface_application_form_assessment_path %>
+
+<%= form_with model: @form, url: [:review, :assessor_interface, @application_form, @assessment, @qualification_request] do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl">Review qualification</h1>
+
+  <h2 class="govuk-heading-m">
+    <%= qualification_title(@qualification_request.qualification) %>
+  </h2>
+
+  <%= govuk_inset_text do %>
+    <h3 class="govuk-heading-s">Internal note</h3>
+    <%= simple_format @qualification_request.verify_note %>
+  <% end %>
+
+  <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "After review, does the response confirm that this qualification is legitimate?", size: "s" } do %>
+    <%= f.govuk_radio_button :passed, :true, link_errors: true %>
+    <%= f.govuk_radio_button :passed, :false do %>
+      <%= f.govuk_text_area :note, label: { text: "Internal note: briefly explain why the qualification should not be accepted." } %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit do %>
+    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
+  <% end %>
+<% end %>

--- a/app/views/assessor_interface/reference_requests/edit_review.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit_review.html.erb
@@ -1,0 +1,28 @@
+<% content_for :page_title, title_with_error_prefix("Review reference", error: @form.errors.any?) %>
+<% content_for :back_link_url, review_assessor_interface_application_form_assessment_path %>
+
+<%= form_with model: @form, url: [:review, :assessor_interface, @application_form, @assessment, @reference_request] do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl">Review reference</h1>
+
+  <h2 class="govuk-heading-m">
+    <%= work_history_name(@reference_request.work_history) %>
+  </h2>
+
+  <%= govuk_inset_text do %>
+    <h3 class="govuk-heading-s">Internal note</h3>
+    <%= simple_format @reference_request.verify_note %>
+  <% end %>
+
+  <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "After review, does the response confirm that this reference is legitimate?", size: "s" } do %>
+    <%= f.govuk_radio_button :passed, :true, link_errors: true %>
+    <%= f.govuk_radio_button :passed, :false do %>
+      <%= f.govuk_text_area :note, label: { text: "Internal note: briefly explain why the reference should not be accepted." } %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_submit do %>
+    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,7 +135,12 @@ Rails.application.routes.draw do
 
         resources :qualification_requests,
                   path: "/qualification-requests",
-                  only: %i[index edit update]
+                  only: %i[index edit update] do
+          member do
+            get "review", to: "qualification_requests#edit_review"
+            post "review", to: "qualification_requests#update_review"
+          end
+        end
 
         resources :reference_requests,
                   path: "/reference-requests",
@@ -143,6 +148,11 @@ Rails.application.routes.draw do
           post "verify-references",
                to: "reference_requests#update_verify_references",
                on: :collection
+
+          member do
+            get "review", to: "reference_requests#edit_review"
+            post "review", to: "reference_requests#update_review"
+          end
         end
       end
     end

--- a/spec/policies/assessor_interface/qualification_request_policy_spec.rb
+++ b/spec/policies/assessor_interface/qualification_request_policy_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe AssessorInterface::QualificationRequestPolicy do
     it_behaves_like "a policy method requiring the assess permission"
   end
 
+  describe "#update_review?" do
+    subject(:update_review?) { policy.update_review? }
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+
+  describe "#edit_review?" do
+    subject(:edit_review?) { policy.edit_review? }
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+
   describe "#destroy?" do
     subject(:destroy?) { policy.destroy? }
     it_behaves_like "a policy method without permission"

--- a/spec/policies/assessor_interface/reference_request_policy_spec.rb
+++ b/spec/policies/assessor_interface/reference_request_policy_spec.rb
@@ -46,6 +46,16 @@ RSpec.describe AssessorInterface::ReferenceRequestPolicy do
     it_behaves_like "a policy method requiring the change work history permission"
   end
 
+  describe "#update_review?" do
+    subject(:update_review?) { policy.update_review? }
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+
+  describe "#edit_review?" do
+    subject(:edit_review?) { policy.edit_review? }
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+
   describe "#destroy?" do
     subject(:destroy?) { policy.destroy? }
     it_behaves_like "a policy method without permission"

--- a/spec/support/autoload/page_objects/assessor_interface/reference_requests.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/reference_requests.rb
@@ -6,10 +6,7 @@ module PageObjects
       set_url "/assessor/applications/{reference}/assessments/{assessment_id}" \
                 "/reference-requests"
 
-      section :task_list, ".app-task-list__item" do
-        elements :reference_requests, ".app-task-list__task-name a"
-        elements :status_tags, ".app-task-list__tag"
-      end
+      section :task_list, TaskList, ".app-task-list"
 
       section :form, "form" do
         element :yes_radio_item,

--- a/spec/support/autoload/page_objects/assessor_interface/review_further_information_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/review_further_information_request.rb
@@ -1,22 +1,13 @@
+# frozen_string_literal: true
+
 module PageObjects
   module AssessorInterface
-    class ReviewFurtherInformationRequest < SitePrism::Page
+    class ReviewFurtherInformationRequest < ReviewRequestablePage
       set_url "/assessor/applications/{reference}/assessments/{assessment_id}" \
-                "/further-information-requests/{further_information_request_id}/edit"
+                "/further-information-requests/{id}/edit"
 
       element :heading, ".govuk-heading-xl"
       sections :summary_lists, GovukSummaryList, ".govuk-summary-list"
-
-      section :form, "form" do
-        section :yes_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(1)"
-        section :no_radio_item,
-                PageObjects::GovukRadioItem,
-                ".govuk-radios__item:nth-of-type(2)"
-        element :failure_reason_textarea, ".govuk-textarea"
-        element :continue_button, "button"
-      end
     end
   end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/review_qualification_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/review_qualification_request.rb
@@ -2,9 +2,9 @@
 
 module PageObjects
   module AssessorInterface
-    class ReviewProfessionalStandingRequest < ReviewRequestablePage
+    class ReviewQualificationRequest < ReviewRequestablePage
       set_url "/assessor/applications/{reference}/assessments/{assessment_id}" \
-                "/professional-standing-request/review"
+                "/qualification-requests/{id}/review"
     end
   end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/review_reference_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/review_reference_request.rb
@@ -2,9 +2,9 @@
 
 module PageObjects
   module AssessorInterface
-    class ReviewProfessionalStandingRequest < ReviewRequestablePage
+    class ReviewReferenceRequest < ReviewRequestablePage
       set_url "/assessor/applications/{reference}/assessments/{assessment_id}" \
-                "/professional-standing-request/review"
+                "/reference-requests/{id}/review"
     end
   end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/review_requestable_page.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/review_requestable_page.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class ReviewRequestablePage < SitePrism::Page
+      section :form, "form" do
+        section :yes_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(1)"
+        section :no_radio_item,
+                PageObjects::GovukRadioItem,
+                ".govuk-radios__item:nth-of-type(2)"
+        element :note_textarea, ".govuk-textarea"
+        element :submit_button, ".govuk-button"
+      end
+
+      def submit_yes
+        form.yes_radio_item.choose
+        form.submit_button.click
+      end
+
+      def submit_no(note:)
+        form.no_radio_item.choose
+        form.note_textarea.fill_in with: note
+        form.submit_button.click
+      end
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -206,6 +206,16 @@ module PageHelpers
       PageObjects::AssessorInterface::ReviewProfessionalStandingRequest.new
   end
 
+  def assessor_review_qualification_request_page
+    @assessor_review_qualification_request_page ||=
+      PageObjects::AssessorInterface::ReviewQualificationRequest.new
+  end
+
+  def assessor_review_reference_request_page
+    @assessor_review_reference_request_page ||=
+      PageObjects::AssessorInterface::ReviewReferenceRequest.new
+  end
+
   def assessor_review_verifications_page
     @assessor_review_verifications_page ||=
       PageObjects::AssessorInterface::ReviewVerifications.new

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
       :assessor_review_further_information_request_page,
       reference:,
       assessment_id:,
-      further_information_request_id:,
+      id: further_information_request.id,
     )
     and_i_see_the_check_your_answers_items
 
@@ -33,7 +33,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
       :assessor_review_further_information_request_page,
       reference:,
       assessment_id:,
-      further_information_request_id:,
+      id: further_information_request.id,
     )
     and_i_see_the_check_your_answers_items
 
@@ -52,7 +52,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
       :assessor_review_further_information_request_page,
       reference:,
       assessment_id:,
-      further_information_request_id:,
+      id: further_information_request.id,
     )
     and_i_see_the_check_your_answers_items
     and_i_do_not_see_the_review_further_information_form
@@ -88,12 +88,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
   end
 
   def when_i_mark_the_section_as_complete
-    assessor_review_further_information_request_page
-      .form
-      .yes_radio_item
-      .input
-      .click
-    assessor_review_further_information_request_page.form.continue_button.click
+    assessor_review_further_information_request_page.submit_yes
   end
 
   def and_i_see_an_award_qts_option
@@ -103,14 +98,9 @@ RSpec.describe "Assessor reviewing further information", type: :system do
   end
 
   def when_i_mark_the_section_as_incomplete
-    assessor_review_further_information_request_page
-      .form
-      .no_radio_item
-      .input
-      .click
-    assessor_review_further_information_request_page.form.failure_reason_textarea.fill_in with:
-      "Failure reason"
-    assessor_review_further_information_request_page.form.continue_button.click
+    assessor_review_further_information_request_page.submit_no(
+      note: "Failure reason",
+    )
   end
 
   def and_i_see_a_decline_qts_option
@@ -148,9 +138,5 @@ RSpec.describe "Assessor reviewing further information", type: :system do
 
   def assessment_id
     application_form.assessment.id
-  end
-
-  def further_information_request_id
-    further_information_request.id
   end
 end

--- a/spec/system/assessor_interface/reviewing_qualifications_spec.rb
+++ b/spec/system/assessor_interface/reviewing_qualifications_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assessor reviewing qualifications", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_an_assessor_user
+    given_there_is_an_application_form_with_failed_qualifications
+  end
+
+  it "sends for review" do
+    when_i_visit_the(:assessor_application_page, reference:)
+    then_i_see_the(:assessor_application_page, reference:)
+
+    when_i_click_on_verification_decision
+    then_i_see_the(:assessor_complete_assessment_page, reference:)
+
+    when_i_select_send_for_review
+    then_i_see_the(:assessor_assessment_recommendation_review_page, reference:)
+
+    when_i_click_continue_from_review
+    then_i_see_the(:assessor_application_status_page, reference:)
+
+    when_i_click_on_overview_button
+    then_i_see_the(:assessor_application_page, reference:)
+
+    when_i_click_on_review_verifications
+    then_i_see_the(
+      :assessor_review_verifications_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_see_the_qualification_rejected
+
+    when_i_click_on_the_qualification
+    then_i_see_the(
+      :assessor_review_qualification_request_page,
+      reference:,
+      assessment_id:,
+    )
+
+    when_i_submit_yes_on_the_review_form
+    then_i_see_the(
+      :assessor_review_verifications_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_see_the_qualification_accepted
+
+    when_i_click_on_the_qualification
+    then_i_see_the(
+      :assessor_review_qualification_request_page,
+      reference:,
+      assessment_id:,
+    )
+
+    when_i_submit_no_on_the_review_form
+    then_i_see_the(
+      :assessor_review_verifications_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_see_the_qualification_rejected
+
+    when_i_click_on_back_to_overview
+    then_i_see_the(:assessor_application_page, reference:)
+
+    when_i_click_on_assessment_decision
+    then_i_see_the(
+      :assessor_complete_assessment_page,
+      reference:,
+      assessment_id:,
+    )
+  end
+
+  private
+
+  def given_there_is_an_application_form_with_failed_qualifications
+    application_form
+  end
+
+  def when_i_click_on_verification_decision
+    assessor_application_page.verification_decision_task.click
+  end
+
+  def when_i_select_send_for_review
+    assessor_complete_assessment_page.send_for_review.choose
+    assessor_complete_assessment_page.continue_button.click
+  end
+
+  def when_i_click_continue_from_review
+    assessor_assessment_recommendation_review_page.continue_button.click
+  end
+
+  def when_i_click_on_overview_button
+    assessor_application_status_page.button_group.overview_button.click
+  end
+
+  def when_i_click_on_review_verifications
+    assessor_application_page.review_verifications_task.click
+  end
+
+  def when_i_click_on_assessment_decision
+    assessor_application_page.assessment_decision_task.click
+  end
+
+  def when_i_click_on_the_qualification
+    assessor_application_page.task_list.click_item("BSc Teaching")
+  end
+
+  def when_i_submit_yes_on_the_review_form
+    assessor_review_qualification_request_page.submit_yes
+  end
+
+  def when_i_submit_no_on_the_review_form
+    assessor_review_qualification_request_page.submit_no(note: "A note.")
+  end
+
+  def when_i_click_on_back_to_overview
+    assessor_review_verifications_page.back_to_overview_button.click
+  end
+
+  def and_i_see_the_qualification_accepted
+    item =
+      assessor_review_verifications_page.task_list.find_item("BSc Teaching")
+    expect(item.status_tag.text).to eq("ACCEPTED")
+  end
+
+  def and_i_see_the_qualification_rejected
+    item =
+      assessor_review_verifications_page.task_list.find_item("BSc Teaching")
+    expect(item.status_tag.text).to eq("REJECTED")
+  end
+
+  def application_form
+    @application_form ||=
+      create(:application_form, :submitted).tap do |application_form|
+        assessment = create(:assessment, :verify, application_form:)
+        qualification =
+          create(:qualification, application_form:, title: "BSc Teaching")
+        create(
+          :qualification_request,
+          :received,
+          assessment:,
+          qualification:,
+          review_passed: false,
+          verify_passed: false,
+        )
+      end
+  end
+
+  delegate :reference, to: :application_form
+
+  def assessment_id
+    application_form.assessment.id
+  end
+end

--- a/spec/system/assessor_interface/reviewing_references_spec.rb
+++ b/spec/system/assessor_interface/reviewing_references_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assessor reviewing references", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_an_assessor_user
+    given_there_is_an_application_form_with_failed_references
+  end
+
+  it "sends for review" do
+    when_i_visit_the(:assessor_application_page, reference:)
+    then_i_see_the(:assessor_application_page, reference:)
+
+    when_i_click_on_verification_decision
+    then_i_see_the(:assessor_complete_assessment_page, reference:)
+
+    when_i_select_send_for_review
+    then_i_see_the(:assessor_assessment_recommendation_review_page, reference:)
+
+    when_i_click_continue_from_review
+    then_i_see_the(:assessor_application_status_page, reference:)
+
+    when_i_click_on_overview_button
+    then_i_see_the(:assessor_application_page, reference:)
+
+    when_i_click_on_review_verifications
+    then_i_see_the(
+      :assessor_review_verifications_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_see_the_reference_not_started
+
+    when_i_click_on_the_reference
+    then_i_see_the(
+      :assessor_review_reference_request_page,
+      reference:,
+      assessment_id:,
+    )
+
+    when_i_submit_yes_on_the_review_form
+    then_i_see_the(
+      :assessor_review_verifications_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_see_the_reference_accepted
+
+    when_i_click_on_the_reference
+    then_i_see_the(
+      :assessor_review_reference_request_page,
+      reference:,
+      assessment_id:,
+    )
+
+    when_i_submit_no_on_the_review_form
+    then_i_see_the(
+      :assessor_review_verifications_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_see_the_reference_rejected
+
+    when_i_click_on_back_to_overview
+    then_i_see_the(:assessor_application_page, reference:)
+
+    when_i_click_on_assessment_decision
+    then_i_see_the(
+      :assessor_complete_assessment_page,
+      reference:,
+      assessment_id:,
+    )
+  end
+
+  private
+
+  def given_there_is_an_application_form_with_failed_references
+    application_form
+  end
+
+  def when_i_click_on_verification_decision
+    assessor_application_page.verification_decision_task.click
+  end
+
+  def when_i_select_send_for_review
+    assessor_complete_assessment_page.send_for_review.choose
+    assessor_complete_assessment_page.continue_button.click
+  end
+
+  def when_i_click_continue_from_review
+    assessor_assessment_recommendation_review_page.continue_button.click
+  end
+
+  def when_i_click_on_overview_button
+    assessor_application_status_page.button_group.overview_button.click
+  end
+
+  def when_i_click_on_review_verifications
+    assessor_application_page.review_verifications_task.click
+  end
+
+  def when_i_click_on_assessment_decision
+    assessor_application_page.assessment_decision_task.click
+  end
+
+  def when_i_click_on_the_reference
+    assessor_application_page.task_list.click_item("School")
+  end
+
+  def when_i_submit_yes_on_the_review_form
+    assessor_review_reference_request_page.submit_yes
+  end
+
+  def when_i_submit_no_on_the_review_form
+    assessor_review_reference_request_page.submit_no(note: "A note.")
+  end
+
+  def when_i_click_on_back_to_overview
+    assessor_review_verifications_page.back_to_overview_button.click
+  end
+
+  def and_i_see_the_reference_not_started
+    item = assessor_review_verifications_page.task_list.find_item("School")
+    expect(item.status_tag.text).to eq("NOT STARTED")
+  end
+
+  def and_i_see_the_reference_accepted
+    item = assessor_review_verifications_page.task_list.find_item("School")
+    expect(item.status_tag.text).to eq("ACCEPTED")
+  end
+
+  def and_i_see_the_reference_rejected
+    item = assessor_review_verifications_page.task_list.find_item("School")
+    expect(item.status_tag.text).to eq("REJECTED")
+  end
+
+  def application_form
+    @application_form ||=
+      create(:application_form, :submitted).tap do |application_form|
+        assessment =
+          create(
+            :assessment,
+            :verify,
+            application_form:,
+            induction_required: false,
+            references_verified: true,
+          )
+        create(:reference_request, :received, assessment:, verify_passed: false)
+      end
+  end
+
+  delegate :reference, to: :application_form
+
+  def assessment_id
+    application_form.assessment.id
+  end
+end

--- a/spec/system/assessor_interface/verifying_references_spec.rb
+++ b/spec/system/assessor_interface/verifying_references_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Assessor verifying references", type: :system do
   end
 
   def when_i_click_on_a_reference_request
-    assessor_reference_requests_page.task_list.reference_requests.first.click
+    assessor_reference_requests_page.task_list.sections.first.items.first.click
   end
 
   def and_i_see_the_reference_summary
@@ -116,7 +116,14 @@ RSpec.describe "Assessor verifying references", type: :system do
 
   def then_i_see_the_reference_request_status_is_accepted
     expect(
-      assessor_reference_requests_page.task_list.status_tags.first.text,
+      assessor_reference_requests_page
+        .task_list
+        .sections
+        .first
+        .items
+        .first
+        .status_tag
+        .text,
     ).to eq("COMPLETED")
   end
 
@@ -127,7 +134,14 @@ RSpec.describe "Assessor verifying references", type: :system do
 
   def then_i_see_the_verify_references_task_is_completed
     expect(
-      assessor_application_page.verify_references_task.status_tag.text,
+      assessor_reference_requests_page
+        .task_list
+        .sections
+        .first
+        .items
+        .first
+        .status_tag
+        .text,
     ).to eq("COMPLETED")
   end
 


### PR DESCRIPTION
This adds the ability to review qualifications and references. It's not currently possible to get to these URLs directly, but they will be used in the new verification journey.

The designs for the review of qualifications and references matches the existing designs for LoPS which is why we can build this now before building the rest of the qualifications and references journeys.

https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/1830 is based off this branch to show the while flow working together.

## Screenshots

![Screenshot 2023-12-12 at 14 21 17](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/bcd2d539-6ad2-470c-aa59-303fdf5b561c)
![Screenshot 2023-12-12 at 14 21 23](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/cd6bfa08-c2e8-4476-b6cc-113994fb7255)
![Screenshot 2023-12-12 at 14 21 27](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/901faaab-a5a2-4bdb-8244-e4a16770f081)
