### PR TITLE
Track history on each controller

### DIFF
--- a/app/controllers/assessor_interface/application_forms_controller.rb
+++ b/app/controllers/assessor_interface/application_forms_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class ApplicationFormsController < BaseController
+    include HistoryTrackable
+
     before_action only: %i[index apply_filters clear_filters] do
       authorize %i[assessor_interface application_form]
     end

--- a/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class AssessmentRecommendationAwardController < BaseController
+    include HistoryTrackable
+
     before_action :ensure_can_award
     before_action :load_assessment_and_application_form
     before_action :load_important_notes, only: %i[edit update]

--- a/app/controllers/assessor_interface/assessment_recommendation_decline_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_decline_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class AssessmentRecommendationDeclineController < BaseController
+    include HistoryTrackable
+
     before_action :ensure_can_decline
     before_action :load_assessment_and_application_form
 

--- a/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class AssessmentRecommendationReviewController < BaseController
+    include HistoryTrackable
+
     before_action :ensure_can_review
     before_action :load_assessment_and_application_form
 

--- a/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class AssessmentRecommendationVerifyController < BaseController
+    include HistoryTrackable
+
     before_action :ensure_can_verify
     before_action :load_assessment_and_application_form
 
@@ -72,8 +74,8 @@ module AssessorInterface
           redirect_to [
                         :qualification_requests,
                         :assessor_interface,
-                        @application_form,
-                        @assessment,
+                        application_form,
+                        assessment,
                         :assessment_recommendation_verify,
                       ]
         elsif (check_path = history_stack.last_path_if_check)

--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class AssessmentSectionsController < BaseController
+    include HistoryTrackable
+
     before_action { authorize [:assessor_interface, assessment_section] }
 
     def show

--- a/app/controllers/assessor_interface/assessments_controller.rb
+++ b/app/controllers/assessor_interface/assessments_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class AssessmentsController < BaseController
+    include HistoryTrackable
+
     before_action :load_assessment_and_application_form
 
     before_action only: %i[edit update] do

--- a/app/controllers/assessor_interface/assessor_assignments_controller.rb
+++ b/app/controllers/assessor_interface/assessor_assignments_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class AssessorAssignmentsController < BaseController
+    include HistoryTrackable
+
     before_action { authorize %i[assessor_interface staff_assignment] }
 
     def new

--- a/app/controllers/assessor_interface/base_controller.rb
+++ b/app/controllers/assessor_interface/base_controller.rb
@@ -2,7 +2,6 @@
 
 class AssessorInterface::BaseController < ApplicationController
   include AssessorCurrentNamespace
-  include HistoryTrackable
   include StaffAuthenticatable
 
   after_action :verify_authorized

--- a/app/controllers/assessor_interface/documents_controller.rb
+++ b/app/controllers/assessor_interface/documents_controller.rb
@@ -3,6 +3,7 @@
 module AssessorInterface
   class DocumentsController < BaseController
     include ActiveStorage::Streaming
+    include HistoryTrackable
     include StreamedResponseAuthenticatable
     include RescueActiveStorageErrors
     include UploadHelper

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class FurtherInformationRequestsController < BaseController
+    include HistoryTrackable
+
     before_action only: %i[preview new create] do
       authorize %i[assessor_interface further_information_request]
     end

--- a/app/controllers/assessor_interface/notes_controller.rb
+++ b/app/controllers/assessor_interface/notes_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class NotesController < BaseController
+    include HistoryTrackable
+
     before_action { authorize %i[assessor_interface note] }
 
     def new

--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class ProfessionalStandingRequestsController < BaseController
+    include HistoryTrackable
+
     before_action :set_variables
 
     before_action do

--- a/app/controllers/assessor_interface/qualification_requests_controller.rb
+++ b/app/controllers/assessor_interface/qualification_requests_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class QualificationRequestsController < BaseController
+    include HistoryTrackable
+
     before_action :set_collection_variables, only: %i[index consent_letter]
     before_action :set_member_variables, except: %i[index consent_letter]
 

--- a/app/controllers/assessor_interface/reference_requests_controller.rb
+++ b/app/controllers/assessor_interface/reference_requests_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class ReferenceRequestsController < BaseController
+    include HistoryTrackable
+
     before_action :set_individual_variables, except: :index
 
     define_history_origin :index

--- a/app/controllers/assessor_interface/reviewer_assignments_controller.rb
+++ b/app/controllers/assessor_interface/reviewer_assignments_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class ReviewerAssignmentsController < BaseController
+    include HistoryTrackable
+
     before_action { authorize %i[assessor_interface staff_assignment] }
 
     def new

--- a/app/controllers/assessor_interface/uploads_controller.rb
+++ b/app/controllers/assessor_interface/uploads_controller.rb
@@ -3,6 +3,7 @@
 module AssessorInterface
   class UploadsController < BaseController
     include ActiveStorage::Streaming
+    include HistoryTrackable
     include StreamedResponseAuthenticatable
     include RescueActiveStorageErrors
     include UploadHelper

--- a/app/controllers/assessor_interface/work_histories_controller.rb
+++ b/app/controllers/assessor_interface/work_histories_controller.rb
@@ -2,6 +2,8 @@
 
 module AssessorInterface
   class WorkHistoriesController < BaseController
+    include HistoryTrackable
+
     before_action { authorize [:assessor_interface, work_history] }
 
     def edit


### PR DESCRIPTION
By including the HistoryTrackable module on the BaseController we end up sharing the origin, check and reset actions across the various controllers that inherit from the BaseController which can lead to bugs if the actions are named the same (for example any `:edit` action was being recorded as a check action because it had been defined once).

[Jira Issue](https://dfedigital.atlassian.net/browse/AQTS-173)