### PR TITLE
Handle consent expiration

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -289,12 +289,12 @@ class ApplicationForm < ApplicationRecord
     end
   end
 
-  def expires_after
-    submitted? ? nil : 6.months
+  def expires_from
+    created_at
   end
 
-  def requested_at
-    created_at
+  def expires_after
+    submitted? ? nil : 6.months
   end
 
   private

--- a/app/models/concerns/expirable.rb
+++ b/app/models/concerns/expirable.rb
@@ -4,9 +4,9 @@ module Expirable
   extend ActiveSupport::Concern
 
   def expires_at
-    return nil if requested_at.nil? || expires_after.nil?
+    return nil if expires_from.nil? || expires_after.nil?
 
-    requested_at + expires_after
+    expires_from + expires_after
   end
 
   def days_until_expired

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -18,6 +18,10 @@ module Requestable
     has_one :application_form, through: :assessment
   end
 
+  def expires_from
+    requested_at || try(:consent_requested_at)
+  end
+
   def requested!
     update!(requested_at: Time.zone.now)
   end

--- a/spec/factories/qualification_requests.rb
+++ b/spec/factories/qualification_requests.rb
@@ -39,6 +39,17 @@ FactoryBot.define do
     association :assessment
     association :qualification, :completed
 
+    trait :consent_required do
+      signed_consent_document_required { true }
+    end
+
+    trait :consent_requested do
+      consent_required
+      consent_requested_at do
+        Faker::Time.between(from: 1.month.ago, to: Time.zone.now)
+      end
+    end
+
     trait :requested do
       requested_at { Faker::Time.between(from: 1.month.ago, to: Time.zone.now) }
     end

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -56,9 +56,49 @@ RSpec.describe QualificationRequest, type: :model do
     end
   end
 
+  describe "#expires_from" do
+    subject(:expires_from) { qualification_request.expires_from }
+
+    context "when consent has been requested" do
+      let(:qualification_request) do
+        create(
+          :qualification_request,
+          consent_requested_at: Date.new(2020, 1, 1),
+        )
+      end
+
+      it { is_expected.to eq(Date.new(2020, 1, 1)) }
+    end
+
+    context "when verification has been requested" do
+      let(:qualification_request) do
+        create(
+          :qualification_request,
+          consent_requested_at: Date.new(2020, 1, 1),
+          requested_at: Date.new(2021, 1, 1),
+        )
+      end
+
+      it { is_expected.to eq(Date.new(2021, 1, 1)) }
+    end
+  end
+
   describe "#expires_after" do
-    subject(:expires_after) { described_class.new.expires_after }
-    it { is_expected.to eq(6.weeks) }
+    subject(:expires_after) { qualification_request.expires_after }
+
+    context "when consent has been requested" do
+      let(:qualification_request) do
+        create(:qualification_request, :consent_requested)
+      end
+
+      it { is_expected.to eq(6.weeks) }
+    end
+
+    context "when verification has been requested" do
+      let(:qualification_request) { create(:qualification_request, :requested) }
+
+      it { is_expected.to eq(6.weeks) }
+    end
   end
 
   describe "#consent_requested!" do


### PR DESCRIPTION
This makes it possible for consent qualification request to expire after 6 weeks, and a normal qualification request to expire after 6 weeks as well.