### PR TITLE
Remove show all applications feature

### DIFF
--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -64,13 +64,11 @@
       <% end %>
     </section>
 
-    <% if FeatureFlags::FeatureFlag.active?(:show_all_applications_filter) %>
-      <section id="app-applications-show-all-applicants">
-        <%= f.govuk_check_boxes_fieldset :show_all, legend: nil, multiple: false, small: true do %>
-          <%= f.govuk_check_box :show_all, :true, multiple: false, label: { text: "Show applications completed over 90 days ago" }, checked: @view_object.filter_form.show_all == "true" %>
-        <% end %>
-      </section>
-    <% end %>
+    <section id="app-applications-show-all-applicants">
+      <%= f.govuk_check_boxes_fieldset :show_all, legend: nil, multiple: false, small: true do %>
+        <%= f.govuk_check_box :show_all, :true, multiple: false, label: { text: "Show applications completed over 90 days ago" }, checked: @view_object.filter_form.show_all == "true" %>
+      <% end %>
+    </section>
   <% end %>
 </div>
 

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -28,12 +28,6 @@ feature_flags:
       When service_open is deactivated, and this flag is enabled, the user will
       have full access to the service. Should be inactive on production.
 
-  show_all_applications_filter:
-    author: Nick Diplos
-    description: >
-      Adds a filter that allows assessors to view applications that are older
-      than 90 days old.
-
   teacher_applications:
     author: Thomas Leese
     description: >

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -7,10 +7,7 @@ RSpec.describe "Assessor filtering application forms", type: :system do
     given_the_service_is_open
     given_there_are_application_forms
     given_i_am_authorized_as_an_assessor_user
-    given_show_all_applications_is_activated
   end
-
-  after { given_show_all_applications_is_deactivated }
 
   it "applies the filters" do
     when_i_visit_the(:assessor_applications_page)
@@ -59,14 +56,6 @@ RSpec.describe "Assessor filtering application forms", type: :system do
 
   def given_there_are_application_forms
     application_forms
-  end
-
-  def given_show_all_applications_is_activated
-    FeatureFlags::FeatureFlag.activate(:show_all_applications_filter)
-  end
-
-  def given_show_all_applications_is_deactivated
-    FeatureFlags::FeatureFlag.deactivate(:show_all_applications_filter)
   end
 
   def when_i_visit_the_applications_page


### PR DESCRIPTION
This has been enabled in production now and it's not likely that we'll need to turn it off so we can remove the feature flag.