### PR TITLE
Ensure recommendation_assessor_note is not nil

### DIFF
--- a/app/forms/assessor_interface/assessment_declaration_decline_form.rb
+++ b/app/forms/assessor_interface/assessment_declaration_decline_form.rb
@@ -18,7 +18,9 @@ class AssessorInterface::AssessmentDeclarationDeclineForm
   def save
     return false unless valid?
 
-    assessment.update!(recommendation_assessor_note:)
+    assessment.update!(
+      recommendation_assessor_note: recommendation_assessor_note.presence || "",
+    )
 
     true
   end


### PR DESCRIPTION
If the field is nil this ends up with an exception being raised as the column is marked as not nullable.

https://dfe-teacher-services.sentry.io/issues/5087041583/