### PR TITLE
Stop using document completed field

### DIFF
--- a/app/forms/concerns/uploadable_form.rb
+++ b/app/forms/concerns/uploadable_form.rb
@@ -41,8 +41,6 @@ module UploadableForm
     if FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
       fetch_and_update_malware_scan_results
     end
-
-    document.update!(completed: !document.uploads.empty?)
   end
 
   private

--- a/app/forms/teacher_interface/delete_upload_form.rb
+++ b/app/forms/teacher_interface/delete_upload_form.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
-module TeacherInterface
-  class DeleteUploadForm < BaseForm
-    attribute :confirm, :boolean
-    attr_accessor :upload
+class TeacherInterface::DeleteUploadForm < TeacherInterface::BaseForm
+  attr_accessor :upload
+  attribute :confirm, :boolean
 
-    validates :confirm, inclusion: { in: [true, false] }
-    validates :upload, presence: true, if: :confirm
+  validates :upload, presence: true
+  validates :confirm, inclusion: { in: [true, false] }
 
-    def update_model
-      upload.destroy! if confirm
-
-      document.update!(completed: false) if document.uploads.empty?
-    end
-
-    delegate :application_form, :document, to: :upload
+  def update_model
+    upload.destroy! if confirm
   end
+
+  delegate :application_form, :document, to: :upload
 end

--- a/app/forms/teacher_interface/document_available_form.rb
+++ b/app/forms/teacher_interface/document_available_form.rb
@@ -8,10 +8,7 @@ class TeacherInterface::DocumentAvailableForm < TeacherInterface::BaseForm
   validates :available, inclusion: { in: [true, false] }
 
   def update_model
-    document.update!(
-      available:,
-      completed: available ? !document.uploads.empty? : true,
-    )
+    document.update!(available:)
   end
 
   delegate :application_form, to: :document

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -31,9 +31,6 @@ class Document < ApplicationRecord
            -> { where(translation: true) },
            class_name: "Upload"
 
-  scope :completed, -> { where(completed: true) }
-  scope :not_completed, -> { where(completed: false) }
-
   UNTRANSLATABLE_TYPES = %w[
     english_language_proficiency
     identification
@@ -69,6 +66,10 @@ class Document < ApplicationRecord
 
   def optional?
     written_statement? && application_form.written_statement_optional
+  end
+
+  def completed?
+    uploads.present? || (optional? && available == false)
   end
 
   def downloadable?

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -31,6 +31,8 @@ class Upload < ApplicationRecord
        },
        _prefix: :scan_result
 
+  delegate :application_form, to: :document
+
   def original?
     !translation?
   end
@@ -44,8 +46,6 @@ class Upload < ApplicationRecord
   def url
     attachment.url(expires_in: 5.minutes)
   end
-
-  delegate :application_form, to: :document
 
   def is_pdf?
     attachment.blob.content_type == "application/pdf"

--- a/spec/factories/documents.rb
+++ b/spec/factories/documents.rb
@@ -20,25 +20,18 @@ FactoryBot.define do
   factory :document do
     association :documentable, factory: :application_form
     sequence :document_type, Document::UNTRANSLATABLE_TYPES.cycle
-    completed { false }
-
-    trait :completed do
-      completed { true }
-    end
 
     trait :translatable do
       sequence :document_type, Document::TRANSLATABLE_TYPES.cycle
     end
 
     trait :with_upload do
-      completed
       after(:create) do |document, _evaluator|
         create(:upload, :clean, document:)
       end
     end
 
     trait :with_translation do
-      completed
       after(:create) do |document, _evaluator|
         create(:upload, :translation, :clean, document:)
       end

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -19,7 +19,7 @@
 #
 FactoryBot.define do
   factory :upload do
-    association :document, :completed
+    association :document
 
     attachment do
       Rack::Test::UploadedFile.new(
@@ -45,10 +45,6 @@ FactoryBot.define do
 
     trait :suspect do
       malware_scan_result { "suspect" }
-    end
-
-    after(:create) do |upload, _evaluator|
-      upload.document.update!(completed: true)
     end
   end
 end

--- a/spec/forms/teacher_interface/delete_upload_form_spec.rb
+++ b/spec/forms/teacher_interface/delete_upload_form_spec.rb
@@ -6,21 +6,17 @@ RSpec.describe TeacherInterface::DeleteUploadForm, type: :model do
   subject(:form) { described_class.new(confirm:, upload:) }
 
   describe "validations" do
-    let(:confirm) { "" }
+    let(:confirm) { nil }
     let(:upload) { nil }
 
+    it { is_expected.to validate_presence_of(:upload) }
     it { is_expected.to allow_values(true, false).for(:confirm) }
-
-    context "when confirm is true" do
-      let(:confirm) { "true" }
-      it { is_expected.to validate_presence_of(:upload) }
-    end
   end
 
   describe "#save" do
     subject(:save) { form.save(validate: true) }
 
-    let(:document) { create(:document, :completed) }
+    let(:document) { create(:document) }
     let!(:upload) { create(:upload, document:) }
 
     context "when confirm is true" do
@@ -31,14 +27,16 @@ RSpec.describe TeacherInterface::DeleteUploadForm, type: :model do
       end
 
       it "marks the document as incomplete" do
-        expect { save }.to change(document, :completed).from(true).to(false)
+        expect { save }.to change { document.reload.completed? }.from(true).to(
+          false,
+        )
       end
 
       context "with another upload" do
         before { create(:upload, document:) }
 
         it "doesn't mark the document as incomplete" do
-          expect { save }.to_not change(document, :completed).from(true)
+          expect { save }.to_not change(document, :completed?).from(true)
         end
       end
     end

--- a/spec/forms/teacher_interface/document_available_form_spec.rb
+++ b/spec/forms/teacher_interface/document_available_form_spec.rb
@@ -1,7 +1,12 @@
 require "rails_helper"
 
 RSpec.describe TeacherInterface::DocumentAvailableForm, type: :model do
-  let(:document) { create(:document) }
+  let(:application_form) do
+    create(:application_form, written_statement_optional: true)
+  end
+  let(:document) do
+    create(:document, :written_statement, documentable: application_form)
+  end
 
   subject(:form) { described_class.new(document:, available:) }
 
@@ -20,7 +25,7 @@ RSpec.describe TeacherInterface::DocumentAvailableForm, type: :model do
 
       it "saves the document" do
         expect(document.available).to eq(true)
-        expect(document.completed).to eq(false)
+        expect(document.completed?).to eq(false)
       end
     end
 
@@ -29,7 +34,7 @@ RSpec.describe TeacherInterface::DocumentAvailableForm, type: :model do
 
       it "saves the document" do
         expect(document.available).to eq(false)
-        expect(document.completed).to eq(true)
+        expect(document.completed?).to eq(true)
       end
     end
   end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -40,25 +40,6 @@ RSpec.describe Document, type: :model do
     end
   end
 
-  describe "scopes" do
-    let!(:incomplete_document) { create(:document) }
-    let!(:complete_document) { create(:document, :completed) }
-
-    describe "completed" do
-      it "includes only complete documents" do
-        expect(Document.completed).to include(complete_document)
-        expect(Document.completed).to_not include(incomplete_document)
-      end
-    end
-
-    describe "not_completed" do
-      it "includes only incomplete documents" do
-        expect(Document.not_completed).to include(incomplete_document)
-        expect(Document.not_completed).to_not include(complete_document)
-      end
-    end
-  end
-
   describe "#original_uploads" do
     subject(:original_uploads) { document.original_uploads }
 

--- a/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe TeacherInterface::ConsentRequestsViewObject do
 
         context "when the signed consent document is uploaded" do
           before do
-            consent_request.signed_consent_document.update!(completed: true)
+            create(:upload, document: consent_request.signed_consent_document)
           end
 
           it do


### PR DESCRIPTION
We don't want to store this in the database as it'll be dynamic and there will be more than one single status (completed, pending, not started).