### PR TITLE
Add filename to uploads

### DIFF
--- a/app/forms/concerns/uploadable_form.rb
+++ b/app/forms/concerns/uploadable_form.rb
@@ -27,6 +27,7 @@ module UploadableForm
     if original_attachment.present?
       document.uploads.create!(
         attachment: original_attachment,
+        filename: original_attachment.original_filename,
         translation: false,
       )
     end
@@ -34,6 +35,7 @@ module UploadableForm
     if translated_attachment.present?
       document.uploads.create!(
         attachment: translated_attachment,
+        filename: translated_attachment.original_filename,
         translation: true,
       )
     end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -3,6 +3,7 @@
 # Table name: uploads
 #
 #  id                  :bigint           not null, primary key
+#  filename            :string           default(""), not null
 #  malware_scan_result :string           default("pending"), not null
 #  translation         :boolean          not null
 #  created_at          :datetime         not null

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -390,12 +390,13 @@
     - updated_at
     - work_history_id
   :uploads:
-    - id
-    - document_id
-    - translation
     - created_at
-    - updated_at
+    - document_id
+    - filename
+    - id
     - malware_scan_result
+    - translation
+    - updated_at
   :work_histories:
     - application_form_id
     - canonical_contact_email

--- a/db/migrate/20240410150439_add_filename_to_uploads.rb
+++ b/db/migrate/20240410150439_add_filename_to_uploads.rb
@@ -1,0 +1,5 @@
+class AddFilenameToUploads < ActiveRecord::Migration[7.1]
+  def change
+    add_column :uploads, :filename, :string, null: false, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_10_091803) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_10_150439) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -533,6 +533,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_10_091803) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "malware_scan_result", default: "pending", null: false
+    t.string "filename", default: "", null: false
     t.index ["document_id"], name: "index_uploads_on_document_id"
   end
 

--- a/lib/tasks/uploads.rake
+++ b/lib/tasks/uploads.rake
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+namespace :uploads do
+  desc "Resend blob data for uploads that have a pending malware scan result"
+  task update_filename: :environment do
+    Upload
+      .where(filename: "")
+      .with_attached_attachment
+      .find_each do |upload|
+        upload.update!(filename: upload.attachment.filename || "unknown")
+      end
+  end
+end

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -359,7 +359,7 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
 
       it "renders the value" do
         expect(row.at_css(".govuk-summary-list__value a").text).to eq(
-          "translation_upload.pdf (opens in a new tab)",
+          "upload.pdf (opens in a new tab)",
         )
 
         document = model.translatable_document

--- a/spec/factories/uploads.rb
+++ b/spec/factories/uploads.rb
@@ -3,6 +3,7 @@
 # Table name: uploads
 #
 #  id                  :bigint           not null, primary key
+#  filename            :string           default(""), not null
 #  malware_scan_result :string           default("pending"), not null
 #  translation         :boolean          not null
 #  created_at          :datetime         not null
@@ -21,21 +22,18 @@ FactoryBot.define do
   factory :upload do
     association :document
 
+    filename { Faker::File.file_name(ext: "pdf") }
+
     attachment do
       Rack::Test::UploadedFile.new(
         "spec/fixtures/files/upload.pdf",
         "application/pdf",
       )
     end
+
     translation { false }
 
     trait :translation do
-      attachment do
-        Rack::Test::UploadedFile.new(
-          "spec/fixtures/files/translation_upload.pdf",
-          "application/pdf",
-        )
-      end
       translation { true }
     end
 

--- a/spec/models/upload_spec.rb
+++ b/spec/models/upload_spec.rb
@@ -3,6 +3,7 @@
 # Table name: uploads
 #
 #  id                  :bigint           not null, primary key
+#  filename            :string           default(""), not null
 #  malware_scan_result :string           default("pending"), not null
 #  translation         :boolean          not null
 #  created_at          :datetime         not null


### PR DESCRIPTION
This adds a new column to the upload model which we'll use to store the filename. This is necessary as we delete attachments if they're scanned as a virus, so we need to store the name elsewhere so it can be rendered.