### PR TITLE
Swap qualifications

### DIFF
--- a/app/lib/service_pattern.rb
+++ b/app/lib/service_pattern.rb
@@ -11,10 +11,8 @@ module ServicePattern
   end
 
   module ClassMethods
-    def call(**args)
-      return new.call if args.empty?
-
-      new(**args).call
+    def call(*args, **kwargs)
+      new(*args, **kwargs).call
     end
   end
 end

--- a/app/services/swap_qualifications.rb
+++ b/app/services/swap_qualifications.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class SwapQualifications
+  include ServicePattern
+
+  def initialize(qualification1, qualification2, note:, user:)
+    @qualification1 = qualification1
+    @qualification2 = qualification2
+    @note = note
+    @user = user
+
+    if qualification1.application_form != qualification2.application_form
+      raise "Application forms must match."
+    end
+  end
+
+  def call
+    created_at1 = qualification1.created_at
+    created_at2 = qualification2.created_at
+
+    ActiveRecord::Base.transaction do
+      qualification2.update!(created_at: created_at1)
+      qualification1.update!(created_at: created_at2)
+
+      CreateNote.call(
+        application_form: qualification1.application_form,
+        author: user,
+        text: note,
+      )
+    end
+  end
+
+  private
+
+  attr_reader :qualification1, :qualification2, :note, :user
+end

--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -34,4 +34,25 @@ namespace :application_forms do
         puts "#{application_form.reference}: #{application_form.action_required_by} - #{application_form.status}"
       end
   end
+
+  desc "Swap the teaching qualification for an application form."
+  task :swap_teaching_qualification,
+       %i[reference index staff_email] => :environment do |_task, args|
+    application_form = ApplicationForm.find_by!(reference: args[:reference])
+    teaching_qualification = application_form.teaching_qualification
+    degree_qualification =
+      application_form.qualifications.ordered[args[:index].to_i]
+    note =
+      "We switched the teaching qualification to be the first eligible " \
+        "qualification provided from #{teaching_qualification.title} to " \
+        "#{degree_qualification.title}. This was approved by Humzah."
+    user = Staff.find_by!(email: args[:staff_email])
+
+    SwapQualifications.call(
+      teaching_qualification,
+      degree_qualification,
+      note:,
+      user:,
+    )
+  end
 end

--- a/spec/services/swap_qualifications_spec.rb
+++ b/spec/services/swap_qualifications_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SwapQualifications do
+  let(:application_form) { create(:application_form) }
+  let!(:teaching_qualification) do
+    create(:qualification, application_form:, created_at: Date.new(2020, 1, 1))
+  end
+  let!(:degree_qualification) do
+    create(:qualification, application_form:, created_at: Date.new(2020, 1, 2))
+  end
+  let(:note) { "A note." }
+  let(:user) { create(:staff) }
+
+  subject(:call) do
+    described_class.call(
+      teaching_qualification,
+      degree_qualification,
+      note:,
+      user:,
+    )
+  end
+
+  it "swaps the first created_at" do
+    expect { call }.to change(teaching_qualification, :created_at).to(
+      Date.new(2020, 1, 2),
+    )
+  end
+
+  it "swaps the second created_at" do
+    expect { call }.to change(degree_qualification, :created_at).to(
+      Date.new(2020, 1, 1),
+    )
+  end
+
+  it "creates a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :note_created,
+      creator: user,
+    )
+  end
+end


### PR DESCRIPTION
This adds a service which allows us to swap the qualifications on an application, effectively changing which one is the teaching qualification. We also record a note to ensure that we have a record of this being done.

I've tested the task locally, but we will also run this in pre-production before applying to production.