### PR TITLE
Fix timeline events not showing failure reasons

### DIFF
--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -453,29 +453,4 @@ RSpec.describe TimelineEvent do
       it { is_expected.to validate_absence_of(:note_text) }
     end
   end
-
-  describe "#is_latest_of_type?" do
-    let(:application_form) { create(:application_form) }
-    let!(:timeline_event_1) do
-      create(
-        :timeline_event,
-        :assessment_section_recorded,
-        application_form:,
-        created_at: Date.new(2020, 1, 1),
-      )
-    end
-    let!(:timeline_event_2) do
-      create(
-        :timeline_event,
-        :assessment_section_recorded,
-        application_form:,
-        created_at: Date.new(2020, 1, 2),
-      )
-    end
-
-    it "returns the correct value" do
-      expect(timeline_event_1.is_latest_of_type?).to be false
-      expect(timeline_event_2.is_latest_of_type?).to be true
-    end
-  end
 end


### PR DESCRIPTION
There was a bug in a recent change that meant we would only see the failure reasons for the most recent timeline event across the entire application.