### PR TITLE
Don't track history for documents

### DIFF
--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -12,6 +12,7 @@ module TeacherInterface
     skip_before_action :authenticate_teacher!
     before_action -> { authenticate_or_redirect(:teacher) }
 
+    skip_before_action :track_history, only: :show
     before_action :redirect_unless_draft_or_additional_information
     before_action :load_application_form
     before_action :load_document


### PR DESCRIPTION
When visiting the documents we don't want to track these in the history stack as they're opened in new tabs, and therefore once closed shouldn't have affected the history.