### PR TITLE
Add ReviewAssessment

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_review_controller.rb
@@ -52,13 +52,7 @@ module AssessorInterface
     end
 
     def update
-      ActiveRecord::Base.transaction do
-        assessment.review!
-        ApplicationFormStatusUpdater.call(
-          application_form:,
-          user: current_staff,
-        )
-      end
+      ReviewAssessment.call(assessment:, user: current_staff)
 
       redirect_to [:status, :assessor_interface, application_form]
     end

--- a/app/services/review_assessment.rb
+++ b/app/services/review_assessment.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class ReviewAssessment
+  include ServicePattern
+
+  def initialize(assessment:, user:)
+    @assessment = assessment
+    @user = user
+  end
+
+  def call
+    raise AlreadyReviewed if assessment.review?
+
+    ActiveRecord::Base.transaction do
+      assessment.review!
+
+      ApplicationFormStatusUpdater.call(application_form:, user:)
+    end
+  end
+
+  class AlreadyReviewed < StandardError
+  end
+
+  private
+
+  attr_reader :assessment, :user
+
+  delegate :application_form, to: :assessment
+end

--- a/spec/services/review_assessment_spec.rb
+++ b/spec/services/review_assessment_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ReviewAssessment do
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:assessment) { create(:assessment, application_form:) }
+  let(:user) { create(:staff) }
+
+  subject(:call) { described_class.call(assessment:, user:) }
+
+  context "when already verified" do
+    let(:assessment) { create(:assessment, :review, application_form:) }
+
+    it "raises an error" do
+      expect { call }.to raise_error(ReviewAssessment::AlreadyReviewed)
+    end
+  end
+
+  it "changes the assessment recommendation" do
+    expect { call }.to change(assessment, :recommendation).to("review")
+  end
+
+  it "changes the application form stage" do
+    expect { call }.to change(application_form, :stage).to("review")
+  end
+end


### PR DESCRIPTION
This adds a service which encapsulates the logic of sending an assessment to review so it can be used outside the controller.