### PR TITLE
Request LoPS after preliminary checks

### DIFF
--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -31,6 +31,7 @@ module AssessorInterface
       if @form.save
         if assessment_section.preliminary?
           if assessment.all_preliminary_sections_passed?
+            request_professional_standing
             unassign_assessor
           else
             redirect_to [
@@ -91,6 +92,16 @@ module AssessorInterface
         params.require(:assessor_interface_assessment_section_form),
       )
     end
+
+    def request_professional_standing
+      requestable = assessment.professional_standing_request
+      return if requestable.nil? || requestable.requested?
+
+      RequestRequestable.call(requestable:, user: current_staff)
+
+      ApplicationFormStatusUpdater.call(application_form:, user: current_staff)
+    end
+
     def unassign_assessor
       AssignApplicationFormAssessor.call(
         application_form:,

--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -31,7 +31,6 @@ module AssessorInterface
       if @form.save
         if assessment_section.preliminary?
           if assessment.all_preliminary_sections_passed?
-            notify_teacher
             unassign_assessor
           else
             redirect_to [
@@ -92,19 +91,6 @@ module AssessorInterface
         params.require(:assessor_interface_assessment_section_form),
       )
     end
-
-    def notify_teacher
-      unless application_form.teaching_authority_provides_written_statement
-        return
-      end
-
-      DeliverEmail.call(
-        application_form:,
-        mailer: TeacherMailer,
-        action: :initial_checks_passed,
-      )
-    end
-
     def unassign_assessor
       AssignApplicationFormAssessor.call(
         application_form:,

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -38,8 +38,18 @@ class ProfessionalStandingRequest < ApplicationRecord
     end
   end
 
+  def after_requested(*)
+    if should_send_emails?
+      DeliverEmail.call(
+        application_form:,
+        mailer: TeacherMailer,
+        action: :initial_checks_passed,
+      )
+    end
+  end
+
   def after_received(*)
-    if should_send_received_email?
+    if should_send_emails?
       DeliverEmail.call(
         application_form:,
         mailer: TeacherMailer,
@@ -59,7 +69,7 @@ class ProfessionalStandingRequest < ApplicationRecord
 
   private
 
-  def should_send_received_email?
+  def should_send_emails?
     application_form.declined_at.nil? &&
       application_form.teaching_authority_provides_written_statement
   end

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -64,9 +64,11 @@ class SubmitApplicationForm
   def create_professional_standing_request(assessment)
     return unless teaching_authority_provides_written_statement
 
-    ProfessionalStandingRequest
-      .create!(assessment:)
-      .tap { |requestable| RequestRequestable.call(requestable:, user:) }
+    requestable = ProfessionalStandingRequest.create!(assessment:)
+
+    unless requires_preliminary_check
+      RequestRequestable.call(requestable:, user:)
+    end
   end
 
   def perform_duplicate_jobs

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -38,15 +38,6 @@ class SubmitApplicationForm
       action: :application_received,
     )
 
-    if !application_form.requires_preliminary_check &&
-         application_form.teaching_authority_provides_written_statement
-      DeliverEmail.call(
-        application_form:,
-        mailer: TeacherMailer,
-        action: :initial_checks_passed,
-      )
-    end
-
     if region.teaching_authority_requires_submission_email
       DeliverEmail.call(
         application_form:,

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -119,15 +119,24 @@ class AssessorInterface::ApplicationFormsShowViewObject
         I18n.t(
           "assessor_interface.application_forms.show.assessment_tasks.items.await_professional_standing_request",
         ),
-      link: [
-        :locate,
-        :assessor_interface,
-        application_form,
-        assessment,
-        :professional_standing_request,
-      ],
+      link:
+        if professional_standing_request.requested?
+          [
+            :locate,
+            :assessor_interface,
+            application_form,
+            assessment,
+            :professional_standing_request,
+          ]
+        end,
       status:
-        professional_standing_request.received? ? :completed : :waiting_on,
+        if professional_standing_request.received?
+          :completed
+        elsif professional_standing_request.requested?
+          :waiting_on
+        else
+          :cannot_start
+        end,
     }
   end
 

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -84,24 +84,13 @@ FactoryBot.define do
 
     trait :with_further_information_request do
       after(:create) do |assessment, _evaluator|
-        create(
-          :further_information_request,
-          :requested,
-          :with_items,
-          assessment:,
-        )
+        create(:requested_further_information_request, :with_items, assessment:)
       end
     end
 
     trait :with_professional_standing_request do
       after(:create) do |assessment, _evaluator|
         create(:professional_standing_request, assessment:)
-      end
-    end
-
-    trait :with_requested_professional_standing_request do
-      after(:create) do |assessment, _evaluator|
-        create(:requested_professional_standing_request, assessment:)
       end
     end
 

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       let!(:professional_standing_request) do
         create(:professional_standing_request, assessment:)
       end
+
       before do
         application_form.update!(
           teaching_authority_provides_written_statement: true,
@@ -112,8 +113,20 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
         is_expected.to include_task_list_item(
           "Pre-assessment tasks",
           "Awaiting third-party professional standing",
-          status: :waiting_on,
+          status: :cannot_start,
         )
+      end
+
+      context "and professional standing request is requested" do
+        before { professional_standing_request.requested! }
+
+        it do
+          is_expected.to include_task_list_item(
+            "Pre-assessment tasks",
+            "Awaiting third-party professional standing",
+            status: :waiting_on,
+          )
+        end
       end
 
       context "and professional standing request received" do


### PR DESCRIPTION
This changes when we mark the LoPS as having been requested to ensure this happens after the preliminary checks (if there are preliminary checks). The motivation for this change is to give applicants more time to get their LoPS after their pass preliminary check, as currently they've got 36 weeks after submission but we only tell them to request the LoPS after we pass preliminary check, so for example, if we take 30 weeks to do that, they've only got 6 weeks to get their LoPS.
