### PR TITLE
Capture consent method more accurately

### DIFF
--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -58,7 +58,11 @@ class TeacherMailer < ApplicationMailer
 
   def consent_reminder
     @expires_at =
-      assessment.qualification_requests.consent_required.map(&:expires_at).max
+      assessment
+        .qualification_requests
+        .signed_consent_required
+        .map(&:expires_at)
+        .max
 
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
@@ -69,7 +73,11 @@ class TeacherMailer < ApplicationMailer
 
   def consent_requested
     @expires_at =
-      assessment.qualification_requests.consent_required.map(&:expires_at).max
+      assessment
+        .qualification_requests
+        .signed_consent_required
+        .map(&:expires_at)
+        .max
 
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -68,7 +68,7 @@ class Document < ApplicationRecord
   end
 
   def optional?
-    (signed_consent? && !documentable.signed_consent_document_required) ||
+    (signed_consent? && !documentable.signed_consent_required?) ||
       (written_statement? && application_form.written_statement_optional)
   end
 

--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -5,6 +5,7 @@
 # Table name: qualification_requests
 #
 #  id                                   :bigint           not null, primary key
+#  consent_method                       :string           default("unknown"), not null
 #  consent_received_at                  :datetime
 #  consent_requested_at                 :datetime
 #  expired_at                           :datetime
@@ -14,7 +15,6 @@
 #  review_note                          :string           default(""), not null
 #  review_passed                        :boolean
 #  reviewed_at                          :datetime
-#  signed_consent_document_required     :boolean          default(FALSE), not null
 #  unsigned_consent_document_downloaded :boolean          default(FALSE), not null
 #  verified_at                          :datetime
 #  verify_note                          :text             default(""), not null

--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -50,7 +50,11 @@ class QualificationRequest < ApplicationRecord
        },
        _prefix: true
 
-  scope :consent_required, -> { where(signed_consent_document_required: true) }
+  scope :signed_consent_required,
+        -> do
+          consent_method_signed_ecctis.or(consent_method_signed_institution)
+        end
+
   scope :consent_requested, -> { where.not(consent_requested_at: nil) }
   scope :consent_received, -> { where.not(consent_received_at: nil) }
   scope :consent_respondable,
@@ -68,6 +72,10 @@ class QualificationRequest < ApplicationRecord
 
   def expires_after
     6.weeks
+  end
+
+  def signed_consent_required?
+    consent_method_signed_ecctis? || consent_method_signed_institution?
   end
 
   def consent_requested!

--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -42,6 +42,14 @@ class QualificationRequest < ApplicationRecord
 
   belongs_to :qualification
 
+  enum consent_method: {
+         signed_ecctis: "signed_ecctis",
+         signed_institution: "signed_institution",
+         unknown: "unknown",
+         unsigned: "unsigned",
+       },
+       _prefix: true
+
   scope :consent_required, -> { where(signed_consent_document_required: true) }
   scope :consent_requested, -> { where.not(consent_requested_at: nil) }
   scope :consent_received, -> { where.not(consent_received_at: nil) }

--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -156,7 +156,7 @@ class TeacherInterface::ApplicationFormViewObject
     return false if assessment.nil?
 
     required_qualification_requests =
-      qualification_requests.where(signed_consent_document_required: true)
+      qualification_requests.signed_consent_required
 
     return false if required_qualification_requests.empty?
 

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -208,6 +208,7 @@
     - part_of_university_degree
   :qualification_requests:
     - assessment_id
+    - consent_method
     - consent_received_at
     - consent_requested_at
     - created_at
@@ -220,7 +221,6 @@
     - review_note
     - review_passed
     - reviewed_at
-    - signed_consent_document_required
     - unsigned_consent_document_downloaded
     - updated_at
     - verified_at

--- a/db/migrate/20240215085624_add_consent_method_to_qualification_requests.rb
+++ b/db/migrate/20240215085624_add_consent_method_to_qualification_requests.rb
@@ -1,0 +1,11 @@
+class AddConsentMethodToQualificationRequests < ActiveRecord::Migration[7.1]
+  def change
+    change_table :qualification_requests, bulk: true do |t|
+      t.remove :signed_consent_document_required,
+               type: :boolean,
+               default: false,
+               null: false
+      t.string :consent_method, default: "unknown", null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_08_101256) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_15_085624) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -292,7 +292,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_08_101256) do
     t.boolean "unsigned_consent_document_downloaded", default: false, null: false
     t.datetime "consent_received_at"
     t.datetime "consent_requested_at"
-    t.boolean "signed_consent_document_required", default: false, null: false
+    t.string "consent_method", default: "unknown", null: false
     t.index ["assessment_id"], name: "index_qualification_requests_on_assessment_id"
     t.index ["qualification_id"], name: "index_qualification_requests_on_qualification_id"
   end

--- a/spec/factories/qualification_requests.rb
+++ b/spec/factories/qualification_requests.rb
@@ -5,6 +5,7 @@
 # Table name: qualification_requests
 #
 #  id                                   :bigint           not null, primary key
+#  consent_method                       :string           default("unknown"), not null
 #  consent_received_at                  :datetime
 #  consent_requested_at                 :datetime
 #  expired_at                           :datetime
@@ -14,7 +15,6 @@
 #  review_note                          :string           default(""), not null
 #  review_passed                        :boolean
 #  reviewed_at                          :datetime
-#  signed_consent_document_required     :boolean          default(FALSE), not null
 #  unsigned_consent_document_downloaded :boolean          default(FALSE), not null
 #  verified_at                          :datetime
 #  verify_note                          :text             default(""), not null

--- a/spec/factories/qualification_requests.rb
+++ b/spec/factories/qualification_requests.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
     association :qualification, :completed
 
     trait :consent_required do
-      signed_consent_document_required { true }
+      consent_method { %i[signed_ecctis signed_institution].sample }
 
       after(:create) do |qualification_request, _evaluator|
         create(

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -5,6 +5,7 @@
 # Table name: qualification_requests
 #
 #  id                                   :bigint           not null, primary key
+#  consent_method                       :string           default("unknown"), not null
 #  consent_received_at                  :datetime
 #  consent_requested_at                 :datetime
 #  expired_at                           :datetime
@@ -14,7 +15,6 @@
 #  review_note                          :string           default(""), not null
 #  review_passed                        :boolean
 #  reviewed_at                          :datetime
-#  signed_consent_document_required     :boolean          default(FALSE), not null
 #  unsigned_consent_document_downloaded :boolean          default(FALSE), not null
 #  verified_at                          :datetime
 #  verify_note                          :text             default(""), not null

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -45,6 +45,20 @@ RSpec.describe QualificationRequest, type: :model do
     subject { create(:qualification_request, :receivable) }
   end
 
+  describe "columns" do
+    it do
+      is_expected.to define_enum_for(:consent_method)
+        .with_values(
+          signed_ecctis: "signed_ecctis",
+          signed_institution: "signed_institution",
+          unknown: "unknown",
+          unsigned: "unsigned",
+        )
+        .with_prefix
+        .backed_by_column_of_type(:string)
+    end
+  end
+
   describe "validations" do
     it { is_expected.to_not validate_presence_of(:consent_requested_at) }
     it { is_expected.to_not validate_presence_of(:consent_received_at) }


### PR DESCRIPTION
This replaces the `signed_consent_document_required` column with a `consent_method` enum which captures all possible states that the qualification request consent can be in.