### PR TITLE
Remove convert to PDF link

### DIFF
--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -22,33 +22,16 @@ module DocumentHelper
 
       malware_scan_active =
         FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
-      convert_to_pdf_active =
-        FeatureFlags::FeatureFlag.active?(:convert_documents_to_pdf)
 
-      [
-        uploads
-          .map { |upload| upload_link_to(upload) }
-          .join("<br />")
-          .html_safe,
-        if malware_scan_active && scope.scan_result_suspect.exists?
-          "<em>#{scope.count} #{"file upload".pluralize(scope.count)} has been scanned as malware and deleted.</em>"
-        elsif request.path.starts_with?("/assessor") && convert_to_pdf_active &&
-              !uploads.all?(&:is_pdf?)
-          govuk_link_to(
-            "Download as PDF (opens in a new tab)",
-            Rails
-              .application
-              .routes
-              .url_helpers
-              .assessor_interface_application_form_document_pdf_path(
-              document,
-              translated ? "translated" : "original",
-            ),
-            target: :_blank,
-            rel: :noopener,
-          )
-        end,
-      ].compact_blank.join("<br /><br />").html_safe
+      items = uploads.map { |upload| upload_link_to(upload) }
+
+      if malware_scan_active && scope.scan_result_suspect.exists?
+        items << tag.em(
+          "#{scope.count} #{"file upload".pluralize(scope.count)} has been scanned as malware and deleted.",
+        )
+      end
+
+      tag.ul(class: "govuk-list") { items.map { |item| concat(tag.li(item)) } }
     end
   end
 end

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -1,10 +1,4 @@
 feature_flags:
-  convert_documents_to_pdf:
-    author: Thomas Leese
-    description: >
-      Provide a way of automatically converting documents to a single PDF suitable for
-      uploading to the Ecctis portal.
-
   fetch_malware_scan_result:
     author: Steve Laing
     description: >

--- a/lib/tasks/review_app.rake
+++ b/lib/tasks/review_app.rake
@@ -7,7 +7,6 @@ namespace :review_app do
       raise "THIS TASK CANNOT BE RUN IN PRODUCTION"
     end
 
-    FeatureFlags::FeatureFlag.activate(:convert_documents_to_pdf)
     FeatureFlags::FeatureFlag.activate(:personas)
     FeatureFlags::FeatureFlag.activate(:teacher_applications)
   end


### PR DESCRIPTION
We're not going to have a convert to PDF link available on all uploads, only those related to consent so we can remove these from the document links.