### PR TITLE
Add RequestConsent

### DIFF
--- a/app/controllers/assessor_interface/consent_requests_controller.rb
+++ b/app/controllers/assessor_interface/consent_requests_controller.rb
@@ -38,26 +38,7 @@ module AssessorInterface
     end
 
     def update_request
-      if consent_requests.present?
-        ActiveRecord::Base.transaction do
-          consent_requests.each do |requestable|
-            RequestRequestable.call(requestable:, user: current_staff)
-          end
-
-          application_form.reload
-
-          ApplicationFormStatusUpdater.call(
-            application_form:,
-            user: current_staff,
-          )
-        end
-
-        DeliverEmail.call(
-          application_form:,
-          mailer: TeacherMailer,
-          action: :consent_requested,
-        )
-      end
+      RequestConsent.call(assessment:, user: current_staff)
 
       redirect_to [
                     :assessor_interface,

--- a/app/services/request_consent.rb
+++ b/app/services/request_consent.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class RequestConsent
+  include ServicePattern
+
+  def initialize(assessment:, user:)
+    @assessment = assessment
+    @user = user
+  end
+
+  def call
+    return unless consent_requests.exists?
+
+    raise AlreadyRequested if consent_requests.requested.exists?
+
+    create_and_request
+    send_email
+  end
+
+  class AlreadyRequested < StandardError
+  end
+
+  private
+
+  attr_reader :assessment, :user
+
+  delegate :application_form, to: :assessment
+  delegate :consent_requests, to: :assessment
+
+  def create_and_request
+    ActiveRecord::Base.transaction do
+      consent_requests.each do |requestable|
+        RequestRequestable.call(requestable:, user:)
+      end
+
+      application_form.reload
+
+      ApplicationFormStatusUpdater.call(application_form:, user:)
+    end
+  end
+
+  def send_email
+    DeliverEmail.call(
+      application_form:,
+      mailer: TeacherMailer,
+      action: :consent_requested,
+    )
+  end
+end

--- a/spec/services/request_consent_spec.rb
+++ b/spec/services/request_consent_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RequestConsent do
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:assessment) { create(:assessment, application_form:) }
+  let(:user) { create(:staff) }
+
+  subject(:call) { described_class.call(assessment:, user:) }
+
+  before { create(:consent_request, assessment:) }
+
+  it "changes the application form statuses" do
+    expect { call }.to change(application_form, :statuses).to(
+      %w[waiting_on_consent],
+    )
+  end
+
+  it "queues an email job" do
+    expect { call }.to have_enqueued_mail(TeacherMailer, :consent_requested)
+  end
+
+  it "records a requestable requested timeline event" do
+    expect { call }.to have_recorded_timeline_event(:requestable_requested)
+  end
+
+  context "with an existing request" do
+    before { create(:requested_consent_request, assessment:) }
+
+    it "raises an error" do
+      expect { call }.to raise_error(RequestConsent::AlreadyRequested)
+    end
+  end
+end


### PR DESCRIPTION
This adds a service which encapsulates the logic related to requesting consent so it can be used outside the controller.