### PR TITLE
Handle documents with a single upload only

### DIFF
--- a/app/forms/teacher_interface/upload_form.rb
+++ b/app/forms/teacher_interface/upload_form.rb
@@ -21,6 +21,8 @@ module TeacherInterface
     attr_reader :timeout_error
 
     def update_model
+      document.uploads.each(&:destroy!) unless document.allow_multiple_uploads?
+
       if original_attachment.present?
         document.uploads.create!(
           attachment: original_attachment,

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -39,16 +39,21 @@ class Document < ApplicationRecord
     identification
     medium_of_instruction
     name_change
-    signed_consent
-    unsigned_consent
   ].freeze
+
+  UNTRANSLATABLE_SINGLE_TYPES = %w[signed_consent unsigned_consent].freeze
+
   TRANSLATABLE_TYPES = %w[
     qualification_certificate
     qualification_document
     qualification_transcript
     written_statement
   ].freeze
-  DOCUMENT_TYPES = (UNTRANSLATABLE_TYPES + TRANSLATABLE_TYPES).freeze
+
+  DOCUMENT_TYPES =
+    (
+      UNTRANSLATABLE_TYPES + UNTRANSLATABLE_SINGLE_TYPES + TRANSLATABLE_TYPES
+    ).freeze
 
   enum document_type:
          DOCUMENT_TYPES.each_with_object({}) { |type, memo| memo[type] = type }
@@ -56,6 +61,10 @@ class Document < ApplicationRecord
 
   def translatable?
     TRANSLATABLE_TYPES.include?(document_type)
+  end
+
+  def allow_multiple_uploads?
+    !UNTRANSLATABLE_SINGLE_TYPES.include?(document_type)
   end
 
   def optional?

--- a/app/views/teacher_interface/documents/edit_uploads.html.erb
+++ b/app/views/teacher_interface/documents/edit_uploads.html.erb
@@ -8,13 +8,25 @@
 <%= govuk_summary_list do |summary_list|
   @document.uploads.order(:created_at).each_with_index do |upload, index|
     summary_list.with_row do |row|
-      row.with_key(text: "File #{index + 1}")
+      if @document.allow_multiple_uploads?
+        row.with_key(text: "File #{index + 1}")
+      end
+
       row.with_value { upload_link_to(upload) }
-      row.with_action(
-        text: "Delete",
-        href: delete_teacher_interface_application_form_document_upload_path(@document, upload),
-        visually_hidden_text: upload.attachment.filename
-      )
+
+      if @document.allow_multiple_uploads?
+        row.with_action(
+          text: "Delete",
+          href: delete_teacher_interface_application_form_document_upload_path(@document, upload),
+          visually_hidden_text: upload.attachment.filename
+        )
+      else
+        row.with_action(
+          text: "Change",
+          href: new_teacher_interface_application_form_document_upload_path(@document),
+          visually_hidden_text: upload.attachment.filename
+        )
+      end
     end
   end
 end %>
@@ -22,11 +34,15 @@ end %>
 <%= form_with model: @form, url: [:teacher_interface, :application_form, @document], method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_radio_buttons_fieldset :add_another,
-                                     legend: { text: "Do you need to upload another page?" },
-                                     hint: { text: "If your document has several pages or you’re providing an image of the other side of your identity card or driving license, you can upload them here. Otherwise, select ‘No’ and then ‘Continue’." } do %>
-    <%= f.govuk_radio_button :add_another, "true", label: { text: "Yes" } %>
-    <%= f.govuk_radio_button :add_another, "false", label: { text: "No" } %>
+  <% if @document.allow_multiple_uploads? %>
+    <%= f.govuk_radio_buttons_fieldset :add_another,
+                                       legend: { text: "Do you need to upload another page?" },
+                                       hint: { text: "If your document has several pages or you’re providing an image of the other side of your identity card or driving license, you can upload them here. Otherwise, select ‘No’ and then ‘Continue’." } do %>
+      <%= f.govuk_radio_button :add_another, "true", label: { text: "Yes" } %>
+      <%= f.govuk_radio_button :add_another, "false", label: { text: "No" } %>
+    <% end %>
+  <% else %>
+    <%= f.hidden_field :add_another, value: "false" %>
   <% end %>
 
   <%= render "shared/save_submit_buttons", f: %>

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -106,4 +106,16 @@ RSpec.describe Document, type: :model do
       it { is_expected.to be(true) }
     end
   end
+
+  describe "#allow_multiple_uploads?" do
+    subject(:allow_multiple_uploads?) { document.allow_multiple_uploads? }
+
+    it { is_expected.to be(true) }
+
+    context "with a single page document" do
+      before { document.document_type = :signed_consent }
+
+      it { is_expected.to be(false) }
+    end
+  end
 end


### PR DESCRIPTION
This adds the ability for some documents to only support a single upload, which is what we need for the consent documents.