### PR TITLE
Remove BackLinkHelper

### DIFF
--- a/app/helpers/back_link_helper.rb
+++ b/app/helpers/back_link_helper.rb
@@ -1,5 +1,0 @@
-module BackLinkHelper
-  def back_link_url(back = url_for(:back))
-    params[:next].presence || back
-  end
-end

--- a/app/views/eligibility_interface/countries/new.html.erb
+++ b/app/views/eligibility_interface/countries/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix(t("helpers.label.eligibility_interface_country_form.location"), error: @form.errors.any?) %>
-<% content_for :back_link_url, back_link_url(FeatureFlags::FeatureFlag.active?(:teacher_applications) ? create_or_new_teacher_session_path : eligibility_interface_start_path) %>
+<% content_for :back_link_url, FeatureFlags::FeatureFlag.active?(:teacher_applications) ? create_or_new_teacher_session_path : eligibility_interface_start_path %>
 
 <%= form_with model: @form, url: [:eligibility_interface, :countries] do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/eligibility_interface/degrees/new.html.erb
+++ b/app/views/eligibility_interface/degrees/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Do you have a university degree?", error: @form.errors.any?) %>
-<% content_for :back_link_url, back_link_url(eligibility_interface_qualifications_path) %>
+<% content_for :back_link_url, eligibility_interface_qualifications_path %>
 
 <%= form_with model: @form, url: [:eligibility_interface, :degree] do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/eligibility_interface/misconduct/new.html.erb
+++ b/app/views/eligibility_interface/misconduct/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Do you have any sanctions or restrictions on your employment record?", error: @form.errors.any?) %>
-<% content_for :back_link_url, back_link_url(eligibility_interface_work_experience_path) %>
+<% content_for :back_link_url, eligibility_interface_work_experience_path %>
 
 <%= form_with model: @form, url: [:eligibility_interface, :misconduct] do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/eligibility_interface/qualifications/new.html.erb
+++ b/app/views/eligibility_interface/qualifications/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Do you have a teaching qualification?", error: @form.errors.any?) %>
-<% content_for :back_link_url, back_link_url(eligibility_interface_countries_path) %>
+<% content_for :back_link_url, eligibility_interface_countries_path %>
 
 <%= form_with model: @form, url: [:eligibility_interface, :qualifications] do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/eligibility_interface/qualified_for_subject/new.html.erb
+++ b/app/views/eligibility_interface/qualified_for_subject/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Does your teaching qualification or university degree qualify you to teach one of the following subjects?", error: @form.errors.any?) %>
-<% content_for :back_link_url, back_link_url(eligibility_interface_teach_children_path) %>
+<% content_for :back_link_url, eligibility_interface_teach_children_path %>
 
 <%= form_with model: @form, url: [:eligibility_interface, :qualified_for_subject] do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/eligibility_interface/region/new.html.erb
+++ b/app/views/eligibility_interface/region/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix(t("helpers.legend.eligibility_interface_region_form.region_id"), error: @form.errors.any?) %>
-<% content_for :back_link_url, back_link_url(eligibility_interface_countries_path) %>
+<% content_for :back_link_url, eligibility_interface_countries_path %>
 
 <%= form_with model: @form, url: [:eligibility_interface, :region] do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/eligibility_interface/result/eligible.html.erb
+++ b/app/views/eligibility_interface/result/eligible.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "You’re eligible" %>
-<% content_for :back_link_url, back_link_url %>
+<% content_for :back_link_url, eligibility_interface_misconduct_path %>
 
 <%= render "shared/eligible_region_content", region: @region, eligibility_check: @eligibility_check %>
 

--- a/app/views/eligibility_interface/result/ineligible.html.erb
+++ b/app/views/eligibility_interface/result/ineligible.html.erb
@@ -1,11 +1,13 @@
+<% ineligible_country = @eligibility_check.ineligible_reasons.include?(:country) %>
+
 <% content_for :page_title, "You’re not eligible" %>
-<% content_for :back_link_url, back_link_url %>
+<% content_for :back_link_url, ineligible_country ? eligibility_interface_countries_path : eligibility_interface_misconduct_path %>
 
 <h1 class="govuk-heading-xl">
   You’re not eligible to apply for qualified teacher status (QTS) in England
 </h1>
 
-<% if @eligibility_check.ineligible_reasons.include?(:country) %>
+<% if ineligible_country %>
   <% if @eligibility_check.england_or_wales? %>
     <p class="govuk-body">This service is for qualified teachers who trained to teach outside of England who want to apply for qualified teacher status (QTS) to teach in English schools.</p>
     <p class="govuk-body">If you trained in England or Wales, or have not yet qualified, learn more about <%= govuk_link_to "other routes to QTS", "https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk" %>.</p>
@@ -48,7 +50,7 @@
   <% end %>
 <% end %>
 
-<% if @eligibility_check.ineligible_reasons.include?(:country) %>
+<% if ineligible_country %>
   <%= render "shared/help_us_to_improve_this_service" %>
 <% else %>
   <p class="govuk-body">If you have any questions about QTS contact the help team at:</p>

--- a/app/views/eligibility_interface/teach_children/new.html.erb
+++ b/app/views/eligibility_interface/teach_children/new.html.erb
@@ -10,7 +10,7 @@
 %>
 
 <% content_for :page_title, title_with_error_prefix(legend, error: @form.errors.any?) %>
-<% content_for :back_link_url, back_link_url(eligibility_interface_degree_path) %>
+<% content_for :back_link_url, eligibility_interface_degree_path %>
 
 <%= form_with model: @form, url: [:eligibility_interface, :teach_children] do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/eligibility_interface/work_experience/new.html.erb
+++ b/app/views/eligibility_interface/work_experience/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix(t("helpers.legend.eligibility_interface_work_experience_form.work_experience"), error: @form.errors.any?) %>
-<% content_for :back_link_url, back_link_url(@eligibility_check.qualified_for_subject_required? ? eligibility_interface_qualified_for_subject_path : eligibility_interface_teach_children_path) %>
+<% content_for :back_link_url, @eligibility_check.qualified_for_subject_required? ? eligibility_interface_qualified_for_subject_path : eligibility_interface_teach_children_path %>
 
 <%= form_with model: @form, url: [:eligibility_interface, :work_experience] do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/shared/eligible_region_content_components/_english_language.html.erb
+++ b/app/views/shared/eligible_region_content_components/_english_language.html.erb
@@ -45,7 +45,7 @@
 <% if region.reduced_evidence_accepted %>
   <p class="govuk-body">Find an <a href="https://register.ofqual.gov.uk/Search?category=Qualifications&query=ESOl" class="govuk-link">approved provider</a> if you need to get an English language certificate.</p>
 <% else %>
-  <p class="govuk-body">Find an <%= govuk_link_to "approved provider", english_language_guidance_path%> if you need to get an English language certificate.</p>
+  <p class="govuk-body">Find an <%= govuk_link_to "approved provider", english_language_guidance_path %> if you need to get an English language certificate.</p>
 <% end %>
 
 <%= govuk_details(summary_text: "What if you have more than one nationality?") do %>

--- a/app/views/static/english_language_guidance.html.erb
+++ b/app/views/static/english_language_guidance.html.erb
@@ -1,5 +1,4 @@
 <% content_for :page_title, "English language guidance" %>
-<% content_for :back_link_url, back_link_url %>
 
 <h1 class="govuk-heading-xl">Use an English language test in your qualified teacher status (QTS) application</h1>
 

--- a/app/views/support_interface/english_language_providers/edit.html.erb
+++ b/app/views/support_interface/english_language_providers/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Edit ‘#{@english_language_provider.name}’" %>
-<% content_for :back_link_url, back_link_url(support_interface_english_language_providers_path) %>
+<% content_for :back_link_url, support_interface_english_language_providers_path %>
 
 <h1 class="govuk-heading-l"><%= yield(:page_title) %></h1>
 

--- a/app/views/teachers/sessions/new_or_create.html.erb
+++ b/app/views/teachers/sessions/new_or_create.html.erb
@@ -1,4 +1,4 @@
-<% content_for :back_link_url, back_link_url(eligibility_interface_start_path) %>
+<% content_for :back_link_url, eligibility_interface_start_path %>
 
 <h1 class="govuk-heading-l">
   Check your eligibility to apply for qualified teacher status (QTS) in England


### PR DESCRIPTION
We're not using a `next` parameter on the eligibility checker where this helper is being used, so we can reduce the chances of it being used maliciously.