### PR TITLE
Refactor TeacherMailer to take the application form

### DIFF
--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -96,10 +96,7 @@ module AssessorInterface
         return
       end
 
-      TeacherMailer
-        .with(teacher: application_form.teacher)
-        .initial_checks_passed
-        .deliver_later
+      TeacherMailer.with(application_form:).initial_checks_passed.deliver_later
     end
 
     def unassign_assessor

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -4,9 +4,6 @@ class TeacherMailer < ApplicationMailer
   include RegionHelper
 
   before_action :set_application_form
-  before_action :set_further_information_request,
-                only: :further_information_reminder
-  before_action :set_further_information_requested, only: :application_declined
 
   helper :application_form, :region
 
@@ -76,6 +73,8 @@ class TeacherMailer < ApplicationMailer
   end
 
   def further_information_reminder
+    @further_information_request = params[:further_information_request]
+
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
       to: teacher.email,
@@ -129,23 +128,13 @@ class TeacherMailer < ApplicationMailer
 
   private
 
-  def teacher
-    params[:teacher]
+  def application_form
+    params[:application_form]
   end
 
-  delegate :application_form, to: :teacher
-  delegate :assessment, :region, to: :application_form
+  delegate :assessment, :region, :teacher, to: :application_form
 
   def set_application_form
     @application_form = application_form
-  end
-
-  def set_further_information_request
-    @further_information_request = params[:further_information_request]
-  end
-
-  def set_further_information_requested
-    @further_information_requested =
-      assessment.further_information_requests.any?
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -267,13 +267,13 @@ class ApplicationForm < ApplicationRecord
     case name
     when "expiration"
       TeacherMailer
-        .with(teacher:, number_of_reminders_sent:)
+        .with(application_form: self, number_of_reminders_sent:)
         .application_not_submitted
         .deliver_later
     when "references"
       TeacherMailer
         .with(
-          teacher:,
+          application_form: self,
           number_of_reminders_sent:,
           reference_requests:
             reference_requests_not_yet_received_or_rejected.to_a,

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -48,7 +48,7 @@ class FurtherInformationRequest < ApplicationRecord
 
   def send_reminder_email(_name, _number_of_reminders_sent)
     TeacherMailer
-      .with(teacher:, further_information_request: self)
+      .with(application_form:, further_information_request: self)
       .further_information_reminder
       .deliver_later
   end
@@ -63,7 +63,10 @@ class FurtherInformationRequest < ApplicationRecord
   end
 
   def after_received(*)
-    TeacherMailer.with(teacher:).further_information_received.deliver_later
+    TeacherMailer
+      .with(application_form:)
+      .further_information_received
+      .deliver_later
   end
 
   def after_expired(user:)

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -40,7 +40,10 @@ class ProfessionalStandingRequest < ApplicationRecord
 
   def after_received(*)
     if should_send_received_email?
-      TeacherMailer.with(teacher:).professional_standing_received.deliver_later
+      TeacherMailer
+        .with(application_form:)
+        .professional_standing_received
+        .deliver_later
     end
   end
 

--- a/app/services/award_qts.rb
+++ b/app/services/award_qts.rb
@@ -24,12 +24,15 @@ class AwardQTS
     raise MissingTRN if trn.blank?
 
     ActiveRecord::Base.transaction do
-      teacher.update!(trn:, access_your_teaching_qualifications_url:)
+      application_form.teacher.update!(
+        trn:,
+        access_your_teaching_qualifications_url:,
+      )
       application_form.update!(awarded_at: Time.zone.now)
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end
 
-    TeacherMailer.with(teacher:).application_awarded.deliver_later
+    TeacherMailer.with(application_form:).application_awarded.deliver_later
   end
 
   class InvalidState < StandardError
@@ -44,6 +47,4 @@ class AwardQTS
               :user,
               :trn,
               :access_your_teaching_qualifications_url
-
-  delegate :teacher, to: :application_form
 end

--- a/app/services/create_further_information_request.rb
+++ b/app/services/create_further_information_request.rb
@@ -29,7 +29,10 @@ class CreateFurtherInformationRequest
         requestable
       end
 
-    TeacherMailer.with(teacher:).further_information_requested.deliver_later
+    TeacherMailer
+      .with(application_form:)
+      .further_information_requested
+      .deliver_later
 
     further_information_request
   end
@@ -38,11 +41,5 @@ class CreateFurtherInformationRequest
 
   attr_reader :assessment, :user
 
-  def application_form
-    @application_form ||= assessment.application_form
-  end
-
-  def teacher
-    @teacher ||= application_form.teacher
-  end
+  delegate :application_form, to: :assessment
 end

--- a/app/services/decline_qts.rb
+++ b/app/services/decline_qts.rb
@@ -16,11 +16,10 @@ class DeclineQTS
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end
 
-    TeacherMailer.with(teacher:).application_declined.deliver_later
+    TeacherMailer.with(application_form:).application_declined.deliver_later
   end
 
   private
 
   attr_reader :application_form, :user
-  delegate :teacher, to: :application_form
 end

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -32,17 +32,11 @@ class SubmitApplicationForm
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end
 
-    TeacherMailer
-      .with(teacher: application_form.teacher)
-      .application_received
-      .deliver_later
+    TeacherMailer.with(application_form:).application_received.deliver_later
 
     if !application_form.requires_preliminary_check &&
          application_form.teaching_authority_provides_written_statement
-      TeacherMailer
-        .with(teacher: application_form.teacher)
-        .initial_checks_passed
-        .deliver_later
+      TeacherMailer.with(application_form:).initial_checks_passed.deliver_later
     end
 
     if region.teaching_authority_requires_submission_email

--- a/app/services/update_work_history_contact.rb
+++ b/app/services/update_work_history_contact.rb
@@ -28,7 +28,7 @@ class UpdateWorkHistoryContact
     if email.present? && (reference_request = work_history.reference_request)
       RefereeMailer.with(reference_request:).reference_requested.deliver_later
       TeacherMailer
-        .with(teacher:, reference_requests: [reference_request])
+        .with(application_form:, reference_requests: [reference_request])
         .references_requested
         .deliver_later
     end
@@ -39,7 +39,6 @@ class UpdateWorkHistoryContact
   attr_reader :work_history, :user, :name, :job, :email
 
   delegate :application_form, to: :work_history
-  delegate :teacher, to: :application_form
 
   def change_value(column_name, new_value)
     old_value = work_history.send(column_name)

--- a/app/services/verify_assessment.rb
+++ b/app/services/verify_assessment.rb
@@ -52,9 +52,7 @@ class VerifyAssessment
               :work_histories
 
   delegate :application_form, to: :assessment
-  delegate :teacher,
-           :teaching_authority_provides_written_statement,
-           to: :application_form
+  delegate :teaching_authority_provides_written_statement, to: :application_form
 
   def create_professional_standing_request
     if professional_standing && !teaching_authority_provides_written_statement
@@ -84,7 +82,7 @@ class VerifyAssessment
     end
 
     TeacherMailer
-      .with(teacher:, reference_requests:)
+      .with(application_form:, reference_requests:)
       .references_requested
       .deliver_later
   end

--- a/app/views/assessor_interface/assessment_recommendation_award/preview.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_award/preview.html.erb
@@ -8,7 +8,7 @@
 <%= render(PreviewMailer::Component.new(
   mailer_class: TeacherMailer,
   name: :application_awarded,
-  teacher: @application_form.teacher,
+  application_form: @application_form,
 )) %>
 
 <div class="govuk-button-group">

--- a/app/views/assessor_interface/assessment_recommendation_decline/preview.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_decline/preview.html.erb
@@ -8,7 +8,7 @@
 <%= render(PreviewMailer::Component.new(
   mailer_class: TeacherMailer,
   name: :application_declined,
-  teacher: @application_form.teacher,
+  application_form: @application_form,
 )) %>
 
 <div class="govuk-button-group">

--- a/app/views/assessor_interface/assessment_recommendation_verify/preview_teacher.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/preview_teacher.html.erb
@@ -10,7 +10,7 @@
 <%= render(PreviewMailer::Component.new(
   mailer_class: TeacherMailer,
   name: :references_requested,
-  teacher: @application_form.teacher,
+  application_form: @application_form,
   reference_requests: [OpenStruct.new(
     expires_at: Time.zone.now + 6.weeks,
   )],

--- a/app/views/assessor_interface/further_information_requests/new.html.erb
+++ b/app/views/assessor_interface/further_information_requests/new.html.erb
@@ -6,7 +6,7 @@
 <%= render(PreviewMailer::Component.new(
   mailer_class: TeacherMailer,
   name: :further_information_requested,
-  teacher: @application_form.teacher,
+  application_form: @application_form,
 )) %>
 
 <%= form_with model: [:assessor_interface, @application_form, @assessment, @further_information_request] do |f| %>

--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -29,7 +29,7 @@ namespace :application_forms do
       next unless teacher.application_form == application_form
 
       TeacherMailer
-        .with(teacher:)
+        .with(application_form:)
         .application_from_ineligible_country
         .deliver_now
     end

--- a/spec/lib/application_mailer_observer_spec.rb
+++ b/spec/lib/application_mailer_observer_spec.rb
@@ -31,9 +31,7 @@ RSpec.describe ApplicationMailerObserver do
 
   context "with a teacher mailer" do
     let(:application_form) { create(:application_form) }
-    let(:message) do
-      TeacherMailer.with(teacher: application_form.teacher).application_received
-    end
+    let(:message) { TeacherMailer.with(application_form:).application_received }
 
     include_examples "observes mail"
   end

--- a/spec/lib/mailer_preview_spec.rb
+++ b/spec/lib/mailer_preview_spec.rb
@@ -2,9 +2,10 @@ require "rails_helper"
 
 RSpec.describe MailerPreview do
   let(:further_information_request) { create(:further_information_request) }
-  let(:teacher) do
-    further_information_request.assessment.application_form.teacher
+  let(:application_form) do
+    further_information_request.assessment.application_form
   end
+  let(:teacher) { application_form.teacher }
   let(:notify_key) { "notify-key" }
   let(:notify_client) do
     double(generate_template_preview: notify_template_preview)
@@ -27,7 +28,7 @@ RSpec.describe MailerPreview do
     subject do
       described_class.with(
         TeacherMailer,
-        teacher:,
+        application_form:,
         further_information_request:,
       ).further_information_requested
     end

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe TeacherMailer, type: :mailer do
   end
 
   describe "#application_awarded" do
-    subject(:mail) { described_class.with(teacher:).application_awarded }
+    subject(:mail) do
+      described_class.with(application_form:).application_awarded
+    end
 
     before do
       teacher.update!(
@@ -54,7 +56,9 @@ RSpec.describe TeacherMailer, type: :mailer do
   end
 
   describe "#application_declined" do
-    subject(:mail) { described_class.with(teacher:).application_declined }
+    subject(:mail) do
+      described_class.with(application_form:).application_declined
+    end
 
     describe "#subject" do
       subject(:subject) { mail.subject }
@@ -81,7 +85,9 @@ RSpec.describe TeacherMailer, type: :mailer do
 
   describe "#application_from_ineligible_country" do
     subject(:mail) do
-      described_class.with(teacher:).application_from_ineligible_country
+      described_class.with(
+        application_form:,
+      ).application_from_ineligible_country
     end
 
     describe "#subject" do
@@ -119,7 +125,7 @@ RSpec.describe TeacherMailer, type: :mailer do
   describe "#application_not_submitted" do
     subject(:mail) do
       described_class.with(
-        teacher:,
+        application_form:,
         number_of_reminders_sent:,
       ).application_not_submitted
     end
@@ -199,7 +205,9 @@ RSpec.describe TeacherMailer, type: :mailer do
   end
 
   describe "#application_received" do
-    subject(:mail) { described_class.with(teacher:).application_received }
+    subject(:mail) do
+      described_class.with(application_form:).application_received
+    end
 
     describe "#subject" do
       subject(:subject) { mail.subject }
@@ -250,7 +258,7 @@ RSpec.describe TeacherMailer, type: :mailer do
 
   describe "#further_information_received" do
     subject(:mail) do
-      described_class.with(teacher:).further_information_received
+      described_class.with(application_form:).further_information_received
     end
 
     describe "#subject" do
@@ -282,7 +290,7 @@ RSpec.describe TeacherMailer, type: :mailer do
   describe "#further_information_requested" do
     subject(:mail) do
       described_class.with(
-        teacher:,
+        application_form:,
         further_information_request:,
       ).further_information_requested
     end
@@ -325,7 +333,7 @@ RSpec.describe TeacherMailer, type: :mailer do
   describe "#further_information_reminder" do
     subject(:mail) do
       described_class.with(
-        teacher:,
+        application_form:,
         further_information_request:,
       ).further_information_reminder
     end
@@ -373,7 +381,7 @@ RSpec.describe TeacherMailer, type: :mailer do
 
   describe "#professional_standing_received" do
     subject(:mail) do
-      described_class.with(teacher:).professional_standing_received
+      described_class.with(application_form:).professional_standing_received
     end
 
     describe "#subject" do
@@ -428,7 +436,7 @@ RSpec.describe TeacherMailer, type: :mailer do
     let(:number_of_reminders_sent) { nil }
     subject(:mail) do
       described_class.with(
-        teacher:,
+        application_form:,
         number_of_reminders_sent:,
         reference_requests: [reference_request],
       ).references_reminder
@@ -489,7 +497,7 @@ RSpec.describe TeacherMailer, type: :mailer do
   describe "#references_requested" do
     subject(:mail) do
       described_class.with(
-        teacher:,
+        application_form:,
         reference_requests: [
           create(:reference_request, :requested, assessment:),
         ],

--- a/spec/services/award_qts_spec.rb
+++ b/spec/services/award_qts_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe AwardQTS do
       expect { call }.to have_enqueued_mail(
         TeacherMailer,
         :application_awarded,
-      ).with(params: { teacher: }, args: [])
+      ).with(params: { application_form: }, args: [])
     end
 
     it "changes the status" do
@@ -93,7 +93,7 @@ RSpec.describe AwardQTS do
       expect { call }.to have_enqueued_mail(
         TeacherMailer,
         :application_awarded,
-      ).with(params: { teacher: }, args: [])
+      ).with(params: { application_form: }, args: [])
     end
 
     it "changes the status" do

--- a/spec/services/decline_qts_spec.rb
+++ b/spec/services/decline_qts_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe DeclineQTS do
       expect { call }.to have_enqueued_mail(
         TeacherMailer,
         :application_declined,
-      ).with(params: { teacher: }, args: [])
+      ).with(params: { application_form: }, args: [])
     end
 
     it "changes the stage" do

--- a/spec/services/send_reminder_email_spec.rb
+++ b/spec/services/send_reminder_email_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SendReminderEmail do
           :further_information_reminder,
         ).with(
           params: {
-            teacher:,
+            application_form:,
             further_information_request: remindable,
           },
           args: [],
@@ -67,7 +67,7 @@ RSpec.describe SendReminderEmail do
           :application_not_submitted,
         ).with(
           params: {
-            teacher: remindable.teacher,
+            application_form: remindable,
             number_of_reminders_sent: a_kind_of(Integer),
           },
           args: [],
@@ -84,7 +84,7 @@ RSpec.describe SendReminderEmail do
           :references_reminder,
         ).with(
           params: {
-            teacher: remindable.teacher,
+            application_form: remindable,
             number_of_reminders_sent: a_kind_of(Integer),
             reference_requests: [reference_request],
           },

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe SubmitApplicationForm do
       expect { call }.to have_enqueued_mail(
         TeacherMailer,
         :application_received,
-      ).with(params: { teacher: application_form.teacher }, args: [])
+      ).with(params: { application_form: }, args: [])
     end
   end
 
@@ -191,7 +191,7 @@ RSpec.describe SubmitApplicationForm do
         expect { call }.to have_enqueued_mail(
           TeacherMailer,
           :initial_checks_passed,
-        ).with(params: { teacher: application_form.teacher }, args: [])
+        ).with(params: { application_form: }, args: [])
       end
     end
   end


### PR DESCRIPTION
Currently the `TeacherMailer` takes in the teacher as a parameter and then extracts the most recent application form from it. This works in most cases, but there are a few specific cases where this causes problems, notably if the teacher has multiple application forms. In this case we can end up choosing the incorrect application form and emails can end up associated with the wrong application form.