### PR TITLE
Remove location_note column from qualifications

### DIFF
--- a/app/models/qualification_request.rb
+++ b/app/models/qualification_request.rb
@@ -7,7 +7,6 @@
 #  id               :bigint           not null, primary key
 #  consent_method   :string           default("unknown"), not null
 #  expired_at       :datetime
-#  location_note    :text             default(""), not null
 #  received_at      :datetime
 #  requested_at     :datetime
 #  review_note      :string           default(""), not null

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -229,7 +229,6 @@
     - created_at
     - expired_at
     - id
-    - location_note
     - qualification_id
     - received_at
     - requested_at

--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -33,7 +33,6 @@
   :qualifications:
     - institution_name
   :qualification_requests:
-    - location_note
     - review_note
     - verify_note
   :reference_requests:

--- a/db/migrate/20240402084241_remove_location_note_from_qualification_requests.rb
+++ b/db/migrate/20240402084241_remove_location_note_from_qualification_requests.rb
@@ -1,0 +1,9 @@
+class RemoveLocationNoteFromQualificationRequests < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :qualification_requests,
+                  :location_note,
+                  :text,
+                  default: "",
+                  null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_28_101225) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_02_084241) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -300,7 +300,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_28_101225) do
     t.bigint "assessment_id", null: false
     t.bigint "qualification_id", null: false
     t.datetime "received_at"
-    t.text "location_note", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "reviewed_at"

--- a/spec/factories/qualification_requests.rb
+++ b/spec/factories/qualification_requests.rb
@@ -7,7 +7,6 @@
 #  id               :bigint           not null, primary key
 #  consent_method   :string           default("unknown"), not null
 #  expired_at       :datetime
-#  location_note    :text             default(""), not null
 #  received_at      :datetime
 #  requested_at     :datetime
 #  review_note      :string           default(""), not null
@@ -54,7 +53,6 @@ FactoryBot.define do
     end
 
     trait :receivable do
-      location_note { Faker::Lorem.sentence }
     end
   end
 end

--- a/spec/models/qualification_request_spec.rb
+++ b/spec/models/qualification_request_spec.rb
@@ -7,7 +7,6 @@
 #  id               :bigint           not null, primary key
 #  consent_method   :string           default("unknown"), not null
 #  expired_at       :datetime
-#  location_note    :text             default(""), not null
 #  received_at      :datetime
 #  requested_at     :datetime
 #  review_note      :string           default(""), not null
@@ -52,14 +51,6 @@ RSpec.describe QualificationRequest, type: :model do
         )
         .with_prefix
         .backed_by_column_of_type(:string)
-    end
-  end
-
-  describe "validations" do
-    context "when received" do
-      subject { build(:qualification_request, :received) }
-
-      it { is_expected.to_not validate_presence_of(:location_note) }
     end
   end
 


### PR DESCRIPTION
This column isn't used anywhere anymore so it can be safely removed.