### PR TITLE
Update decline reasons with recommendation note

### DIFF
--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -104,7 +104,7 @@ class TeacherInterface::ApplicationFormViewObject
       reasons = {}
 
       if (note = assessment&.recommendation_assessor_note).present?
-        reasons.merge!({ "" => [note] })
+        reasons.merge!({ "" => [{ name: note }] })
       end
 
       if assessment.present? && further_information_request.nil?

--- a/spec/view_objects/teacher_interface/application_form_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_view_object_spec.rb
@@ -268,7 +268,7 @@ RSpec.describe TeacherInterface::ApplicationFormViewObject do
 
     context "with a recommendation note" do
       before { assessment.update!(recommendation_assessor_note: "A note.") }
-      it { is_expected.to eq({ "" => ["A note."] }) }
+      it { is_expected.to eq({ "" => [{ name: "A note." }] }) }
     end
 
     context "with failure reasons" do


### PR DESCRIPTION
This adds to 19c45feffc2d599e4059a21cb84db94b417c0324 to make sure that any declined reasons coming from recommendation notes are handled correctly.

https://dfe-teacher-services.sentry.io/issues/4972346762/