### PR TITLE
Add create timeline event service

### DIFF
--- a/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
+++ b/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
@@ -66,10 +66,10 @@ module AssessorInterface::AgeRangeSubjectsForm
   end
 
   def create_timeline_event
-    TimelineEvent.create!(
-      creator: user,
-      event_type: "age_range_subjects_verified",
+    CreateTimelineEvent.call(
+      "age_range_subjects_verified",
       application_form:,
+      user:,
       assessment:,
       age_range_min: assessment.age_range_min,
       age_range_max: assessment.age_range_max,

--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -13,8 +13,10 @@ class ApplicationFormStatusUpdater
       if (old_action_required_by = application_form.action_required_by) !=
            action_required_by
         application_form.action_required_by = action_required_by
-        create_timeline_event(
-          event_type: "action_required_by_changed",
+        CreateTimelineEvent.call(
+          "action_required_by_changed",
+          application_form:,
+          user:,
           old_value: old_action_required_by,
           new_value: action_required_by,
         )
@@ -22,8 +24,10 @@ class ApplicationFormStatusUpdater
 
       if (old_stage = application_form.stage) != stage
         application_form.stage = stage
-        create_timeline_event(
-          event_type: "stage_changed",
+        CreateTimelineEvent.call(
+          "stage_changed",
+          application_form:,
+          user:,
           old_value: old_stage,
           new_value: stage,
         )
@@ -284,18 +288,5 @@ class ApplicationFormStatusUpdater
       .reject(&:reviewed?)
       .reject(&:expired?)
       .any?(&:received?)
-  end
-
-  def create_timeline_event(event_type:, **kwargs)
-    creator = user.is_a?(String) ? nil : user
-    creator_name = user.is_a?(String) ? user : ""
-
-    TimelineEvent.create!(
-      application_form:,
-      event_type:,
-      creator:,
-      creator_name:,
-      **kwargs,
-    )
   end
 end

--- a/app/lib/application_mailer_observer.rb
+++ b/app/lib/application_mailer_observer.rb
@@ -12,10 +12,12 @@ class ApplicationMailerObserver
       return
     end
 
-    TimelineEvent.create!(
-      creator_name: "Mailer",
-      event_type: "email_sent",
-      application_form_id:,
+    application_form = ApplicationForm.find(application_form_id)
+
+    CreateTimelineEvent.call(
+      "email_sent",
+      application_form:,
+      user: "Mailer",
       mailer_class_name:,
       mailer_action_name:,
       message_subject:,

--- a/app/services/assign_application_form_assessor.rb
+++ b/app/services/assign_application_form_assessor.rb
@@ -15,10 +15,10 @@ class AssignApplicationFormAssessor
     ActiveRecord::Base.transaction do
       application_form.update!(assessor:)
 
-      TimelineEvent.create!(
+      CreateTimelineEvent.call(
+        "assessor_assigned",
         application_form:,
-        event_type: "assessor_assigned",
-        creator: user,
+        user:,
         assignee: assessor,
       )
     end

--- a/app/services/assign_application_form_reviewer.rb
+++ b/app/services/assign_application_form_reviewer.rb
@@ -15,10 +15,10 @@ class AssignApplicationFormReviewer
     ActiveRecord::Base.transaction do
       application_form.update!(reviewer:)
 
-      TimelineEvent.create!(
+      CreateTimelineEvent.call(
+        "reviewer_assigned",
         application_form:,
-        event_type: "reviewer_assigned",
-        creator: user,
+        user:,
         assignee: reviewer,
       )
     end

--- a/app/services/create_note.rb
+++ b/app/services/create_note.rb
@@ -13,10 +13,10 @@ class CreateNote
     ActiveRecord::Base.transaction do
       note = Note.create!(application_form:, author:, text:)
 
-      TimelineEvent.create!(
+      CreateTimelineEvent.call(
+        "note_created",
         application_form:,
-        event_type: "note_created",
-        creator: author,
+        user: author,
         note:,
       )
 

--- a/app/services/create_timeline_event.rb
+++ b/app/services/create_timeline_event.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class CreateTimelineEvent
+  include ServicePattern
+
+  def initialize(event_type, application_form:, user:, **kwargs)
+    @event_type = event_type
+    @application_form = application_form
+    @user = user
+    @kwargs = kwargs
+  end
+
+  def call
+    creator = user.is_a?(String) ? nil : user
+    creator_name = user.is_a?(String) ? user : ""
+
+    TimelineEvent.create!(
+      application_form:,
+      event_type:,
+      creator:,
+      creator_name:,
+      **kwargs,
+    )
+  end
+
+  private
+
+  attr_reader :application_form, :user, :event_type, :kwargs
+end

--- a/app/services/receive_requestable.rb
+++ b/app/services/receive_requestable.rb
@@ -13,7 +13,14 @@ class ReceiveRequestable
 
     ActiveRecord::Base.transaction do
       requestable.received!
-      create_timeline_event
+
+      CreateTimelineEvent.call(
+        "requestable_received",
+        application_form:,
+        user:,
+        requestable:,
+      )
+
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end
 
@@ -28,17 +35,4 @@ class ReceiveRequestable
   attr_reader :requestable, :user
 
   delegate :application_form, to: :requestable
-
-  def create_timeline_event
-    creator = user.is_a?(String) ? nil : user
-    creator_name = user.is_a?(String) ? user : ""
-
-    TimelineEvent.create!(
-      application_form:,
-      creator:,
-      creator_name:,
-      event_type: "requestable_received",
-      requestable:,
-    )
-  end
 end

--- a/app/services/request_requestable.rb
+++ b/app/services/request_requestable.rb
@@ -13,7 +13,13 @@ class RequestRequestable
 
     ActiveRecord::Base.transaction do
       requestable.requested!
-      create_timeline_event
+
+      CreateTimelineEvent.call(
+        "requestable_requested",
+        application_form:,
+        user:,
+        requestable:,
+      )
     end
 
     requestable.after_requested(user:)
@@ -27,17 +33,4 @@ class RequestRequestable
   attr_reader :requestable, :user
 
   delegate :application_form, to: :requestable
-
-  def create_timeline_event
-    creator = user.is_a?(String) ? nil : user
-    creator_name = user.is_a?(String) ? user : ""
-
-    TimelineEvent.create!(
-      application_form:,
-      creator:,
-      creator_name:,
-      event_type: "requestable_requested",
-      requestable:,
-    )
-  end
 end

--- a/app/services/review_requestable.rb
+++ b/app/services/review_requestable.rb
@@ -34,11 +34,11 @@ class ReviewRequestable
   attr_reader :requestable, :user, :passed, :note
 
   def create_timeline_event(old_status:)
-    TimelineEvent.create!(
-      creator: user,
-      event_type: "requestable_reviewed",
-      requestable:,
+    CreateTimelineEvent.call(
+      "requestable_reviewed",
       application_form:,
+      user:,
+      requestable:,
       old_value: old_status,
       new_value: requestable.review_status,
       note_text: note,

--- a/app/services/update_application_form_name.rb
+++ b/app/services/update_application_form_name.rb
@@ -28,14 +28,11 @@ class UpdateApplicationFormName
     return if new_value == old_value
 
     application_form.update!(column_name => new_value)
-    create_timeline_event(column_name, old_value, new_value)
-  end
 
-  def create_timeline_event(column_name, old_value, new_value)
-    TimelineEvent.create!(
-      event_type: "information_changed",
+    CreateTimelineEvent.call(
+      "information_changed",
       application_form:,
-      creator: user,
+      user:,
       column_name:,
       old_value:,
       new_value:,

--- a/app/services/update_assessment_section.rb
+++ b/app/services/update_assessment_section.rb
@@ -65,11 +65,11 @@ class UpdateAssessmentSection
     new_status = assessment_section.status
     return if old_status == new_status
 
-    TimelineEvent.create!(
-      creator: user,
-      event_type: "assessment_section_recorded",
-      assessment_section:,
+    CreateTimelineEvent.call(
+      "assessment_section_recorded",
       application_form:,
+      user:,
+      assessment_section:,
       old_value: old_status,
       new_value: new_status,
     )

--- a/app/services/update_work_history_contact.rb
+++ b/app/services/update_work_history_contact.rb
@@ -48,10 +48,10 @@ class UpdateWorkHistoryContact
   end
 
   def create_timeline_event(column_name, old_value, new_value)
-    TimelineEvent.create!(
-      event_type: "information_changed",
+    CreateTimelineEvent.call(
+      "information_changed",
       application_form:,
-      creator: user,
+      user:,
       work_history:,
       column_name:,
       old_value:,

--- a/app/services/verify_requestable.rb
+++ b/app/services/verify_requestable.rb
@@ -23,7 +23,15 @@ class VerifyRequestable
       requestable.after_verified(user:)
       application_form.reload
 
-      create_timeline_event(old_status:)
+      CreateTimelineEvent.call(
+        "requestable_verified",
+        application_form:,
+        user:,
+        requestable:,
+        old_value: old_status,
+        new_value: requestable.verify_status,
+        note_text: note,
+      )
 
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end
@@ -32,18 +40,6 @@ class VerifyRequestable
   private
 
   attr_reader :requestable, :user, :passed, :note
-
-  def create_timeline_event(old_status:)
-    TimelineEvent.create!(
-      creator: user,
-      event_type: "requestable_verified",
-      requestable:,
-      application_form:,
-      old_value: old_status,
-      new_value: requestable.verify_status,
-      note_text: note,
-    )
-  end
 
   delegate :application_form, to: :requestable
 end

--- a/spec/services/create_timeline_event_spec.rb
+++ b/spec/services/create_timeline_event_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CreateTimelineEvent do
+  let(:application_form) { create(:application_form) }
+
+  subject(:call) do
+    described_class.call(
+      "status_changed",
+      application_form:,
+      user:,
+      old_value: "submitted",
+      new_value: "awarded",
+    )
+  end
+
+  context "with a staff user" do
+    let(:user) { create(:staff) }
+
+    it "records a timeline event" do
+      expect { call }.to have_recorded_timeline_event(
+        :status_changed,
+        creator: user,
+        creator_name: "",
+      )
+    end
+  end
+
+  context "with a string user" do
+    let(:user) { "Awarded" }
+
+    it "records a timeline event" do
+      expect { call }.to have_recorded_timeline_event(
+        :status_changed,
+        creator: nil,
+        creator_name: "Awarded",
+      )
+    end
+  end
+end


### PR DESCRIPTION
This adds a new service for creating timeline events which encapsulates the logic around whether the `user` is a `String` or an instance of a `Staff` model.