### PR TITLE
Hide LoPS request page when not received

### DIFF
--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -140,6 +140,7 @@ class TeacherInterface::ApplicationFormViewObject
   def request_professional_standing_certificate?
     teaching_authority_provides_written_statement &&
       professional_standing_request&.requested? &&
+      !professional_standing_request&.received? &&
       (
         !requires_preliminary_check ||
           assessment&.all_preliminary_sections_passed?


### PR DESCRIPTION
If the LoPS has been received we should hide the page asking the applicants to request their LoPS as it's confusing.