### PR TITLE
Prevent duplicate FIs being created

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
@@ -13,7 +13,6 @@ module AssessorInterface
     end
 
     skip_before_action :track_history, only: :show
-    define_history_origin :edit
 
     def show
       redirect_to [

--- a/app/controllers/assessor_interface/assessment_recommendation_decline_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_decline_controller.rb
@@ -12,7 +12,6 @@ module AssessorInterface
     end
 
     skip_before_action :track_history, only: :show
-    define_history_origin :edit
 
     def show
       redirect_to [

--- a/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
@@ -12,7 +12,6 @@ module AssessorInterface
     end
 
     skip_before_action :track_history, only: :show
-    define_history_origin :edit
 
     def show
       redirect_to [

--- a/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
@@ -12,7 +12,6 @@ module AssessorInterface
     end
 
     skip_before_action :track_history, only: :show
-    define_history_origin :verify_qualifications
     define_history_check :edit
 
     def show

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -25,11 +25,14 @@ module AssessorInterface
 
     def create
       ActiveRecord::Base.transaction do
-        assessment.request_further_information!
         CreateFurtherInformationRequest.call(assessment:, user: current_staff)
+        assessment.request_further_information!
       end
 
       redirect_to [:status, :assessor_interface, application_form]
+    rescue CreateFurtherInformationRequest::AlreadyExists
+      flash[:warning] = "Further information has already been requested."
+      render :preview, status: :unprocessable_entity
     end
 
     def edit

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -13,7 +13,7 @@ module AssessorInterface
     end
 
     before_action :load_application_form_and_assessment,
-                  only: %i[preview new show edit]
+                  only: %i[preview new edit]
     before_action :load_new_further_information_request, only: %i[preview new]
     before_action :load_view_object, only: %i[edit update]
 
@@ -26,22 +26,12 @@ module AssessorInterface
     end
 
     def create
-      further_information_request =
-        ActiveRecord::Base.transaction do
-          assessment.request_further_information!
-          CreateFurtherInformationRequest.call(assessment:, user: current_staff)
-        end
+      ActiveRecord::Base.transaction do
+        assessment.request_further_information!
+        CreateFurtherInformationRequest.call(assessment:, user: current_staff)
+      end
 
-      redirect_to [
-                    :assessor_interface,
-                    application_form,
-                    assessment,
-                    further_information_request,
-                  ]
-    end
-
-    def show
-      @further_information_request = further_information_request
+      redirect_to [:status, :assessor_interface, application_form]
     end
 
     def edit

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -17,8 +17,6 @@ module AssessorInterface
     before_action :load_new_further_information_request, only: %i[preview new]
     before_action :load_view_object, only: %i[edit update]
 
-    define_history_origin :preview
-
     def preview
     end
 

--- a/app/policies/assessor_interface/further_information_request_policy.rb
+++ b/app/policies/assessor_interface/further_information_request_policy.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class AssessorInterface::FurtherInformationRequestPolicy < ApplicationPolicy
-  def show?
-    true
-  end
-
   def create?
     user.assess_permission
   end

--- a/app/services/create_further_information_request.rb
+++ b/app/services/create_further_information_request.rb
@@ -9,8 +9,13 @@ class CreateFurtherInformationRequest
   end
 
   def call
+    raise AlreadyExists if assessment.further_information_requests.exists?
+
     create_and_request
     send_email
+  end
+
+  class AlreadyExists < StandardError
   end
 
   private

--- a/app/views/assessor_interface/application_forms/status.html.erb
+++ b/app/views/assessor_interface/application_forms/status.html.erb
@@ -2,6 +2,8 @@
              "Application sent for review"
            elsif @view_object.assessment.verify?
              "Verifications requested"
+           elsif @view_object.assessment.request_further_information?
+             "Further information email sent successfully"
            else
              "QTS application #{@view_object.application_form.reference} has been #{@view_object.status.downcase}"
            end %>
@@ -20,6 +22,8 @@
 <% elsif @view_object.assessment.verify? %>
   <p class="govuk-body">You have submitted your verification requests.</p>
   <p class="govuk-body">These will now be verified by an admin. You do not need to do anything further with this application unless it is flagged for review.</p>
+<% elsif @view_object.assessment.request_further_information? %>
+  <p class="govuk-body">You’ve successfully sent your further information request email to the applicant.</p>
 <% elsif @view_object.application_form.declined_at.present? %>
   <p class="govuk-body">The application will be deleted after 90 days unless the applicant chooses to appeal.</p>
 <% elsif @view_object.application_form.dqt_trn_request.present? %>

--- a/app/views/assessor_interface/application_forms/status.html.erb
+++ b/app/views/assessor_interface/application_forms/status.html.erb
@@ -9,7 +9,7 @@
            end %>
 
 <% content_for :page_title, title %>
-<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@view_object.application_form)) %>
+<% content_for :back_link_url, back_history_path(origin: true, default: assessor_interface_application_form_path(@view_object.application_form)) %>
 
 <% if @view_object.application_form.awarded_at.present? %>
   <%= govuk_panel(text: title) %>

--- a/app/views/assessor_interface/further_information_requests/show.erb
+++ b/app/views/assessor_interface/further_information_requests/show.erb
@@ -1,9 +1,0 @@
-<% content_for :back_link_url, back_history_path(default: assessor_interface_application_form_path(@application_form)) %>
-
-<%= govuk_panel(title_text: "Further information email sent successfully") %>
-
-<p class="govuk-body">You’ve successfully sent your further information request email to the applicant.</p>
-<p class="govuk-body">You can now return to the application itself, or go back to your list of applications.</p>
-
-<%= govuk_button_link_to "See application overview", assessor_interface_application_form_path(@application_form) %>
-<%= govuk_button_link_to "Back to application list", assessor_interface_application_forms_path, secondary: true %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,7 +104,7 @@ Rails.application.routes.draw do
 
         resources :further_information_requests,
                   path: "/further-information-requests",
-                  only: %i[new create show edit update] do
+                  only: %i[new create edit update] do
           get "preview",
               to: "further_information_requests#preview",
               on: :collection

--- a/spec/policies/assessor_interface/further_information_request_policy_spec.rb
+++ b/spec/policies/assessor_interface/further_information_request_policy_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe AssessorInterface::FurtherInformationRequestPolicy do
 
   describe "#show?" do
     subject(:show?) { policy.show? }
-    it_behaves_like "a policy method with permission"
+    it_behaves_like "a policy method without permission"
   end
 
   describe "#preview?" do

--- a/spec/services/create_further_information_request_spec.rb
+++ b/spec/services/create_further_information_request_spec.rb
@@ -45,4 +45,14 @@ RSpec.describe CreateFurtherInformationRequest do
   it "records a requestable requested timeline event" do
     expect { call }.to have_recorded_timeline_event(:requestable_requested)
   end
+
+  context "with an existing request" do
+    before { create(:further_information_request, assessment:) }
+
+    it "raises an error" do
+      expect { call }.to raise_error(
+        CreateFurtherInformationRequest::AlreadyExists,
+      )
+    end
+  end
 end

--- a/spec/support/autoload/page_objects/assessor_interface/further_information_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/further_information_request.rb
@@ -1,8 +1,0 @@
-module PageObjects
-  module AssessorInterface
-    class FurtherInformationRequest < SitePrism::Page
-      set_url "/assessor/applications/{reference}/assessments/{assessment_id}" \
-                "/further-information-requests/{further_information_request_id}"
-    end
-  end
-end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -122,11 +122,6 @@ module PageHelpers
       PageObjects::AssessorInterface::EmailConsentLettersAssessmentRecommendationVerify.new
   end
 
-  def assessor_further_information_request_page
-    @assessor_further_information_request_page ||=
-      PageObjects::AssessorInterface::FurtherInformationRequest.new
-  end
-
   def assessor_further_information_request_preview_page
     @assessor_further_information_request_preview_page ||=
       PageObjects::AssessorInterface::FurtherInformationRequestPreview.new

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -50,12 +50,7 @@ RSpec.describe "Assessor requesting further information", type: :system do
     and_i_see_the_email_preview
 
     when_i_click_send_to_applicant
-    then_i_see_the(
-      :assessor_further_information_request_page,
-      reference:,
-      assessment_id:,
-      further_information_request_id:,
-    )
+    then_i_see_the(:assessor_application_status_page, reference:)
     and_i_receive_a_further_information_requested_email
   end
 
@@ -165,9 +160,5 @@ RSpec.describe "Assessor requesting further information", type: :system do
 
   def assessment_id
     application_form.assessment.id
-  end
-
-  def further_information_request_id
-    FurtherInformationRequest.last.id
   end
 end


### PR DESCRIPTION
With the new back links introduce in #2007 sometimes the assessors end up back on the request FI page and try to create the further information request again. This adds some safeguards to prevent duplicate FIs from being created, while also fixing the back links so assessors don't end up on the page.

[Jira Issue](https://dfedigital.atlassian.net/browse/AQTS-176)