### PR TITLE
Handle nil in find_by_email

### DIFF
--- a/app/models/concerns/emailable.rb
+++ b/app/models/concerns/emailable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Emailable
   extend ActiveSupport::Concern
 
@@ -14,7 +16,7 @@ module Emailable
 
   class_methods do
     def find_by_email(email)
-      find_by("LOWER(email) = ?", email.downcase)
+      find_by("LOWER(email) = ?", email&.downcase)
     end
 
     def find_or_initialize_by_email(email)

--- a/spec/models/staff_spec.rb
+++ b/spec/models/staff_spec.rb
@@ -55,6 +55,8 @@ require "rails_helper"
 RSpec.describe Staff, type: :model do
   subject(:staff) { build(:staff) }
 
+  it_behaves_like "an emailable"
+
   describe "validations" do
     it { is_expected.to be_valid }
 

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -27,6 +27,8 @@ require "rails_helper"
 RSpec.describe Teacher, type: :model do
   subject(:teacher) { create(:teacher) }
 
+  it_behaves_like "an emailable"
+
   describe "validations" do
     it { is_expected.to be_valid }
 

--- a/spec/support/shared_examples/emailable.rb
+++ b/spec/support/shared_examples/emailable.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples "an emailable" do
+  describe "#find_by_email" do
+    it "accepts nil" do
+      expect { described_class.find_by_email(nil) }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
This gracefully handles a `nil` value being passed in to this method, in the same way that `find_by(email: nil)` would handle it.