### PR TITLE
Don't install Microsoft packages

### DIFF
--- a/.github/actions/prepare-app-env/action.yml
+++ b/.github/actions/prepare-app-env/action.yml
@@ -9,8 +9,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Update apt
+      run: sudo rm /etc/apt/sources.list.d/microsoft-prod.list && sudo apt-get update
+      shell: bash
+
     - name: Install libvips
-      run: sudo apt update && sudo apt install -y libvips
+      run: sudo apt install -y libvips
       shell: bash
 
     - name: Set up Ruby


### PR DESCRIPTION
This fixes an issue with the Microsoft repository that's not working currently, and since we don't use any Microsoft packages we can skip them.

https://github.com/orgs/community/discussions/120966