### PR TITLE
Track accurate assessment section statuses

### DIFF
--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -23,7 +23,7 @@
     <% elsif timeline_event.assessment_section_recorded? %>
       <p class="govuk-body">
         <%= description_vars[:section_name] %>:
-        <%= render StatusTag::Component.new(description_vars[:passed] ? "accepted" : "rejected") %>
+        <%= render StatusTag::Component.new(description_vars[:status]) %>
       </p>
 
       <% if (visible_failure_reasons = description_vars[:visible_failure_reasons]).present? %>
@@ -66,7 +66,7 @@
       <p class="govuk-body">
         Status has changed to: <%= render(StatusTag::Component.new(:declined)) %>
       </p>
-      
+
       <% TeacherInterface::ApplicationFormViewObject.new(application_form: timeline_event.application_form).declined_reasons.each do |title, reasons| %>
         <% if title.present? %>
           <h4 class="govuk-heading-s"><%= title %></h4>
@@ -78,7 +78,7 @@
             <% if reason[:assessor_note].present? %>
               <li><%= simple_format reason[:assessor_note] %></li>
             <% end %>
-          <% end %> 
+          <% end %>
         </ul>
       <% end %>
 

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -72,7 +72,26 @@ module TimelineEntry
 
     def assessment_section_recorded_vars
       section = timeline_event.assessment_section
-      selected_failure_reasons = section.selected_failure_reasons
+
+      # to handle old timeline events
+      status =
+        if timeline_event.new_value == "action_required"
+          "rejected"
+        elsif timeline_event.new_value == "completed" &&
+              timeline_event.is_latest_of_type?
+          section.status
+        else
+          timeline_event.new_value
+        end
+
+      selected_failure_reasons =
+        (
+          if timeline_event.is_latest_of_type?
+            section.selected_failure_reasons.to_a
+          else
+            []
+          end
+        )
 
       visible_failure_reasons =
         (
@@ -94,7 +113,7 @@ module TimelineEntry
 
       {
         section_name: section.key.titleize,
-        passed: section.passed,
+        status:,
         visible_failure_reasons:,
         hidden_failure_reasons:,
       }

--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -90,7 +90,7 @@ class ApplicationFormStatusUpdater
         "verification"
       elsif overdue_further_information || received_further_information ||
             waiting_on_further_information ||
-            assessment&.any_not_preliminary_section_finished?
+            assessment&.any_not_preliminary_section_assessed?
         "assessment"
       elsif application_form.submitted_at.present?
         "not_started"
@@ -122,7 +122,7 @@ class ApplicationFormStatusUpdater
           requestable_statuses
         elsif assessment_in_verify?
           %w[verification_in_progress]
-        elsif assessment.any_not_preliminary_section_finished?
+        elsif assessment.any_not_preliminary_section_assessed?
           %w[assessment_in_progress]
         else
           %w[assessment_not_started]

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -116,7 +116,7 @@ class Assessment < ApplicationRecord
   def can_decline?
     if unknown?
       any_preliminary_section_failed? ||
-        (all_sections_finished? && any_section_failed? && any_section_declines?)
+        (all_sections_assessed? && any_section_failed? && any_section_declines?)
     elsif request_further_information?
       all_further_information_requests_reviewed? &&
         any_further_information_requests_failed?
@@ -137,7 +137,7 @@ class Assessment < ApplicationRecord
 
   def can_request_further_information?
     if unknown?
-      all_sections_finished? && any_section_failed? && no_section_declines?
+      all_sections_assessed? && any_section_failed? && no_section_declines?
     elsif request_further_information?
       further_information_requests.empty?
     else
@@ -191,15 +191,15 @@ class Assessment < ApplicationRecord
   end
 
   def all_preliminary_sections_passed?
-    sections.preliminary.all?(&:passed)
+    sections.preliminary.all?(&:passed?)
   end
 
   def any_preliminary_section_failed?
-    sections.preliminary.any?(&:failed)
+    sections.preliminary.any?(&:failed?)
   end
 
-  def any_not_preliminary_section_finished?
-    sections.not_preliminary.any?(&:finished?)
+  def any_not_preliminary_section_assessed?
+    sections.not_preliminary.any?(&:assessed?)
   end
 
   def enough_reference_requests_verify_passed?
@@ -221,16 +221,16 @@ class Assessment < ApplicationRecord
 
   private
 
-  def all_sections_finished?
-    sections.all?(&:finished?)
+  def all_sections_assessed?
+    sections.all?(&:assessed?)
   end
 
   def all_sections_passed?
-    sections.all?(&:passed)
+    sections.all?(&:passed?)
   end
 
   def any_section_failed?
-    sections.any?(&:failed)
+    sections.any?(&:failed?)
   end
 
   def any_section_declines?

--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -56,19 +56,29 @@ class AssessmentSection < ApplicationRecord
             absence: true,
             if: -> { passed || passed.nil? }
 
-  def finished?
-    !passed.nil?
-  end
-
-  def status
-    finished? ? :completed : :not_started
-  end
-
   def declines_assessment?
     selected_failure_reasons.declinable.any?
   end
 
-  def failed
+  def passed?
+    passed == true
+  end
+
+  def failed?
     passed == false
+  end
+
+  def assessed?
+    passed? || failed?
+  end
+
+  def status
+    if passed?
+      "accepted"
+    elsif failed?
+      "rejected"
+    else
+      "not_started"
+    end
   end
 end

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -174,4 +174,11 @@ class TimelineEvent < ApplicationRecord
     requestable_expired? || requestable_received? || requestable_requested? ||
       requestable_reviewed? || requestable_verified?
   end
+
+  def is_latest_of_type?
+    application_form
+      .timeline_events
+      .order(created_at: :desc)
+      .find_by(event_type:) == self
+  end
 end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -189,10 +189,12 @@ class AssessorInterface::ApplicationFormsShowViewObject
         assessment_section,
       ],
       status:
-        if preliminary && assessment_section.failed && assessment.unknown?
+        if preliminary && assessment_section.failed? && assessment.unknown?
           :in_progress
+        elsif assessment_section.assessed?
+          :completed
         else
-          assessment_section.status
+          :not_started
         end,
     }
   end

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
       create(
         :timeline_event,
         :assessment_section_recorded,
-        new_value: "completed",
+        new_value: "rejected",
         assessment_section:,
       )
     end

--- a/spec/models/assessment_section_spec.rb
+++ b/spec/models/assessment_section_spec.rb
@@ -72,17 +72,17 @@ RSpec.describe AssessmentSection, type: :model do
 
     context "with a passed assessment" do
       before { assessment_section.passed = true }
-      it { is_expected.to eq(:completed) }
+      it { is_expected.to eq("accepted") }
     end
 
     context "with a failed assessment" do
       before { assessment_section.passed = false }
-      it { is_expected.to eq(:completed) }
+      it { is_expected.to eq("rejected") }
     end
 
     context "with no assessment yet" do
       before { assessment_section.passed = nil }
-      it { is_expected.to eq(:not_started) }
+      it { is_expected.to eq("not_started") }
     end
   end
 

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -453,4 +453,29 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:note_text) }
     end
   end
+
+  describe "#is_latest_of_type?" do
+    let(:application_form) { create(:application_form) }
+    let!(:timeline_event_1) do
+      create(
+        :timeline_event,
+        :assessment_section_recorded,
+        application_form:,
+        created_at: Date.new(2020, 1, 1),
+      )
+    end
+    let!(:timeline_event_2) do
+      create(
+        :timeline_event,
+        :assessment_section_recorded,
+        application_form:,
+        created_at: Date.new(2020, 1, 2),
+      )
+    end
+
+    it "returns the correct value" do
+      expect(timeline_event_1.is_latest_of_type?).to be false
+      expect(timeline_event_2.is_latest_of_type?).to be true
+    end
+  end
 end

--- a/spec/services/update_assessment_section_spec.rb
+++ b/spec/services/update_assessment_section_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe UpdateAssessmentSection do
 
     it "sets the state" do
       expect { subject }.to change(assessment_section, :status).from(
-        :not_started,
-      ).to(:completed)
+        "not_started",
+      ).to("rejected")
     end
 
     it "records a timeline event" do


### PR DESCRIPTION
When recording a timeline event we currently only record once the assessment section has been recorded for the first time, and this refactor will ensure that we continue to see timeline events if the assessment section is changed multiple times.