### PR TITLE
Allow reviewing consent requests

### DIFF
--- a/app/controllers/assessor_interface/assessments_controller.rb
+++ b/app/controllers/assessor_interface/assessments_controller.rb
@@ -18,6 +18,13 @@ module AssessorInterface
       @professional_standing_request =
         assessment.professional_standing_request if assessment.professional_standing_request&.verify_failed?
 
+      @consent_requests =
+        assessment
+          .consent_requests
+          .includes(:qualification)
+          .where(verify_passed: false)
+          .order_by_role
+
       @qualification_requests =
         assessment
           .qualification_requests

--- a/app/controllers/assessor_interface/consent_requests_controller.rb
+++ b/app/controllers/assessor_interface/consent_requests_controller.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module AssessorInterface
+  class ConsentRequestsController < BaseController
+    include HistoryTrackable
+
+    before_action :set_variables
+
+    def edit_review
+      @form = RequestableReviewForm.new(requestable:)
+    end
+
+    def update_review
+      @form =
+        RequestableReviewForm.new(
+          requestable:,
+          user: current_staff,
+          **review_form_params,
+        )
+
+      if @form.save
+        redirect_to [:review, :assessor_interface, application_form, assessment]
+      else
+        render :edit_review, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def application_form
+      @application_form ||=
+        ApplicationForm.includes(:assessment).find_by(
+          reference: params[:application_form_reference],
+          assessment: {
+            id: params[:assessment_id],
+          },
+        )
+    end
+
+    def assessment
+      @assessment ||= application_form.assessment
+    end
+
+    def consent_requests
+      @consent_requests ||= assessment.consent_requests
+    end
+
+    def consent_request
+      @consent_request ||= consent_requests.find(params[:id])
+    end
+
+    alias_method :requestable, :consent_request
+
+    def set_variables
+      @consent_request = authorize [:assessor_interface, consent_request]
+      @application_form = application_form
+      @assessment = assessment
+    end
+
+    def review_form_params
+      params.require(:assessor_interface_requestable_review_form).permit(
+        :passed,
+        :note,
+      )
+    end
+  end
+end

--- a/app/policies/assessor_interface/consent_request_policy.rb
+++ b/app/policies/assessor_interface/consent_request_policy.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AssessorInterface::ConsentRequestPolicy < ApplicationPolicy
+  def update_review?
+    user.assess_permission
+  end
+
+  alias_method :edit_review?, :update_review?
+end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -257,14 +257,14 @@ class AssessorInterface::ApplicationFormsShowViewObject
 
   def verification_task_list_section
     return unless pre_assessment_complete?
+    return if assessment.unknown? || assessment.request_further_information?
 
     items = [
       qualification_requests_task_list_item,
       reference_requests_task_list_item,
       professional_standing_request_task_list_item,
+      verification_decision_task_list_item,
     ].compact
-
-    items << verification_decision_task_list_item if items.present?
 
     {
       title:

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -85,7 +85,8 @@ class AssessorInterface::ApplicationFormsShowViewObject
            :teaching_authority_provides_written_statement,
            :work_histories,
            to: :application_form
-  delegate :professional_standing_request,
+  delegate :consent_requests,
+           :professional_standing_request,
            :qualification_requests,
            :reference_requests,
            to: :assessment
@@ -370,7 +371,8 @@ class AssessorInterface::ApplicationFormsShowViewObject
     if (
          !teaching_authority_provides_written_statement &&
            professional_standing_request&.verify_failed?
-       ) || qualification_requests.any?(&:verify_failed?) ||
+       ) || consent_requests.any?(&:verify_failed?) ||
+         qualification_requests.any?(&:verify_failed?) ||
          reference_requests.any?(&:verify_failed?)
       {
         title:
@@ -398,7 +400,8 @@ class AssessorInterface::ApplicationFormsShowViewObject
         elsif (
               !teaching_authority_provides_written_statement &&
                 professional_standing_request&.reviewed?
-            ) || reference_requests.any?(:reviewed?)
+            ) || consent_requests.any?(:reviewed?) ||
+              reference_requests.any?(:reviewed?)
           :in_progress
         else
           :not_started

--- a/app/views/assessor_interface/assessments/review.html.erb
+++ b/app/views/assessor_interface/assessments/review.html.erb
@@ -21,11 +21,17 @@
       ],
     }
   end,
-  if @qualification_requests.present?
+  if @consent_requests.present? || @qualification_requests.present?
     {
       title: "Qualifications",
       indentation: false,
-      items: @qualification_requests.map do |qualification_request|
+      items: @consent_requests.map do |consent_request|
+        {
+          name: qualification_title(consent_request.qualification),
+          link: [:review, :assessor_interface, @application_form, @assessment, consent_request],
+          status: consent_request.review_status,
+        }
+      end + @qualification_requests.map do |qualification_request|
         {
           name: qualification_title(qualification_request.qualification),
           link: [:review, :assessor_interface, @application_form, @assessment, qualification_request],

--- a/app/views/assessor_interface/consent_requests/edit_review.html.erb
+++ b/app/views/assessor_interface/consent_requests/edit_review.html.erb
@@ -1,0 +1,41 @@
+<% title = "Review qualification" %>
+
+<% content_for :page_title, title_with_error_prefix(title, error: @form.errors.any?) %>
+<% content_for :back_link_url, back_history_path(default: review_assessor_interface_application_form_assessment_path(@application_form, @assessment)) %>
+
+<%= form_with model: @form, url: [:review, :assessor_interface, @application_form, @assessment, @consent_request] do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl"><%= title %></h1>
+
+  <h2 class="govuk-heading-m">
+    <%= qualification_title(@consent_request.qualification) %>
+  </h2>
+
+  <% if @consent_request.expired? && @consent_request.received? %>
+    <%= govuk_inset_text do %>
+      <p>This qualifications’s status has changed from <%= render(StatusTag::Component.new("overdue")) %> to <%= render(StatusTag::Component.new("received")) %>.</p>
+    <% end %>
+
+    <%= govuk_details(summary_text: "See previous notes") do %>
+      <%= govuk_inset_text do %>
+        <h3 class="govuk-heading-s">Internal note</h3>
+        <%= simple_format @consent_request.verify_note %>
+      <% end %>
+    <% end %>
+  <% else %>
+    <%= govuk_inset_text do %>
+      <h3 class="govuk-heading-s">Internal note</h3>
+      <%= simple_format @consent_request.verify_note %>
+    <% end %>
+  <% end %>
+
+  <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "After review, does the response confirm that this qualification is legitimate?", size: "s" } do %>
+    <%= f.govuk_radio_button :passed, :true, link_errors: true %>
+    <%= f.govuk_radio_button :passed, :false do %>
+      <%= f.govuk_text_area :note, label: { text: "Internal note: briefly explain why the qualification should not be accepted." } %>
+    <% end %>
+  <% end %>
+
+  <%= render "shared/assessor_interface/continue_cancel_button", f: %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,13 @@ Rails.application.routes.draw do
                  "assessment_recommendation_verify#update_professional_standing"
         end
 
+        resources :consent_requests, path: "/consent-requests", only: [] do
+          member do
+            get "review", to: "consent_requests#edit_review"
+            post "review", to: "consent_requests#update_review"
+          end
+        end
+
         resources :further_information_requests,
                   path: "/further-information-requests",
                   only: %i[new create edit update] do

--- a/spec/policies/assessor_interface/consent_request_policy_spec.rb
+++ b/spec/policies/assessor_interface/consent_request_policy_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::ConsentRequestPolicy do
+  it_behaves_like "a policy"
+
+  let(:user) { nil }
+  let(:record) { nil }
+
+  subject(:policy) { described_class.new(user, record) }
+
+  describe "#index?" do
+    subject(:index?) { policy.index? }
+    it_behaves_like "a policy method without permission"
+  end
+
+  describe "#show?" do
+    subject(:show?) { policy.show? }
+    it_behaves_like "a policy method without permission"
+  end
+
+  describe "#create?" do
+    subject(:create?) { policy.create? }
+    it_behaves_like "a policy method without permission"
+  end
+
+  describe "#new?" do
+    subject(:new?) { policy.new? }
+    it_behaves_like "a policy method without permission"
+  end
+
+  describe "#update_review?" do
+    subject(:update_review?) { policy.update_review? }
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+
+  describe "#edit_review?" do
+    subject(:edit_review?) { policy.edit_review? }
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+
+  describe "#destroy?" do
+    subject(:destroy?) { policy.destroy? }
+    it_behaves_like "a policy method without permission"
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/review_consent_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/review_consent_request.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class ReviewConsentRequest < ReviewRequestablePage
+      set_url "/assessor/applications/{reference}/assessments/{assessment_id}" \
+                "/consent-requests/{id}/review"
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -186,6 +186,11 @@ module PageHelpers
       PageObjects::AssessorInterface::ReverseDecision.new
   end
 
+  def assessor_review_consent_request_page
+    @assessor_review_consent_request_page ||=
+      PageObjects::AssessorInterface::ReviewConsentRequest.new
+  end
+
   def assessor_review_further_information_request_page
     @assessor_review_further_information_request_page ||=
       PageObjects::AssessorInterface::ReviewFurtherInformationRequest.new

--- a/spec/system/assessor_interface/reviewing_consent_spec.rb
+++ b/spec/system/assessor_interface/reviewing_consent_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assessor reviewing references", type: :system do
+  before do
+    given_the_service_is_open
+    given_i_am_authorized_as_an_assessor_user
+    given_there_is_an_application_form_with_failed_consent
+  end
+
+  it "sends for review" do
+    when_i_visit_the(:assessor_application_page, reference:)
+    then_i_see_the(:assessor_application_page, reference:)
+
+    when_i_click_on_verification_decision
+    then_i_see_the(:assessor_complete_assessment_page, reference:)
+
+    when_i_select_send_for_review
+    then_i_see_the(:assessor_assessment_recommendation_review_page, reference:)
+
+    when_i_click_continue_from_review
+    then_i_see_the(:assessor_application_status_page, reference:)
+
+    when_i_click_on_overview_button
+    then_i_see_the(:assessor_application_page, reference:)
+
+    when_i_click_on_review_verifications
+    then_i_see_the(
+      :assessor_review_verifications_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_see_the_consent_not_started
+
+    when_i_click_on_back_to_overview
+    then_i_see_the(:assessor_application_page, reference:)
+
+    when_i_click_on_assessment_decision
+    then_i_see_the(
+      :assessor_complete_assessment_page,
+      reference:,
+      assessment_id:,
+    )
+  end
+
+  private
+
+  def given_there_is_an_application_form_with_failed_consent
+    application_form
+  end
+
+  def when_i_click_on_verification_decision
+    assessor_application_page.verification_decision_task.click
+  end
+
+  def when_i_select_send_for_review
+    assessor_complete_assessment_page.send_for_review.choose
+    assessor_complete_assessment_page.continue_button.click
+  end
+
+  def when_i_click_continue_from_review
+    assessor_assessment_recommendation_review_page.continue_button.click
+  end
+
+  def when_i_click_on_overview_button
+    assessor_application_status_page.button_group.overview_button.click
+  end
+
+  def when_i_click_on_review_verifications
+    assessor_application_page.review_verifications_task.click
+  end
+
+  def when_i_click_on_assessment_decision
+    assessor_application_page.assessment_decision_task.click
+  end
+
+  def and_i_see_the_overdue_status
+    expect(assessor_review_verifications_page).to have_content(
+      "This qualifications’s status has changed from OVERDUE to RECEIVED",
+    )
+  end
+
+  def when_i_click_on_back_to_overview
+    assessor_review_verifications_page.back_to_overview_button.click
+  end
+
+  def and_i_see_the_consent_not_started
+    item =
+      assessor_review_verifications_page.task_list.find_item("BSc Teaching")
+    expect(item.status_tag.text).to eq("NOT STARTED")
+  end
+
+  def application_form
+    @application_form ||=
+      begin
+        application_form = create(:application_form, :submitted)
+        qualification =
+          create(
+            :qualification,
+            :completed,
+            application_form:,
+            title: "BSc Teaching",
+          )
+        assessment = create(:assessment, :verify, application_form:)
+        create(
+          :consent_request,
+          :received,
+          :expired,
+          assessment:,
+          verify_passed: false,
+          qualification:,
+        )
+        application_form
+      end
+  end
+
+  delegate :reference, to: :application_form
+
+  def assessment_id
+    application_form.assessment.id
+  end
+end

--- a/spec/system/assessor_interface/reviewing_consent_spec.rb
+++ b/spec/system/assessor_interface/reviewing_consent_spec.rb
@@ -33,6 +33,37 @@ RSpec.describe "Assessor reviewing references", type: :system do
     )
     and_i_see_the_consent_not_started
 
+    when_i_click_on_the_consent
+    then_i_see_the(
+      :assessor_review_consent_request_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_see_the_overdue_status
+
+    when_i_submit_yes_on_the_review_form
+    then_i_see_the(
+      :assessor_review_verifications_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_see_the_consent_accepted
+
+    when_i_click_on_the_consent
+    then_i_see_the(
+      :assessor_review_consent_request_page,
+      reference:,
+      assessment_id:,
+    )
+
+    when_i_submit_no_on_the_review_form
+    then_i_see_the(
+      :assessor_review_verifications_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_see_the_consent_rejected
+
     when_i_click_on_back_to_overview
     then_i_see_the(:assessor_application_page, reference:)
 
@@ -75,10 +106,22 @@ RSpec.describe "Assessor reviewing references", type: :system do
     assessor_application_page.assessment_decision_task.click
   end
 
+  def when_i_click_on_the_consent
+    consent_task_item.click
+  end
+
   def and_i_see_the_overdue_status
     expect(assessor_review_verifications_page).to have_content(
       "This qualifications’s status has changed from OVERDUE to RECEIVED",
     )
+  end
+
+  def when_i_submit_yes_on_the_review_form
+    assessor_review_reference_request_page.submit_yes
+  end
+
+  def when_i_submit_no_on_the_review_form
+    assessor_review_reference_request_page.submit_no(note: "A note.")
   end
 
   def when_i_click_on_back_to_overview
@@ -86,9 +129,21 @@ RSpec.describe "Assessor reviewing references", type: :system do
   end
 
   def and_i_see_the_consent_not_started
-    item =
-      assessor_review_verifications_page.task_list.find_item("BSc Teaching")
-    expect(item.status_tag.text).to eq("NOT STARTED")
+    expect(consent_task_item.status_tag.text).to eq("NOT STARTED")
+  end
+
+  def and_i_see_the_consent_accepted
+    expect(consent_task_item.status_tag.text).to eq("ACCEPTED")
+  end
+
+  def and_i_see_the_consent_rejected
+    expect(consent_task_item.status_tag.text).to eq("REJECTED")
+  end
+
+  def consent_task_item
+    assessor_review_verifications_page.task_list.find_item(
+      "BSc Teaching (University of Teaching)",
+    )
   end
 
   def application_form
@@ -101,6 +156,7 @@ RSpec.describe "Assessor reviewing references", type: :system do
             :completed,
             application_form:,
             title: "BSc Teaching",
+            institution_name: "University of Teaching",
           )
         assessment = create(:assessment, :verify, application_form:)
         create(

--- a/spec/system/assessor_interface/verifying_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/verifying_professional_standing_spec.rb
@@ -253,7 +253,9 @@ RSpec.describe "Assessor verifying professional standing", type: :system do
           create(:application_form, :submitted, :verification_stage)
         create(
           :assessment,
+          :started,
           :with_professional_standing_request,
+          :verify,
           application_form:,
         )
         application_form

--- a/spec/system/assessor_interface/verifying_qualifications_spec.rb
+++ b/spec/system/assessor_interface/verifying_qualifications_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "Assessor verifying qualifications", type: :system do
 
   def and_i_see_an_in_progress_status
     expect(assessor_application_page.status_summary.value).to have_text(
-      "ASSESSMENT IN PROGRESS",
+      "VERIFICATION IN PROGRESS",
     )
   end
 
@@ -160,7 +160,7 @@ RSpec.describe "Assessor verifying qualifications", type: :system do
             statuses: %w[waiting_on_qualification],
           )
         qualification = create(:qualification, :completed, application_form:)
-        assessment = create(:assessment, :started, application_form:)
+        assessment = create(:assessment, :started, :verify, application_form:)
         create(:qualification_request, :requested, assessment:, qualification:)
         application_form
       end

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -359,7 +359,10 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
     end
 
     context "with a professional standing request" do
-      before { create(:professional_standing_request, assessment:) }
+      before do
+        assessment.verify!
+        create(:professional_standing_request, assessment:)
+      end
 
       it do
         is_expected.to include_task_list_item("Verification", "Verify LoPS")
@@ -373,7 +376,10 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
     end
 
     context "with a qualification request" do
-      before { create(:qualification_request, assessment:) }
+      before do
+        assessment.verify!
+        create(:qualification_request, assessment:)
+      end
 
       it do
         is_expected.to include_task_list_item(
@@ -390,7 +396,10 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
     end
 
     context "with a reference request" do
-      before { create(:reference_request, assessment:) }
+      before do
+        assessment.verify!
+        create(:reference_request, assessment:)
+      end
 
       it do
         is_expected.to include_task_list_item(


### PR DESCRIPTION
This adds the ability for assessors to review consent requests which have sent for review. See individual commits for more details.