### PR TITLE
Move consent letter to be on collection

### DIFF
--- a/app/lib/consent_letter.rb
+++ b/app/lib/consent_letter.rb
@@ -3,8 +3,15 @@
 class ConsentLetter
   include ApplicationFormHelper
 
-  def initialize(qualification_request:)
-    @qualification_request = qualification_request
+  def initialize(application_form:)
+    @application_form = application_form
+    @date_of_consent =
+      application_form
+        .assessment
+        .qualification_requests
+        .first
+        .created_at
+        .to_date
   end
 
   def render_pdf
@@ -13,9 +20,7 @@ class ConsentLetter
 
   private
 
-  attr_reader :qualification_request
-
-  delegate :application_form, to: :qualification_request
+  attr_reader :application_form, :date_of_consent
 
   MARGIN = 62
   LINE_PAD = 12
@@ -48,7 +53,7 @@ class ConsentLetter
             pdf.text "Date of birth: #{application_form.date_of_birth.to_fs(:long_ordinal_uk)}"
           end
 
-          pdf.text "Date of consent: #{qualification_request.created_at.to_date.to_fs(:long_ordinal_uk)}"
+          pdf.text "Date of consent: #{date_of_consent.to_fs(:long_ordinal_uk)}"
 
           pdf.pad(SECTION_PAD) do
             pdf.text "The service is run by the Teaching Regulation Agency (TRA) an executive agency of the " \

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -132,8 +132,11 @@ Rails.application.routes.draw do
         resources :qualification_requests,
                   path: "/qualification-requests",
                   only: %i[index edit update] do
-          member do
+          collection do
             get "consent-letter", to: "qualification_requests#consent_letter"
+          end
+
+          member do
             get "review", to: "qualification_requests#edit_review"
             post "review", to: "qualification_requests#update_review"
           end

--- a/lib/tasks/consent_letter.rake
+++ b/lib/tasks/consent_letter.rake
@@ -2,11 +2,12 @@
 
 namespace :consent_letter do
   desc "Generate a consent letter PDF for a qualification request."
-  task :generate, %i[qualification_request_id] => :environment do |_task, args|
-    qualification_request =
-      QualificationRequest.find(args[:qualification_request_id])
+  task :generate,
+       %i[application_form_reference] => :environment do |_task, args|
+    application_form =
+      ApplicationForm.find_by!(reference: args[:application_form_reference])
 
-    pdf = ConsentLetter.new(qualification_request:).render_pdf
+    pdf = ConsentLetter.new(application_form:).render_pdf
 
     File.open("consent-letter.pdf", "wb") { |file| file.write(pdf) }
   end

--- a/spec/lib/consent_letter_spec.rb
+++ b/spec/lib/consent_letter_spec.rb
@@ -4,15 +4,17 @@ require "rails_helper"
 
 RSpec.describe ConsentLetter do
   let(:application_form) do
-    create(:application_form, :with_personal_information)
+    create(
+      :application_form,
+      :with_personal_information,
+      :with_teaching_qualification,
+    )
   end
-  let(:assessment) { create(:assessment, application_form:) }
-  let(:qualification_request) { create(:qualification_request, assessment:) }
+
+  before { create(:assessment, :with_qualification_request, application_form:) }
 
   describe "#render_pdf" do
-    subject(:render_pdf) do
-      described_class.new(qualification_request:).render_pdf
-    end
+    subject(:render_pdf) { described_class.new(application_form:).render_pdf }
 
     it "doesn't raise an error" do
       expect { render_pdf }.to_not raise_error


### PR DESCRIPTION
This changes the consent letter controller method to be on the collection since we only need to generate it once per application form, rather than per qualification request.