### PR TITLE
Refactor work history order scopes

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
@@ -34,6 +34,7 @@ module AssessorInterface
           .reference_requests
           .includes(:work_history)
           .where(verify_passed: false)
+          .order_by_role
 
       render layout: "full_from_desktop"
     end

--- a/app/controllers/assessor_interface/assessments_controller.rb
+++ b/app/controllers/assessor_interface/assessments_controller.rb
@@ -27,6 +27,7 @@ module AssessorInterface
           .reference_requests
           .includes(:work_history)
           .where(verify_passed: false)
+          .order_by_role
 
       render layout: "full_from_desktop"
     end

--- a/app/controllers/assessor_interface/reference_requests_controller.rb
+++ b/app/controllers/assessor_interface/reference_requests_controller.rb
@@ -121,7 +121,7 @@ module AssessorInterface
               reference: params[:application_form_reference],
             },
           )
-          .order("work_histories.start_date": :desc)
+          .order_by_role
     end
 
     def reference_request

--- a/app/controllers/teacher_interface/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/work_histories_controller.rb
@@ -23,7 +23,7 @@ module TeacherInterface
         redirect_to %i[new teacher_interface application_form work_history]
       elsif (
             work_history =
-              application_form.work_histories.ordered.find(&:incomplete?)
+              application_form.work_histories.order_by_user.find(&:incomplete?)
           )
         redirect_to [
                       :school,
@@ -42,7 +42,7 @@ module TeacherInterface
     end
 
     def check_collection
-      @work_histories = application_form.work_histories.ordered
+      @work_histories = application_form.work_histories.order_by_user
       @came_from_add_another =
         history_stack.last_entry&.fetch(:path) ==
           add_another_teacher_interface_application_form_work_histories_path
@@ -202,7 +202,7 @@ module TeacherInterface
     def check_member
       @work_history = work_history
 
-      work_histories = application_form.work_histories.ordered.to_a
+      work_histories = application_form.work_histories.order_by_user.to_a
       @next_work_history =
         work_histories[work_histories.index(work_history) + 1]
     end

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -67,6 +67,9 @@ class ReferenceRequest < ApplicationRecord
             .merge(ApplicationForm.assessable)
         end
 
+  scope :order_by_role, -> { order("work_histories.start_date": :desc) }
+  scope :order_by_user, -> { order("work_histories.created_at": :asc) }
+
   with_options if: :received? do
     validates :contact_response, inclusion: [true, false]
     validates :dates_response, inclusion: [true, false]

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -40,11 +40,12 @@ class WorkHistory < ApplicationRecord
           required: false,
           dependent: :destroy
 
-  scope :ordered, -> { order(created_at: :asc) }
+  scope :order_by_role, -> { order(start_date: :desc) }
+  scope :order_by_user, -> { order(created_at: :asc) }
 
   def current_or_most_recent_role?
     application_form.work_histories.empty? ||
-      application_form.work_histories.ordered.first == self
+      application_form.work_histories.order_by_role.first == self
   end
 
   def locale_key

--- a/app/views/assessor_interface/assessment_recommendation_verify/edit_reference_requests.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/edit_reference_requests.html.erb
@@ -11,7 +11,7 @@
   <p class="govuk-body">These are shown below.</p>
 
   <%= f.govuk_collection_check_boxes :work_history_ids,
-                                      @application_form.work_histories.ordered,
+                                      @application_form.work_histories.order_by_role,
                                       :id,
                                       :school_name,
                                       small: true %>

--- a/app/views/assessor_interface/assessment_sections/_work_history_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_work_history_summary.html.erb
@@ -1,12 +1,12 @@
 <% if application_form.created_under_new_regulations? %>
   <%= render "shared/application_form/work_history_summary",
-             work_histories: application_form.work_histories.ordered,
+             work_histories: application_form.work_histories.order_by_user,
              highlighted_contact_emails: highlighted_work_history_contact_emails %>
 <% else %>
   <%= render "shared/application_form/work_history_old_regs_summary",
              application_form:,
              show_has_work_history: true,
-             work_histories: application_form.work_histories.ordered,
+             work_histories: application_form.work_histories.order_by_user,
              highlighted_contact_emails: highlighted_work_history_contact_emails,
              changeable: false %>
 <% end %>

--- a/app/views/teacher_interface/application_forms/edit.html.erb
+++ b/app/views/teacher_interface/application_forms/edit.html.erb
@@ -21,7 +21,7 @@
     <h2 class="govuk-heading-m">Your work history</h2>
 
     <%= render "shared/application_form/work_history_summary",
-               work_histories: @application_form.work_histories.ordered,
+               work_histories: @application_form.work_histories.order_by_user,
                highlighted_contact_emails: [] %>
   </section>
 <% end %>

--- a/spec/models/work_history_spec.rb
+++ b/spec/models/work_history_spec.rb
@@ -39,13 +39,22 @@ RSpec.describe WorkHistory, type: :model do
     it { is_expected.to be_valid }
   end
 
-  describe "#ordered" do
+  describe "#order_by_role" do
+    subject(:order_by_role) { described_class.order_by_role }
+
+    let!(:newest) { create(:work_history, start_date: 1.week.ago) }
+    let!(:oldest) { create(:work_history, start_date: 1.month.ago) }
+
+    it { is_expected.to eq([newest, oldest]) }
+  end
+
+  describe "#order_by_user" do
+    subject(:order_by_user) { described_class.order_by_user }
+
     let!(:newest) { create(:work_history, created_at: 1.week.ago) }
     let!(:oldest) { create(:work_history, created_at: 1.month.ago) }
 
-    it "orders in reverse order of start date" do
-      expect(described_class.ordered).to eq([oldest, newest])
-    end
+    it { is_expected.to eq([oldest, newest]) }
   end
 
   describe "#current_or_most_recent_role?" do


### PR DESCRIPTION
We've got two ways of ordering the work history so we should have these two scopes available and use them in all places.