### PR TITLE
Add UnsignedConsentDocumentForm

### DIFF
--- a/app/forms/assessor_interface/unsigned_consent_document_form.rb
+++ b/app/forms/assessor_interface/unsigned_consent_document_form.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AssessorInterface::UnsignedConsentDocumentForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :assessment
+  validates :assessment, presence: true
+
+  attribute :generated, :boolean
+  validates :generated, presence: true
+
+  def save
+    return false if invalid?
+
+    assessment.update!(unsigned_consent_document_generated: true) if generated
+
+    true
+  end
+end

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -407,6 +407,10 @@ en:
           attributes:
             scotland_full_registration:
               inclusion: Select whether the teacher has or is eligible for full registration
+        assessor_interface/unsigned_consent_document_form:
+          attributes:
+            generated:
+              blank: Confirm you have generated the non-signed TRA consent document
         assessor_interface/verify_professional_standing_form:
           attributes:
             verify_professional_standing:

--- a/spec/forms/assessor_interface/unsigned_consent_document_form_spec.rb
+++ b/spec/forms/assessor_interface/unsigned_consent_document_form_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::UnsignedConsentDocumentForm, type: :model do
+  let(:assessment) { create(:assessment) }
+
+  subject(:form) { described_class.new(assessment:, generated:) }
+
+  describe "validations" do
+    let(:generated) { "" }
+
+    it { is_expected.to validate_presence_of(:assessment) }
+    it { is_expected.to validate_presence_of(:generated) }
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    context "with a positive response" do
+      let(:generated) { "true" }
+
+      it "sets unsigned_consent_document_downloaded" do
+        expect { save }.to change(
+          assessment,
+          :unsigned_consent_document_generated,
+        ).to(true)
+      end
+    end
+
+    context "with a negative response" do
+      let(:generated) { "false" }
+
+      it "doesn't set unsigned_consent_document_downloaded" do
+        expect { save }.to_not change(
+          assessment,
+          :unsigned_consent_document_generated,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds a form for recording when an assessor has generated the unsigned consent document.