### PR TITLE
Aqts 36 add decline note to timeline for all cases

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -61,6 +61,24 @@
         has changed from <strong class="govuk-!-font-weight-bold"><%= description_vars[:old_value] %></strong>
         to <strong class="govuk-!-font-weight-bold"><%= description_vars[:new_value] %></strong>.
       </p>
+
+    <% elsif timeline_event.application_declined? %>
+      <p class="govuk-body">
+        Status has changed to: <%= render(StatusTag::Component.new(:declined)) %>
+      </p>
+      
+      <% TeacherInterface::ApplicationFormViewObject.new(application_form: timeline_event.application_form).declined_reasons.each do |title, reasons| %>
+        <% if title.present? %>
+          <h4 class="govuk-heading-s"><%= title %></h4>
+        <% end %>
+
+        <ul class="govuk-list govuk-list--bullet">
+          <% reasons.each do |reason| %>
+            <li><%= simple_format reason %></li>
+          <% end %>
+        </ul>
+      <% end %>
+
     <% else %>
       <p class="govuk-body"><%= simple_format description.html_safe %></p>
     <% end %>

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -199,5 +199,9 @@ module TimelineEntry
           ).strip,
       }
     end
+
+    def application_declined_vars
+      {}
+    end
   end
 end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -64,6 +64,7 @@ class TimelineEvent < ApplicationRecord
   enum event_type: {
          action_required_by_changed: "action_required_by_changed",
          age_range_subjects_verified: "age_range_subjects_verified",
+         application_declined: "application_declined",
          assessment_section_recorded: "assessment_section_recorded",
          assessor_assigned: "assessor_assigned",
          email_sent: "email_sent",

--- a/app/services/decline_qts.rb
+++ b/app/services/decline_qts.rb
@@ -14,6 +14,7 @@ class DeclineQTS
     ActiveRecord::Base.transaction do
       application_form.update!(declined_at: Time.zone.now)
       ApplicationFormStatusUpdater.call(application_form:, user:)
+      CreateTimelineEvent.call("application_declined", application_form:, user:)
     end
 
     TeacherMailer.with(application_form:).application_declined.deliver_later

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -51,6 +51,7 @@ en:
       title:
         action_required_by_changed: Action required by changed
         age_range_subjects_verified: Age range and subjects verified
+        application_declined: Application declined
         assessment_section_completed: Section completed
         assessment_section_recorded: Assessment section recorded
         assessor_assigned: Assessor assigned

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe TimelineEvent do
       is_expected.to define_enum_for(:event_type).with_values(
         action_required_by_changed: "action_required_by_changed",
         age_range_subjects_verified: "age_range_subjects_verified",
+        application_declined: "application_declined",
         assessment_section_recorded: "assessment_section_recorded",
         assessor_assigned: "assessor_assigned",
         email_sent: "email_sent",

--- a/spec/services/decline_qts_spec.rb
+++ b/spec/services/decline_qts_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe DeclineQTS do
         )
       end
     end
+
+    it "records a timeline event" do
+      expect { call }.to have_recorded_timeline_event(
+        :application_declined,
+        creator: user,
+        application_form:,
+      )
+    end
   end
 
   context "with a declined application form" do
@@ -51,6 +59,14 @@ RSpec.describe DeclineQTS do
 
     it "doesn't change the declined at date" do
       expect { call }.to_not change(application_form, :declined_at)
+    end
+
+    it "doesn't record a timeline event" do
+      expect { call }.to_not have_recorded_timeline_event(
+        :application_declined,
+        creator: user,
+        application_form:,
+      )
     end
   end
 end

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe "Assessor completing assessment", type: :system do
     double(generate_template_preview: notify_template_preview)
   end
   let(:notify_template_preview) { double(html: "I am an email") }
+  let(:assessor_user) do
+    create(:staff, :with_assess_permission, :confirmed, name: "Authorized User")
+  end
 
   around do |example|
     ClimateControl.modify GOVUK_NOTIFY_API_KEY: notify_key do
@@ -184,6 +187,9 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_click_on_overview_button
     then_the_application_form_is_declined
+
+    and_i_click_view_timeline
+    then_i_see_application_declined
   end
 
   private
@@ -397,6 +403,21 @@ RSpec.describe "Assessor completing assessment", type: :system do
     expect(assessor_application_page.status_summary.value).to have_text(
       "DECLINED",
     )
+  end
+
+  def and_i_click_view_timeline
+    assessor_application_page.click_link(
+      "View timeline of this applications actions",
+    )
+  end
+
+  def then_i_see_application_declined
+    declined_timeline_event =
+      assessor_timeline_page.timeline_items.find do |timeline_event|
+        timeline_event.title.text.include?("Application declined")
+      end
+
+    expect(declined_timeline_event).to_not be_nil
   end
 
   delegate :reference, to: :application_form


### PR DESCRIPTION
This feature will add a Declined status tag under a new Application Declined timeline even for all cases where the application has been declined. All notes for decline reason will also show in the timeline event.

https://dfedigital.atlassian.net/jira/software/projects/AQTS/boards/207?selectedIssue=AQTS-36