### PR TITLE
Move unsigned_consent_document_generated

### DIFF
--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -15,6 +15,7 @@
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null
+#  unsigned_consent_document_generated       :boolean          default(FALSE), not null
 #  working_days_since_started                :integer
 #  working_days_started_to_recommendation    :integer
 #  working_days_submission_to_recommendation :integer

--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -16,7 +16,6 @@
 #  review_passed                        :boolean
 #  reviewed_at                          :datetime
 #  unsigned_consent_document_downloaded :boolean          default(FALSE), not null
-#  unsigned_consent_document_generated  :boolean          default(FALSE), not null
 #  verified_at                          :datetime
 #  verify_note                          :text             default(""), not null
 #  verify_passed                        :boolean

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -80,6 +80,7 @@
     - started_at
     - subjects
     - subjects_note
+    - unsigned_consent_document_generated
     - updated_at
     - working_days_since_started
     - working_days_started_to_recommendation
@@ -222,7 +223,6 @@
     - review_passed
     - reviewed_at
     - unsigned_consent_document_downloaded
-    - unsigned_consent_document_generated
     - updated_at
     - verified_at
     - verify_note

--- a/db/migrate/20240216114800_add_unsigned_consent_document_generated_to_assessment.rb
+++ b/db/migrate/20240216114800_add_unsigned_consent_document_generated_to_assessment.rb
@@ -1,0 +1,17 @@
+class AddUnsignedConsentDocumentGeneratedToAssessment < ActiveRecord::Migration[
+  7.1
+]
+  def change
+    add_column :assessments,
+               :unsigned_consent_document_generated,
+               :boolean,
+               default: false,
+               null: false
+
+    remove_column :qualification_requests,
+                  :unsigned_consent_document_generated,
+                  :boolean,
+                  default: false,
+                  null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_15_092915) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_16_114800) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -141,6 +141,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_15_092915) do
     t.text "recommendation_assessor_note", default: "", null: false
     t.boolean "references_verified"
     t.boolean "scotland_full_registration"
+    t.boolean "unsigned_consent_document_generated", default: false, null: false
     t.index ["application_form_id"], name: "index_assessments_on_application_form_id"
   end
 
@@ -293,7 +294,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_15_092915) do
     t.datetime "consent_received_at"
     t.datetime "consent_requested_at"
     t.string "consent_method", default: "unknown", null: false
-    t.boolean "unsigned_consent_document_generated", default: false, null: false
     t.index ["assessment_id"], name: "index_qualification_requests_on_assessment_id"
     t.index ["qualification_id"], name: "index_qualification_requests_on_qualification_id"
   end

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -15,6 +15,7 @@
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null
+#  unsigned_consent_document_generated       :boolean          default(FALSE), not null
 #  working_days_since_started                :integer
 #  working_days_started_to_recommendation    :integer
 #  working_days_submission_to_recommendation :integer

--- a/spec/factories/qualification_requests.rb
+++ b/spec/factories/qualification_requests.rb
@@ -16,7 +16,6 @@
 #  review_passed                        :boolean
 #  reviewed_at                          :datetime
 #  unsigned_consent_document_downloaded :boolean          default(FALSE), not null
-#  unsigned_consent_document_generated  :boolean          default(FALSE), not null
 #  verified_at                          :datetime
 #  verify_note                          :text             default(""), not null
 #  verify_passed                        :boolean

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -17,6 +17,7 @@
 #  started_at                                :datetime
 #  subjects                                  :text             default([]), not null, is an Array
 #  subjects_note                             :text             default(""), not null
+#  unsigned_consent_document_generated       :boolean          default(FALSE), not null
 #  working_days_since_started                :integer
 #  working_days_started_to_recommendation    :integer
 #  working_days_submission_to_recommendation :integer

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -16,7 +16,6 @@
 #  review_passed                        :boolean
 #  reviewed_at                          :datetime
 #  unsigned_consent_document_downloaded :boolean          default(FALSE), not null
-#  unsigned_consent_document_generated  :boolean          default(FALSE), not null
 #  verified_at                          :datetime
 #  verify_note                          :text             default(""), not null
 #  verify_passed                        :boolean


### PR DESCRIPTION
This moves the column to the assessment model as the unsigned consent document only has be generated once, not per qualification.