### PR TITLE
Change default LoPS name

### DIFF
--- a/app/helpers/region_helper.rb
+++ b/app/helpers/region_helper.rb
@@ -3,7 +3,7 @@
 module RegionHelper
   def region_certificate_name(region)
     region.teaching_authority_certificate.presence ||
-      "letter that proves you’re recognised as a teacher"
+      "Letter of Professional Standing"
   end
 
   def region_certificate_phrase(region)

--- a/app/views/support_interface/regions/edit.html.erb
+++ b/app/views/support_interface/regions/edit.html.erb
@@ -69,7 +69,7 @@
     <%= f.govuk_text_area :teaching_authority_address, label: { text: "Address" } %>
     <%= f.govuk_text_area :teaching_authority_emails_string, label: { text: "Email" }, hint: { text: "One email per line (if more than one)" } %>
     <%= f.govuk_text_area :teaching_authority_websites_string, label: { text: "Websites" }, hint: { text: "One website per line (if more than one)" } %>
-    <%= f.govuk_text_field :teaching_authority_certificate, label: { text: "Name given to describe the Letter of Professional standing" } %>
+    <%= f.govuk_text_field :teaching_authority_certificate, label: { text: "Name given to describe the Letter of Professional standing" }, hint: { text: "Default: Letter of Professional Standing" } %>
     <%= f.govuk_text_field :teaching_authority_online_checker_url, label: { text: "Online checker website" } %>
 
     <%= f.govuk_collection_radio_buttons :teaching_authority_requires_submission_email,

--- a/spec/helpers/region_helper_spec.rb
+++ b/spec/helpers/region_helper_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RegionHelper do
 
     it do
       is_expected.to eq(
-        "a <span lang=\"FR\">letter that proves you’re recognised as a teacher</span>",
+        "a <span lang=\"FR\">Letter of Professional Standing</span>",
       )
     end
 

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -511,7 +511,7 @@ RSpec.describe TeacherMailer, type: :mailer do
       it do
         is_expected.to eq(
           "Your qualified teacher status application – we’ve received your " \
-            "letter that proves you’re recognised as a teacher",
+            "Letter of Professional Standing",
         )
       end
     end
@@ -529,9 +529,9 @@ RSpec.describe TeacherMailer, type: :mailer do
       it { is_expected.to include("abc") }
       it do
         is_expected.to include(
-          "Thank you for requesting your letter that proves you’re recognised as a teacher from " \
-            "the teaching authority. We have now received this document and attached it " \
-            "to your application.",
+          "Thank you for requesting your Letter of Professional Standing from the " \
+            "teaching authority. We have now received this document and attached " \
+            "it to your application.",
         )
       end
     end

--- a/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
+++ b/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "Assessor pre-assessment tasks", type: :system do
     expect(TeacherMailer.deliveries.first.subject).to eq(
       I18n.t(
         "mailer.teacher.professional_standing_received.subject",
-        certificate: "letter that proves you’re recognised as a teacher",
+        certificate: "Letter of Professional Standing",
       ),
     )
   end

--- a/spec/view_objects/teacher_interface/application_form_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_view_object_spec.rb
@@ -256,9 +256,8 @@ RSpec.describe TeacherInterface::ApplicationFormViewObject do
             "" => [
               {
                 name:
-                  "Your application has been declined as we did not receive your letter " \
-                    "that proves you’re recognised as a teacher from teaching authority " \
-                    "within 180 days.",
+                  "Your application has been declined as we did not receive your Letter " \
+                    "of Professional Standing from teaching authority within 180 days.",
               },
             ],
           },

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
       it do
         is_expected.to match(/Your QTS application has been declined/)
         is_expected.to match(
-          /we did not receive your letter that proves you’re recognised as a teacher/,
+          /we did not receive your Letter of Professional Standing/,
         )
         is_expected.to match(/from teaching authority within 180 days/)
       end


### PR DESCRIPTION
This matches the majority of regions and makes it more likely that the seed data matches production.