### PR TITLE
Add recommendation confirmation checkbox

### DIFF
--- a/app/assets/stylesheets/_alerts.scss
+++ b/app/assets/stylesheets/_alerts.scss
@@ -1,0 +1,28 @@
+.hods-alert {
+  @extend .govuk-inset-text;
+  border-color: #2b8cc4;
+  background-color: #dbeff9;
+
+  &--success {
+    border-color: #28a197;
+    background-color: #c6ece9;
+  }
+
+  &--error {
+    border-color: #c42b2b;
+    background-color: #f3dede;
+  }
+
+  &:first-child {
+    @include govuk-responsive-margin(0, "top");
+  }
+
+  &:last-child {
+    @include govuk-responsive-margin(0, "bottom");
+  }
+
+  &__heading {
+    @include govuk-font(19, "bold");
+    @include govuk-responsive-margin(3, "bottom");
+  }
+}

--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -9,6 +9,7 @@ $moj-images-path: "/";
 @import "dfe-autocomplete/src/dfe-autocomplete";
 @import "location-autocomplete.min";
 
+@import "_alerts";
 @import "_application_forms";
 @import "_checkbox_search_filter";
 @import "_description_list";

--- a/app/controllers/assessor_interface/assessments_controller.rb
+++ b/app/controllers/assessor_interface/assessments_controller.rb
@@ -50,6 +50,11 @@ module AssessorInterface
       @form =
         AssessmentRecommendationForm.new(
           assessment:,
+          confirmation:
+            params.dig(
+              :assessor_interface_assessment_recommendation_form,
+              :confirmation,
+            ),
           recommendation:
             params.dig(
               :assessor_interface_assessment_recommendation_form,

--- a/app/forms/assessor_interface/assessment_recommendation_form.rb
+++ b/app/forms/assessor_interface/assessment_recommendation_form.rb
@@ -13,4 +13,12 @@ class AssessorInterface::AssessmentRecommendationForm
             inclusion: {
               in: ->(form) { form.assessment&.available_recommendations.to_a },
             }
+
+  attribute :confirmation, :boolean
+  validates :confirmation, presence: true, if: :requires_confirmation?
+
+  def requires_confirmation?
+    assessment&.can_verify? &&
+      assessment&.application_form&.submitted_under_old_criteria?
+  end
 end

--- a/app/forms/assessor_interface/assessment_recommendation_form.rb
+++ b/app/forms/assessor_interface/assessment_recommendation_form.rb
@@ -5,16 +5,12 @@ class AssessorInterface::AssessmentRecommendationForm
   include ActiveModel::Attributes
 
   attr_accessor :assessment
-  attribute :recommendation, :string
+  validates :assessment, presence: true
 
-  validates :assessment, :recommendation, presence: true
-  validate :recommendation_allowed
-
-  def recommendation_allowed
-    return if assessment.blank? || recommendation.blank?
-
-    unless assessment.available_recommendations.include?(recommendation)
-      errors.add(:recommendation, :inclusion)
-    end
-  end
+  attribute :recommendation
+  validates :recommendation,
+            presence: true,
+            inclusion: {
+              in: ->(form) { form.assessment&.available_recommendations.to_a },
+            }
 end

--- a/app/views/assessor_interface/assessments/edit.html.erb
+++ b/app/views/assessor_interface/assessments/edit.html.erb
@@ -33,6 +33,21 @@
     <p class="govuk-body">Note: for <%= CountryName.from_region(@application_form.region, with_definite_article: true) %> applications you can still award QTS if the qualifications could not be verified.
   <% end %>
 
+  <% if @form.requires_confirmation? %>
+    <div class="hods-alert">
+      <h2 class="hods-alert__heading">
+        Eligibility criteria for <%= CountryName.from_country(@application_form.country, with_definite_article: true) %> has changed.
+      </h2>
+
+      <p>By continuing, you agree you assessed this application against the criteria in place on the date it was submitted.</p>
+      <p>This application was submitted on <strong><%= @application_form.submitted_at.to_date.to_fs %></strong>.</p>
+    </div>
+
+    <%= f.govuk_check_boxes_fieldset :confirmation, multiple: false, small: true, legend: nil do %>
+      <%= f.govuk_check_box :confirmation, true, false, link_errors: true, multiple: false, label: { size: "s" } %>
+    <% end %>
+  <% end %>
+
   <%= f.govuk_collection_radio_buttons :recommendation,
                                        @assessment.available_recommendations,
                                        :itself,

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -241,6 +241,8 @@ en:
               blank: You must confirm that you have reviewed this QTS application
         assessor_interface/assessment_recommendation_form:
           attributes:
+            confirmation:
+              blank: Confirm you have assessed this application based on the eligibility criteria that was in place on the date that it was submitted
             recommendation:
               blank: Select your recommendation
               inclusion: Select your recommendation

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -67,6 +67,8 @@ en:
       assessor_interface_application_form_email_form:
         email: New email address
       assessor_interface_assessment_recommendation_form:
+        confirmation_options:
+          true: I have assessed this application based on the eligibility criteria that was in place on the date that it was submitted.
         recommendation_options:
           award: Award QTS
           decline: Decline QTS
@@ -284,6 +286,8 @@ en:
           document: "Example: The right-hand section of your teaching qualification document is missing, please take a new image and upload it."
           decline: "Example: We declined this QTS application as you already have another application in progress."
     legend:
+      assessor_interface_assessment_recommendation_form:
+        confirmation: Confirmation
       assessor_interface_assessment_section_form:
         selected_failure_reasons: What are the reasons for your recommendation?
         scotland_full_registration: Does the applicant have or are they eligible for full registration?

--- a/spec/forms/assessor_interface/assessment_recommendation_form_spec.rb
+++ b/spec/forms/assessor_interface/assessment_recommendation_form_spec.rb
@@ -3,13 +3,15 @@
 require "rails_helper"
 
 RSpec.describe AssessorInterface::AssessmentRecommendationForm, type: :model do
-  let(:assessment) { create(:assessment) }
+  let(:application_form) { create(:application_form) }
+  let(:assessment) { create(:assessment, application_form:) }
 
   subject(:form) { described_class.new(assessment:) }
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:assessment) }
     it { is_expected.to validate_presence_of(:recommendation) }
+    it { is_expected.to_not validate_presence_of(:confirmation) }
 
     context "with an award-able assessment" do
       before { allow(assessment).to receive(:can_award?).and_return(true) }
@@ -43,6 +45,14 @@ RSpec.describe AssessorInterface::AssessmentRecommendationForm, type: :model do
           %w[request_further_information],
         )
       end
+    end
+
+    context "with an application under old criteria" do
+      let(:application_form) { create(:application_form, :old_regulations) }
+
+      before { allow(assessment).to receive(:can_verify?).and_return(true) }
+
+      it { is_expected.to validate_presence_of(:confirmation) }
     end
   end
 end

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
   it "award" do
     given_i_am_authorized_as_an_assessor_user
-    given_there_is_an_awardable_application_form(%i[old_regulations])
+    given_there_is_an_awardable_application_form
     given_i_can_request_dqt_api
 
     when_i_visit_the(
@@ -59,7 +59,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
   it "verify" do
     given_i_am_authorized_as_an_assessor_user
-    given_there_is_an_awardable_application_form_with_work_history
+    given_there_is_a_verifiable_application_form_with_work_history
 
     when_i_visit_the(
       :assessor_complete_assessment_page,
@@ -112,7 +112,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
   it "verify with reduced evidence" do
     given_i_am_authorized_as_an_assessor_user
-    given_there_is_an_awardable_application_form_with_reduced_evidence
+    given_there_is_a_verifiable_application_form_with_reduced_evidence
 
     when_i_visit_the(
       :assessor_complete_assessment_page,
@@ -189,36 +189,42 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
   private
 
-  def given_there_is_an_awardable_application_form(traits = [])
+  def given_there_is_a_verifiable_application_form
     @application_form ||=
       create(
         :application_form,
         :with_personal_information,
         :with_teaching_qualification,
         :submitted,
-        *traits,
         reduced_evidence_accepted: false,
       )
 
     assessment =
       create(
         :assessment,
-        application_form:,
-        age_range_min: 8,
         age_range_max: 11,
+        age_range_min: 8,
+        application_form:,
         subjects: %w[mathematics],
       )
 
     create(:assessment_section, :personal_information, :passed, assessment:)
   end
 
-  def given_there_is_an_awardable_application_form_with_work_history
-    given_there_is_an_awardable_application_form
+  def given_there_is_an_awardable_application_form
+    given_there_is_a_verifiable_application_form
+
+    application_form.assessment.verify!
+    application_form.assessment.update!(induction_required: false)
+  end
+
+  def given_there_is_a_verifiable_application_form_with_work_history
+    given_there_is_a_verifiable_application_form
     create(:work_history, :completed, application_form:)
   end
 
-  def given_there_is_an_awardable_application_form_with_reduced_evidence
-    given_there_is_an_awardable_application_form
+  def given_there_is_a_verifiable_application_form_with_reduced_evidence
+    given_there_is_a_verifiable_application_form
     application_form.update!(reduced_evidence_accepted: true)
   end
 


### PR DESCRIPTION
This adds a checkbox when an assessor is making a recommendation for the first time and where the application is under different assessment criteria to current applications. The assessors are required to confirm they understand this before continuing.

## Screenshots

![Screenshot 2024-05-02 at 08 21 21](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/4ba64a77-d3f7-4b0d-810a-5a560791d3d9)
![Screenshot 2024-05-02 at 08 21 27](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/fde1b3c0-d4af-4673-b141-f7443f6e77a3)
