### PR TITLE
Ensure admins are responsible for Ecctis

### DIFF
--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -52,13 +52,13 @@ class ApplicationFormStatusUpdater
            application_form.awarded_at.present?
         "none"
       elsif dqt_trn_request.present? || assessment_in_review? ||
-            overdue_further_information || overdue_ecctis ||
-            received_further_information || received_ecctis
+            overdue_further_information || received_further_information
         "assessor"
       elsif preliminary_check? || need_to_request_lops? ||
             need_to_request_consent? || need_to_request_ecctis? ||
-            overdue_consent || received_consent || overdue_lops ||
-            received_lops || overdue_reference || received_reference
+            overdue_consent || received_consent || overdue_ecctis ||
+            received_ecctis || overdue_lops || received_lops ||
+            overdue_reference || received_reference
         "admin"
       elsif waiting_on_consent || waiting_on_further_information ||
             waiting_on_lops || waiting_on_ecctis || waiting_on_reference

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe ApplicationFormStatusUpdater do
         create(:qualification_request, :received, assessment:)
       end
 
-      include_examples "changes action required by", "assessor"
+      include_examples "changes action required by", "admin"
       include_examples "changes stage", "verification"
       include_examples "changes statuses", %w[received_ecctis]
     end


### PR DESCRIPTION
This fixes an issue where the assessors will still marked as responsible for Ecctis.