### PR TITLE
Reset Sidekiq retry options

### DIFF
--- a/app/jobs/update_dqt_trn_request_job.rb
+++ b/app/jobs/update_dqt_trn_request_job.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class UpdateDQTTRNRequestJob < ApplicationJob
-  sidekiq_options retry: 14
-
   def perform(dqt_trn_request)
     return if dqt_trn_request.complete?
 


### PR DESCRIPTION
This removes the custom Sidekiq retry options for the DQT TRN Request jobs. The 14 retries limit means we were retrying for approximately 1 day, but often the DQT issues will not get resolved so quickly. By leaving it to the default settings, the job will be retried for almost 3 weeks before being dropped.

https://github.com/sidekiq/sidekiq/wiki/Error-Handling