### PR TITLE
Remove part_of_university_degree (part 3 of 3)

### DIFF
--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -2,17 +2,16 @@
 #
 # Table name: qualifications
 #
-#  id                        :bigint           not null, primary key
-#  certificate_date          :date
-#  complete_date             :date
-#  institution_country_code  :text             default(""), not null
-#  institution_name          :text             default(""), not null
-#  part_of_university_degree :boolean
-#  start_date                :date
-#  title                     :text             default(""), not null
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  application_form_id       :bigint           not null
+#  id                       :bigint           not null, primary key
+#  certificate_date         :date
+#  complete_date            :date
+#  institution_country_code :text             default(""), not null
+#  institution_name         :text             default(""), not null
+#  start_date               :date
+#  title                    :text             default(""), not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  application_form_id      :bigint           not null
 #
 # Indexes
 #

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -213,17 +213,16 @@
     - verify_note
     - verify_passed
   :qualifications:
-    - id
     - application_form_id
-    - title
-    - institution_name
-    - institution_country_code
-    - start_date
-    - complete_date
     - certificate_date
+    - complete_date
     - created_at
+    - id
+    - institution_country_code
+    - institution_name
+    - start_date
+    - title
     - updated_at
-    - part_of_university_degree
   :qualification_requests:
     - assessment_id
     - consent_method

--- a/db/migrate/20240227142809_add_teaching_qualification_part_of_degree_to_application_forms.rb
+++ b/db/migrate/20240227142809_add_teaching_qualification_part_of_degree_to_application_forms.rb
@@ -5,14 +5,5 @@ class AddTeachingQualificationPartOfDegreeToApplicationForms < ActiveRecord::Mig
     add_column :application_forms,
                :teaching_qualification_part_of_degree,
                :boolean
-
-    ApplicationForm
-      .includes(:qualifications)
-      .find_each do |application_form|
-        application_form.update!(
-          teaching_qualification_part_of_degree:
-            application_form.teaching_qualification&.part_of_university_degree,
-        )
-      end
   end
 end

--- a/db/migrate/20240227154108_remove_part_of_university_degree_from_qualifications.rb
+++ b/db/migrate/20240227154108_remove_part_of_university_degree_from_qualifications.rb
@@ -1,0 +1,7 @@
+class RemovePartOfUniversityDegreeFromQualifications < ActiveRecord::Migration[
+  7.1
+]
+  def change
+    remove_column :qualifications, :part_of_university_degree, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -326,7 +326,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_28_140334) do
     t.date "certificate_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "part_of_university_degree"
     t.index ["application_form_id"], name: "index_qualifications_on_application_form_id"
   end
 

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -2,17 +2,16 @@
 #
 # Table name: qualifications
 #
-#  id                        :bigint           not null, primary key
-#  certificate_date          :date
-#  complete_date             :date
-#  institution_country_code  :text             default(""), not null
-#  institution_name          :text             default(""), not null
-#  part_of_university_degree :boolean
-#  start_date                :date
-#  title                     :text             default(""), not null
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  application_form_id       :bigint           not null
+#  id                       :bigint           not null, primary key
+#  certificate_date         :date
+#  complete_date            :date
+#  institution_country_code :text             default(""), not null
+#  institution_name         :text             default(""), not null
+#  start_date               :date
+#  title                    :text             default(""), not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  application_form_id      :bigint           not null
 #
 # Indexes
 #

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -2,17 +2,16 @@
 #
 # Table name: qualifications
 #
-#  id                        :bigint           not null, primary key
-#  certificate_date          :date
-#  complete_date             :date
-#  institution_country_code  :text             default(""), not null
-#  institution_name          :text             default(""), not null
-#  part_of_university_degree :boolean
-#  start_date                :date
-#  title                     :text             default(""), not null
-#  created_at                :datetime         not null
-#  updated_at                :datetime         not null
-#  application_form_id       :bigint           not null
+#  id                       :bigint           not null, primary key
+#  certificate_date         :date
+#  complete_date            :date
+#  institution_country_code :text             default(""), not null
+#  institution_name         :text             default(""), not null
+#  start_date               :date
+#  title                    :text             default(""), not null
+#  created_at               :datetime         not null
+#  updated_at               :datetime         not null
+#  application_form_id      :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
This removes the column that is no longer used anywhere and has been replaced with the `teaching_qualification_part_of_degree` column on the application form.