### PR TITLE
Add consent fields to qualification requests

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -68,7 +68,8 @@ class Document < ApplicationRecord
   end
 
   def optional?
-    written_statement? && application_form.written_statement_optional
+    (signed_consent? && !documentable.signed_consent_document_required) ||
+      (written_statement? && application_form.written_statement_optional)
   end
 
   def for_further_information_request?

--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -5,6 +5,8 @@
 # Table name: qualification_requests
 #
 #  id                                   :bigint           not null, primary key
+#  consent_received_at                  :datetime
+#  consent_requested_at                 :datetime
 #  expired_at                           :datetime
 #  location_note                        :text             default(""), not null
 #  received_at                          :datetime
@@ -12,6 +14,7 @@
 #  review_note                          :string           default(""), not null
 #  review_passed                        :boolean
 #  reviewed_at                          :datetime
+#  signed_consent_document_required     :boolean          default(FALSE), not null
 #  unsigned_consent_document_downloaded :boolean          default(FALSE), not null
 #  verified_at                          :datetime
 #  verify_note                          :text             default(""), not null

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -208,6 +208,8 @@
     - part_of_university_degree
   :qualification_requests:
     - assessment_id
+    - consent_received_at
+    - consent_requested_at
     - created_at
     - expired_at
     - id
@@ -218,6 +220,7 @@
     - review_note
     - review_passed
     - reviewed_at
+    - signed_consent_document_required
     - unsigned_consent_document_downloaded
     - updated_at
     - verified_at

--- a/db/migrate/20240208101256_add_consent_to_qualification_requests.rb
+++ b/db/migrate/20240208101256_add_consent_to_qualification_requests.rb
@@ -1,0 +1,9 @@
+class AddConsentToQualificationRequests < ActiveRecord::Migration[7.1]
+  def change
+    change_table :qualification_requests, bulk: true do |t|
+      t.datetime :consent_received_at
+      t.datetime :consent_requested_at
+      t.boolean :signed_consent_document_required, default: false, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_05_134202) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_08_101256) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -290,6 +290,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_05_134202) do
     t.text "verify_note", default: "", null: false
     t.datetime "verified_at"
     t.boolean "unsigned_consent_document_downloaded", default: false, null: false
+    t.datetime "consent_received_at"
+    t.datetime "consent_requested_at"
+    t.boolean "signed_consent_document_required", default: false, null: false
     t.index ["assessment_id"], name: "index_qualification_requests_on_assessment_id"
     t.index ["qualification_id"], name: "index_qualification_requests_on_qualification_id"
   end

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       custom_key: "Custom key value",
       nil_value: nil,
       boolean: true,
-      document: create(:document, :with_upload),
+      document: create(:document, :with_upload, document_type: :identification),
       array: %w[a b c],
       translatable_document:,
     )

--- a/spec/factories/qualification_requests.rb
+++ b/spec/factories/qualification_requests.rb
@@ -5,6 +5,8 @@
 # Table name: qualification_requests
 #
 #  id                                   :bigint           not null, primary key
+#  consent_received_at                  :datetime
+#  consent_requested_at                 :datetime
 #  expired_at                           :datetime
 #  location_note                        :text             default(""), not null
 #  received_at                          :datetime
@@ -12,6 +14,7 @@
 #  review_note                          :string           default(""), not null
 #  review_passed                        :boolean
 #  reviewed_at                          :datetime
+#  signed_consent_document_required     :boolean          default(FALSE), not null
 #  unsigned_consent_document_downloaded :boolean          default(FALSE), not null
 #  verified_at                          :datetime
 #  verify_note                          :text             default(""), not null

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -5,6 +5,8 @@
 # Table name: qualification_requests
 #
 #  id                                   :bigint           not null, primary key
+#  consent_received_at                  :datetime
+#  consent_requested_at                 :datetime
 #  expired_at                           :datetime
 #  location_note                        :text             default(""), not null
 #  received_at                          :datetime
@@ -12,6 +14,7 @@
 #  review_note                          :string           default(""), not null
 #  review_passed                        :boolean
 #  reviewed_at                          :datetime
+#  signed_consent_document_required     :boolean          default(FALSE), not null
 #  unsigned_consent_document_downloaded :boolean          default(FALSE), not null
 #  verified_at                          :datetime
 #  verify_note                          :text             default(""), not null

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -46,6 +46,9 @@ RSpec.describe QualificationRequest, type: :model do
   end
 
   describe "validations" do
+    it { is_expected.to_not validate_presence_of(:consent_requested_at) }
+    it { is_expected.to_not validate_presence_of(:consent_received_at) }
+
     context "when received" do
       subject { build(:qualification_request, :received) }
 
@@ -56,5 +59,29 @@ RSpec.describe QualificationRequest, type: :model do
   describe "#expires_after" do
     subject(:expires_after) { described_class.new.expires_after }
     it { is_expected.to eq(6.weeks) }
+  end
+
+  describe "#consent_requested!" do
+    let(:call) { subject.consent_requested! }
+
+    it "sets the consent requested at date" do
+      freeze_time do
+        expect { call }.to change(subject, :consent_requested_at).from(nil).to(
+          Time.zone.now,
+        )
+      end
+    end
+  end
+
+  describe "#consent_received!" do
+    let(:call) { subject.consent_received! }
+
+    it "sets the consent received at date" do
+      freeze_time do
+        expect { call }.to change(subject, :consent_received_at).from(nil).to(
+          Time.zone.now,
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds a number of new fields to the qualification requests ready for the new consent journey.