### PR TITLE
Add unsigned_consent_document_downloaded column

### DIFF
--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -4,21 +4,22 @@
 #
 # Table name: qualification_requests
 #
-#  id               :bigint           not null, primary key
-#  expired_at       :datetime
-#  location_note    :text             default(""), not null
-#  received_at      :datetime
-#  requested_at     :datetime
-#  review_note      :string           default(""), not null
-#  review_passed    :boolean
-#  reviewed_at      :datetime
-#  verified_at      :datetime
-#  verify_note      :text             default(""), not null
-#  verify_passed    :boolean
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  assessment_id    :bigint           not null
-#  qualification_id :bigint           not null
+#  id                                   :bigint           not null, primary key
+#  expired_at                           :datetime
+#  location_note                        :text             default(""), not null
+#  received_at                          :datetime
+#  requested_at                         :datetime
+#  review_note                          :string           default(""), not null
+#  review_passed                        :boolean
+#  reviewed_at                          :datetime
+#  unsigned_consent_document_downloaded :boolean          default(FALSE), not null
+#  verified_at                          :datetime
+#  verify_note                          :text             default(""), not null
+#  verify_passed                        :boolean
+#  created_at                           :datetime         not null
+#  updated_at                           :datetime         not null
+#  assessment_id                        :bigint           not null
+#  qualification_id                     :bigint           not null
 #
 # Indexes
 #

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -218,6 +218,7 @@
     - review_note
     - review_passed
     - reviewed_at
+    - unsigned_consent_document_downloaded
     - updated_at
     - verified_at
     - verify_note

--- a/db/migrate/20240205134202_add_consent_document_to_qualification_requests.rb
+++ b/db/migrate/20240205134202_add_consent_document_to_qualification_requests.rb
@@ -1,0 +1,9 @@
+class AddConsentDocumentToQualificationRequests < ActiveRecord::Migration[7.1]
+  def change
+    add_column :qualification_requests,
+               :unsigned_consent_document_downloaded,
+               :boolean,
+               default: false,
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_21_091416) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_05_134202) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -289,6 +289,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_21_091416) do
     t.boolean "verify_passed"
     t.text "verify_note", default: "", null: false
     t.datetime "verified_at"
+    t.boolean "unsigned_consent_document_downloaded", default: false, null: false
     t.index ["assessment_id"], name: "index_qualification_requests_on_assessment_id"
     t.index ["qualification_id"], name: "index_qualification_requests_on_qualification_id"
   end

--- a/spec/factories/qualification_requests.rb
+++ b/spec/factories/qualification_requests.rb
@@ -4,21 +4,22 @@
 #
 # Table name: qualification_requests
 #
-#  id               :bigint           not null, primary key
-#  expired_at       :datetime
-#  location_note    :text             default(""), not null
-#  received_at      :datetime
-#  requested_at     :datetime
-#  review_note      :string           default(""), not null
-#  review_passed    :boolean
-#  reviewed_at      :datetime
-#  verified_at      :datetime
-#  verify_note      :text             default(""), not null
-#  verify_passed    :boolean
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  assessment_id    :bigint           not null
-#  qualification_id :bigint           not null
+#  id                                   :bigint           not null, primary key
+#  expired_at                           :datetime
+#  location_note                        :text             default(""), not null
+#  received_at                          :datetime
+#  requested_at                         :datetime
+#  review_note                          :string           default(""), not null
+#  review_passed                        :boolean
+#  reviewed_at                          :datetime
+#  unsigned_consent_document_downloaded :boolean          default(FALSE), not null
+#  verified_at                          :datetime
+#  verify_note                          :text             default(""), not null
+#  verify_passed                        :boolean
+#  created_at                           :datetime         not null
+#  updated_at                           :datetime         not null
+#  assessment_id                        :bigint           not null
+#  qualification_id                     :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -4,21 +4,22 @@
 #
 # Table name: qualification_requests
 #
-#  id               :bigint           not null, primary key
-#  expired_at       :datetime
-#  location_note    :text             default(""), not null
-#  received_at      :datetime
-#  requested_at     :datetime
-#  review_note      :string           default(""), not null
-#  review_passed    :boolean
-#  reviewed_at      :datetime
-#  verified_at      :datetime
-#  verify_note      :text             default(""), not null
-#  verify_passed    :boolean
-#  created_at       :datetime         not null
-#  updated_at       :datetime         not null
-#  assessment_id    :bigint           not null
-#  qualification_id :bigint           not null
+#  id                                   :bigint           not null, primary key
+#  expired_at                           :datetime
+#  location_note                        :text             default(""), not null
+#  received_at                          :datetime
+#  requested_at                         :datetime
+#  review_note                          :string           default(""), not null
+#  review_passed                        :boolean
+#  reviewed_at                          :datetime
+#  unsigned_consent_document_downloaded :boolean          default(FALSE), not null
+#  verified_at                          :datetime
+#  verify_note                          :text             default(""), not null
+#  verify_passed                        :boolean
+#  created_at                           :datetime         not null
+#  updated_at                           :datetime         not null
+#  assessment_id                        :bigint           not null
+#  qualification_id                     :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
This adds a new column to qualification requests for capturing whether an applicant has downloaded the unsigned consent document.