### PR TITLE
Track subject limited on application forms

### DIFF
--- a/app/lib/application_form_factory.rb
+++ b/app/lib/application_form_factory.rb
@@ -18,6 +18,7 @@ class ApplicationFormFactory
         reference:,
         region:,
         requires_preliminary_check:,
+        subject_limited:,
         teacher:,
         teaching_authority_provides_written_statement:,
         written_statement_optional:,
@@ -30,6 +31,7 @@ class ApplicationFormFactory
   attr_reader :teacher, :region
 
   delegate :reduced_evidence_accepted,
+           :requires_preliminary_check,
            :teaching_authority_provides_written_statement,
            :written_statement_optional,
            to: :region
@@ -57,7 +59,7 @@ class ApplicationFormFactory
     region.status_check_online? || region.sanction_check_online?
   end
 
-  def requires_preliminary_check
-    region.requires_preliminary_check
+  def subject_limited
+    region.country.subject_limited
   end
 end

--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -71,12 +71,12 @@ class AssessmentFactory
       "teaching_qualifications_completed_in_eligible_country",
       "qualified_in_mainstream_education",
       (
-        if application_form.country.subject_limited
+        if application_form.subject_limited
           "qualified_to_teach_children_11_to_16"
         end
       ),
       (
-        if application_form.country.subject_limited
+        if application_form.subject_limited
           "teaching_qualification_subjects_criteria"
         end
       ),
@@ -106,12 +106,12 @@ class AssessmentFactory
       FailureReasons::QUALIFICATIONS_DONT_MATCH_SUBJECTS,
       FailureReasons::QUALIFICATIONS_DONT_MATCH_OTHER_DETAILS,
       (
-        if application_form.country.subject_limited
+        if application_form.subject_limited
           FailureReasons::QUALIFIED_TO_TEACH_CHILDREN_11_TO_16
         end
       ),
       (
-        if application_form.country.subject_limited
+        if application_form.subject_limited
           FailureReasons::TEACHING_QUALIFICATION_SUBJECTS_CRITERIA
         end
       ),
@@ -130,12 +130,12 @@ class AssessmentFactory
     checks = [
       "qualified_in_mainstream_education",
       (
-        if application_form.country.subject_limited
+        if application_form.subject_limited
           "qualified_to_teach_children_11_to_16"
         end
       ),
       (
-        if application_form.country.subject_limited
+        if application_form.subject_limited
           "teaching_qualification_subjects_criteria"
         end
       ),

--- a/app/lib/preliminary_assessment_sections_factory.rb
+++ b/app/lib/preliminary_assessment_sections_factory.rb
@@ -25,7 +25,7 @@ class PreliminaryAssessmentSectionsFactory
   end
 
   def qualifications_checks
-    if application_form.country.subject_limited
+    if application_form.subject_limited
       %w[
         qualifications_meet_level_6_or_equivalent
         teaching_qualification_subjects_criteria
@@ -38,7 +38,7 @@ class PreliminaryAssessmentSectionsFactory
   def qualifications_failure_reasons
     [
       FailureReasons::TEACHING_QUALIFICATIONS_NOT_AT_REQUIRED_LEVEL,
-      if application_form.country.subject_limited
+      if application_form.subject_limited
         FailureReasons::TEACHING_QUALIFICATION_SUBJECTS_CRITERIA
       end,
     ].compact

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -38,6 +38,7 @@
 #  requires_preliminary_check                    :boolean          default(FALSE), not null
 #  stage                                         :string           default("draft"), not null
 #  statuses                                      :string           default(["\"draft\""]), not null, is an Array
+#  subject_limited                               :boolean          default(FALSE), not null
 #  subjects                                      :text             default([]), not null, is an Array
 #  subjects_status                               :string           default("not_started"), not null
 #  submitted_at                                  :datetime

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -14,6 +14,7 @@ class SubmitApplicationForm
     ActiveRecord::Base.transaction do
       application_form.update!(
         requires_preliminary_check: region.requires_preliminary_check,
+        subject_limited: region.country.subject_limited,
         subjects: application_form.subjects.compact_blank,
         submitted_at: Time.zone.now,
         working_days_since_submission: 0,

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -42,6 +42,7 @@
     - reviewer_id
     - stage
     - statuses
+    - subject_limited
     - subjects
     - subjects_status
     - submitted_at

--- a/db/migrate/20240424081136_add_subject_limited_to_application_forms.rb
+++ b/db/migrate/20240424081136_add_subject_limited_to_application_forms.rb
@@ -1,0 +1,14 @@
+class AddSubjectLimitedToApplicationForms < ActiveRecord::Migration[7.1]
+  def change
+    add_column :application_forms,
+               :subject_limited,
+               :boolean,
+               null: false,
+               default: false
+
+    ApplicationForm
+      .joins(:region)
+      .where(region: { country: Country.where(subject_limited: true) })
+      .update_all(subject_limited: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_10_151207) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_24_081136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -97,6 +97,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_10_151207) do
     t.string "statuses", default: ["draft"], null: false, array: true
     t.boolean "qualification_changed_work_history_duration", default: false, null: false
     t.boolean "teaching_qualification_part_of_degree"
+    t.boolean "subject_limited", default: false, null: false
     t.index ["action_required_by"], name: "index_application_forms_on_action_required_by"
     t.index ["assessor_id"], name: "index_application_forms_on_assessor_id"
     t.index ["english_language_provider_id"], name: "index_application_forms_on_english_language_provider_id"

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -38,6 +38,7 @@
 #  requires_preliminary_check                    :boolean          default(FALSE), not null
 #  stage                                         :string           default("draft"), not null
 #  statuses                                      :string           default(["\"draft\""]), not null, is an Array
+#  subject_limited                               :boolean          default(FALSE), not null
 #  subjects                                      :text             default([]), not null, is an Array
 #  subjects_status                               :string           default("not_started"), not null
 #  submitted_at                                  :datetime
@@ -94,13 +95,18 @@ FactoryBot.define do
     end
     reduced_evidence_accepted { region.reduced_evidence_accepted }
     written_statement_optional { region.written_statement_optional }
+    requires_preliminary_check { region.requires_preliminary_check }
+    subject_limited { region.country.subject_limited }
     teaching_authority_provides_written_statement do
       region.teaching_authority_provides_written_statement
     end
-    requires_preliminary_check { region.requires_preliminary_check }
 
     trait :requires_preliminary_check do
       requires_preliminary_check { true }
+    end
+
+    trait :subject_limited do
+      subject_limited { true }
     end
 
     trait :teaching_authority_provides_written_statement do

--- a/spec/lib/application_form_factory_spec.rb
+++ b/spec/lib/application_form_factory_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe ApplicationFormFactory do
   let(:teacher) { create(:teacher) }
-  let(:region) { create(:region) }
+  let(:region) { create(:region, country:) }
+  let(:country) { create(:country) }
 
   describe "#call" do
     subject(:call) { described_class.call(teacher:, region:) }
@@ -129,6 +130,14 @@ RSpec.describe ApplicationFormFactory do
 
       it "sets requires preliminary check" do
         expect(application_form.requires_preliminary_check).to be true
+      end
+    end
+
+    context "when subject limited" do
+      let(:country) { create(:country, :subject_limited) }
+
+      it "sets subject limited" do
+        expect(application_form.subject_limited).to be true
       end
     end
   end

--- a/spec/lib/application_form_factory_spec.rb
+++ b/spec/lib/application_form_factory_spec.rb
@@ -117,6 +117,10 @@ RSpec.describe ApplicationFormFactory do
       end
     end
 
+    it "doesn't set reduced evidence accepted" do
+      expect(application_form.reduced_evidence_accepted).to be false
+    end
+
     context "when reduced evidence is accepted" do
       let(:region) { create(:region, :reduced_evidence_accepted) }
 
@@ -125,12 +129,20 @@ RSpec.describe ApplicationFormFactory do
       end
     end
 
+    it "doesn't set requires preliminary check" do
+      expect(application_form.requires_preliminary_check).to be false
+    end
+
     context "when preliminary check is required" do
       let(:region) { create(:region, requires_preliminary_check: true) }
 
       it "sets requires preliminary check" do
         expect(application_form.requires_preliminary_check).to be true
       end
+    end
+
+    it "doesn't set subject limited" do
+      expect(application_form.subject_limited).to be false
     end
 
     context "when subject limited" do

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe AssessmentFactory do
         end
 
         context "when secondary education teaching qualification is required" do
-          let(:country) { create(:country, :subject_limited) }
+          before { application_form.subject_limited = true }
 
           it "has the right checks and failure reasons" do
             section = sections.qualifications.first
@@ -190,7 +190,7 @@ RSpec.describe AssessmentFactory do
         end
 
         context "with an application form with subject criteria" do
-          let(:country) { create(:country, :subject_limited) }
+          before { application_form.subject_limited = true }
 
           it "has the right checks and failure reasons" do
             section = sections.age_range_subjects.first
@@ -232,7 +232,7 @@ RSpec.describe AssessmentFactory do
           end
 
           context "with an application form with subject criteria" do
-            let(:country) { create(:country, :subject_limited) }
+            before { application_form.subject_limited = true }
 
             it "has the right checks and failure reasons" do
               section = sections.preliminary.qualifications.first

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -38,6 +38,7 @@
 #  requires_preliminary_check                    :boolean          default(FALSE), not null
 #  stage                                         :string           default("draft"), not null
 #  statuses                                      :string           default(["\"draft\""]), not null, is an Array
+#  subject_limited                               :boolean          default(FALSE), not null
 #  subjects                                      :text             default([]), not null, is an Array
 #  subjects_status                               :string           default("not_started"), not null
 #  submitted_at                                  :datetime

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe SubmitApplicationForm do
-  let(:region) { create(:region) }
+  let(:country) { create(:country) }
+  let(:region) { create(:region, country:) }
   let(:application_form) do
     create(
       :application_form,
@@ -9,6 +10,7 @@ RSpec.describe SubmitApplicationForm do
       :with_teaching_qualification,
       region:,
       requires_preliminary_check: false,
+      subject_limited: false,
       subjects: ["Maths", "", ""],
     )
   end
@@ -20,6 +22,16 @@ RSpec.describe SubmitApplicationForm do
     expect { call }.to change(application_form, :stage).from("draft").to(
       "not_started",
     )
+  end
+
+  context "when country is subject limited" do
+    let(:country) { create(:country, :subject_limited) }
+
+    it "sets subject limited on the application form" do
+      expect { call }.to change(application_form, :subject_limited).from(
+        false,
+      ).to(true)
+    end
   end
 
   context "when region requires preliminary check" do

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe SubmitApplicationForm do
     )
   end
 
+  it "doesn't set subject limited on the application form" do
+    expect { call }.to_not change(application_form, :subject_limited).from(
+      false,
+    )
+  end
+
   context "when country is subject limited" do
     let(:country) { create(:country, :subject_limited) }
 
@@ -32,6 +38,13 @@ RSpec.describe SubmitApplicationForm do
         false,
       ).to(true)
     end
+  end
+
+  it "doesn't set requires preliminary check on the application form" do
+    expect { call }.to_not change(
+      application_form,
+      :requires_preliminary_check,
+    ).from(false)
   end
 
   context "when region requires preliminary check" do


### PR DESCRIPTION
This tracks whether an application form is subject limited on each individual application form rather than going out to the country, where the value may have changed since the application was submitted.