### PR TITLE
Reduce time to check for malware

### DIFF
--- a/app/forms/concerns/uploadable_form.rb
+++ b/app/forms/concerns/uploadable_form.rb
@@ -63,7 +63,7 @@ module UploadableForm
 
   def fetch_and_update_malware_scan_results
     document.uploads.each do |upload|
-      UpdateMalwareScanResultJob.set(wait: 5.seconds).perform_later(upload)
+      UpdateMalwareScanResultJob.set(wait: 2.seconds).perform_later(upload)
     end
   end
 end

--- a/app/services/resend_stored_blob_data.rb
+++ b/app/services/resend_stored_blob_data.rb
@@ -22,7 +22,7 @@ class ResendStoredBlobData
     response = blob_service.call(:put, put_blob_url, attachment_data, headers)
 
     if response.success?
-      UpdateMalwareScanResultJob.set(wait: 5.seconds).perform_later(upload)
+      UpdateMalwareScanResultJob.set(wait: 2.seconds).perform_later(upload)
     end
   rescue ActiveStorage::FileNotFoundError
     upload.update!(malware_scan_result: "error")


### PR DESCRIPTION
It looks like the scan runs quicker than we'd anticipated, the jobs don't retry after 5 seconds so we could reduce this down to 2 seconds.