### PR TITLE
Remove hidden_from_assessment column

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -24,7 +24,6 @@
 #  given_names                                   :text             default(""), not null
 #  has_alternative_name                          :boolean
 #  has_work_history                              :boolean
-#  hidden_from_assessment                        :boolean          default(FALSE), not null
 #  identification_document_status                :string           default("not_started"), not null
 #  needs_registration_number                     :boolean          not null
 #  needs_work_history                            :boolean          not null

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -21,8 +21,6 @@
     - record_id
     - blob_id
     - created_at
-  :application_forms:
-    - hidden_from_assessment
   :sessions:
     - id
     - session_id

--- a/db/migrate/20231221091416_remove_hidden_from_assessment_from_application_forms.rb
+++ b/db/migrate/20231221091416_remove_hidden_from_assessment_from_application_forms.rb
@@ -1,0 +1,11 @@
+class RemoveHiddenFromAssessmentFromApplicationForms < ActiveRecord::Migration[
+  7.1
+]
+  def change
+    remove_column :application_forms,
+                  :hidden_from_assessment,
+                  :boolean,
+                  default: false,
+                  null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_07_095541) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_21_091416) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -95,7 +95,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_07_095541) do
     t.string "action_required_by", default: "none", null: false
     t.string "stage", default: "draft", null: false
     t.string "statuses", default: ["draft"], null: false, array: true
-    t.boolean "hidden_from_assessment", default: false, null: false
     t.boolean "qualification_changed_work_history_duration", default: false, null: false
     t.index ["action_required_by"], name: "index_application_forms_on_action_required_by"
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -24,7 +24,6 @@
 #  given_names                                   :text             default(""), not null
 #  has_alternative_name                          :boolean
 #  has_work_history                              :boolean
-#  hidden_from_assessment                        :boolean          default(FALSE), not null
 #  identification_document_status                :string           default("not_started"), not null
 #  needs_registration_number                     :boolean          not null
 #  needs_work_history                            :boolean          not null

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -24,7 +24,6 @@
 #  given_names                                   :text             default(""), not null
 #  has_alternative_name                          :boolean
 #  has_work_history                              :boolean
-#  hidden_from_assessment                        :boolean          default(FALSE), not null
 #  identification_document_status                :string           default("not_started"), not null
 #  needs_registration_number                     :boolean          not null
 #  needs_work_history                            :boolean          not null


### PR DESCRIPTION
This removes a column which we used previously to hide applications from assessors, but we're no longer using this feature so we can remove the column to reduce maintenance.

This can only be merged after #1881 is deployed.