### PR TITLE
Add task for changing qualification certificate dates

### DIFF
--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -29,6 +29,7 @@
 #  assignee_id           :bigint
 #  creator_id            :integer
 #  note_id               :bigint
+#  qualification_id      :bigint
 #  requestable_id        :bigint
 #  work_history_id       :bigint
 #
@@ -39,6 +40,7 @@
 #  index_timeline_events_on_assessment_section_id  (assessment_section_id)
 #  index_timeline_events_on_assignee_id            (assignee_id)
 #  index_timeline_events_on_note_id                (note_id)
+#  index_timeline_events_on_qualification_id       (qualification_id)
 #  index_timeline_events_on_requestable            (requestable_type,requestable_id)
 #  index_timeline_events_on_work_history_id        (work_history_id)
 #
@@ -49,6 +51,7 @@
 #  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #  fk_rails_...  (assignee_id => staff.id)
 #  fk_rails_...  (note_id => notes.id)
+#  fk_rails_...  (qualification_id => qualifications.id)
 #  fk_rails_...  (work_history_id => work_histories.id)
 #
 class TimelineEvent < ApplicationRecord
@@ -58,6 +61,7 @@ class TimelineEvent < ApplicationRecord
   belongs_to :assignee, class_name: "Staff", optional: true
   belongs_to :creator, polymorphic: true, optional: true
   belongs_to :note, optional: true
+  belongs_to :qualification, optional: true
   belongs_to :requestable, polymorphic: true, optional: true
   belongs_to :work_history, optional: true
 
@@ -165,8 +169,9 @@ class TimelineEvent < ApplicationRecord
             unless: -> { requestable_reviewed? || requestable_verified? }
 
   validates :column_name, presence: true, if: :information_changed?
-  validates :work_history_id,
-            :column_name,
+  validates :column_name,
+            :qualification_id,
+            :work_history_id,
             absence: true,
             unless: :information_changed?
 

--- a/app/services/update_qualification_certificate_date.rb
+++ b/app/services/update_qualification_certificate_date.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class UpdateQualificationCertificateDate
+  include ServicePattern
+
+  def initialize(qualification:, user:, certificate_date:)
+    @qualification = qualification
+    @user = user
+    @certificate_date = certificate_date
+  end
+
+  def call
+    old_certificate_date = qualification.certificate_date
+
+    ActiveRecord::Base.transaction do
+      qualification.update!(certificate_date:)
+      create_timeline_event(old_certificate_date:)
+    end
+  end
+
+  private
+
+  attr_reader :qualification, :user, :certificate_date
+
+  delegate :application_form, to: :qualification
+
+  def create_timeline_event(old_certificate_date:)
+    CreateTimelineEvent.call(
+      "information_changed",
+      application_form:,
+      user:,
+      qualification:,
+      column_name: "certificate_date",
+      old_value: old_certificate_date.strftime("%B %Y").strip,
+      new_value: certificate_date.strftime("%B %Y").strip,
+    )
+  end
+end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -384,6 +384,7 @@
     - new_value
     - note_id
     - old_value
+    - qualification_id
     - requestable_id
     - requestable_type
     - subjects

--- a/db/migrate/20240425074307_add_qualification_to_timeline_events.rb
+++ b/db/migrate/20240425074307_add_qualification_to_timeline_events.rb
@@ -1,0 +1,5 @@
+class AddQualificationToTimelineEvents < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :timeline_events, :qualification, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_24_081136) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_25_074307) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -519,11 +519,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_24_081136) do
     t.text "old_value", default: "", null: false
     t.text "new_value", default: "", null: false
     t.text "note_text", default: "", null: false
+    t.bigint "qualification_id"
     t.index ["application_form_id"], name: "index_timeline_events_on_application_form_id"
     t.index ["assessment_id"], name: "index_timeline_events_on_assessment_id"
     t.index ["assessment_section_id"], name: "index_timeline_events_on_assessment_section_id"
     t.index ["assignee_id"], name: "index_timeline_events_on_assignee_id"
     t.index ["note_id"], name: "index_timeline_events_on_note_id"
+    t.index ["qualification_id"], name: "index_timeline_events_on_qualification_id"
     t.index ["requestable_type", "requestable_id"], name: "index_timeline_events_on_requestable"
     t.index ["work_history_id"], name: "index_timeline_events_on_work_history_id"
   end
@@ -589,6 +591,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_24_081136) do
   add_foreign_key "timeline_events", "assessment_sections"
   add_foreign_key "timeline_events", "assessments"
   add_foreign_key "timeline_events", "notes"
+  add_foreign_key "timeline_events", "qualifications"
   add_foreign_key "timeline_events", "staff", column: "assignee_id"
   add_foreign_key "timeline_events", "work_histories"
   add_foreign_key "uploads", "documents"

--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -92,4 +92,26 @@ namespace :application_forms do
       user:,
     )
   end
+
+  desc "Change the certificate date of a qualification for an application form."
+  task :update_teaching_qualification_certificate_date,
+       %i[reference staff_email certificate_date] =>
+         :environment do |_task, args|
+    application_form = ApplicationForm.find_by!(reference: args[:reference])
+    qualification = application_form.teaching_qualification
+    user = Staff.find_by!(email: args[:staff_email])
+    certificate_date = Date.parse(args[:certificate_date])
+
+    UpdateQualificationCertificateDate.call(
+      qualification:,
+      user:,
+      certificate_date:,
+    )
+
+    note =
+      "Amended date to accurately reflect the qualification (deemed by the assessor). " \
+        "This was approved by Humzah and Natalie on 16/04/2024."
+
+    CreateNote.call(application_form:, author: user, text: note)
+  end
 end

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -27,6 +27,7 @@
 #  assignee_id           :bigint
 #  creator_id            :integer
 #  note_id               :bigint
+#  qualification_id      :bigint
 #  requestable_id        :bigint
 #  work_history_id       :bigint
 #
@@ -37,6 +38,7 @@
 #  index_timeline_events_on_assessment_section_id  (assessment_section_id)
 #  index_timeline_events_on_assignee_id            (assignee_id)
 #  index_timeline_events_on_note_id                (note_id)
+#  index_timeline_events_on_qualification_id       (qualification_id)
 #  index_timeline_events_on_requestable            (requestable_type,requestable_id)
 #  index_timeline_events_on_work_history_id        (work_history_id)
 #
@@ -47,6 +49,7 @@
 #  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #  fk_rails_...  (assignee_id => staff.id)
 #  fk_rails_...  (note_id => notes.id)
+#  fk_rails_...  (qualification_id => qualifications.id)
 #  fk_rails_...  (work_history_id => work_histories.id)
 #
 FactoryBot.define do

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -27,6 +27,7 @@
 #  assignee_id           :bigint
 #  creator_id            :integer
 #  note_id               :bigint
+#  qualification_id      :bigint
 #  requestable_id        :bigint
 #  work_history_id       :bigint
 #
@@ -37,6 +38,7 @@
 #  index_timeline_events_on_assessment_section_id  (assessment_section_id)
 #  index_timeline_events_on_assignee_id            (assignee_id)
 #  index_timeline_events_on_note_id                (note_id)
+#  index_timeline_events_on_qualification_id       (qualification_id)
 #  index_timeline_events_on_requestable            (requestable_type,requestable_id)
 #  index_timeline_events_on_work_history_id        (work_history_id)
 #
@@ -47,6 +49,7 @@
 #  fk_rails_...  (assessment_section_id => assessment_sections.id)
 #  fk_rails_...  (assignee_id => staff.id)
 #  fk_rails_...  (note_id => notes.id)
+#  fk_rails_...  (qualification_id => qualifications.id)
 #  fk_rails_...  (work_history_id => work_histories.id)
 #
 require "rails_helper"

--- a/spec/services/update_qualification_certificate_date_spec.rb
+++ b/spec/services/update_qualification_certificate_date_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UpdateQualificationCertificateDate do
+  let(:qualification) do
+    create(:qualification, certificate_date: Date.new(2020, 1, 1))
+  end
+  let(:application_form) { qualification.application_form }
+  let(:user) { create(:staff) }
+  let(:new_certificate_date) { Date.new(2021, 1, 1) }
+
+  subject(:call) do
+    described_class.call(
+      qualification:,
+      user:,
+      certificate_date: new_certificate_date,
+    )
+  end
+
+  it "changes the certificate date" do
+    expect { call }.to change(qualification, :certificate_date).to(
+      new_certificate_date,
+    )
+  end
+
+  it "records a timeline event" do
+    expect { call }.to have_recorded_timeline_event(
+      :information_changed,
+      creator: user,
+      application_form:,
+      qualification:,
+      column_name: "certificate_date",
+      old_value: "January 2020",
+      new_value: "January 2021",
+    )
+  end
+end


### PR DESCRIPTION
This adds a Rake task that makes it possible to change the certificate date of a qualification and record that in the timeline as requested by assessors.