### PR TITLE
Fix eligible region content flaky test

### DIFF
--- a/spec/views/shared/eligible_region_content_spec.rb
+++ b/spec/views/shared/eligible_region_content_spec.rb
@@ -47,8 +47,9 @@ RSpec.describe "Eligible region content", type: :view do
     let(:region) do
       create(
         :region,
-        status_check: :online,
+        application_form_skip_work_history: false,
         sanction_check: :written,
+        status_check: :online,
         teaching_authority_address: "address",
         teaching_authority_certificate: "certificate",
       )


### PR DESCRIPTION
The test relies on the application form not skipping work history so we should make that explicit in the test.