### PR TITLE
Track email domains

### DIFF
--- a/app/forms/teacher_interface/work_history_contact_form.rb
+++ b/app/forms/teacher_interface/work_history_contact_form.rb
@@ -14,11 +14,14 @@ module TeacherInterface
     validates :contact_email, presence: true, valid_for_notify: true
 
     def update_model
+      email_address = EmailAddress.new(contact_email)
+
       work_history.update!(
         contact_name:,
         contact_job:,
         contact_email:,
-        canonical_contact_email: EmailAddress.canonical(contact_email),
+        canonical_contact_email: email_address.canonical,
+        contact_email_domain: email_address.host_name,
       )
     end
 

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -32,7 +32,11 @@ class Teacher < ApplicationRecord
 
   has_many :application_forms
 
-  before_create { self.canonical_email = EmailAddress.canonical(email) }
+  before_create do
+    email_address = EmailAddress.new(email)
+    self.canonical_email = email_address.canonical
+    self.email_domain = email_address.host_name
+  end
 
   def application_form
     @application_form ||=

--- a/app/models/teacher.rb
+++ b/app/models/teacher.rb
@@ -7,7 +7,8 @@
 #  canonical_email                         :text             default(""), not null
 #  current_sign_in_at                      :datetime
 #  current_sign_in_ip                      :string
-#  email                                   :string           default(""), not null
+#  email                                   :string           not null
+#  email_domain                            :text             default(""), not null
 #  last_sign_in_at                         :datetime
 #  last_sign_in_ip                         :string
 #  sign_in_count                           :integer          default(0), not null

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -8,6 +8,7 @@
 #  canonical_contact_email :text             default(""), not null
 #  city                    :text             default(""), not null
 #  contact_email           :text             default(""), not null
+#  contact_email_domain    :text             default(""), not null
 #  contact_job             :string           default(""), not null
 #  contact_name            :text             default(""), not null
 #  country_code            :text             default(""), not null

--- a/app/services/update_work_history_contact.rb
+++ b/app/services/update_work_history_contact.rb
@@ -19,8 +19,11 @@ class UpdateWorkHistoryContact
 
       if email.present?
         change_value("contact_email", email)
+
+        email_address = EmailAddress.new(email)
         work_history.update!(
-          canonical_contact_email: EmailAddress.canonical(email),
+          canonical_contact_email: email_address.canonical,
+          contact_email_domain: email_address.host_name,
         )
       end
     end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -355,6 +355,7 @@
     - current_sign_in_at
     - current_sign_in_ip
     - email
+    - email_domain
     - id
     - last_sign_in_at
     - last_sign_in_ip
@@ -401,6 +402,7 @@
     - canonical_contact_email
     - city
     - contact_email
+    - contact_email_domain
     - contact_job
     - contact_name
     - country_code

--- a/db/migrate/20240328081412_add_email_domain_to_teachers_and_work_history.rb
+++ b/db/migrate/20240328081412_add_email_domain_to_teachers_and_work_history.rb
@@ -1,0 +1,14 @@
+class AddEmailDomainToTeachersAndWorkHistory < ActiveRecord::Migration[7.1]
+  def change
+    change_table :teachers, bulk: true do |t|
+      t.change_default :email, from: "", to: nil
+      t.text :email_domain, default: "", null: false
+    end
+
+    add_column :work_histories,
+               :contact_email_domain,
+               :text,
+               default: "",
+               null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_28_140334) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_28_081412) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -474,7 +474,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_28_140334) do
   end
 
   create_table "teachers", force: :cascade do |t|
-    t.string "email", default: "", null: false
+    t.string "email", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "sign_in_count", default: 0, null: false
@@ -486,6 +486,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_28_140334) do
     t.uuid "uuid", default: -> { "gen_random_uuid()" }, null: false
     t.text "canonical_email", default: "", null: false
     t.string "access_your_teaching_qualifications_url"
+    t.text "email_domain", default: "", null: false
     t.index "lower((email)::text)", name: "index_teacher_on_lower_email", unique: true
     t.index ["canonical_email"], name: "index_teachers_on_canonical_email"
     t.index ["uuid"], name: "index_teachers_on_uuid", unique: true
@@ -554,6 +555,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_28_140334) do
     t.boolean "end_date_is_estimate", default: false, null: false
     t.string "contact_job", default: "", null: false
     t.text "canonical_contact_email", default: "", null: false
+    t.text "contact_email_domain", default: "", null: false
     t.index ["application_form_id"], name: "index_work_histories_on_application_form_id"
     t.index ["canonical_contact_email"], name: "index_work_histories_on_canonical_contact_email"
   end

--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -1,0 +1,19 @@
+namespace :emails do
+  desc "Backfill the domain column for teachers and work history."
+  task backfill_domains: :environment do
+    Teacher
+      .where(email_domain: "")
+      .find_each do |teacher|
+        teacher.update!(email_domain: EmailAddress.new(teacher.email).host_name)
+      end
+
+    WorkHistory
+      .where(contact_email_domain: "")
+      .find_each do |work_history|
+        work_history.update!(
+          contact_email_domain:
+            EmailAddress.new(work_history.contact_email).host_name,
+        )
+      end
+  end
+end

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -7,7 +7,8 @@
 #  canonical_email                         :text             default(""), not null
 #  current_sign_in_at                      :datetime
 #  current_sign_in_ip                      :string
-#  email                                   :string           default(""), not null
+#  email                                   :string           not null
+#  email_domain                            :text             default(""), not null
 #  last_sign_in_at                         :datetime
 #  last_sign_in_ip                         :string
 #  sign_in_count                           :integer          default(0), not null

--- a/spec/factories/teachers.rb
+++ b/spec/factories/teachers.rb
@@ -28,6 +28,7 @@ FactoryBot.define do
     sequence(:email) { |n| "teacher#{n}@example.org" }
     uuid { SecureRandom.uuid }
     canonical_email { EmailAddress.canonical(email) }
+    email_domain { EmailAddress.new(email).host_name }
 
     trait :with_trn do
       trn { Faker::Number.leading_zero_number(digits: 6) }

--- a/spec/factories/work_histories.rb
+++ b/spec/factories/work_histories.rb
@@ -6,6 +6,7 @@
 #  canonical_contact_email :text             default(""), not null
 #  city                    :text             default(""), not null
 #  contact_email           :text             default(""), not null
+#  contact_email_domain    :text             default(""), not null
 #  contact_job             :string           default(""), not null
 #  contact_name            :text             default(""), not null
 #  country_code            :text             default(""), not null

--- a/spec/factories/work_histories.rb
+++ b/spec/factories/work_histories.rb
@@ -36,6 +36,7 @@ FactoryBot.define do
     association :application_form
 
     canonical_contact_email { EmailAddress.canonical(contact_email) }
+    contact_email_domain { EmailAddress.new(contact_email).host_name }
 
     trait :completed do
       city { Faker::Address.city }

--- a/spec/forms/teacher_interface/work_history_contact_form_spec.rb
+++ b/spec/forms/teacher_interface/work_history_contact_form_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe TeacherInterface::WorkHistoryContactForm, type: :model do
       expect(work_history.contact_name).to eq("First Last")
       expect(work_history.contact_job).to eq("Job")
       expect(work_history.contact_email).to eq("school@example.com")
+      expect(work_history.contact_email_domain).to eq("example.com")
       expect(work_history.canonical_contact_email).to eq("school@example.com")
     end
 

--- a/spec/models/teacher_spec.rb
+++ b/spec/models/teacher_spec.rb
@@ -7,7 +7,8 @@
 #  canonical_email                         :text             default(""), not null
 #  current_sign_in_at                      :datetime
 #  current_sign_in_ip                      :string
-#  email                                   :string           default(""), not null
+#  email                                   :string           not null
+#  email_domain                            :text             default(""), not null
 #  last_sign_in_at                         :datetime
 #  last_sign_in_ip                         :string
 #  sign_in_count                           :integer          default(0), not null

--- a/spec/models/work_history_spec.rb
+++ b/spec/models/work_history_spec.rb
@@ -6,6 +6,7 @@
 #  canonical_contact_email :text             default(""), not null
 #  city                    :text             default(""), not null
 #  contact_email           :text             default(""), not null
+#  contact_email_domain    :text             default(""), not null
 #  contact_job             :string           default(""), not null
 #  contact_name            :text             default(""), not null
 #  country_code            :text             default(""), not null

--- a/spec/services/update_work_history_contact_spec.rb
+++ b/spec/services/update_work_history_contact_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe UpdateWorkHistoryContact do
     )
   end
 
+  it "changes the contact email domain" do
+    expect { call }.to change(work_history, :contact_email_domain).to(
+      "example.com",
+    )
+  end
+
   it "doesn't send any emails" do
     expect { call }.to_not have_enqueued_mail(
       RefereeMailer,


### PR DESCRIPTION
This adds the ability to track the domains of any email addresses associated with work history or teachers so we can perform analytics on it.