### PR TITLE
Trigger lint job on every pull request

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,6 @@
 name: Lint
 
-on:
-  push:
-    branches:
-      - "**"
-      - "!main"
+on: pull_request
 
 jobs:
   prettier:


### PR DESCRIPTION
This allows us to run linting jobs for external pull requests from forks, which is currently not the case.