### PR TITLE
Improve design of verification summary list

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -54,6 +54,10 @@ ul.autocomplete__menu {
   font-style: normal;
 }
 
+.app-summary-list .govuk-summary-list__actions {
+  vertical-align: middle;
+}
+
 .govuk-footer__navigation {
   margin-left: 0px;
   margin-right: 0px;

--- a/app/views/assessor_interface/assessment_recommendation_verify/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/edit.html.erb
@@ -5,7 +5,7 @@
 
 <p class="govuk-body">You have selected the following items for verification:</p>
 
-<%= govuk_summary_list do |summary_list| %>
+<%= govuk_summary_list(classes: %w[app-summary-list]) do |summary_list| %>
   <%= summary_list.with_row do |row|
     row.with_key { "Qualifications" }
     row.with_value do %>

--- a/app/views/assessor_interface/assessment_recommendation_verify/edit.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_verify/edit.html.erb
@@ -7,12 +7,6 @@
 
 <%= govuk_summary_list do |summary_list| %>
   <%= summary_list.with_row do |row|
-    row.with_key { "LoPS" }
-    row.with_value { @professional_standing ? region_teaching_authority_name(@application_form.region).upcase_first : "Not selected" }
-    row.with_action(text: "Change", href: [:professional_standing, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify], visually_hidden_text: "LoPS")
-  end %>
-
-  <%= summary_list.with_row do |row|
     row.with_key { "Qualifications" }
     row.with_value do %>
       <% if @qualifications.present? %>
@@ -26,6 +20,12 @@
       <% end %>
     <% end
     row.with_action(text: "Change", href: [:verify_qualifications, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify], visually_hidden_text: "qualifications")
+  end %>
+
+  <%= summary_list.with_row do |row|
+    row.with_key { "LoPS" }
+    row.with_value { @professional_standing ? region_teaching_authority_name(@application_form.region).upcase_first : "Not selected" }
+    row.with_action(text: "Change", href: [:professional_standing, :assessor_interface, @application_form, @assessment, :assessment_recommendation_verify], visually_hidden_text: "LoPS")
   end %>
 
   <%= summary_list.with_row do |row|


### PR DESCRIPTION
This reorders the LoPS and qualifications, and makes sure that the change link is vertically aligned in the middle.