### PR TITLE
Use UnreceiveRequestable service

### DIFF
--- a/app/forms/assessor_interface/professional_standing_request_location_form.rb
+++ b/app/forms/assessor_interface/professional_standing_request_location_form.rb
@@ -19,7 +19,7 @@ class AssessorInterface::ProfessionalStandingRequestLocationForm
       if received && !requestable.received?
         ReceiveRequestable.call(requestable:, user:)
       elsif !received && requestable.received?
-        revert_receive_requestable
+        UnreceiveRequestable.call(requestable:, user:)
       end
 
       if requestable.requested? && requestable.reviewed?
@@ -33,13 +33,5 @@ class AssessorInterface::ProfessionalStandingRequestLocationForm
     true
   end
 
-  private
-
   delegate :application_form, to: :requestable
-
-  def revert_receive_requestable
-    requestable.requested!
-    TimelineEvent.requestable_received.where(requestable:).destroy_all
-    ApplicationFormStatusUpdater.call(application_form:, user:)
-  end
 end

--- a/app/forms/assessor_interface/qualification_request_form.rb
+++ b/app/forms/assessor_interface/qualification_request_form.rb
@@ -26,7 +26,7 @@ class AssessorInterface::QualificationRequestForm
       if received && !requestable.received?
         ReceiveRequestable.call(requestable:, user:)
       elsif !received && requestable.received?
-        revert_receive_requestable
+        UnreceiveRequestable.call(requestable:, user:)
       end
 
       if review_passed.nil?
@@ -55,11 +55,5 @@ class AssessorInterface::QualificationRequestForm
     else
       failed ? false : nil
     end
-  end
-
-  def revert_receive_requestable
-    requestable.requested!
-    TimelineEvent.requestable_received.where(requestable:).destroy_all
-    ApplicationFormStatusUpdater.call(application_form:, user:)
   end
 end


### PR DESCRIPTION
This changes two forms to use the UnreceiveRequestable service rather than duplicating logic.