### PR TITLE
Don't track history for documents

### DIFF
--- a/app/controllers/assessor_interface/documents_controller.rb
+++ b/app/controllers/assessor_interface/documents_controller.rb
@@ -3,7 +3,6 @@
 module AssessorInterface
   class DocumentsController < BaseController
     include ActiveStorage::Streaming
-    include HistoryTrackable
     include StreamedResponseAuthenticatable
     include RescueActiveStorageErrors
     include UploadHelper

--- a/app/controllers/assessor_interface/uploads_controller.rb
+++ b/app/controllers/assessor_interface/uploads_controller.rb
@@ -3,7 +3,6 @@
 module AssessorInterface
   class UploadsController < BaseController
     include ActiveStorage::Streaming
-    include HistoryTrackable
     include StreamedResponseAuthenticatable
     include RescueActiveStorageErrors
     include UploadHelper


### PR DESCRIPTION
When visiting the documents we don't want to track these in the history stack as they're opened in new tabs, and therefore once closed shouldn't have affected the history.