### PR TITLE
Add resend referee email feature

### DIFF
--- a/app/policies/assessor_interface/reference_request_policy.rb
+++ b/app/policies/assessor_interface/reference_request_policy.rb
@@ -25,4 +25,8 @@ class AssessorInterface::ReferenceRequestPolicy < ApplicationPolicy
   end
 
   alias_method :edit_verify_failed?, :update_verify_failed?
+
+  def resend_email?
+    user.assess_permission || user.verify_permission
+  end
 end

--- a/app/views/assessor_interface/reference_requests/edit_verify.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit_verify.html.erb
@@ -1,6 +1,7 @@
 <% work_history = @reference_request.work_history %>
 <% can_edit_work_history = policy([:assessor_interface, work_history]).edit? %>
 <% can_update_verify_reference_request = @assessment.verify? && policy([:assessor_interface, @reference_request]).update_verify? %>
+<% can_resend_email_reference_request = @assessment.verify? && policy([:assessor_interface, @reference_request]).resend_email? %>
 
 <% title = can_update_verify_reference_request ? "Review reference" : "View reference" %>
 
@@ -34,16 +35,20 @@
       end
     end
 
-    if can_edit_work_history
-      summary_list.with_row do |row|
-        row.with_key { "Job title of reference" }
-        row.with_value { work_history.contact_job }
+    summary_list.with_row do |row|
+      row.with_key { "Job title of reference" }
+      row.with_value { work_history.contact_job }
+
+      if can_edit_work_history
         row.with_action(text: "Change", href: [:edit, :assessor_interface, @application_form, work_history])
       end
+    end
 
-      summary_list.with_row do |row|
-        row.with_key { "Email address of reference" }
-        row.with_value { work_history.contact_email }
+    summary_list.with_row do |row|
+      row.with_key { "Email address of reference" }
+      row.with_value { work_history.contact_email }
+
+      if can_edit_work_history
         row.with_action(text: "Change", href: [:edit, :assessor_interface, @application_form, work_history])
       end
     end
@@ -55,6 +60,18 @@
     <% end %>
 
     <%= render "shared/reference_request_summary", reference_request: @reference_request, changeable: false %>
+  <% elsif @reference_request.requested? && can_resend_email_reference_request %>
+    <%= govuk_details(summary_text: "Resend reference request email") do %>
+      <%= govuk_warning_text(text: "Only resend reference requests if you have been asked to do so.") %>
+
+      <% if (timeline_event = @application_form.timeline_events.email_sent.where(mailer_class_name: "RefereeMailer", mailer_action_name: "reference_requested").order(created_at: :desc).first) %>
+        <p class="govuk-body">This email was last sent on <%= timeline_event.created_at.to_fs(:date_and_time) %></p>
+      <% end %>
+
+      <%= govuk_button_link_to "Resend reference request email", [:resend_email, :assessor_interface, @application_form, @assessment, @reference_request] %>
+
+      <p class="govuk-body">Resending this email will not affect the original reminder schedule. Reminders will be sent automatically 2 weeks and 4 weeks after the original reference request email was sent.</p>
+    <% end %>
   <% end %>
 
   <% if @reference_request.expired? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -190,6 +190,7 @@ Rails.application.routes.draw do
             post "verify", to: "reference_requests#update_verify"
             get "verify-failed", to: "reference_requests#edit_verify_failed"
             post "verify-failed", to: "reference_requests#update_verify_failed"
+            get "resend-email", to: "reference_requests#resend_email"
           end
         end
       end

--- a/spec/policies/assessor_interface/reference_request_policy_spec.rb
+++ b/spec/policies/assessor_interface/reference_request_policy_spec.rb
@@ -62,6 +62,12 @@ RSpec.describe AssessorInterface::ReferenceRequestPolicy do
     it_behaves_like "a policy method requiring the verify permission"
   end
 
+  describe "#resend_email?" do
+    subject(:resend_email?) { policy.resend_email? }
+    it_behaves_like "a policy method requiring the assess permission"
+    it_behaves_like "a policy method requiring the verify permission"
+  end
+
   describe "#destroy?" do
     subject(:destroy?) { policy.destroy? }
     it_behaves_like "a policy method without permission"

--- a/spec/support/autoload/page_objects/assessor_interface/verify_reference_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/verify_reference_request.rb
@@ -13,6 +13,11 @@ module PageObjects
         elements :keys, ".govuk-summary-list__key"
         elements :values, ".govuk-summary-list__value"
       end
+
+      section :send_email_details, ".govuk-details" do
+        element :summary, ".govuk-details__summary"
+        element :button, ".govuk-button"
+      end
     end
   end
 end


### PR DESCRIPTION
This adds a new feature when verifying references that allows users to resend the initial reference requested email without needing to change the email address.

## Screenshots

![Screenshot 2024-03-26 at 21 06 05](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/bd2edd8b-2ca3-412e-a5cb-dea7cd7c960b)
