### PR TITLE
Update swap teaching qualification message

### DIFF
--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -80,7 +80,8 @@ namespace :application_forms do
     note =
       "We switched the teaching qualification to be the first eligible " \
         "qualification provided from #{teaching_qualification.title} to " \
-        "#{degree_qualification.title}. This was approved by Humzah on 14/02/2024."
+        "#{degree_qualification.title}. This was approved by Humzah and " \
+        "Natalie on 28/03/2024."
     user = Staff.find_by!(email: args[:staff_email])
 
     SwapQualifications.call(


### PR DESCRIPTION
This updates the message that we show in the timeline when qualifications are swapped.