### PR TITLE
Handle applications from countries which are now ineligible

### DIFF
--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -29,6 +29,15 @@ class TeacherMailer < ApplicationMailer
     )
   end
 
+  def application_from_ineligible_country
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: teacher.email,
+      subject:
+        I18n.t("mailer.teacher.application_from_ineligible_country.subject"),
+    )
+  end
+
   def application_not_submitted
     @number_of_reminders_sent = params[:number_of_reminders_sent]
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -182,6 +182,15 @@ class ApplicationForm < ApplicationRecord
           )
         end
 
+  scope :from_ineligible_country,
+        -> do
+          joins(region: :country).where(
+            countries: {
+              eligibility_enabled: false,
+            },
+          )
+        end
+
   def submitted?
     submitted_at.present?
   end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -160,12 +160,10 @@ class ApplicationForm < ApplicationRecord
 
   scope :active,
         -> do
-          where(hidden_from_assessment: false).merge(
-            assessable
-              .or(where("awarded_at >= ?", 90.days.ago))
-              .or(where("declined_at >= ?", 90.days.ago))
-              .or(where("withdrawn_at >= ?", 90.days.ago)),
-          )
+          assessable
+            .or(where("awarded_at >= ?", 90.days.ago))
+            .or(where("declined_at >= ?", 90.days.ago))
+            .or(where("withdrawn_at >= ?", 90.days.ago))
         end
 
   scope :destroyable,

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -177,8 +177,14 @@ class ApplicationForm < ApplicationRecord
 
   scope :remindable,
         -> do
-          verification_stage.or(
-            where(submitted_at: nil).where("created_at < ?", 5.months.ago),
+          joins(region: :country).verification_stage.or(
+            where(
+              countries: {
+                eligibility_enabled: true,
+              },
+              created_at: ...5.months.ago,
+              submitted_at: nil,
+            ),
           )
         end
 

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -13,7 +13,6 @@ class SubmitApplicationForm
 
     ActiveRecord::Base.transaction do
       application_form.update!(
-        hidden_from_assessment:,
         requires_preliminary_check: region.requires_preliminary_check,
         subjects: application_form.subjects.compact_blank,
         submitted_at: Time.zone.now,
@@ -75,9 +74,5 @@ class SubmitApplicationForm
     ProfessionalStandingRequest
       .create!(assessment:)
       .tap { |requestable| RequestRequestable.call(requestable:, user:) }
-  end
-
-  def hidden_from_assessment
-    region.country.code == "ZW"
   end
 end

--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -60,7 +60,7 @@ class TeacherInterface::ApplicationFormViewObject
   end
 
   def declined_reasons
-    if country_ineligible?
+    if from_ineligible_country?
       country_name = CountryName.from_country(region.country)
       teaching_authority_name = region_teaching_authority_name(region)
 
@@ -109,8 +109,6 @@ class TeacherInterface::ApplicationFormViewObject
   def declined_cannot_reapply?
     return false if assessment.nil?
 
-    return true if country_ineligible?
-
     assessment.sections.any? do |section|
       section.selected_failure_reasons.any? do |failure_reason|
         %w[authorisation_to_teach applicant_already_qts].include?(
@@ -118,6 +116,10 @@ class TeacherInterface::ApplicationFormViewObject
         )
       end
     end
+  end
+
+  def from_ineligible_country?
+    @from_ineligible_country ||= !region.country.eligibility_enabled
   end
 
   def request_further_information?
@@ -217,10 +219,6 @@ class TeacherInterface::ApplicationFormViewObject
 
   def task_list_item_status(key)
     application_form.send("#{key}_status")
-  end
-
-  def country_ineligible?
-    @country_ineligible ||= !region.country.eligibility_enabled
   end
 
   def assessment_declined_reasons

--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -9,7 +9,7 @@ class TeacherInterface::ApplicationFormViewObject
 
   attr_reader :application_form
 
-  delegate :assessment, :region, :teacher, to: :application_form
+  delegate :assessment, :country, :region, :teacher, to: :application_form
 
   def further_information_request
     @further_information_request ||=
@@ -61,7 +61,7 @@ class TeacherInterface::ApplicationFormViewObject
 
   def declined_reasons
     if from_ineligible_country?
-      country_name = CountryName.from_country(region.country)
+      country_name = CountryName.from_country(country)
       teaching_authority_name = region_teaching_authority_name(region)
 
       {
@@ -119,7 +119,7 @@ class TeacherInterface::ApplicationFormViewObject
   end
 
   def from_ineligible_country?
-    @from_ineligible_country ||= !region.country.eligibility_enabled
+    @from_ineligible_country ||= !country.eligibility_enabled
   end
 
   def request_further_information?

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -12,6 +12,8 @@
   <%= render "teacher_interface/application_forms/show/request_professional_standing_certificate", view_object: @view_object %>
 <% elsif @view_object.application_form.submitted? %>
   <%= render "teacher_interface/application_forms/show/complete", view_object: @view_object %>
+<% elsif @view_object.from_ineligible_country? %>
+  <%= render "teacher_interface/application_forms/show/from_ineligible_country", view_object: @view_object %>
 <% else %>
   <%= render "teacher_interface/application_forms/show/draft", view_object: @view_object %>
 <% end %>

--- a/app/views/teacher_interface/application_forms/show/_declined.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_declined.html.erb
@@ -19,23 +19,27 @@
 <% unless view_object.declined_cannot_reapply? %>
   <h2 class="govuk-heading-l">What you can do next</h2>
 
-  <p class="govuk-body">You’ll be able to make a new application for QTS once you've addressed the decline reasons we've given. If you reapply for QTS, you’ll not be able to review the details of your previous application.</p>
+  <% unless view_object.from_ineligible_country? %>
+    <p class="govuk-body">You’ll be able to make a new application for QTS once you've addressed the decline reasons we've given. If you reapply for QTS, you’ll not be able to review the details of your previous application.</p>
 
-  <p class="govuk-body"><%= govuk_button_link_to "Apply again", %i[new teacher_interface application_form] %></p>
+    <p class="govuk-body"><%= govuk_button_link_to "Apply again", %i[new teacher_interface application_form] %></p>
+  <% end %>
 
   <p class="govuk-body">You may want to <%= govuk_link_to "explore other routes to getting QTS", "https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk" %>.</p>
 <% end %>
 
-<h2 class="govuk-heading-l">Decision review</h2>
+<% unless view_object.from_ineligible_country? %>
+  <h2 class="govuk-heading-l">Decision review</h2>
 
-<p class="govuk-body">Applicants who have been declined for QTS are entitled to a review of the decline decision by a Casework Manager.</p>
-<p class="govuk-body">If you would like to request a decision review, you’ll need to provide:</p>
+  <p class="govuk-body">Applicants who have been declined for QTS are entitled to a review of the decline decision by a Casework Manager.</p>
+  <p class="govuk-body">If you would like to request a decision review, you’ll need to provide:</p>
 
-<ul class="govuk-list govuk-list--bullet">
-  <li>formal evidence and reasoning as to how you meet the required assessment criteria</li>
-  <li>additional information not included in your original application that would support your decision review</li>
-</ul>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>formal evidence and reasoning as to how you meet the required assessment criteria</li>
+    <li>additional information not included in your original application that would support your decision review</li>
+  </ul>
 
-<p class="govuk-body">Your request for review must be received within 28 days of receipt of the decision to decline QTS.</p>
-<p class="govuk-body">Email your request for review, including the information required as above, to <%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %>.</p>
-<p class="govuk-body">If you are not satisfied with the outcome of the decision review, you can request a final formal appeal to a senior Teacher Qualification Manager.</p>
+  <p class="govuk-body">Your request for review must be received within 28 days of receipt of the decision to decline QTS.</p>
+  <p class="govuk-body">Email your request for review, including the information required as above, to <%= govuk_link_to t("service.email.enquiries"), "mailto:#{t("service.email.enquiries")}" %>.</p>
+  <p class="govuk-body">If you are not satisfied with the outcome of the decision review, you can request a final formal appeal to a senior Teacher Qualification Manager.</p>
+<% end %>

--- a/app/views/teacher_interface/application_forms/show/_declined.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_declined.html.erb
@@ -16,20 +16,10 @@
   </ul>
 <% end %>
 
-<% unless view_object.declined_cannot_reapply? %>
-  <h2 class="govuk-heading-l">What you can do next</h2>
-
-  <% unless view_object.from_ineligible_country? %>
-    <p class="govuk-body">You’ll be able to make a new application for QTS once you've addressed the decline reasons we've given. If you reapply for QTS, you’ll not be able to review the details of your previous application.</p>
-
-    <p class="govuk-body"><%= govuk_button_link_to "Apply again", %i[new teacher_interface application_form] %></p>
-  <% end %>
-
-  <p class="govuk-body">You may want to <%= govuk_link_to "explore other routes to getting QTS", "https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk" %>.</p>
-<% end %>
+<%= render "teacher_interface/application_forms/show/what_can_you_do_next", view_object: %>
 
 <% unless view_object.from_ineligible_country? %>
-  <h2 class="govuk-heading-l">Decision review</h2>
+  <h3 class="govuk-heading-m">Decision review</h3>
 
   <p class="govuk-body">Applicants who have been declined for QTS are entitled to a review of the decline decision by a Casework Manager.</p>
   <p class="govuk-body">If you would like to request a decision review, you’ll need to provide:</p>

--- a/app/views/teacher_interface/application_forms/show/_from_ineligible_country.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_from_ineligible_country.html.erb
@@ -1,0 +1,21 @@
+<h2 class="govuk-heading-l">Your QTS application has been closed</h2>
+
+<p class="govuk-body">
+  Thank you for beginning your application for qualified teacher status (QTS) in England. Unfortunately, your application has been closed.
+</p>
+
+<p class="govuk-body">
+  As we are unable to verify professional standing documents with the <%= region_teaching_authority_name(view_object.region) %> in <%= CountryName.from_country(view_object.country) %>, we have removed <%= CountryName.from_country(view_object.country) %> from the list of eligible countries.
+</p>
+
+<p class="govuk-body">
+  This means you will not be able to complete and submit your application.
+</p>
+
+<h3 class="govuk-heading-m">Why we need to verify documents</h3>
+
+<p class="govuk-body">
+  We need to be able to verify all documents submitted by applicants with the relevant authorities. This is to ensure QTS requirements are applied fairly and consistently to every teacher, regardless of the country they trained to teach in.
+</p>
+
+<%= render "teacher_interface/application_forms/show/what_can_you_do_next", view_object: %>

--- a/app/views/teacher_interface/application_forms/show/_what_can_you_do_next.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_what_can_you_do_next.html.erb
@@ -1,0 +1,11 @@
+<% unless view_object.declined_cannot_reapply? %>
+  <h3 class="govuk-heading-m">What you can do next</h3>
+
+  <% unless view_object.from_ineligible_country? %>
+    <p class="govuk-body">You’ll be able to make a new application for QTS once you've addressed the decline reasons we've given. If you reapply for QTS, you’ll not be able to review the details of your previous application.</p>
+
+    <p class="govuk-body"><%= govuk_button_link_to "Apply again", %i[new teacher_interface application_form] %></p>
+  <% end %>
+
+  <p class="govuk-body">You may want to <%= govuk_link_to "explore other routes to getting QTS", "https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk" %>.</p>
+<% end %>

--- a/app/views/teacher_mailer/application_declined.text.erb
+++ b/app/views/teacher_mailer/application_declined.text.erb
@@ -16,7 +16,7 @@ Thank you for applying for QTS in England. Unfortunately, your application has b
 <% end %>
 
 <% end %>
-<% unless @view_object.declined_cannot_reapply? %>
+<% unless @view_object.declined_cannot_reapply? || @view_object.from_ineligible_country? %>
 # What you can do next
 
 You’ll be able to make a new application for QTS once you've addressed the decline reasons we've given. If you reapply for QTS, you’ll not be able to review the details of your previous application.
@@ -26,6 +26,7 @@ You’ll be able to make a new application for QTS once you've addressed the dec
 You may want to [explore other routes to getting QTS](https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk).
 
 <% end %>
+<% unless @view_object.from_ineligible_country? %>
 # Decision review
 
 Applicants who have been declined for QTS are entitled to a review of the decline decision by a Casework Manager.
@@ -38,6 +39,7 @@ Your request for review must be received within 28 days of receipt of the decisi
 
 If you are not satisfied with the outcome of the decision review, you can request a final formal appeal to a senior Teacher Qualification Manager.
 
+<% end %>
 [Sign in](<%= new_teacher_session_url %>) to review the outcome of your application.
 
 <%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/application_declined.text.erb
+++ b/app/views/teacher_mailer/application_declined.text.erb
@@ -1,4 +1,8 @@
+<% if @view_object.from_ineligible_country? %>
+Dear <%= application_form_full_name(@application_form) %>,
+<% else %>
 Dear <%= application_form_full_name(@application_form) %>
+<% end %>
 
 <%= render "shared/teacher_mailer/reference_number" %>
 
@@ -12,9 +16,9 @@ Thank you for applying for QTS in England. Unfortunately, your application has b
 
 <% end %>
 <% reasons.each do |reason| %>
-- <%= reason.gsub("\n\n", "\n").gsub("\n", "\n  ") %>
-<% end %>
+<%= reason %>
 
+<% end %>
 <% end %>
 <% unless @view_object.declined_cannot_reapply? || @view_object.from_ineligible_country? %>
 # What you can do next
@@ -26,7 +30,9 @@ You’ll be able to make a new application for QTS once you've addressed the dec
 You may want to [explore other routes to getting QTS](https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk).
 
 <% end %>
-<% unless @view_object.from_ineligible_country? %>
+<% if @view_object.from_ineligible_country? %>
+[Sign in](<%= new_teacher_session_url %>) for more information about QTS in England.
+<% else %>
 # Decision review
 
 Applicants who have been declined for QTS are entitled to a review of the decline decision by a Casework Manager.
@@ -39,7 +45,7 @@ Your request for review must be received within 28 days of receipt of the decisi
 
 If you are not satisfied with the outcome of the decision review, you can request a final formal appeal to a senior Teacher Qualification Manager.
 
-<% end %>
 [Sign in](<%= new_teacher_session_url %>) to review the outcome of your application.
+<% end %>
 
 <%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/application_from_ineligible_country.text.erb
+++ b/app/views/teacher_mailer/application_from_ineligible_country.text.erb
@@ -1,0 +1,15 @@
+Dear <%= application_form_full_name(@application_form) %>,
+
+Thank you for beginning your application for qualified teacher status (QTS) in England. Unfortunately, we have had to close your application.
+
+As we are unable to verify professional standing documents with the <%= region_teaching_authority_name(@application_form.region) %> in <%= CountryName.from_country(@application_form.country) %>, we have removed <%= CountryName.from_country(@application_form.country) %> from the list of eligible countries.
+
+This means you will not be able to complete and submit your application.
+
+## Why we need to verify documents
+
+We need to be able to verify all documents submitted by applicants with the relevant authorities. This is to ensure QTS requirements are applied fairly and consistently to every teacher, regardless of the country they trained to teach in.
+
+[Sign in](<%= new_teacher_session_url %>) for more information about QTS in England.
+
+<%= render "shared/teacher_mailer/footer" %>

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -12,6 +12,8 @@ en:
         subject: Your QTS application was successful
       application_declined:
         subject: Your QTS application was unsuccessful
+      application_from_ineligible_country:
+        subject: "Update: Your qualified teacher status (QTS) application"
       application_not_submitted:
         subject:
           0: Your draft QTS application will be deleted in 2 weeks

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -306,8 +306,14 @@ COUNTRIES = {
   },
   "UA" => [{ reduced_evidence_accepted: true }],
   "ZW" => {
+    eligibility_enabled: false,
     subject_limited: true,
-    regions: [{ status_check: "written" }],
+    regions: [
+      {
+        status_check: "written",
+        teaching_authority_name: "Ministry of Primary and Secondary Education",
+      },
+    ],
   },
   "GG" => [],
   "JE" => [],

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -325,14 +325,6 @@ RSpec.describe ApplicationForm, type: :model do
 
         it { is_expected.to eq([application_form]) }
       end
-
-      context "when hidden from assessment" do
-        before do
-          create(:application_form, :submitted, hidden_from_assessment: true)
-        end
-
-        it { is_expected.to be_empty }
-      end
     end
 
     describe "#destroyable" do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -409,6 +409,23 @@ RSpec.describe ApplicationForm, type: :model do
         it { is_expected.to be_empty }
       end
     end
+
+    describe "#from_ineligible_country" do
+      subject(:from_ineligible_country) do
+        described_class.from_ineligible_country
+      end
+
+      let(:eligible_application_form) { create(:application_form) }
+      let(:ineligible_application_form) do
+        create(
+          :application_form,
+          region: create(:region, country: create(:country, :ineligible)),
+        )
+      end
+
+      it { is_expected.to_not include(eligible_application_form) }
+      it { is_expected.to include(ineligible_application_form) }
+    end
   end
 
   it "attaches empty documents" do

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -25,26 +25,6 @@ RSpec.describe SubmitApplicationForm do
     end
   end
 
-  describe "hidden_from_assessment column" do
-    context "when country is not Zimbabwe and work history is above 9 months" do
-      let(:region) { create(:region, :in_country, country_code: "FR") }
-
-      it "doesn't hide the application form" do
-        expect { call }.to_not change(application_form, :hidden_from_assessment)
-      end
-    end
-
-    context "when country is Zimbabwe" do
-      let(:region) { create(:region, :in_country, country_code: "ZW") }
-
-      it "hides the application form" do
-        expect { call }.to change(application_form, :hidden_from_assessment).to(
-          true,
-        )
-      end
-    end
-  end
-
   describe "compacting blank subjects" do
     subject(:subjects) { application_form.subjects }
 

--- a/spec/view_objects/teacher_interface/application_form_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_view_object_spec.rb
@@ -5,7 +5,9 @@ require "rails_helper"
 RSpec.describe TeacherInterface::ApplicationFormViewObject do
   subject(:view_object) { described_class.new(application_form:) }
 
-  let(:application_form) { create(:application_form) }
+  let(:country) { create(:country) }
+  let(:region) { create(:region, country:) }
+  let(:application_form) { create(:application_form, region:) }
 
   describe "#assessment" do
     subject(:assessment) { view_object.assessment }
@@ -206,6 +208,24 @@ RSpec.describe TeacherInterface::ApplicationFormViewObject do
     it { is_expected.to be_empty }
 
     let(:assessment) { create(:assessment, application_form:) }
+
+    context "when the country has been made ineligible" do
+      let(:country) { create(:country, :ineligible, code: "ZW") }
+
+      it do
+        is_expected.to eq(
+          {
+            "" => [
+              "As we are unable to verify professional standing documents with the teaching authority in Zimbabwe, " \
+                "we have removed Zimbabwe from the list of eligible countries.\n\nWe need to be able to verify all " \
+                "documents submitted by applicants with the relevant authorities. This is to ensure QTS requirements " \
+                "are applied fairly and consistently to every teacher, regardless of the country they trained to " \
+                "teach in.",
+            ],
+          },
+        )
+      end
+    end
 
     context "when further_information_request is present and expired" do
       before { create(:further_information_request, :expired, assessment:) }

--- a/spec/view_objects/teacher_interface/application_form_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_view_object_spec.rb
@@ -332,15 +332,21 @@ RSpec.describe TeacherInterface::ApplicationFormViewObject do
 
         it { is_expected.to be true }
       end
+    end
+  end
 
-      context "with an ineligible country" do
-        let(:country) { create(:country, :ineligible) }
-        let(:application_form) do
-          create(:application_form, region: create(:region, country:))
-        end
+  describe "#from_ineligible_country?" do
+    subject(:from_ineligible_country?) { view_object.from_ineligible_country? }
 
-        it { is_expected.to be true }
+    it { is_expected.to be false }
+
+    context "with an ineligible country" do
+      let(:country) { create(:country, :ineligible) }
+      let(:application_form) do
+        create(:application_form, region: create(:region, country:))
       end
+
+      it { is_expected.to be true }
     end
   end
 


### PR DESCRIPTION
This adds the ability to delete or decline applications which are now associated with a country that has become ineligible since the applications were started or submitted. For draft applications we send a bespoke email before deleting the application, and for submitted applications they are declined and see an appropriate reason.
