### PR TITLE
Simplify authentication for development

### DIFF
--- a/app/controllers/staff/omniauth_callbacks_controller.rb
+++ b/app/controllers/staff/omniauth_callbacks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Staff::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  skip_before_action :authenticate
+  skip_before_action :authenticate_support!
 
   def azure_activedirectory_v2
     auth = request.env["omniauth.auth"]

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -21,13 +21,6 @@ feature_flags:
     author: Richard Pattinson
     description: Allow users to sign in using accounts in Active Directory.
 
-  staff_test_user:
-    author: David Feetenby
-    description: >
-      Add extra user with access to the eligibility checker for user research.
-      When service_open is deactivated, and this flag is enabled, the user will
-      have full access to the service. Should be inactive on production.
-
   teacher_applications:
     author: Thomas Leese
     description: >

--- a/spec/controllers/assessor_interface/uploads_controller_spec.rb
+++ b/spec/controllers/assessor_interface/uploads_controller_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe AssessorInterface::UploadsController, type: :controller do
-  before { FeatureFlags::FeatureFlag.activate(:service_open) }
-
   let(:staff) { create(:staff, :with_assess_permission, :confirmed) }
   let(:application_form) { create(:application_form) }
 

--- a/spec/controllers/history_controller_spec.rb
+++ b/spec/controllers/history_controller_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe HistoryController, type: :controller do
-  before { FeatureFlags::FeatureFlag.activate(:service_open) }
-
   describe "GET back" do
     let(:default) { "/fallback" }
 

--- a/spec/controllers/teacher_interface/age_range_controller_spec.rb
+++ b/spec/controllers/teacher_interface/age_range_controller_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe TeacherInterface::AgeRangeController, type: :controller do
-  before { FeatureFlags::FeatureFlag.activate(:service_open) }
-
   let(:teacher) { create(:teacher) }
   let(:application_form) { create(:application_form, teacher:) }
 

--- a/spec/controllers/teacher_interface/documents_controller_spec.rb
+++ b/spec/controllers/teacher_interface/documents_controller_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe TeacherInterface::DocumentsController, type: :controller do
-  before { FeatureFlags::FeatureFlag.activate(:service_open) }
-
   let(:teacher) { create(:teacher) }
   let(:application_form) { create(:application_form, teacher:) }
 

--- a/spec/controllers/teacher_interface/english_language_controller_spec.rb
+++ b/spec/controllers/teacher_interface/english_language_controller_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe TeacherInterface::EnglishLanguageController, type: :controller do
-  before { FeatureFlags::FeatureFlag.activate(:service_open) }
-
   let(:teacher) { create(:teacher) }
   let(:application_form) { create(:application_form, teacher:) }
 

--- a/spec/controllers/teacher_interface/personal_information_controller_spec.rb
+++ b/spec/controllers/teacher_interface/personal_information_controller_spec.rb
@@ -4,8 +4,6 @@ require "rails_helper"
 
 RSpec.describe TeacherInterface::PersonalInformationController,
                type: :controller do
-  before { FeatureFlags::FeatureFlag.activate(:service_open) }
-
   let(:teacher) { create(:teacher) }
   let(:application_form) { create(:application_form, teacher:) }
 

--- a/spec/controllers/teacher_interface/qualifications_controller_spec.rb
+++ b/spec/controllers/teacher_interface/qualifications_controller_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe TeacherInterface::QualificationsController, type: :controller do
-  before { FeatureFlags::FeatureFlag.activate(:service_open) }
-
   let(:teacher) { create(:teacher) }
   let!(:application_form) { create(:application_form, teacher:) }
 

--- a/spec/controllers/teacher_interface/registration_number_controller_spec.rb
+++ b/spec/controllers/teacher_interface/registration_number_controller_spec.rb
@@ -4,8 +4,6 @@ require "rails_helper"
 
 RSpec.describe TeacherInterface::RegistrationNumberController,
                type: :controller do
-  before { FeatureFlags::FeatureFlag.activate(:service_open) }
-
   let(:teacher) { create(:teacher) }
   let(:application_form) { create(:application_form, teacher:) }
 

--- a/spec/controllers/teacher_interface/subjects_controller_spec.rb
+++ b/spec/controllers/teacher_interface/subjects_controller_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe TeacherInterface::SubjectsController, type: :controller do
-  before { FeatureFlags::FeatureFlag.activate(:service_open) }
-
   let(:teacher) { create(:teacher) }
   let(:application_form) { create(:application_form, teacher:) }
 

--- a/spec/controllers/teacher_interface/uploads_controller_spec.rb
+++ b/spec/controllers/teacher_interface/uploads_controller_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe TeacherInterface::UploadsController, type: :controller do
-  before { FeatureFlags::FeatureFlag.activate(:service_open) }
-
   let(:teacher) { create(:teacher) }
   let(:application_form) { create(:application_form, teacher:) }
 

--- a/spec/controllers/teacher_interface/work_histories_controller_spec.rb
+++ b/spec/controllers/teacher_interface/work_histories_controller_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe TeacherInterface::WorkHistoriesController, type: :controller do
-  before { FeatureFlags::FeatureFlag.activate(:service_open) }
-
   let(:teacher) { create(:teacher) }
   let(:application_form) { create(:application_form, teacher:) }
 

--- a/spec/requests/staff_sign_in_spec.rb
+++ b/spec/requests/staff_sign_in_spec.rb
@@ -1,15 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "Staff sign in", type: :request do
-  before do
-    FeatureFlags::FeatureFlag.activate(:service_open)
-    FeatureFlags::FeatureFlag.activate(:sign_in_with_active_directory)
-  end
+  before { FeatureFlags::FeatureFlag.activate(:sign_in_with_active_directory) }
 
-  after do
-    FeatureFlags::FeatureFlag.deactivate(:service_open)
-    FeatureFlags::FeatureFlag.deactivate(:sign_in_with_active_directory)
-  end
+  after { FeatureFlags::FeatureFlag.deactivate(:sign_in_with_active_directory) }
 
   shared_examples "an Azure login" do
     it "redirects to Azure login" do

--- a/spec/requests/throttling_spec.rb
+++ b/spec/requests/throttling_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Throttling", rack_attack: true do
-  before { FeatureFlags::FeatureFlag.activate(:service_open) }
-
   shared_examples "throttled" do |path|
     context path do
       subject(:cache_count) do

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -1,18 +1,8 @@
+# frozen_string_literal: true
+
 module SystemHelpers
   include PageHelpers
   include Warden::Test::Helpers
-
-  def given_the_service_is_open
-    FeatureFlags::FeatureFlag.activate(:service_open)
-  end
-
-  def given_the_service_is_closed
-    FeatureFlags::FeatureFlag.deactivate(:service_open)
-  end
-
-  def given_the_service_allows_teacher_applications
-    FeatureFlags::FeatureFlag.activate(:teacher_applications)
-  end
 
   def given_an_eligible_eligibility_check(country_check:)
     country = create(:country, :with_national_region, code: "GB-SCT")
@@ -80,8 +70,8 @@ module SystemHelpers
     user =
       create(
         :staff,
-        :with_assess_permission,
         :confirmed,
+        :with_assess_permission,
         name: "Authorized User",
       )
     given_i_am_authorized_as_a_user(user)
@@ -91,8 +81,8 @@ module SystemHelpers
     user =
       create(
         :staff,
-        :with_verify_permission,
         :confirmed,
+        :with_verify_permission,
         name: "Authorized User",
       )
     given_i_am_authorized_as_a_user(user)
@@ -123,26 +113,11 @@ module SystemHelpers
     allow(stubbed_service).to receive(:call).and_return(stubbed_response)
   end
 
-  def when_i_am_authorized_as_a_test_user
-    page.driver.basic_authorize(
-      ENV.fetch("TEST_USERNAME", "test"),
-      ENV.fetch("TEST_PASSWORD", "test"),
-    )
-  end
-
   def when_i_sign_out
     sign_out @user
   end
 
   alias_method :then_i_sign_out, :when_i_sign_out
-
-  def given_the_test_user_is_disabled
-    FeatureFlags::FeatureFlag.deactivate(:staff_test_user)
-  end
-
-  def given_the_test_user_is_enabled
-    FeatureFlags::FeatureFlag.activate(:staff_test_user)
-  end
 
   def when_i_choose_yes
     choose "Yes", visible: false

--- a/spec/system/assessor_interface/assigning_assessor_spec.rb
+++ b/spec/system/assessor_interface/assigning_assessor_spec.rb
@@ -3,10 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Assigning an assessor", type: :system do
-  before do
-    given_the_service_is_open
-    given_there_is_an_application_form
-  end
+  before { given_there_is_an_application_form }
 
   it "assigns an assessor" do
     given_i_am_authorized_as_an_assessor_user

--- a/spec/system/assessor_interface/authentication_spec.rb
+++ b/spec/system/assessor_interface/authentication_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor authentication", type: :system do
   it "allows signing in and signing out" do
-    given_the_service_is_open
     given_staff_exist
 
     when_i_visit_the(:assessor_applications_page)

--- a/spec/system/assessor_interface/change_application_form_name_spec.rb
+++ b/spec/system/assessor_interface/change_application_form_name_spec.rb
@@ -3,10 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Assessor change application form name", type: :system do
-  before do
-    given_the_service_is_open
-    given_there_is_an_application_form
-  end
+  before { given_there_is_an_application_form }
 
   it "checks manage applications permission" do
     given_i_am_authorized_as_a_user(assessor)

--- a/spec/system/assessor_interface/change_work_history_spec.rb
+++ b/spec/system/assessor_interface/change_work_history_spec.rb
@@ -3,10 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Assessor change work history", type: :system do
-  before do
-    given_the_service_is_open
-    given_there_is_an_application_form
-  end
+  before { given_there_is_an_application_form }
 
   it "checks manage applications permission" do
     given_i_am_authorized_as_a_user(assessor)

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor check submitted details", type: :system do
   before do
-    given_the_service_is_open
     given_there_is_an_application_form
     given_i_am_authorized_as_an_assessor_user
   end

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   it "award" do
-    given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_awardable_application_form(%i[old_regs])
     given_i_can_request_dqt_api
@@ -85,7 +84,6 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   it "verify" do
-    given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_awardable_application_form_with_work_history
 
@@ -139,7 +137,6 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   it "verify with reduced evidence" do
-    given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_awardable_application_form_with_reduced_evidence
 
@@ -179,7 +176,6 @@ RSpec.describe "Assessor completing assessment", type: :system do
   end
 
   it "decline" do
-    given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user
     given_there_is_a_declinable_application_form
 

--- a/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
+++ b/spec/system/assessor_interface/confirming_english_language_exemption_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor confirms English language section", type: :system do
   it "exemption via citizenship in the Personal Information section" do
-    given_the_service_is_open
     given_there_is_an_application_form
     and_the_application_states_english_language_exemption_by_citizenship
     given_i_am_authorized_as_an_assessor_user
@@ -39,7 +38,6 @@ RSpec.describe "Assessor confirms English language section", type: :system do
   end
 
   it "exemption via qualification in the Qualifications section" do
-    given_the_service_is_open
     given_there_is_an_application_form
     and_the_application_states_english_language_exemption_by_qualification
     given_i_am_authorized_as_an_assessor_user
@@ -72,7 +70,6 @@ RSpec.describe "Assessor confirms English language section", type: :system do
   end
 
   it "confirmation of proficiency by SELT from approved provider" do
-    given_the_service_is_open
     given_there_is_an_application_form
     and_the_application_english_language_proof_method_is_provider
     given_i_am_authorized_as_an_assessor_user
@@ -91,7 +88,6 @@ RSpec.describe "Assessor confirms English language section", type: :system do
   end
 
   it "confirmation of proficiency by medium of instruction document" do
-    given_the_service_is_open
     given_there_is_an_application_form
     and_the_application_english_language_proof_method_is_moi
     given_i_am_authorized_as_an_assessor_user

--- a/spec/system/assessor_interface/creating_note_spec.rb
+++ b/spec/system/assessor_interface/creating_note_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Creating a note", type: :system do
   it "creates a note" do
-    given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_application_form
 

--- a/spec/system/assessor_interface/duplicate_applicant_application_form_spec.rb
+++ b/spec/system/assessor_interface/duplicate_applicant_application_form_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe "Assessor views duplicate applicant's application form",
                type: :system do
   it "displays information about the duplicate applicant" do
-    given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_application_form
     and_the_applicant_matches_a_record_in_dqt

--- a/spec/system/assessor_interface/filtering_application_forms_spec.rb
+++ b/spec/system/assessor_interface/filtering_application_forms_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor filtering application forms", type: :system do
   before do
-    given_the_service_is_open
     given_there_are_application_forms
     given_i_am_authorized_as_an_assessor_user
   end

--- a/spec/system/assessor_interface/listing_application_forms_spec.rb
+++ b/spec/system/assessor_interface/listing_application_forms_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor listing application forms", type: :system do
   before do
-    given_the_service_is_open
     given_there_are_application_forms
     given_i_am_authorized_as_an_assessor_user
   end

--- a/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
+++ b/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor pre-assessment tasks", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_application_form_with_professional_standing_request
   end

--- a/spec/system/assessor_interface/requesting_further_information_spec.rb
+++ b/spec/system/assessor_interface/requesting_further_information_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe "Assessor requesting further information", type: :system do
   end
 
   it "completes an assessment" do
-    given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_application_form_with_failure_reasons
 

--- a/spec/system/assessor_interface/reverse_decision_spec.rb
+++ b/spec/system/assessor_interface/reverse_decision_spec.rb
@@ -3,10 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Assessor reverse decision", type: :system do
-  before do
-    given_the_service_is_open
-    given_there_is_an_application_form
-  end
+  before { given_there_is_an_application_form }
 
   it "checks manage applications permission" do
     given_i_am_authorized_as_a_user(assessor)

--- a/spec/system/assessor_interface/reviewing_consent_spec.rb
+++ b/spec/system/assessor_interface/reviewing_consent_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor reviewing references", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_application_form_with_failed_consent
   end

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor reviewing further information", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_application_form_with_failure_reasons
     given_there_is_further_information_received

--- a/spec/system/assessor_interface/reviewing_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/reviewing_professional_standing_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor reviewing verifications", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_application_form_with_failed_verifications
   end

--- a/spec/system/assessor_interface/reviewing_qualifications_spec.rb
+++ b/spec/system/assessor_interface/reviewing_qualifications_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor reviewing qualifications", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_application_form_with_failed_qualifications
   end

--- a/spec/system/assessor_interface/reviewing_references_spec.rb
+++ b/spec/system/assessor_interface/reviewing_references_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor reviewing references", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_application_form_with_failed_references
   end

--- a/spec/system/assessor_interface/verifying_professional_standing_spec.rb
+++ b/spec/system/assessor_interface/verifying_professional_standing_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor verifying professional standing", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_an_admin_user
     given_there_is_an_application_form_with_professional_standing_request
   end

--- a/spec/system/assessor_interface/verifying_qualifications_spec.rb
+++ b/spec/system/assessor_interface/verifying_qualifications_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor verifying qualifications", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_an_admin_user
     given_there_is_an_application_form_with_qualification_request
   end

--- a/spec/system/assessor_interface/verifying_references_spec.rb
+++ b/spec/system/assessor_interface/verifying_references_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor verifying references", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_an_admin_user
     given_there_is_an_application_form_with_reference_request
   end

--- a/spec/system/assessor_interface/view_application_form_spec.rb
+++ b/spec/system/assessor_interface/view_application_form_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor view application form", type: :system do
   it "displays the application overview" do
-    given_the_service_is_open
     given_there_is_an_application_form
     given_i_am_authorized_as_an_assessor_user
 

--- a/spec/system/assessor_interface/view_timeline_events_spec.rb
+++ b/spec/system/assessor_interface/view_timeline_events_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Assessor view timeline events", type: :system do
   before do
-    given_the_service_is_open
     given_an_assessor_exists
     given_an_application_form_exists
     given_i_am_authorized_as_a_user(assessor)

--- a/spec/system/assessor_interface/withdraw_application_spec.rb
+++ b/spec/system/assessor_interface/withdraw_application_spec.rb
@@ -3,10 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Assessor withdraw application", type: :system do
-  before do
-    given_the_service_is_open
-    given_there_is_an_application_form
-  end
+  before { given_there_is_an_application_form }
 
   it "checks manage applications permission" do
     given_i_am_authorized_as_a_user(assessor)

--- a/spec/system/eligibility_spec.rb
+++ b/spec/system/eligibility_spec.rb
@@ -3,10 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Eligibility check", type: :system do
-  before do
-    given_countries_exist
-    given_the_service_is_open
-  end
+  before { given_countries_exist }
 
   it "happy path" do
     when_i_visit_the(:eligibility_start_page)
@@ -190,38 +187,6 @@ RSpec.describe "Eligibility check", type: :system do
 
     when_i_select_a_region
     then_i_see_the(:eligibility_qualification_page)
-  end
-
-  it "service is closed" do
-    given_the_service_is_closed
-    when_i_visit_the(:eligibility_start_page)
-    then_access_is_denied
-
-    given_the_service_is_open
-    given_i_am_authorized_as_a_support_user
-    when_i_visit_the(:eligibility_start_page)
-    then_i_see_the(:eligibility_start_page)
-
-    when_i_press_start_now
-    then_i_see_the(:eligibility_country_page)
-
-    when_i_select_an_eligible_country
-    then_i_see_the(:eligibility_qualification_page)
-  end
-
-  it "test user is disabled" do
-    given_the_service_is_closed
-    when_i_visit_the(:eligibility_start_page)
-    then_access_is_denied
-
-    when_i_am_authorized_as_a_test_user
-    when_i_visit_the(:eligibility_start_page)
-    then_access_is_denied
-
-    given_the_test_user_is_enabled
-    when_i_am_authorized_as_a_test_user
-    when_i_visit_the(:eligibility_start_page)
-    then_i_see_the(:eligibility_start_page)
   end
 
   it "happy path when filtering by country requiring qualification for subject" do

--- a/spec/system/personas_spec.rb
+++ b/spec/system/personas_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe "Personas", type: :system do
-  before { given_the_service_is_open }
-
   it "active" do
     given_personas_are_activated
     given_personas_exist

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Countries support", type: :system do
-  before { given_the_service_is_open }
-
   it "requires permission" do
     given_i_am_authorized_as_an_assessor_user
     when_i_visit_the_countries_page

--- a/spec/system/support_interface/english_language_providers_spec.rb
+++ b/spec/system/support_interface/english_language_providers_spec.rb
@@ -3,10 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "English language providers support", type: :system do
-  before do
-    given_the_service_is_open
-    given_there_are_english_language_providers
-  end
+  before { given_there_are_english_language_providers }
 
   it "requires permission" do
     given_i_am_authorized_as_an_assessor_user

--- a/spec/system/support_interface/features_spec.rb
+++ b/spec/system/support_interface/features_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Features support", type: :system do
-  before { given_the_service_is_open }
-
   it "requires permission" do
     given_i_am_authorized_as_an_assessor_user
     when_i_visit_the_feature_flags_page

--- a/spec/system/support_interface/sidekiq_spec.rb
+++ b/spec/system/support_interface/sidekiq_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Sidekiq support", type: :system do
   end
 
   def then_i_see_the_access_denied_page
-    expect(page).to have_content("Access denied")
+    expect(page).to have_content("Page not found")
   end
 
   def then_i_see_the_sidekiq_dashboard

--- a/spec/system/support_interface/staff_spec.rb
+++ b/spec/system/support_interface/staff_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Staff support", type: :system do
-  before { given_the_service_is_open }
-
   it "requires permission" do
     given_i_am_authorized_as_an_assessor_user
     when_i_visit_the_staff_page

--- a/spec/system/teacher_interface/age_range_and_subjects_spec.rb
+++ b/spec/system/teacher_interface/age_range_and_subjects_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher age range and subjects", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
   end

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "Teacher authentication", type: :system do
-  before { given_the_service_is_open }
-
   it "allows signing up and signing in" do
     given_countries_exist
 

--- a/spec/system/teacher_interface/back_links_spec.rb
+++ b/spec/system/teacher_interface/back_links_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher back links", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
     given_malware_scanning_is_enabled

--- a/spec/system/teacher_interface/check_answers_spec.rb
+++ b/spec/system/teacher_interface/check_answers_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher application check answers", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
 

--- a/spec/system/teacher_interface/consent_spec.rb
+++ b/spec/system/teacher_interface/consent_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher consent", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
     given_there_is_a_consent_request

--- a/spec/system/teacher_interface/documents_spec.rb
+++ b/spec/system/teacher_interface/documents_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher documents", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
     given_malware_scanning_is_enabled

--- a/spec/system/teacher_interface/english_language_spec.rb
+++ b/spec/system/teacher_interface/english_language_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher English language", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
     given_malware_scanning_is_enabled

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher further information", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
     given_malware_scanning_is_enabled

--- a/spec/system/teacher_interface/malware_scanning_spec.rb
+++ b/spec/system/teacher_interface/malware_scanning_spec.rb
@@ -2,7 +2,6 @@ require "rails_helper"
 
 RSpec.describe "Malware scanning", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
     given_malware_scanning_is_enabled(scan_result: "Malicious")

--- a/spec/system/teacher_interface/personal_information_spec.rb
+++ b/spec/system/teacher_interface/personal_information_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher personal information", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
     given_malware_scanning_is_enabled

--- a/spec/system/teacher_interface/qualifications_spec.rb
+++ b/spec/system/teacher_interface/qualifications_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher qualifications", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
     given_malware_scanning_is_enabled

--- a/spec/system/teacher_interface/reapply_spec.rb
+++ b/spec/system/teacher_interface/reapply_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher reapply", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
   end

--- a/spec/system/teacher_interface/reference_spec.rb
+++ b/spec/system/teacher_interface/reference_spec.rb
@@ -3,10 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "Teacher reference", type: :system do
-  before do
-    given_the_service_is_open
-    given_there_is_a_reference_request
-  end
+  before { given_there_is_a_reference_request }
 
   it "allows filling in the reference" do
     when_i_visit_the(:teacher_reference_requested_page, slug:)

--- a/spec/system/teacher_interface/registration_number_spec.rb
+++ b/spec/system/teacher_interface/registration_number_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher registration number", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
   end

--- a/spec/system/teacher_interface/submitting_spec.rb
+++ b/spec/system/teacher_interface/submitting_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher submitting", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
   end

--- a/spec/system/teacher_interface/work_history_spec.rb
+++ b/spec/system/teacher_interface/work_history_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher work history", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
     given_malware_scanning_is_enabled

--- a/spec/system/teacher_interface/written_statement_spec.rb
+++ b/spec/system/teacher_interface/written_statement_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Teacher written statement", type: :system do
   before do
-    given_the_service_is_open
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
     given_malware_scanning_is_enabled


### PR DESCRIPTION
This removes the need to enter username/password credentials when testing or development and only requires the `service_open` feature flag to be specified in production.