### PR TITLE
Add VerifyAgeRangeSubjects

### DIFF
--- a/app/services/verify_age_range_subjects.rb
+++ b/app/services/verify_age_range_subjects.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class VerifyAgeRangeSubjects
+  include ServicePattern
+
+  def initialize(
+    assessment:,
+    user:,
+    age_range_min:,
+    age_range_max:,
+    age_range_note:,
+    subjects:,
+    subjects_note:
+  )
+    @assessment = assessment
+    @user = user
+    @age_range_min = age_range_min
+    @age_range_max = age_range_max
+    @age_range_note = age_range_note.presence || ""
+    @subjects = subjects
+    @subjects_note = subjects_note.presence || ""
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      assessment.update!(
+        age_range_min:,
+        age_range_max:,
+        age_range_note:,
+        subjects:,
+        subjects_note:,
+      )
+
+      create_timeline_event
+    end
+  end
+
+  private
+
+  attr_reader :assessment,
+              :user,
+              :age_range_min,
+              :age_range_max,
+              :age_range_note,
+              :subjects,
+              :subjects_note
+
+  def create_timeline_event
+    CreateTimelineEvent.call(
+      "age_range_subjects_verified",
+      application_form:,
+      user:,
+      assessment:,
+      age_range_min:,
+      age_range_max:,
+      age_range_note:,
+      subjects:,
+      subjects_note:,
+    )
+  end
+
+  delegate :application_form, to: :assessment
+end

--- a/spec/services/verify_age_range_subjects_spec.rb
+++ b/spec/services/verify_age_range_subjects_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe VerifyAgeRangeSubjects do
+  let(:assessment) { create(:assessment) }
+  let(:user) { create(:staff) }
+  let(:age_range_min) { 8 }
+  let(:age_range_max) { 11 }
+  let(:age_range_note) { "A note." }
+  let(:subjects) { %w[english_studies mathematics] }
+  let(:subjects_note) { "A note." }
+
+  subject(:call) do
+    described_class.call(
+      assessment:,
+      user:,
+      age_range_min:,
+      age_range_max:,
+      age_range_note:,
+      subjects:,
+      subjects_note:,
+    )
+  end
+
+  it "sets the minimum age" do
+    expect { call }.to change(assessment, :age_range_min).to(8)
+  end
+
+  it "sets the maximum age" do
+    expect { call }.to change(assessment, :age_range_max).to(11)
+  end
+
+  it "sets the age note" do
+    expect { call }.to change(assessment, :age_range_note).to("A note.")
+  end
+
+  it "sets the subjects" do
+    expect { call }.to change(assessment, :subjects).to(
+      %w[english_studies mathematics],
+    )
+  end
+
+  it "sets the subjects note" do
+    expect { call }.to change(assessment, :subjects_note).to("A note.")
+  end
+
+  it "records a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :age_range_subjects_verified,
+      creator: user,
+    )
+  end
+end


### PR DESCRIPTION
This adds a service which encapsulates the logic related to verifying the age range and subjects of an assessment so we can use it without the form.