### PR TITLE
Enable analytics entity table check

### DIFF
--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 DfE::Analytics.configure do |config|
-  config.queue = :analytics
+  config.entity_table_checks_enabled = Rails.env.production?
   config.environment = HostingEnvironment.name
+  config.queue = :analytics
 
   config.enable_analytics =
     proc do

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -45,6 +45,11 @@ send_reference_request_reminders:
   class: SendReminderEmailsJob
   args: ["ReferenceRequest"]
 
+analytics_entity_table_check:
+  cron: "0 4 * * *"
+  class: DfE::Analytics::EntityTableCheckJob
+  queue: analytics
+
 fetch_malware_scan_results:
   cron: "*/30 * * * *"
   class: FetchMalwareScanResultsJob


### PR DESCRIPTION
This enables a new feature of DfE Analytics that allows us to check the latest version of an entity table in BigQuery is in sync with the database.