### PR TITLE
Store recommendation note on assessment

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_decline_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_decline_controller.rb
@@ -27,13 +27,15 @@ module AssessorInterface
     def edit
       @form =
         AssessmentDeclarationDeclineForm.new(
-          recommendation_assessor_note: session[:recommendation_assessor_note],
+          assessment:,
+          recommendation_assessor_note: assessment.recommendation_assessor_note,
         )
     end
 
     def update
       @form =
         AssessmentDeclarationDeclineForm.new(
+          assessment:,
           declaration:
             params.dig(
               :assessor_interface_assessment_declaration_decline_form,
@@ -44,8 +46,6 @@ module AssessorInterface
               :assessor_interface_assessment_declaration_decline_form,
               :recommendation_assessor_note,
             ),
-          session:,
-          assessment:,
         )
 
       if @form.save
@@ -86,13 +86,6 @@ module AssessorInterface
         if @form.confirmation
           ActiveRecord::Base.transaction do
             assessment.decline!
-
-            if (
-                 recommendation_assessor_note =
-                   session[:recommendation_assessor_note]
-               ).present?
-              assessment.update!(recommendation_assessor_note:)
-            end
 
             DeclineQTS.call(application_form:, user: current_staff)
           end

--- a/app/forms/assessor_interface/assessment_declaration_decline_form.rb
+++ b/app/forms/assessor_interface/assessment_declaration_decline_form.rb
@@ -4,7 +4,8 @@ class AssessorInterface::AssessmentDeclarationDeclineForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attr_accessor :session, :assessment
+  attr_accessor :assessment
+  validates :assessment, presence: true
 
   attribute :declaration, :boolean
   attribute :recommendation_assessor_note, :string
@@ -17,7 +18,8 @@ class AssessorInterface::AssessmentDeclarationDeclineForm
   def save
     return false unless valid?
 
-    session[:recommendation_assessor_note] = recommendation_assessor_note
+    assessment.update!(recommendation_assessor_note:)
+
     true
   end
 end

--- a/spec/forms/assessor_interface/assessment_declaration_decline_form_spec.rb
+++ b/spec/forms/assessor_interface/assessment_declaration_decline_form_spec.rb
@@ -3,25 +3,24 @@
 require "rails_helper"
 RSpec.describe AssessorInterface::AssessmentDeclarationDeclineForm,
                type: :model do
-  let(:session) { {} }
   subject(:form) do
     described_class.new(
-      session:,
       assessment:,
       declaration: true,
       recommendation_assessor_note: "Note",
     )
   end
 
+  let(:assessment) { create(:assessment, :decline) }
+
   describe "validations" do
     context "when recommendation is declined with no failure reasons" do
-      let(:assessment) { create(:assessment, :decline) }
-
       it { is_expected.to validate_presence_of(:recommendation_assessor_note) }
     end
 
     context "when recommendation is started" do
-      let(:assessment) { create(:assessment, :started) }
+      before { assessment.update!(started_at: Time.zone.now) }
+
       it { is_expected.to validate_presence_of(:declaration) }
     end
 
@@ -29,7 +28,6 @@ RSpec.describe AssessorInterface::AssessmentDeclarationDeclineForm,
       before do
         create(:assessment_section, :declines_with_already_qts, assessment:)
       end
-      let(:assessment) { create(:assessment, :decline) }
 
       it do
         is_expected.not_to validate_presence_of(:recommendation_assessor_note)
@@ -38,13 +36,13 @@ RSpec.describe AssessorInterface::AssessmentDeclarationDeclineForm,
   end
 
   describe "#save" do
-    let(:assessment) { create(:assessment, :decline) }
     context "when valid" do
       subject(:save) { form.save }
 
       it { is_expected.to be true }
-      it "sets the session" do
-        expect { save }.to change { session[:recommendation_assessor_note] }.to(
+
+      it "sets the recommendation note" do
+        expect { save }.to change(assessment, :recommendation_assessor_note).to(
           "Note",
         )
       end


### PR DESCRIPTION
This allows it to be seen in the email preview which will give confidence back to the assessors, and it ensures that we don't accidentally show a different decline reason from the session.

[Jira Issue](https://dfedigital.atlassian.net/browse/AQTS-178)