### PR TITLE
Set namespace correctly for errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,6 @@
-class ErrorsController < ApplicationController
-  include EligibilityCurrentNamespace
+# frozen_string_literal: true
 
+class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def forbidden
@@ -23,5 +23,18 @@ class ErrorsController < ApplicationController
     render "internal_server_error",
            formats: :html,
            status: :internal_server_error
+  end
+
+  def current_namespace
+    path = request.original_fullpath
+    if path.starts_with?("/assessor")
+      "assessor"
+    elsif path.starts_with?("/support")
+      "support"
+    elsif path.starts_with?("/teacher")
+      "teacher"
+    else
+      "eligibility"
+    end
   end
 end


### PR DESCRIPTION
This is to prevent the requests being recorded in the analytics database as being part of the eligibility namespace when that might not be the case.