### PR TITLE
Fix reference to deleted view

### DIFF
--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -31,7 +31,7 @@ module AssessorInterface
       redirect_to [:status, :assessor_interface, application_form]
     rescue RequestFurtherInformation::AlreadyExists
       flash[:warning] = "Further information has already been requested."
-      render :preview, status: :unprocessable_entity
+      render :new, status: :unprocessable_entity
     end
 
     def edit


### PR DESCRIPTION
The `preview` view no longer exists and has been replaced with the `new` one so we should render that instead.

This should fix https://dfe-teacher-services.sentry.io/issues/5242453363/