### PR TITLE
Update swap qualifications note text

### DIFF
--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -45,7 +45,7 @@ namespace :application_forms do
     note =
       "We switched the teaching qualification to be the first eligible " \
         "qualification provided from #{teaching_qualification.title} to " \
-        "#{degree_qualification.title}. This was approved by Humzah."
+        "#{degree_qualification.title}. This was approved by Humzah on 12/12/2023."
     user = Staff.find_by!(email: args[:staff_email])
 
     SwapQualifications.call(


### PR DESCRIPTION
This updates the note text when we swap qualifications to make it clearer exactly when it was approved.