### PR TITLE
Handle sign out without a resource

### DIFF
--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -63,7 +63,7 @@ class Teachers::SessionsController < Devise::SessionsController
   end
 
   def after_sign_out_path_for(resource)
-    if (application_form = resource.application_form)
+    if (application_form = resource.try(:application_form))
       view_object =
         TeacherInterface::ApplicationFormViewObject.new(application_form:)
 


### PR DESCRIPTION
Sometimes the sign out might not be related to a resource, in which case we need to handle that case.

https://dfe-teacher-services.sentry.io/issues/4976448619/