### PR TITLE
Don't mark contact_job as PII

### DIFF
--- a/config/analytics_pii.yml
+++ b/config/analytics_pii.yml
@@ -22,7 +22,6 @@
     - failure_reason_assessor_feedback
     - response
     - contact_name
-    - contact_job
     - contact_email
   :notes:
     - text


### PR DESCRIPTION
We don't mark it as PII in the work history itself so we don't need it to be PII in the further information.