### PR TITLE
Show virus scanning feedback to users

### DIFF
--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -32,6 +32,7 @@ module StatusTag
       cannot_start: "grey",
       declined: "red",
       draft: "grey",
+      error: "red",
       expired: "pink",
       in_progress: "blue",
       invalid: "red",

--- a/app/components/task_list/component.html.erb
+++ b/app/components/task_list/component.html.erb
@@ -1,6 +1,6 @@
 <ol class="app-task-list">
   <% sections.each do |section| %>
-    <li>
+    <li id="app-task-list-<%= section[:key] %>">
       <% if (title = section[:title]).present? %>
         <h2 class="app-task-list__section">
           <% if sections.count > 1 %>

--- a/app/controllers/assessor_interface/consent_requests_controller.rb
+++ b/app/controllers/assessor_interface/consent_requests_controller.rb
@@ -80,8 +80,7 @@ module AssessorInterface
     end
 
     def check_upload
-      unless consent_request.unsigned_consent_document.completed? &&
-               consent_request.unsigned_consent_document.downloadable?
+      unless consent_request.unsigned_consent_document.completed?
         history_stack.pop
 
         redirect_to [

--- a/app/controllers/assessor_interface/documents_controller.rb
+++ b/app/controllers/assessor_interface/documents_controller.rb
@@ -14,7 +14,7 @@ module AssessorInterface
       authorize %i[assessor_interface application_form]
 
       unless document.completed?
-        render "shared/malware_scan"
+        render "errors/forbidden", status: :forbidden
         return
       end
 

--- a/app/controllers/assessor_interface/documents_controller.rb
+++ b/app/controllers/assessor_interface/documents_controller.rb
@@ -13,7 +13,7 @@ module AssessorInterface
     def show_pdf
       authorize %i[assessor_interface application_form]
 
-      unless document.downloadable?
+      unless document.completed?
         render "shared/malware_scan"
         return
       end

--- a/app/controllers/assessor_interface/uploads_controller.rb
+++ b/app/controllers/assessor_interface/uploads_controller.rb
@@ -16,7 +16,7 @@ module AssessorInterface
       if upload.safe_to_link?
         send_blob_stream(upload.attachment, disposition: :inline)
       else
-        render "shared/malware_scan"
+        render "errors/forbidden", status: :forbidden
       end
     end
 

--- a/app/controllers/assessor_interface/uploads_controller.rb
+++ b/app/controllers/assessor_interface/uploads_controller.rb
@@ -13,7 +13,7 @@ module AssessorInterface
     def show
       authorize %i[assessor_interface application_form]
 
-      if upload.downloadable?
+      if upload.safe_to_link?
         send_blob_stream(upload.attachment, disposition: :inline)
       else
         render "shared/malware_scan"

--- a/app/controllers/teacher_interface/documents_controller.rb
+++ b/app/controllers/teacher_interface/documents_controller.rb
@@ -26,14 +26,21 @@ module TeacherInterface
     end
 
     def edit
-      if show_available_form?
-        @form =
+      @form =
+        if show_available_form?
           DocumentAvailableForm.new(document:, available: document.available)
-        render :edit_available
-      else
-        @form = AddAnotherUploadForm.new
-        render :edit_uploads
+        else
+          AddAnotherUploadForm.new
+        end
+
+      if document.any_unsafe_to_link?
+        @form.errors.add(
+          :uploads,
+          I18n.t("teacher_interface.documents.unsafe_to_link"),
+        )
       end
+
+      render show_available_form? ? :edit_available : :edit_uploads
     end
 
     def update
@@ -56,6 +63,13 @@ module TeacherInterface
               ),
           )
         end
+
+      if document.any_unsafe_to_link?
+        @form.errors.add(
+          :uploads,
+          I18n.t("teacher_interface.documents.unsafe_to_link"),
+        )
+      end
 
       handle_application_form_section(
         form: @form,

--- a/app/controllers/teacher_interface/documents_controller.rb
+++ b/app/controllers/teacher_interface/documents_controller.rb
@@ -13,13 +13,15 @@ module TeacherInterface
 
     def show
       if document.uploads.empty? && !document.optional?
-        redirect_to new_teacher_interface_application_form_document_upload_path(
+        redirect_to [
+                      :new,
+                      :teacher_interface,
+                      :application_form,
                       document,
-                    )
+                      :upload,
+                    ]
       else
-        redirect_to edit_teacher_interface_application_form_document_path(
-                      document,
-                    )
+        redirect_to [:edit, :teacher_interface, :application_form, document]
       end
     end
 
@@ -46,7 +48,7 @@ module TeacherInterface
               ),
           )
         else
-          TeacherInterface::AddAnotherUploadForm.new(
+          AddAnotherUploadForm.new(
             add_another:
               params.dig(
                 :teacher_interface_add_another_upload_form,

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -22,7 +22,7 @@ module TeacherInterface
       if @upload.safe_to_link?
         send_blob_stream(@upload.attachment, disposition: :inline)
       else
-        render "shared/malware_scan"
+        render "errors/forbidden", status: :forbidden
       end
     end
 

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -19,7 +19,7 @@ module TeacherInterface
     before_action :load_upload, only: %i[delete destroy show]
 
     def show
-      if @upload.downloadable?
+      if @upload.safe_to_link?
         send_blob_stream(@upload.attachment, disposition: :inline)
       else
         render "shared/malware_scan"

--- a/app/forms/teacher_interface/add_another_upload_form.rb
+++ b/app/forms/teacher_interface/add_another_upload_form.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-module TeacherInterface
-  class AddAnotherUploadForm < BaseForm
-    attribute :add_another, :boolean
-    validates :add_another, inclusion: { in: [true, false] }
+class TeacherInterface::AddAnotherUploadForm < TeacherInterface::BaseForm
+  attribute :add_another, :boolean
+  validates :add_another, inclusion: { in: [true, false] }
 
-    def update_model
-    end
+  def update_model
   end
 end

--- a/app/helpers/document_helper.rb
+++ b/app/helpers/document_helper.rb
@@ -4,34 +4,26 @@ module DocumentHelper
   include UploadHelper
 
   def document_link_to(document, translated: false)
-    scope =
-      (
-        if translated
-          document.translated_uploads
-        else
-          document.original_uploads
-        end
-      )
-
     if document.optional? && !document.available
-      "<em>The applicant has indicated that they haven't done an induction period " \
-        "and don't have this document.</em>".html_safe
+      tag.em(
+        "The applicant has indicated that they haven't " \
+          "done an induction period and don't have this document.",
+      )
     else
       uploads =
-        scope.order(:created_at).select { |upload| upload.attachment.present? }
-
-      malware_scan_active =
-        FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
-
-      items = uploads.map { |upload| upload_link_to(upload) }
-
-      if malware_scan_active && scope.malware_scan_suspect.exists?
-        items << tag.em(
-          "#{scope.count} #{"file upload".pluralize(scope.count)} has been scanned as malware and deleted.",
+        (
+          if translated
+            document.translated_uploads
+          else
+            document.original_uploads
+          end
         )
-      end
 
-      tag.ul(class: "govuk-list") { items.map { |item| concat(tag.li(item)) } }
+      tag.ul(class: "govuk-list") do
+        uploads
+          .order(:created_at)
+          .each { |upload| concat(tag.li(upload_link_to(upload))) }
+      end
     end
   end
 end

--- a/app/helpers/upload_helper.rb
+++ b/app/helpers/upload_helper.rb
@@ -2,19 +2,23 @@
 
 module UploadHelper
   def upload_link_to(upload)
-    href =
+    if upload.unsafe_to_link?
+      tag.div(class: "govuk-form-group--error") do
+        tag.p(upload.filename, class: "govuk-!-font-weight-bold") +
+          tag.p(
+            I18n.t("teacher_interface.documents.unsafe_to_link"),
+            class: "govuk-error-message",
+          )
+      end
+    elsif upload.safe_to_link?
       govuk_link_to(
         "#{upload.filename} (opens in a new tab)",
         upload_path(upload),
         target: :_blank,
         rel: :noopener,
       )
-
-    if upload.malware_scan_error? || upload.malware_scan_suspect?
-      href +
-        tag.p("There’s a problem with this file", class: "govuk-error-message")
     else
-      href
+      upload.filename
     end
   end
 

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -155,9 +155,10 @@ class ApplicationForm < ApplicationRecord
   ].freeze
 
   STATUS_VALUES = {
-    not_started: "not_started",
-    in_progress: "in_progress",
     completed: "completed",
+    error: "error",
+    in_progress: "in_progress",
+    not_started: "not_started",
   }.freeze
 
   STATUS_COLUMNS.each { |column| enum column, STATUS_VALUES, prefix: column }

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -72,7 +72,11 @@ class Document < ApplicationRecord
   end
 
   def downloadable?
-    uploads.all?(&:downloadable?)
+    uploads.all?(&:safe_to_link?)
+  end
+
+  def any_unsafe_to_link?
+    uploads.any?(&:unsafe_to_link?)
   end
 
   def for_further_information_request?

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -68,15 +68,28 @@ class Document < ApplicationRecord
   end
 
   def completed?
-    uploads.present? || (optional? && available == false)
-  end
-
-  def downloadable?
-    uploads.all?(&:safe_to_link?)
+    (uploads.present? && uploads.all?(&:safe_to_link?)) ||
+      (optional? && available == false)
   end
 
   def any_unsafe_to_link?
     uploads.any?(&:unsafe_to_link?)
+  end
+
+  def empty?
+    uploads.empty? && available.nil?
+  end
+
+  def status
+    if any_unsafe_to_link?
+      "error"
+    elsif completed?
+      "completed"
+    elsif empty?
+      "not_started"
+    else
+      "in_progress"
+    end
   end
 
   def for_further_information_request?

--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -40,8 +40,14 @@ class FurtherInformationRequestItem < ApplicationRecord
          work_history_contact: "work_history_contact",
        }
 
-  def state
-    completed? ? :completed : :not_started
+  def status
+    if completed?
+      "completed"
+    elsif document? && document.any_unsafe_to_link?
+      "error"
+    else
+      "not_started"
+    end
   end
 
   def completed?

--- a/app/models/qualification.rb
+++ b/app/models/qualification.rb
@@ -90,6 +90,11 @@ class Qualification < ApplicationRecord
     !complete?
   end
 
+  def any_documents_unsafe_to_link?
+    certificate_document.any_unsafe_to_link? ||
+      transcript_document.any_unsafe_to_link?
+  end
+
   def institution_country_name
     CountryName.from_code(institution_country_code)
   end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -46,8 +46,12 @@ class Upload < ApplicationRecord
     attachment.blob.content_type == "application/pdf"
   end
 
-  def downloadable?
-    !FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result) ||
-      malware_scan_clean?
+  def safe_to_link?
+    malware_scan_clean? ||
+      !FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
+  end
+
+  def unsafe_to_link?
+    malware_scan_error? || malware_scan_suspect?
   end
 end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -46,10 +46,7 @@ class Upload < ApplicationRecord
     attachment.blob.content_type == "application/pdf"
   end
 
-  def safe_to_link?
-    malware_scan_clean? ||
-      !FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
-  end
+  alias_method :safe_to_link?, :malware_scan_clean?
 
   def unsafe_to_link?
     malware_scan_error? || malware_scan_suspect?

--- a/app/view_objects/assessor_interface/qualification_requests_view_object.rb
+++ b/app/view_objects/assessor_interface/qualification_requests_view_object.rb
@@ -128,9 +128,7 @@ module AssessorInterface
       all_documents_completed =
         qualification_requests.consent_method_signed.count ==
           consent_requests.count &&
-          consent_requests
-            .map(&:unsigned_consent_document)
-            .all? { |document| document.completed? && document.downloadable? }
+          consent_requests.map(&:unsigned_consent_document).all?(&:completed?)
 
       all_consents_requested = consent_requests.all?(&:requested?)
 
@@ -186,17 +184,7 @@ module AssessorInterface
               ]
             end,
           status:
-            (
-              if consent_request&.unsigned_consent_document&.completed?
-                if consent_request&.unsigned_consent_document&.downloadable?
-                  "completed"
-                else
-                  "in_progress"
-                end
-              else
-                "not_started"
-              end
-            ),
+            consent_request&.unsigned_consent_document&.status || "not_started",
         },
         unless send_consent_document_in_all_qualifications?
           send_consent_document_task_item

--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -55,6 +55,12 @@ class TeacherInterface::ApplicationFormViewObject
     end
   end
 
+  def errored_task_list_sections
+    task_list_sections.filter do |section|
+      section[:items].any? { |item| item[:status] == "error" }
+    end
+  end
+
   def can_submit?
     completed_task_list_sections.count == task_list_sections.count
   end

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -30,7 +30,7 @@ module TeacherInterface
                 further_information_request,
                 item,
               ],
-              status: item.state,
+              status: item.status,
             }
           end
 

--- a/app/views/shared/malware_scan.html.erb
+++ b/app/views/shared/malware_scan.html.erb
@@ -1,9 +1,0 @@
-<% content_for :page_title, t(@upload.malware_scan_result, scope: %i[malware_scan title]) %>
-
-<h1 class="govuk-heading-l">
-  <%= t(@upload.malware_scan_result, scope: %i[malware_scan title]) %>
-</h1>
-
-<p class="govuk-body">
-  <%= t(@upload.malware_scan_result, scope: %i[malware_scan body]) %>
-</p>

--- a/app/views/teacher_interface/application_forms/show/_draft.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_draft.html.erb
@@ -1,3 +1,18 @@
+<% if (errored_task_list_sections = view_object.errored_task_list_sections).present? %>
+  <div role="alert" class="govuk-error-summary" data-module="govuk-error-summary">
+    <h2 class="govuk-error-summary__title">There is a problem</h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <% errored_task_list_sections.each do |section| %>
+          <li>
+            <a href="#app-task-list-<%= section[:title].parameterize %>">A selected file in “<%= section[:title] %>” contains a suspected virus. Remove it and upload a new file.</a>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>
+
 <% if view_object.show_work_history_under_submission_banner? || view_object.show_work_history_under_induction_banner? %>
   <%= govuk_notification_banner(title_text: "Important") do %>
     <p>You have added at least one teaching role that started before you were qualified as a teacher.</p>
@@ -35,6 +50,10 @@
 <% end %>
 
 <%= render TaskList::Component.new(view_object.task_list_sections) %>
+
+<% if errored_task_list_sections.present? %>
+  <p class="govuk-body">You cannot submit your application until all errors have been fixed.</p>
+<% end %>
 
 <div class="govuk-button-group">
   <% if view_object.can_submit? %>

--- a/app/views/teacher_interface/documents/edit_available.html.erb
+++ b/app/views/teacher_interface/documents/edit_available.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix("Upload a document", error: @form.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(t("helpers.legend.teacher_interface_document_available_form.available"), error: @form.errors.any?) %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= form_with model: @form, url: [:teacher_interface, :application_form, @document], method: :patch do |f| %>

--- a/app/views/teacher_interface/documents/edit_uploads.html.erb
+++ b/app/views/teacher_interface/documents/edit_uploads.html.erb
@@ -1,14 +1,16 @@
-<% content_for :page_title, title_with_error_prefix("Check your uploaded files", error: @form.errors.any?) %>
+<% title = if @document.allow_multiple_uploads?
+             "Check your uploaded files – #{t("document.document_type.#{@document.document_type}")} document"
+           else
+             "Check your uploaded file"
+           end %>
+
+<% content_for :page_title, title_with_error_prefix(title, error: @form.errors.any?) %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= form_with model: @form, url: [:teacher_interface, :application_form, @document], method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
-  <% if @document.allow_multiple_uploads? %>
-    <h1 class="govuk-heading-xl">Check your uploaded files – <%= t("document.document_type.#{@document.document_type}") %> document</h1>
-  <% else %>
-    <h1 class="govuk-heading-xl">Check your uploaded file</h1>
-  <% end %>
+  <h1 class="govuk-heading-xl"><%= title %></h1>
 
   <% if @document.for_consent_request? %>
     <h2 class="govuk-heading-m"><%= qualification_title(@document.documentable.qualification) %></h2>
@@ -45,12 +47,7 @@
   end %>
 
   <% if @document.allow_multiple_uploads? %>
-    <%= f.govuk_radio_buttons_fieldset :add_another,
-                                       legend: { text: "Do you need to upload another page?" },
-                                       hint: { text: "If your document has several pages or you’re providing an image of the other side of your identity card or driving license, you can upload them here. Otherwise, select ‘No’ and then ‘Continue’." } do %>
-      <%= f.govuk_radio_button :add_another, "true", label: { text: "Yes" } %>
-      <%= f.govuk_radio_button :add_another, "false", label: { text: "No" } %>
-    <% end %>
+    <%= f.govuk_collection_radio_buttons :add_another, %i[true false], :itself %>
   <% else %>
     <%= f.hidden_field :add_another, value: "false" %>
   <% end %>

--- a/app/views/teacher_interface/documents/edit_uploads.html.erb
+++ b/app/views/teacher_interface/documents/edit_uploads.html.erb
@@ -20,7 +20,7 @@
     <h2 class="govuk-heading-m">Files added</h2>
   <% end %>
 
-  <%= govuk_summary_list do |summary_list|
+  <%= govuk_summary_list(html_attributes: { id: "teacher-interface-add-another-upload-form-uploads-field-error" }) do |summary_list|
     @document.uploads.order(:created_at).each_with_index do |upload, index|
       summary_list.with_row do |row|
         if @document.allow_multiple_uploads?

--- a/app/views/teacher_interface/uploads/_upload_timeout_error.html.erb
+++ b/app/views/teacher_interface/uploads/_upload_timeout_error.html.erb
@@ -1,18 +1,16 @@
-<div class="govuk-error-summary" data-module="govuk-error-summary">
-  <div role="alert">
-    <h2 class="govuk-error-summary__title">
-      There was a problem uploading your document
-    </h2>
-    <div class="govuk-error-summary__body">
-      <ul class="govuk-list govuk-error-summary__list">
-        <li>
-          <a href="#teacher-interface-upload-form-original-attachment-field">Please try uploading it again.</a>
-        </li>
-        <li>
-          If you still experience this problem, email us at
-          <%= govuk_link_to t("service.email.enquiries"), email_path("enquiries") %>
-        </li>
-      </ul>
-    </div>
+<div role="alert" class="govuk-error-summary" data-module="govuk-error-summary">
+  <h2 class="govuk-error-summary__title">
+    There was a problem uploading your document
+  </h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+      <li>
+        <a href="#teacher-interface-upload-form-original-attachment-field">Please try uploading it again.</a>
+      </li>
+      <li>
+        If you still experience this problem, email us at
+        <%= govuk_link_to t("service.email.enquiries"), email_path("enquiries") %>
+      </li>
+    </ul>
   </div>
 </div>

--- a/app/views/teacher_interface/uploads/delete.html.erb
+++ b/app/views/teacher_interface/uploads/delete.html.erb
@@ -1,15 +1,12 @@
-<% content_for :page_title, title_with_error_prefix("Delete #{@upload.filename}", error: @form.errors.any?) %>
+<% title = "Are you sure you want to delete #{@upload.filename}?" %>
+
+<% content_for :page_title, title_with_error_prefix(title, error: @form.errors.any?) %>
 <% content_for :back_link_url, back_history_path(default: edit_teacher_interface_application_form_document_path(@document)) %>
 
 <%= form_with model: @form, url: [:teacher_interface, :application_form, @document, @upload], method: :delete do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_collection_radio_buttons :confirm,
-                                       [OpenStruct.new(id: "true", name: "Yes"), OpenStruct.new(id: "false", name: "No")],
-                                       :id,
-                                       :name,
-                                       inline: true,
-                                       legend: { text: "Are you sure you want to delete #{@upload.filename}?", size: "l", tag: "h1" } %>
+  <%= f.govuk_collection_radio_buttons :confirm, %i[true false], :itself, legend: { text: title, size: "l", tag: "h1" } %>
 
   <%= f.govuk_submit %>
 <% end %>

--- a/app/views/teacher_interface/uploads/delete.html.erb
+++ b/app/views/teacher_interface/uploads/delete.html.erb
@@ -1,4 +1,8 @@
-<% title = "Are you sure you want to delete #{@upload.filename}?" %>
+<% title = if @upload.unsafe_to_link?
+             "A suspected virus has been detected in #{@upload.filename}. Delete it and upload a new file."
+           else
+             "Are you sure you want to delete #{@upload.filename}?"
+           end %>
 
 <% content_for :page_title, title_with_error_prefix(title, error: @form.errors.any?) %>
 <% content_for :back_link_url, back_history_path(default: edit_teacher_interface_application_form_document_path(@document)) %>
@@ -6,7 +10,12 @@
 <%= form_with model: @form, url: [:teacher_interface, :application_form, @document, @upload], method: :delete do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_collection_radio_buttons :confirm, %i[true false], :itself, legend: { text: title, size: "l", tag: "h1" } %>
-
-  <%= f.govuk_submit %>
+  <% if @upload.unsafe_to_link? %>
+    <h1 class="govuk-heading-l"><%= title %></h1>
+    <%= f.hidden_field :confirm, value: "true" %>
+    <%= f.govuk_submit("Delete", warning: true) %>
+  <% else %>
+    <%= f.govuk_collection_radio_buttons :confirm, %i[true false], :itself, legend: { text: title, size: "l", tag: "h1" } %>
+    <%= f.govuk_submit %>
+  <% end %>
 <% end %>

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -11,6 +11,7 @@ en:
       completed: Completed
       declined: Declined
       draft: Draft
+      error: Error
       expired: Overdue
       in_progress: In progress
       invalid: Invalid

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,16 +41,6 @@ en:
       unsigned_consent: unsigned consent
       written_statement: written statement
 
-  malware_scan:
-    title:
-      error: There’s a problem with your file
-      pending: We’re checking your file
-      suspect: There’s a problem with your file
-    body:
-      error: There’s a problem with this file. You’ll need to take another image of the document you want to upload, then try again.
-      pending: We’re carrying out some checks on the file you’ve uploaded. Once we’ve successfully completed these checks, you’ll be able to preview your file.
-      suspect: There’s a problem with this file. You’ll need to take another image of the document you want to upload, then try again.
-
   staff:
     omniauth_callbacks:
       failure: There was a problem signing you in. Please try again.

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -29,6 +29,8 @@ en:
         email: We’ll use this to send you an email with a link to continue with your QTS application. Do not use a work or university email that you might lose access to.
       teacher_interface_add_another_qualification_form:
         add_another: Add another degree or qualification if they are related to your teaching career. For example, to show you are qualified to teach a particular subject.
+      teacher_interface_add_another_upload_form:
+        add_another: If your document has several pages or you’re providing an image of the other side of your identity card or driving license, you can upload them here. Otherwise, select ‘No’ and then ‘Continue’.
       teacher_interface_alternative_name_form:
         has_alternative_name: If your name appears differently on your ID documents or qualifications you need to upload proof of your name change, for example, your marriage or civil partnership certificate.
         alternative_given_names: Enter your full name apart from your family name
@@ -168,6 +170,10 @@ en:
         add_another_options:
           true: "Yes"
           false: "No"
+      teacher_interface_add_another_upload_form:
+        add_another_options:
+          true: "Yes"
+          false: "No"
       teacher_interface_alternative_name_form:
         has_alternative_name_options:
           true: Yes – I’ll upload another document to prove this
@@ -177,6 +183,10 @@ en:
       teacher_interface_age_range_form:
         minimum: <span class="govuk-visually-hidden">Age</span> From
         maximum: <span class="govuk-visually-hidden">Age</span> To
+      teacher_interface_delete_upload_form:
+        confirm_options:
+          true: "Yes"
+          false: "No"
       teacher_interface_delete_work_history_form:
         confirm_options:
           true: "Yes"
@@ -293,6 +303,8 @@ en:
         work_experience: How long have you worked as a recognised teacher?
       teacher_interface_add_another_qualification_form:
         add_another: Do you want to add another qualification?
+      teacher_interface_add_another_upload_form:
+        add_another: Do you need to upload another page?
       teacher_interface_add_another_work_history_form:
         add_another: Add another role?
       teacher_interface_alternative_name_form:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -58,6 +58,8 @@ en:
         draft:
           check: Check your application
           save: Save and sign out
+    documents:
+      unsafe_to_link: The selected file contains a suspected virus. Delete it and upload a new file.
     english_language:
       check:
         heading: Check your answers

--- a/spec/components/check_your_answers_summary_component_spec.rb
+++ b/spec/components/check_your_answers_summary_component_spec.rb
@@ -272,25 +272,6 @@ RSpec.describe CheckYourAnswersSummary::Component, type: :component do
       )
     end
 
-    context "with a suspect malware scan" do
-      before do
-        FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result)
-        create(
-          :upload,
-          malware_scan_result: "suspect",
-          document: model.document,
-        )
-      end
-
-      after { FeatureFlags::FeatureFlag.deactivate(:fetch_malware_scan_result) }
-
-      it "includes a warning" do
-        expect(row.at_css(".govuk-summary-list__value").text).to include(
-          "2 file uploads has been scanned as malware and deleted.",
-        )
-      end
-    end
-
     it "renders the change link" do
       a = row.at_css(".govuk-summary-list__actions .govuk-link")
 

--- a/spec/controllers/assessor_interface/uploads_controller_spec.rb
+++ b/spec/controllers/assessor_interface/uploads_controller_spec.rb
@@ -66,8 +66,6 @@ RSpec.describe AssessorInterface::UploadsController, type: :controller do
     context "when the upload malware scan is not clean" do
       let(:upload) { create(:upload, :suspect, document:) }
 
-      before { FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result) }
-
       it "responds with information about the malware scan" do
         perform
         expect(response.status).to eq(403)

--- a/spec/controllers/assessor_interface/uploads_controller_spec.rb
+++ b/spec/controllers/assessor_interface/uploads_controller_spec.rb
@@ -64,14 +64,13 @@ RSpec.describe AssessorInterface::UploadsController, type: :controller do
     end
 
     context "when the upload malware scan is not clean" do
-      render_views true
       let(:upload) { create(:upload, :suspect, document:) }
 
       before { FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result) }
 
       it "responds with information about the malware scan" do
         perform
-        expect(response.body).to include("There’s a problem with your file")
+        expect(response.status).to eq(403)
       end
     end
   end

--- a/spec/controllers/teacher_interface/uploads_controller_spec.rb
+++ b/spec/controllers/teacher_interface/uploads_controller_spec.rb
@@ -104,14 +104,13 @@ RSpec.describe TeacherInterface::UploadsController, type: :controller do
     end
 
     context "when the upload malware scan is not clean" do
-      render_views true
       let(:upload) { create(:upload, :suspect, document:) }
 
       before { FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result) }
 
       it "renders information about the scan result" do
         perform
-        expect(response.body).to include("There’s a problem with your file")
+        expect(response.status).to eq(403)
       end
     end
   end

--- a/spec/controllers/teacher_interface/uploads_controller_spec.rb
+++ b/spec/controllers/teacher_interface/uploads_controller_spec.rb
@@ -106,8 +106,6 @@ RSpec.describe TeacherInterface::UploadsController, type: :controller do
     context "when the upload malware scan is not clean" do
       let(:upload) { create(:upload, :suspect, document:) }
 
-      before { FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result) }
-
       it "renders information about the scan result" do
         perform
         expect(response.status).to eq(403)

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -238,7 +238,11 @@ FactoryBot.define do
     trait :with_identification_document do
       identification_document_status { "completed" }
       after(:create) do |application_form, _evaluator|
-        create(:upload, document: application_form.identification_document)
+        create(
+          :upload,
+          :clean,
+          document: application_form.identification_document,
+        )
       end
     end
 
@@ -247,7 +251,7 @@ FactoryBot.define do
       alternative_given_names { Faker::Name.name }
       alternative_family_name { Faker::Name.last_name }
       after(:create) do |application_form, _evaluator|
-        create(:upload, document: application_form.name_change_document)
+        create(:upload, :clean, document: application_form.name_change_document)
       end
     end
 
@@ -297,6 +301,7 @@ FactoryBot.define do
       after(:create) do |application_form, _evaluator|
         create(
           :upload,
+          :clean,
           document:
             application_form.english_language_medium_of_instruction_document,
         )
@@ -309,6 +314,7 @@ FactoryBot.define do
       after(:create) do |application_form, _evaluator|
         create(
           :upload,
+          :clean,
           document: application_form.english_language_proficiency_document,
         )
       end
@@ -335,6 +341,7 @@ FactoryBot.define do
       after(:create) do |application_form, _evaluator|
         create(
           :upload,
+          :clean,
           document: application_form.english_language_proficiency_document,
         )
       end
@@ -375,7 +382,11 @@ FactoryBot.define do
         if application_form.teaching_authority_provides_written_statement
           application_form.update!(written_statement_confirmation: true)
         else
-          create(:upload, document: application_form.written_statement_document)
+          create(
+            :upload,
+            :clean,
+            document: application_form.written_statement_document,
+          )
         end
       end
     end

--- a/spec/factories/qualifications.rb
+++ b/spec/factories/qualifications.rb
@@ -34,8 +34,8 @@ FactoryBot.define do
       certificate_date { complete_date + 1.year }
 
       after(:create) do |qualification, _evaluator|
-        create(:upload, document: qualification.certificate_document)
-        create(:upload, document: qualification.transcript_document)
+        create(:upload, :clean, document: qualification.certificate_document)
+        create(:upload, :clean, document: qualification.transcript_document)
       end
     end
   end

--- a/spec/forms/teacher_interface/delete_upload_form_spec.rb
+++ b/spec/forms/teacher_interface/delete_upload_form_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe TeacherInterface::DeleteUploadForm, type: :model do
     subject(:save) { form.save(validate: true) }
 
     let(:document) { create(:document) }
-    let!(:upload) { create(:upload, document:) }
+    let!(:upload) { create(:upload, :clean, document:) }
 
     context "when confirm is true" do
       let(:confirm) { "true" }
@@ -33,7 +33,7 @@ RSpec.describe TeacherInterface::DeleteUploadForm, type: :model do
       end
 
       context "with another upload" do
-        before { create(:upload, document:) }
+        before { create(:upload, :clean, document:) }
 
         it "doesn't mark the document as incomplete" do
           expect { save }.to_not change(document, :completed?).from(true)

--- a/spec/helpers/upload_helper_spec.rb
+++ b/spec/helpers/upload_helper_spec.rb
@@ -35,30 +35,19 @@ RSpec.describe UploadHelper do
     context "when the upload malware scan is pending" do
       let(:upload) { build_stubbed(:upload, :pending) }
 
-      before { FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result) }
-
       it "returns text for a pending scan" do
-        expect(upload_link_to).to have_link(
-          upload.filename,
-          href:
-            "/teacher/application/documents/#{upload.document.id}/uploads/#{upload.id}",
-        )
+        expect(upload_link_to).to have_content(upload.filename)
       end
     end
 
     context "when the upload malware scan is suspect" do
       let(:upload) { build_stubbed(:upload, :suspect) }
 
-      before { FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result) }
-
       it "appends an error for a suspect scan" do
         expect(upload_link_to).to have_content(
-          "There’s a problem with this file",
+          "The selected file contains a suspected virus",
         )
-        expect(upload_link_to).to have_css(
-          "p.govuk-error-message",
-          text: "There’s a problem with this file",
-        )
+        expect(upload_link_to).to have_css(".govuk-form-group--error")
       end
     end
   end

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -133,9 +133,10 @@ RSpec.describe ApplicationForm, type: :model do
     it do
       is_expected.to define_enum_for(:personal_information_status)
         .with_values(
-          not_started: "not_started",
-          in_progress: "in_progress",
           completed: "completed",
+          error: "error",
+          in_progress: "in_progress",
+          not_started: "not_started",
         )
         .with_prefix(:personal_information_status)
         .backed_by_column_of_type(:string)
@@ -144,9 +145,10 @@ RSpec.describe ApplicationForm, type: :model do
     it do
       is_expected.to define_enum_for(:identification_document_status)
         .with_values(
-          not_started: "not_started",
-          in_progress: "in_progress",
           completed: "completed",
+          error: "error",
+          in_progress: "in_progress",
+          not_started: "not_started",
         )
         .with_prefix(:identification_document_status)
         .backed_by_column_of_type(:string)
@@ -155,9 +157,10 @@ RSpec.describe ApplicationForm, type: :model do
     it do
       is_expected.to define_enum_for(:qualifications_status)
         .with_values(
-          not_started: "not_started",
-          in_progress: "in_progress",
           completed: "completed",
+          error: "error",
+          in_progress: "in_progress",
+          not_started: "not_started",
         )
         .with_prefix(:qualifications_status)
         .backed_by_column_of_type(:string)
@@ -166,9 +169,10 @@ RSpec.describe ApplicationForm, type: :model do
     it do
       is_expected.to define_enum_for(:age_range_status)
         .with_values(
-          not_started: "not_started",
-          in_progress: "in_progress",
           completed: "completed",
+          error: "error",
+          in_progress: "in_progress",
+          not_started: "not_started",
         )
         .with_prefix(:age_range_status)
         .backed_by_column_of_type(:string)
@@ -177,9 +181,10 @@ RSpec.describe ApplicationForm, type: :model do
     it do
       is_expected.to define_enum_for(:subjects_status)
         .with_values(
-          not_started: "not_started",
-          in_progress: "in_progress",
           completed: "completed",
+          error: "error",
+          in_progress: "in_progress",
+          not_started: "not_started",
         )
         .with_prefix(:subjects_status)
         .backed_by_column_of_type(:string)
@@ -188,9 +193,10 @@ RSpec.describe ApplicationForm, type: :model do
     it do
       is_expected.to define_enum_for(:english_language_status)
         .with_values(
-          not_started: "not_started",
-          in_progress: "in_progress",
           completed: "completed",
+          error: "error",
+          in_progress: "in_progress",
+          not_started: "not_started",
         )
         .with_prefix(:english_language_status)
         .backed_by_column_of_type(:string)
@@ -199,9 +205,10 @@ RSpec.describe ApplicationForm, type: :model do
     it do
       is_expected.to define_enum_for(:work_history_status)
         .with_values(
-          not_started: "not_started",
-          in_progress: "in_progress",
           completed: "completed",
+          error: "error",
+          in_progress: "in_progress",
+          not_started: "not_started",
         )
         .with_prefix(:work_history_status)
         .backed_by_column_of_type(:string)
@@ -210,9 +217,10 @@ RSpec.describe ApplicationForm, type: :model do
     it do
       is_expected.to define_enum_for(:registration_number_status)
         .with_values(
-          not_started: "not_started",
-          in_progress: "in_progress",
           completed: "completed",
+          error: "error",
+          in_progress: "in_progress",
+          not_started: "not_started",
         )
         .with_prefix(:registration_number_status)
         .backed_by_column_of_type(:string)
@@ -221,9 +229,10 @@ RSpec.describe ApplicationForm, type: :model do
     it do
       is_expected.to define_enum_for(:written_statement_status)
         .with_values(
-          not_started: "not_started",
-          in_progress: "in_progress",
           completed: "completed",
+          error: "error",
+          in_progress: "in_progress",
+          not_started: "not_started",
         )
         .with_prefix(:written_statement_status)
         .backed_by_column_of_type(:string)

--- a/spec/models/further_information_request_item_spec.rb
+++ b/spec/models/further_information_request_item_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe FurtherInformationRequestItem do
     create(:further_information_request_item)
   end
 
-  describe "#state" do
-    subject(:state) { further_information_request_item.state }
+  describe "#status" do
+    subject(:status) { further_information_request_item.status }
 
     context "with text information" do
       before do
@@ -54,7 +54,7 @@ RSpec.describe FurtherInformationRequestItem do
       end
 
       context "without a response" do
-        it { is_expected.to eq(:not_started) }
+        it { is_expected.to eq("not_started") }
       end
 
       context "with a response" do
@@ -62,7 +62,7 @@ RSpec.describe FurtherInformationRequestItem do
           further_information_request_item.update!(response: "response")
         end
 
-        it { is_expected.to eq(:completed) }
+        it { is_expected.to eq("completed") }
       end
     end
 
@@ -73,7 +73,7 @@ RSpec.describe FurtherInformationRequestItem do
       end
 
       context "without an upload" do
-        it { is_expected.to eq(:not_started) }
+        it { is_expected.to eq("not_started") }
       end
 
       context "with an upload" do
@@ -81,7 +81,7 @@ RSpec.describe FurtherInformationRequestItem do
           create(:upload, document: further_information_request_item.document)
         end
 
-        it { is_expected.to eq(:completed) }
+        it { is_expected.to eq("completed") }
       end
     end
   end

--- a/spec/models/further_information_request_item_spec.rb
+++ b/spec/models/further_information_request_item_spec.rb
@@ -78,7 +78,11 @@ RSpec.describe FurtherInformationRequestItem do
 
       context "with an upload" do
         before do
-          create(:upload, document: further_information_request_item.document)
+          create(
+            :upload,
+            :clean,
+            document: further_information_request_item.document,
+          )
         end
 
         it { is_expected.to eq("completed") }

--- a/spec/models/qualification_spec.rb
+++ b/spec/models/qualification_spec.rb
@@ -126,8 +126,8 @@ RSpec.describe Qualification, type: :model do
           certificate_date: Date.new(2021, 1, 1),
         )
 
-        create(:upload, document: qualification.certificate_document)
-        create(:upload, document: qualification.transcript_document)
+        create(:upload, :clean, document: qualification.certificate_document)
+        create(:upload, :clean, document: qualification.transcript_document)
       end
 
       it { is_expected.to be true }

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -95,6 +95,10 @@ module SystemHelpers
     allow(stubbed_service).to receive(:call).and_return(stubbed_response)
   end
 
+  def given_malware_scanning_is_disabled
+    FeatureFlags::FeatureFlag.deactivate(:fetch_malware_scan_result)
+  end
+
   def when_i_sign_out
     sign_out @user
   end

--- a/spec/system/teacher_interface/malware_scanning_spec.rb
+++ b/spec/system/teacher_interface/malware_scanning_spec.rb
@@ -18,9 +18,6 @@ RSpec.describe "Malware scanning", type: :system do
     then_i_see_the_check_your_uploaded_files_page
     and_the_uploaded_files_have_been_marked_as_malware
     and_the_uploaded_files_have_been_removed
-
-    when_i_click_on_a_file_marked_as_malware
-    then_i_see_theres_a_problem_with_the_file
   end
 
   def given_there_is_an_application_form
@@ -59,10 +56,10 @@ RSpec.describe "Malware scanning", type: :system do
 
   def and_the_uploaded_files_have_been_marked_as_malware
     expect(teacher_check_uploaded_files_page.files).to have_content(
-      "File 1\tupload.pdf (opens in a new tab)\nThere’s a problem with this file",
+      "File 1\t\nupload.pdf\nThe selected file contains a suspected virus.",
     )
     expect(teacher_check_uploaded_files_page.files).to have_content(
-      "File 2\tupload.pdf (opens in a new tab)\nThere’s a problem with this file",
+      "File 2\t\nupload.pdf\nThe selected file contains a suspected virus.",
     )
   end
 
@@ -73,14 +70,6 @@ RSpec.describe "Malware scanning", type: :system do
     expect(written_statement.uploads.first.attachment.filename).to be_nil
     expect(written_statement.uploads.last.attachment.download).to be_nil
     expect(written_statement.uploads.last.attachment.filename).to be_nil
-  end
-
-  def when_i_click_on_a_file_marked_as_malware
-    first("a", text: "upload.pdf").click
-  end
-
-  def then_i_see_theres_a_problem_with_the_file
-    expect(page).to have_content("There’s a problem with this file")
   end
 
   def teacher

--- a/spec/system/teacher_interface/qualifications_spec.rb
+++ b/spec/system/teacher_interface/qualifications_spec.rb
@@ -6,10 +6,11 @@ RSpec.describe "Teacher qualifications", type: :system do
   before do
     given_i_am_authorized_as_a_user(teacher)
     given_an_application_form_exists
-    given_malware_scanning_is_enabled
   end
 
   it "records qualifications" do
+    given_malware_scanning_is_enabled
+
     when_i_visit_the(:teacher_application_page)
     then_i_see_the(:teacher_application_page)
     and_i_see_the_qualifications_task
@@ -44,6 +45,7 @@ RSpec.describe "Teacher qualifications", type: :system do
   end
 
   it "deletes qualifications" do
+    given_malware_scanning_is_disabled
     given_some_qualifications_exist
 
     when_i_visit_the(:teacher_application_page)

--- a/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
@@ -97,7 +97,11 @@ RSpec.describe TeacherInterface::ConsentRequestsViewObject do
 
         context "when the signed consent document is uploaded" do
           before do
-            create(:upload, document: consent_request.signed_consent_document)
+            create(
+              :upload,
+              :clean,
+              document: consent_request.signed_consent_document,
+            )
           end
 
           it do

--- a/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
           further_information_request,
           text_item,
         ],
-        status: :not_started,
+        status: "not_started",
       )
     end
 
@@ -71,7 +71,7 @@ RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
           further_information_request,
           document_item,
         ],
-        status: :not_started,
+        status: "not_started",
       )
     end
   end


### PR DESCRIPTION
This adds the functionality for showing to users the feedback of their uploads, and specifically preventing them from being able to continue with their application if they upload a file which is scanned as a virus.