### PR TITLE
Fix back link in notes page

### DIFF
--- a/app/controllers/assessor_interface/notes_controller.rb
+++ b/app/controllers/assessor_interface/notes_controller.rb
@@ -17,7 +17,7 @@ module AssessorInterface
         )
 
       if @form.save
-        redirect_to params[:next].presence ||
+        redirect_to history_stack.pop_back ||
                       [:assessor_interface, application_form]
       else
         render :new, status: :unprocessable_entity

--- a/app/views/assessor_interface/notes/new.html.erb
+++ b/app/views/assessor_interface/notes/new.html.erb
@@ -1,9 +1,7 @@
 <% content_for :page_title, title_with_error_prefix("Add a note", error: @form.errors.any?) %>
-<% content_for :back_link_url, params[:next].presence || assessor_interface_application_form_path(@application_form) %>
+<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
 
 <%= form_with model: @form, url: [:assessor_interface, @application_form, :notes] do |f| %>
-  <%= hidden_field_tag :next, params[:next] %>
-
   <%= f.govuk_error_summary %>
 
   <%= f.govuk_text_area :text, label: { tag: "h1", size: "l" }, rows: 5 %>

--- a/app/views/shared/_assessor_header.html.erb
+++ b/app/views/shared/_assessor_header.html.erb
@@ -2,6 +2,6 @@
   <h1 class="govuk-heading-xl"><%= title %></h1>
 
   <%= govuk_button_link_to "Add&nbsp;note".html_safe,
-                           new_assessor_interface_application_form_note_path(application_form, next: request.path),
+                           [:new, :assessor_interface, @application_form, :note],
                            secondary: true %>
 </div>


### PR DESCRIPTION
This updates the notes page to use the history stack, this fixes an unusual flow where the back link would end up in a loop.