### PR TITLE
Use history stack in assessor interface

### DIFF
--- a/app/controllers/assessor_interface/application_forms_controller.rb
+++ b/app/controllers/assessor_interface/application_forms_controller.rb
@@ -10,6 +10,9 @@ module AssessorInterface
       authorize [:assessor_interface, application_form]
     end
 
+    define_history_origin :index, :show
+    define_history_reset :index
+
     def index
       @view_object = ApplicationFormsIndexViewObject.new(params:, session:)
       render layout: "full_from_desktop"

--- a/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
@@ -10,6 +10,9 @@ module AssessorInterface
       authorize %i[assessor_interface assessment_recommendation]
     end
 
+    skip_before_action :track_history, only: :show
+    define_history_origin :edit
+
     def show
       redirect_to [
                     :edit,

--- a/app/controllers/assessor_interface/assessment_recommendation_decline_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_decline_controller.rb
@@ -9,6 +9,9 @@ module AssessorInterface
       authorize %i[assessor_interface assessment_recommendation]
     end
 
+    skip_before_action :track_history, only: :show
+    define_history_origin :edit
+
     def show
       redirect_to [
                     :edit,

--- a/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
@@ -9,6 +9,9 @@ module AssessorInterface
       authorize %i[assessor_interface assessment_recommendation]
     end
 
+    skip_before_action :track_history, only: :show
+    define_history_origin :edit
+
     def show
       redirect_to [
                     :edit,

--- a/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
@@ -9,6 +9,10 @@ module AssessorInterface
       authorize %i[assessor_interface assessment_recommendation]
     end
 
+    skip_before_action :track_history, only: :show
+    define_history_origin :verify_qualifications
+    define_history_check :edit
+
     def show
       redirect_to [
                     :verify_qualifications,

--- a/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
@@ -69,23 +69,23 @@ module AssessorInterface
         session[:qualification_ids] = []
 
         if @form.verify_qualifications
-          # rubocop:disable Layout/LineLength
-          redirect_to qualification_requests_assessor_interface_application_form_assessment_assessment_recommendation_verify_path(
+          redirect_to [
+                        :qualification_requests,
+                        :assessor_interface,
+                        @application_form,
+                        @assessment,
+                        :assessment_recommendation_verify,
+                      ]
+        elsif (check_path = history_stack.last_path_if_check)
+          redirect_to check_path
+        else
+          redirect_to [
+                        :professional_standing,
+                        :assessor_interface,
                         application_form,
                         assessment,
-                        back_to_summary: params[:back_to_summary],
-                      )
-          # rubocop:enable Layout/LineLength
-        else
-          redirect_to back_to_summary_path(
-                        [
-                          :professional_standing,
-                          :assessor_interface,
-                          application_form,
-                          assessment,
-                          :assessment_recommendation_verify,
-                        ],
-                      )
+                        :assessment_recommendation_verify,
+                      ]
         end
       else
         render :edit_verify_qualifications, status: :unprocessable_entity
@@ -120,15 +120,17 @@ module AssessorInterface
         )
 
       if @form.save
-        redirect_to back_to_summary_path(
-                      [
+        if (check_path = history_stack.last_path_if_check)
+          redirect_to check_path
+        else
+          redirect_to [
                         :email_consent_letters,
                         :assessor_interface,
                         application_form,
                         assessment,
                         :assessment_recommendation_verify,
-                      ],
-                    )
+                      ]
+        end
       else
         render :edit_qualification_requests, status: :unprocessable_entity
       end
@@ -173,15 +175,17 @@ module AssessorInterface
       if @form.valid?
         session[:professional_standing] = @form.verify_professional_standing
 
-        redirect_to back_to_summary_path(
-                      [
+        if (check_path = history_stack.last_path_if_check)
+          redirect_to check_path
+        else
+          redirect_to [
                         :reference_requests,
                         :assessor_interface,
                         application_form,
                         assessment,
                         :assessment_recommendation_verify,
-                      ],
-                    )
+                      ]
+        end
       else
         render :edit_professional_standing, status: :unprocessable_entity
       end
@@ -210,15 +214,17 @@ module AssessorInterface
         )
 
       if @form.save
-        redirect_to back_to_summary_path(
-                      [
+        if (check_path = history_stack.last_path_if_check)
+          redirect_to check_path
+        else
+          redirect_to [
                         :edit,
                         :assessor_interface,
                         application_form,
                         assessment,
                         :assessment_recommendation_verify,
-                      ],
-                    )
+                      ]
+        end
       else
         render :edit_reference_requests, status: :unprocessable_entity
       end
@@ -249,20 +255,6 @@ module AssessorInterface
     def load_assessment_and_application_form
       @assessment = assessment
       @application_form = application_form
-    end
-
-    def back_to_summary_path(ordinary_path)
-      if ActiveModel::Type::Boolean.new.cast(params[:back_to_summary])
-        [
-          :edit,
-          :assessor_interface,
-          application_form,
-          assessment,
-          :assessment_recommendation_verify,
-        ]
-      else
-        ordinary_path
-      end
     end
   end
 end

--- a/app/controllers/assessor_interface/base_controller.rb
+++ b/app/controllers/assessor_interface/base_controller.rb
@@ -2,6 +2,7 @@
 
 class AssessorInterface::BaseController < ApplicationController
   include AssessorCurrentNamespace
+  include HistoryTrackable
   include StaffAuthenticatable
 
   after_action :verify_authorized

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -15,6 +15,8 @@ module AssessorInterface
     before_action :load_new_further_information_request, only: %i[preview new]
     before_action :load_view_object, only: %i[edit update]
 
+    define_history_origin :preview
+
     def preview
     end
 

--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -8,6 +8,8 @@ module AssessorInterface
       authorize [:assessor_interface, professional_standing_request]
     end
 
+    define_history_origin :show
+
     def show
       render layout: "full_from_desktop"
     end

--- a/app/controllers/assessor_interface/qualification_requests_controller.rb
+++ b/app/controllers/assessor_interface/qualification_requests_controller.rb
@@ -5,6 +5,8 @@ module AssessorInterface
     before_action :set_collection_variables, only: %i[index consent_letter]
     before_action :set_member_variables, except: %i[index consent_letter]
 
+    define_history_origin :index
+
     def index
       authorize %i[assessor_interface qualification_request]
 

--- a/app/controllers/assessor_interface/reference_requests_controller.rb
+++ b/app/controllers/assessor_interface/reference_requests_controller.rb
@@ -4,6 +4,8 @@ module AssessorInterface
   class ReferenceRequestsController < BaseController
     before_action :set_individual_variables, except: :index
 
+    define_history_origin :index
+
     def index
       authorize %i[assessor_interface reference_request]
 

--- a/app/controllers/concerns/handle_application_form_section.rb
+++ b/app/controllers/concerns/handle_application_form_section.rb
@@ -12,7 +12,8 @@ module HandleApplicationFormSection
     save_and_continue = params[:button] != "save_and_return"
 
     if form.save(validate: save_and_continue)
-      check_path = check_path_if_previous(check_identifier)
+      check_path =
+        history_stack.last_path_if_check(identifier: check_identifier)
 
       if save_and_continue
         redirect_to if_success_then_redirect.try(:call, check_path) ||
@@ -29,21 +30,5 @@ module HandleApplicationFormSection
 
   def history_stack
     @history_stack ||= HistoryStack.new(session:)
-  end
-
-  def check_path_if_previous(check_identifier)
-    entry = history_stack.last_entry
-    return nil unless entry
-
-    return nil unless entry[:check]
-
-    is_check =
-      if check_identifier.present?
-        entry[:check] == true || entry[:check] == check_identifier
-      else
-        entry[:check].present?
-      end
-
-    entry[:path] if is_check
   end
 end

--- a/app/controllers/concerns/history_trackable.rb
+++ b/app/controllers/concerns/history_trackable.rb
@@ -5,6 +5,7 @@ module HistoryTrackable
 
   included do
     before_action :track_history, if: -> { request.get? }
+
     cattr_accessor :history_origin_actions,
                    :history_check_actions,
                    :history_reset_actions

--- a/app/controllers/history_controller.rb
+++ b/app/controllers/history_controller.rb
@@ -12,7 +12,7 @@ class HistoryController < ApplicationController
   private
 
   def default_path
-    URI.parse(back_params[:default] || "/teacher/application").path
+    URI.parse(back_params[:default]).path
   end
 
   def back_params

--- a/app/lib/history_stack.rb
+++ b/app/lib/history_stack.rb
@@ -48,6 +48,20 @@ class HistoryStack
     apply_to_stack(&:second_to_last)
   end
 
+  def last_path_if_check(identifier: nil)
+    entry = last_entry
+    return nil unless entry
+
+    is_check =
+      if identifier.present?
+        entry[:check] == true || entry[:check] == identifier
+      else
+        entry[:check].present?
+      end
+
+    entry[:path] if is_check
+  end
+
   private
 
   def apply_to_stack

--- a/app/views/assessor_interface/application_forms/edit.html.erb
+++ b/app/views/assessor_interface/application_forms/edit.html.erb
@@ -1,7 +1,7 @@
 <% title = "Change details for ‘#{application_form_full_name(@application_form)}’" %>
 
 <% content_for :page_title, title_with_error_prefix(title, error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= form_with model: @form, url: [:assessor_interface, @application_form], method: :put do |f| %>
   <%= f.govuk_error_summary %>
@@ -28,7 +28,5 @@
   <%= f.govuk_text_field :given_names %>
   <%= f.govuk_text_field :family_name %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Application" %>
-<% content_for :back_link_url, assessor_interface_application_forms_path %>
+<% content_for :back_link_url, back_history_path(origin: true, default: assessor_interface_application_forms_path) %>
 
 <% application_form = @view_object.application_form %>
 

--- a/app/views/assessor_interface/application_forms/status.html.erb
+++ b/app/views/assessor_interface/application_forms/status.html.erb
@@ -7,7 +7,7 @@
            end %>
 
 <% content_for :page_title, title %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@view_object.application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@view_object.application_form)) %>
 
 <% if @view_object.application_form.awarded_at.present? %>
   <%= govuk_panel(text: title) %>

--- a/app/views/assessor_interface/application_forms/timeline.html.erb
+++ b/app/views/assessor_interface/application_forms/timeline.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Application history" %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@view_object.application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@view_object.application_form)) %>
 
 <h1 class="govuk-heading-xl">Application history</h1>
 

--- a/app/views/assessor_interface/application_forms/withdraw.html.erb
+++ b/app/views/assessor_interface/application_forms/withdraw.html.erb
@@ -1,12 +1,10 @@
 <% content_for :page_title, "Withdraw application" %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <h1 class="govuk-heading-l">Are you sure you want to withdraw this application?</h1>
 
 <p class="govuk-body">This will require the applicant to reapply if they wish to receive QTS. The applicant will not be informed of the withdrawal.</p>
 
 <%= form_with url: [:assessor_interface, @application_form], method: :delete do |f| %>
-  <%= f.govuk_submit "Withdraw" do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/assessment_recommendation_award/age_range_subjects.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_award/age_range_subjects.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, t(".heading") %>
-<% content_for :back_link_url, edit_assessor_interface_application_form_assessment_assessment_recommendation_award_path(@application_form, @assessment) %>
+<% content_for :back_link_url, back_history_path(default: edit_assessor_interface_application_form_assessment_assessment_recommendation_award_path) %>
 
 <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 
@@ -40,5 +40,5 @@ end %>
 
 <div class="govuk-button-group">
   <%= govuk_button_link_to "Continue", [:preview, :assessor_interface, @application_form, @assessment, :assessment_recommendation_award] %>
-  <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
+  <%= render "shared/assessor_interface/cancel_link" %>
 </div>

--- a/app/views/assessor_interface/assessment_recommendation_award/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_award/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix(t(".heading"), error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= form_with model: @form, url: [:assessor_interface, @application_form, @assessment, :assessment_recommendation_award], method: :put do |f| %>
   <%= f.govuk_error_summary %>
@@ -34,6 +34,6 @@
   <% end %>
 
   <%= f.govuk_submit "Accept and award QTS" do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
+    <%= render "shared/assessor_interface/cancel_link" %>
   <% end %>
 <% end %>

--- a/app/views/assessor_interface/assessment_recommendation_award/edit_age_range_subjects.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_award/edit_age_range_subjects.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix(t(".heading"), error: @form.errors.any?) %>
-<% content_for :back_link_url, age_range_subjects_assessor_interface_application_form_assessment_assessment_recommendation_award_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: age_range_subjects_assessor_interface_application_form_assessment_assessment_recommendation_award_path) %>
 
 <%= form_with model: @form, url: [:age_range_subjects, :edit, :assessor_interface, @application_form, @assessment, :assessment_recommendation_award] do |f| %>
   <%= f.govuk_error_summary %>
@@ -8,7 +8,5 @@
 
   <%= render "shared/age_range_subjects_form_fields", f: %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/assessment_recommendation_award/edit_confirm.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_award/edit_confirm.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix(t(".legend"), error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= form_with model: @form, url: [:confirm, :assessor_interface, @application_form, @assessment, :assessment_recommendation_award] do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/assessor_interface/assessment_recommendation_award/preview.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_award/preview.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, t(".heading") %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 <p class="govuk-body-l"><%= t(".subheading") %></p>
@@ -13,5 +13,5 @@
 
 <div class="govuk-button-group">
   <%= govuk_button_link_to "Continue", [:confirm, :assessor_interface, @application_form, @assessment, :assessment_recommendation_award] %>
-  <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
+  <%= render "shared/assessor_interface/cancel_link" %>
 </div>

--- a/app/views/assessor_interface/assessment_recommendation_decline/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_decline/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix(t(".heading"), error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <% preliminary_decline = @assessment.unknown? && @assessment.any_preliminary_section_failed? %>
 
@@ -75,6 +75,6 @@
   <% end %>
 
   <%= f.govuk_submit "Accept and decline QTS" do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
+    <%= render "shared/assessor_interface/cancel_link" %>
   <% end %>
 <% end %>

--- a/app/views/assessor_interface/assessment_recommendation_decline/edit_confirm.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_decline/edit_confirm.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix(t(".legend"), error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= form_with model: @form, url: [:confirm, :assessor_interface, @application_form, @assessment, :assessment_recommendation_decline] do |f| %>
   <%= f.govuk_error_summary %>

--- a/app/views/assessor_interface/assessment_recommendation_decline/preview.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_decline/preview.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, t(".heading") %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 <p class="govuk-body-l"><%= t(".subheading") %></p>
@@ -13,5 +13,5 @@
 
 <div class="govuk-button-group">
   <%= govuk_button_link_to "Continue", [:confirm, :assessor_interface, @application_form, @assessment, :assessment_recommendation_decline] %>
-  <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
+  <%= render "shared/assessor_interface/cancel_link" %>
 </div>

--- a/app/views/assessor_interface/assessment_recommendation_review/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_review/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, t(".heading") %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 

--- a/app/views/assessor_interface/assessment_recommendation_verify/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/edit.html.erb
@@ -9,7 +9,7 @@
   <%= summary_list.with_row do |row|
     row.with_key { "LoPS" }
     row.with_value { @professional_standing ? region_teaching_authority_name(@application_form.region).upcase_first : "Not selected" }
-    row.with_action(text: "Change", href: professional_standing_assessor_interface_application_form_assessment_assessment_recommendation_verify_path(@application_form, @assessment, back_to_summary: "true"), visually_hidden_text: "LoPS")
+    row.with_action(text: "Change", href: [:professional_standing, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify], visually_hidden_text: "LoPS")
   end %>
 
   <%= summary_list.with_row do |row|
@@ -25,7 +25,7 @@
         <p class="govuk-body">None selected</p>
       <% end %>
     <% end
-    row.with_action(text: "Change", href: verify_qualifications_assessor_interface_application_form_assessment_assessment_recommendation_verify_path(@application_form, @assessment, back_to_summary: "true"), visually_hidden_text: "qualifications")
+    row.with_action(text: "Change", href: [:verify_qualifications, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify], visually_hidden_text: "qualifications")
   end %>
 
   <%= summary_list.with_row do |row|
@@ -37,7 +37,7 @@
         <% end %>
       </ul>
     <% end
-    row.with_action(text: "Change", href: reference_requests_assessor_interface_application_form_assessment_assessment_recommendation_verify_path(@application_form, @assessment, back_to_summary: "true"), visually_hidden_text: "references")
+    row.with_action(text: "Change", href: [:reference_requests, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify], visually_hidden_text: "references")
   end %>
 <% end %>
 

--- a/app/views/assessor_interface/assessment_recommendation_verify/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, t(".heading") %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 

--- a/app/views/assessor_interface/assessment_recommendation_verify/edit_professional_standing.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/edit_professional_standing.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix(t(".heading"), error: @form.errors.any?) %>
-<% content_for :back_link_url, verify_qualifications_assessor_interface_application_form_assessment_assessment_recommendation_verify_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: verify_qualifications_assessor_interface_application_form_assessment_assessment_recommendation_verify_path) %>
 
 <%= form_with model: @form, url: [:professional_standing, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify] do |f| %>
   <%= f.govuk_error_summary %>
@@ -12,7 +12,5 @@
 
   <%= f.govuk_collection_radio_buttons :verify_professional_standing, %i[true false], :itself, legend: nil %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/assessment_recommendation_verify/edit_professional_standing.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/edit_professional_standing.html.erb
@@ -4,8 +4,6 @@
 <%= form_with model: @form, url: [:professional_standing, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify] do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= hidden_field_tag :back_to_summary, params[:back_to_summary] %>
-
   <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 
   <p class="govuk-body">If you choose to verify this application's LoPS an admin will email the competent authority and record the response.</p>

--- a/app/views/assessor_interface/assessment_recommendation_verify/edit_qualification_requests.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/edit_qualification_requests.html.erb
@@ -4,8 +4,6 @@
 <%= form_with model: @form, url: [:qualification_requests, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify] do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= hidden_field_tag :back_to_summary, params[:back_to_summary] %>
-
   <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 
   <p class="govuk-body">The list of qualifications that the applicant has submitted is shown below:</p>

--- a/app/views/assessor_interface/assessment_recommendation_verify/edit_qualification_requests.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/edit_qualification_requests.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix(t(".heading"), error: @form.errors.any?) %>
-<% content_for :back_link_url, verify_qualifications_assessor_interface_application_form_assessment_assessment_recommendation_verify_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: verify_qualifications_assessor_interface_application_form_assessment_assessment_recommendation_verify_path) %>
 
 <%= form_with model: @form, url: [:qualification_requests, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify] do |f| %>
   <%= f.govuk_error_summary %>
@@ -27,7 +27,5 @@
     If you’re happy to proceed, select ‘Continue’.
   </p>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/assessment_recommendation_verify/edit_reference_requests.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/edit_reference_requests.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix(t(".heading"), error: @form.errors.any?) %>
-<% content_for :back_link_url, professional_standing_assessor_interface_application_form_assessment_assessment_recommendation_verify_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: professional_standing_assessor_interface_application_form_assessment_assessment_recommendation_verify_path) %>
 
 <%= form_with model: @form, url: [:reference_requests, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify] do |f| %>
   <%= f.govuk_error_summary %>
@@ -25,7 +25,5 @@
     <li>the selected references add up to the required number of months for this application to progress</li>
   </ul>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/assessment_recommendation_verify/edit_reference_requests.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/edit_reference_requests.html.erb
@@ -4,8 +4,6 @@
 <%= form_with model: @form, url: [:reference_requests, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify] do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= hidden_field_tag :back_to_summary, params[:back_to_summary] %>
-
   <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 
   <p class="govuk-body">Select which references you want to request from the list below.</p>

--- a/app/views/assessor_interface/assessment_recommendation_verify/edit_verify_qualifications.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/edit_verify_qualifications.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix(t(".heading"), error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= form_with model: @form, url: [:verify_qualifications, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify] do |f| %>
   <%= hidden_field_tag :back_to_summary, params[:back_to_summary] %>
@@ -18,7 +18,5 @@
 
   <%= f.govuk_collection_radio_buttons :verify_qualifications, %i[true false], :itself, legend: nil %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/assessment_recommendation_verify/edit_verify_qualifications.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/edit_verify_qualifications.html.erb
@@ -2,8 +2,6 @@
 <% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= form_with model: @form, url: [:verify_qualifications, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify] do |f| %>
-  <%= hidden_field_tag :back_to_summary, params[:back_to_summary] %>
-
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>

--- a/app/views/assessor_interface/assessment_recommendation_verify/email_consent_letters.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/email_consent_letters.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, t(".heading") %>
-<% content_for :back_link_url, qualification_requests_assessor_interface_application_form_assessment_assessment_recommendation_verify_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: qualification_requests_assessor_interface_application_form_assessment_assessment_recommendation_verify_path) %>
 
 <h1 class="govuk-heading-xl"><%= t(".heading") %></h1>
 
@@ -27,5 +27,5 @@
 
 <div class="govuk-button-group">
   <%= govuk_button_link_to "Continue", [:professional_standing, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify] %>
-  <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
+  <%= render "shared/assessor_interface/cancel_link" %>
 </div>

--- a/app/views/assessor_interface/assessment_sections/_form.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_form.html.erb
@@ -80,7 +80,5 @@
     <% end %>
   <% end %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, view_object.application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -1,8 +1,10 @@
 <% preliminary_key = @view_object.assessment_section.preliminary? ? "preliminary" : "not_preliminary" %>
 <% section_key = @view_object.assessment_section.key %>
 
+<% @application_form = @view_object.application_form %>
+
 <% content_for :page_title, title_with_error_prefix(t(".title.#{preliminary_key}.#{section_key}"), error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@view_object.application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= render "linked_application_forms",
           application_forms_contact_email_used_as_teacher: @view_object.work_history_application_forms_contact_email_used_as_teacher,

--- a/app/views/assessor_interface/assessments/edit.html.erb
+++ b/app/views/assessor_interface/assessments/edit.html.erb
@@ -17,7 +17,7 @@
          end %>
 
 <% content_for :page_title, title_with_error_prefix(title, error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= form_with model: @form, url: [:assessor_interface, @application_form, @assessment], method: :put do |f| %>
   <%= f.govuk_error_summary %>
@@ -30,7 +30,5 @@
                                        :itself,
                                        legend: { text: "You can:", size: "s" } %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/assessments/review.html.erb
+++ b/app/views/assessor_interface/assessments/review.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Review verifications" %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <h1 class="govuk-heading-xl">Review verifications</h1>
 

--- a/app/views/assessor_interface/assessments/rollback.html.erb
+++ b/app/views/assessor_interface/assessments/rollback.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Reverse decision" %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <h1 class="govuk-heading-l">Are you sure you want to reverse this decision?</h1>
 
@@ -9,7 +9,5 @@
 </p>
 
 <%= form_with url: [:assessor_interface, @application_form, @assessment], method: :delete do |f| %>
-  <%= f.govuk_submit "Reverse" do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/assessor_assignments/new.html.erb
+++ b/app/views/assessor_interface/assessor_assignments/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Select an assessor", error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= render "shared/assessor_header", title: "Select an assessor", application_form: @application_form %>
 
@@ -12,7 +12,5 @@
                                        :name,
                                        legend: nil %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix(t(".title"), error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@view_object.application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
 
@@ -25,8 +25,6 @@
       <% end %>
     <% end %>
 
-    <%= f.govuk_submit do %>
-      <%= govuk_link_to "Cancel", [:assessor_interface, @view_object.application_form] %>
-    <% end %>
+    <%= render "shared/assessor_interface/continue_cancel_button", f: %>
   <% end %>
 <% end %>

--- a/app/views/assessor_interface/further_information_requests/new.html.erb
+++ b/app/views/assessor_interface/further_information_requests/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Further information request email preview" %>
-<% content_for :back_link_url, preview_assessor_interface_application_form_assessment_further_information_requests_path(@application_form, @assessment) %>
+<% content_for :back_link_url, back_history_path(default: preview_assessor_interface_application_form_assessment_further_information_requests_path) %>
 
 <h1 class="govuk-heading-xl">Further information request email preview</h1>
 

--- a/app/views/assessor_interface/further_information_requests/preview.html.erb
+++ b/app/views/assessor_interface/further_information_requests/preview.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Check the further information you’re asking the applicant for" %>
-<% content_for :back_link_url, edit_assessor_interface_application_form_assessment_path(@application_form, @assessment) %>
+<% content_for :back_link_url, back_history_path(default: edit_assessor_interface_application_form_assessment_path(@application_form, @assessment)) %>
 
 <h1 class="govuk-heading-xl">Check the information you’re asking the applicant for</h1>
 
@@ -22,7 +22,7 @@
       <%= govuk_inset_text do %>
         <%= simple_format items.first.failure_reason_assessor_feedback %>
       <% end %>
-    </section>  
+    </section>
   <% else %>
     <% items.each do |item| %>
       <section class="app-further-information-request-item">
@@ -35,7 +35,7 @@
         <% end %>
       </section>
     <% end %>
-  <% end %>  
+  <% end %>
 <% end %>
 
 <div class="govuk-button-group">

--- a/app/views/assessor_interface/further_information_requests/show.erb
+++ b/app/views/assessor_interface/further_information_requests/show.erb
@@ -1,4 +1,4 @@
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= govuk_panel(title_text: "Further information email sent successfully") %>
 

--- a/app/views/assessor_interface/notes/new.html.erb
+++ b/app/views/assessor_interface/notes/new.html.erb
@@ -8,7 +8,5 @@
 
   <%= f.govuk_text_area :text, label: { tag: "h1", size: "l" }, rows: 5 %>
 
-  <%= f.govuk_submit "Save and continue" do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/professional_standing_requests/edit_locate.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_locate.html.erb
@@ -1,7 +1,7 @@
 <% title = region_certificate_name(@application_form.region) %>
 
 <% content_for :page_title, title_with_error_prefix(title, error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= form_with model: @form, url: [:locate, :assessor_interface, @application_form, @assessment, :professional_standing_request] do |f| %>
   <%= f.govuk_error_summary %>
@@ -23,7 +23,5 @@
 
   <%= f.govuk_text_area :location_note, label: { text: "Where to find the response", size: "m" }, hint: nil %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/professional_standing_requests/edit_request.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_request.html.erb
@@ -1,7 +1,7 @@
 <% title = "Request LoPS verification" %>
 
 <% content_for :page_title, title_with_error_prefix(title, error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= form_with model: @form, url: [:request, :assessor_interface, @application_form, @assessment, :professional_standing_request] do |f| %>
   <h1 class="govuk-heading-xl"><%= title %></h1>
@@ -20,7 +20,5 @@
     <%= f.govuk_check_box :passed, true, false, multiple: false, link_errors: true, label: { text: "Verification has been requested." } %>
   <% end %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form, @assessment, :professional_standing_request] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/professional_standing_requests/edit_review.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_review.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Review LoPS", error: @form.errors.any?) %>
-<% content_for :back_link_url, review_assessor_interface_application_form_assessment_path(@application_form, @assessment) %>
+<% content_for :back_link_url, back_history_path(default: review_assessor_interface_application_form_assessment_path(@application_form, @assessment)) %>
 
 <%= form_with model: @form, url: [:review, :assessor_interface, @application_form, @assessment, :professional_standing_request] do |f| %>
   <%= f.govuk_error_summary %>
@@ -22,7 +22,5 @@
     <% end %>
   <% end %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/professional_standing_requests/edit_verify.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_verify.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Record LoPS response", error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= form_with model: @form, url: [:verify, :assessor_interface, @application_form, @assessment, :professional_standing_request] do |f| %>
   <%= f.govuk_error_summary %>
@@ -38,7 +38,5 @@
     <% end %>
   <% end %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/professional_standing_requests/edit_verify_failed.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_verify_failed.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Send for review", error: @form.errors.any?) %>
-<% content_for :back_link_url, verify_assessor_interface_application_form_assessment_professional_standing_request_path(@application_form, @assessment) %>
+<% content_for :back_link_url, back_history_path(default: verify_assessor_interface_application_form_assessment_professional_standing_request_path) %>
 
 <%= form_with model: @form, url: [:verify_failed, :assessor_interface, @application_form, @assessment, :professional_standing_request] do |f| %>
   <%= f.govuk_error_summary %>
@@ -10,7 +10,5 @@
 
   <%= f.govuk_text_area :note, label: { text: "Internal note: briefly explain to the assessor why you are sending this LoPS for review." } %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/professional_standing_requests/show.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Verify LoPS" %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <h1 class="govuk-heading-xl">Verify LoPS</h1>
 

--- a/app/views/assessor_interface/qualification_requests/edit.html.erb
+++ b/app/views/assessor_interface/qualification_requests/edit.html.erb
@@ -1,7 +1,7 @@
 <% title = qualification_title(@qualification_request.qualification) %>
 
 <% content_for :page_title, title_with_error_prefix(title, error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_assessment_qualification_requests_path(@application_form, @assessment) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_assessment_qualification_requests_path) %>
 
 <%= form_with model: @form, url: [:assessor_interface, @application_form, @assessment, @qualification_request], method: :put do |f| %>
   <%= f.govuk_error_summary %>
@@ -26,7 +26,5 @@
     <% end %>
   <% end %>
 
-  <%= f.govuk_submit "Save and continue" do %>
-    <%= govuk_link_to "Cancel", assessor_interface_application_form_path(@application_form) %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/qualification_requests/edit_review.html.erb
+++ b/app/views/assessor_interface/qualification_requests/edit_review.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Review qualification", error: @form.errors.any?) %>
-<% content_for :back_link_url, review_assessor_interface_application_form_assessment_path %>
+<% content_for :back_link_url, back_history_path(default: review_assessor_interface_application_form_assessment_path(@application_form, @assessment)) %>
 
 <%= form_with model: @form, url: [:review, :assessor_interface, @application_form, @assessment, @qualification_request] do |f| %>
   <%= f.govuk_error_summary %>
@@ -22,7 +22,5 @@
     <% end %>
   <% end %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/qualification_requests/index.html.erb
+++ b/app/views/assessor_interface/qualification_requests/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, t("assessor_interface.application_forms.show.assessment_tasks.items.qualification_requests") %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= render "shared/assessor_header", title: t("assessor_interface.application_forms.show.assessment_tasks.items.qualification_requests"), application_form: @application_form %>
 

--- a/app/views/assessor_interface/reference_requests/edit_review.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit_review.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Review reference", error: @form.errors.any?) %>
-<% content_for :back_link_url, review_assessor_interface_application_form_assessment_path(@application_form, @assessment) %>
+<% content_for :back_link_url, back_history_path(default: review_assessor_interface_application_form_assessment_path(@application_form, @assessment)) %>
 
 <%= form_with model: @form, url: [:review, :assessor_interface, @application_form, @assessment, @reference_request] do |f| %>
   <%= f.govuk_error_summary %>
@@ -13,7 +13,7 @@
   <% if @reference_request.expired? && @reference_request.received? %>
     <%= govuk_inset_text do %>
       <p>This reference’s status has changed from <%= render(StatusTag::Component.new("overdue")) %> to <%= render(StatusTag::Component.new("received")) %>.</p>
-      <p><%= govuk_link_to "View reference details", verify_assessor_interface_application_form_assessment_reference_request_path(@application_form, @assessment, @reference_request, back_to: "review") %></p>
+      <p><%= govuk_link_to "View reference details", [:verify, :assessor_interface, @application_form, @assessment, @reference_request] %></p>
     <% end %>
 
     <%= govuk_details(summary_text: "See previous notes") do %>
@@ -26,7 +26,7 @@
     <%= govuk_inset_text do %>
       <h3 class="govuk-heading-s">Internal note</h3>
       <%= simple_format @reference_request.verify_note %>
-      <p><%= govuk_link_to "View reference details", verify_assessor_interface_application_form_assessment_reference_request_path(@application_form, @assessment, @reference_request, back_to: "review") %></p>
+      <p><%= govuk_link_to "View reference details", [:verify, :assessor_interface, @application_form, @assessment, @reference_request] %></p>
     <% end %>
   <% end %>
 
@@ -37,7 +37,5 @@
     <% end %>
   <% end %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/reference_requests/edit_verify.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit_verify.html.erb
@@ -5,9 +5,7 @@
 <% title = can_update_verify_reference_request ? "Review reference" : "View reference" %>
 
 <% content_for :page_title, title_with_error_prefix(title, error: @form.errors.any?) %>
-<% content_for :back_link_url, params[:back_to] == "review" ?
-                                 review_assessor_interface_application_form_assessment_reference_request_path(@application_form, @assessment, @reference_request) :
-                                 assessor_interface_application_form_assessment_reference_requests_path(@application_form, @assessment) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_assessment_reference_requests_path) %>
 
 <%= form_with model: @form, url: [:verify, :assessor_interface, @application_form, @assessment, @reference_request] do |f| %>
   <%= f.govuk_error_summary %>
@@ -74,8 +72,6 @@
                                            legend: { text: "Do you want to send this reference for review?" } %>
     <% end %>
 
-    <%= f.govuk_submit do %>
-      <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-    <% end %>
+    <%= render "shared/assessor_interface/continue_cancel_button", f: %>
   <% end %>
 <% end %>

--- a/app/views/assessor_interface/reference_requests/edit_verify_failed.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit_verify_failed.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Send for review", error: @form.errors.any?) %>
-<% content_for :back_link_url, verify_assessor_interface_application_form_assessment_reference_request_path(@application_form, @assessment, @reference_request) %>
+<% content_for :back_link_url, back_history_path(default: verify_assessor_interface_application_form_assessment_reference_request_path) %>
 
 <%= form_with model: @form, url: [:verify_failed, :assessor_interface, @application_form, @assessment, @reference_request] do |f| %>
   <%= f.govuk_error_summary %>
@@ -10,7 +10,5 @@
 
   <%= f.govuk_text_area :note, label: { text: "Internal note: briefly explain to the assessor why you are sending this reference for review." } %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/reference_requests/index.html.erb
+++ b/app/views/assessor_interface/reference_requests/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Verify references" %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= render "shared/assessor_header", title: "Verify references", application_form: @application_form %>
 

--- a/app/views/assessor_interface/reviewer_assignments/new.html.erb
+++ b/app/views/assessor_interface/reviewer_assignments/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("Select a reviewer", error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= render "shared/assessor_header", title: "Select a reviewer", application_form: @application_form %>
 
@@ -12,7 +12,5 @@
                                        :name,
                                        legend: nil %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, @application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/work_histories/edit.html.erb
+++ b/app/views/assessor_interface/work_histories/edit.html.erb
@@ -1,10 +1,10 @@
 <% title = "Change details for ‘#{work_history_name(@work_history)}’" %>
-<% application_form = @work_history.application_form %>
+<% @application_form = @work_history.application_form %>
 
 <% content_for :page_title, title_with_error_prefix(title, error: @form.errors.any?) %>
-<% content_for :back_link_url, assessor_interface_application_form_path(application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
-<%= form_with model: @form, url: [:assessor_interface, application_form, @work_history], method: :put do |f| %>
+<%= form_with model: @form, url: [:assessor_interface, @application_form, @work_history], method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl"><%= title %></h1>
@@ -35,7 +35,5 @@
   <%= f.govuk_text_field :job %>
   <%= f.govuk_text_field :email %>
 
-  <%= f.govuk_submit do %>
-    <%= govuk_link_to "Cancel", [:assessor_interface, application_form] %>
-  <% end %>
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/shared/assessor_interface/_cancel_link.html.erb
+++ b/app/views/shared/assessor_interface/_cancel_link.html.erb
@@ -1,0 +1,1 @@
+<%= govuk_link_to "Cancel", back_history_path(origin: true, default: assessor_interface_application_form_path(@application_form)) %>

--- a/app/views/shared/assessor_interface/_continue_cancel_button.html.erb
+++ b/app/views/shared/assessor_interface/_continue_cancel_button.html.erb
@@ -1,0 +1,3 @@
+<%= f.govuk_submit do %>
+  <%= render "shared/assessor_interface/cancel_link" %>
+<% end %>


### PR DESCRIPTION
This changes the assessor interface to use the history stack in a similar way to the teacher interface: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/787

See https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/docs/history-and-back-links.md for more information on the history stack.