### PR TITLE
Refactor date/time formatting

### DIFF
--- a/app/components/check_your_answers_summary/component.rb
+++ b/app/components/check_your_answers_summary/component.rb
@@ -112,8 +112,7 @@ module CheckYourAnswersSummary
     end
 
     def format_date(date, field)
-      format = field[:format] == :without_day ? "%B %Y" : "%e %B %Y"
-      date.strftime(format).strip
+      field[:format] == :without_day ? date.to_fs(:month_and_year) : date.to_fs
     end
 
     def format_document(document, field)

--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -6,7 +6,7 @@
 
   <p class="moj-timeline__date">
   <time datetime="<%= timeline_event.created_at.iso8601 %>">
-    <%= timeline_event.created_at.localtime.to_fs(:date_and_time) %>
+    <%= timeline_event.created_at.localtime.to_fs %>
   </time>
   </p>
 

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -141,8 +141,7 @@ module TimelineEntry
 
     def requestable_received_vars
       {
-        requested_at:
-          timeline_event.requestable.created_at.to_fs(:date_and_time),
+        requested_at: timeline_event.requestable.created_at.to_fs,
         location_note: timeline_event.requestable.try(:location_note),
       }
     end

--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -93,7 +93,7 @@ module ApplicationFormHelper
           text: I18n.t("application_form.summary.submitted_at"),
         },
         value: {
-          text: application_form.submitted_at.strftime("%e %B %Y"),
+          text: application_form.submitted_at.to_date.to_fs,
         },
       },
       {

--- a/app/lib/consent_letter.rb
+++ b/app/lib/consent_letter.rb
@@ -44,10 +44,10 @@ class ConsentLetter
           pdf.text "Name: #{application_form_full_name(application_form)}"
 
           pdf.pad(LINE_PAD * 2) do
-            pdf.text "Date of birth: #{application_form.date_of_birth.to_fs(:long_ordinal_uk)}"
+            pdf.text "Date of birth: #{application_form.date_of_birth.to_fs}"
           end
 
-          pdf.text "Date of consent: #{date_of_consent.to_fs(:long_ordinal_uk)}"
+          pdf.text "Date of consent: #{date_of_consent.to_fs}"
 
           pdf.pad(SECTION_PAD) do
             pdf.text "The service is run by the Teaching Regulation Agency (TRA) an executive agency of the " \

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -99,7 +99,7 @@ module AssessorInterface
       [
         application_form.given_names,
         application_form.family_name,
-        "(#{application_form.date_of_birth.to_fs(:long_ordinal_uk)})",
+        "(#{application_form.date_of_birth.to_fs})",
       ].join(" ")
     end
 

--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -17,11 +17,11 @@ class TeacherInterface::ApplicationFormViewObject
   end
 
   def started_at
-    application_form.created_at.to_fs(:date).strip
+    application_form.created_at.to_date.to_fs
   end
 
   def expires_at
-    application_form.expires_at.to_fs(:date).strip
+    application_form.expires_at.to_date.to_fs
   end
 
   def task_list_sections

--- a/app/views/assessor_interface/reference_requests/edit_verify.html.erb
+++ b/app/views/assessor_interface/reference_requests/edit_verify.html.erb
@@ -65,7 +65,7 @@
       <%= govuk_warning_text(text: "Only resend reference requests if you have been asked to do so.") %>
 
       <% if (timeline_event = @application_form.timeline_events.email_sent.where(mailer_class_name: "RefereeMailer", mailer_action_name: "reference_requested").order(created_at: :desc).first) %>
-        <p class="govuk-body">This email was last sent on <%= timeline_event.created_at.to_fs(:date_and_time) %></p>
+        <p class="govuk-body">This email was last sent on <%= timeline_event.created_at.to_fs %></p>
       <% end %>
 
       <%= govuk_button_link_to "Resend reference request email", [:resend_email, :assessor_interface, @application_form, @assessment, @reference_request] %>

--- a/app/views/referee_mailer/reference_reminder.text.erb
+++ b/app/views/referee_mailer/reference_reminder.text.erb
@@ -16,7 +16,7 @@ The applicant may not be awarded QTS if we cannot confirm the information they h
 
 # What you need to do
 
-You need to answer a few questions about <%= application_form_full_name(@application_form) %> by <%= @reference_request.expires_at.to_date.to_fs(:long_ordinal_uk) %>. This should take no longer than 5 minutes.
+You need to answer a few questions about <%= application_form_full_name(@application_form) %> by <%= @reference_request.expires_at.to_date.to_fs %>. This should take no longer than 5 minutes.
 
 Follow the link below to start.
 

--- a/app/views/referee_mailer/reference_requested.text.erb
+++ b/app/views/referee_mailer/reference_requested.text.erb
@@ -6,7 +6,7 @@ They have given us your name and email address to confirm the information theyâ€
 
 # What you need to do
 
-You need to answer a few questions about <%= application_form_full_name(@application_form) %> by <%= @reference_request.expires_at.to_date.to_fs(:long_ordinal_uk) %>. This should take no longer than 5 minutes.
+You need to answer a few questions about <%= application_form_full_name(@application_form) %> by <%= @reference_request.expires_at.to_date.to_fs %>. This should take no longer than 5 minutes.
 
 Follow the link below to start.
 

--- a/app/views/shared/_reference_request_summary.html.erb
+++ b/app/views/shared/_reference_request_summary.html.erb
@@ -35,13 +35,13 @@
                t(
                  "helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response.current",
                  school_name: work_history.school_name,
-                 start_date: work_history.start_date.strftime("%B %Y"),
+                 start_date: work_history.start_date.to_fs(:month_and_year),
                ) :
                t(
                  "helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response.previous",
                  school_name: work_history.school_name,
-                 start_date: work_history.start_date.strftime("%B %Y"),
-                 end_date: work_history.end_date.strftime("%B %Y"),
+                 start_date: work_history.start_date.to_fs(:month_and_year),
+                 end_date: work_history.end_date.to_fs(:month_and_year),
                ),
       value: reference_request.dates_response ? "Yes" : "No — #{reference_request.dates_comment}",
       href: dates_teacher_interface_reference_request_path(reference_request.slug),

--- a/app/views/teacher_interface/reference_requests/edit_dates.html.erb
+++ b/app/views/teacher_interface/reference_requests/edit_dates.html.erb
@@ -2,13 +2,13 @@
              t(
                "helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response.current",
                school_name: @work_history.school_name,
-               start_date: @work_history.start_date.strftime("%B %Y"),
+               start_date: @work_history.start_date.to_fs(:month_and_year),
              ) :
              t(
                "helpers.legend.teacher_interface_reference_request_dates_response_form.dates_response.previous",
                school_name: @work_history.school_name,
-               start_date: @work_history.start_date.strftime("%B %Y"),
-               end_date: @work_history.end_date.strftime("%B %Y"),
+               start_date: @work_history.start_date.to_fs(:month_and_year),
+               end_date: @work_history.end_date.to_fs(:month_and_year),
              ) %>
 
 <% content_for :page_title, title_with_error_prefix(title, error: @form.errors.any?) %>

--- a/app/views/teacher_interface/reference_requests/show.html.erb
+++ b/app/views/teacher_interface/reference_requests/show.html.erb
@@ -36,7 +36,7 @@
 
   <%= govuk_inset_text do %>
     <p class="govuk-body">
-      <%= @work_history.school_name %> from <%= @work_history.start_date.strftime("%B %Y") %> to <%= (@work_history.end_date || Time.zone.today).strftime("%B %Y") %>
+      <%= @work_history.school_name %> from <%= @work_history.start_date.to_fs(:month_and_year) %> to <%= (@work_history.end_date || Date.today).to_fs(:month_and_year) %>
     </p>
   <% end %>
 

--- a/app/views/teacher_mailer/application_not_submitted.text.erb
+++ b/app/views/teacher_mailer/application_not_submitted.text.erb
@@ -4,11 +4,11 @@ Dear <%= application_form_full_name(@application_form) %>,
 <% when 0 %>
 We’ve noticed that you have a draft application for qualified teacher status (QTS) that has not been submitted.
 
-We need to let you know that if you do not complete and submit your application by <%= @application_form.expires_at.to_date.to_fs(:long_ordinal_uk) %> we’ll delete the application.
+We need to let you know that if you do not complete and submit your application by <%= @application_form.expires_at.to_date.to_fs %> we’ll delete the application.
 <% when 1 %>
 We contacted you a week ago about your draft application for qualified teacher status (QTS).
 
-If you do not complete and submit your application by <%= @application_form.expires_at.to_date.to_fs(:long_ordinal_uk) %> we’ll delete the application.
+If you do not complete and submit your application by <%= @application_form.expires_at.to_date.to_fs %> we’ll delete the application.
 <% end %>
 
 # What happens if your application is deleted?
@@ -19,7 +19,7 @@ Applications are deleted permanently, so if you still wanted to apply for QTS af
 
 # Your next steps
 
-If you still want to apply for QTS you must do so before <%= @application_form.expires_at.to_date.to_fs(:long_ordinal_uk) %>. You can sign in to complete and submit your application using the link below:
+If you still want to apply for QTS you must do so before <%= @application_form.expires_at.to_date.to_fs %>. You can sign in to complete and submit your application using the link below:
 
 <%= new_teacher_session_url %>
 

--- a/app/views/teacher_mailer/consent_reminder.text.erb
+++ b/app/views/teacher_mailer/consent_reminder.text.erb
@@ -2,7 +2,7 @@ Dear <%= application_form_full_name(@application_form) %>,
 
 We recently wrote to you asking for your consent to verify some of your qualifications as part of your QTS application.
 
-We have not received your consent documents. If you do not send them by <%= @expires_at.to_fs(:date) %> we will not be able to proceed with your application.
+We have not received your consent documents. If you do not send them by <%= @expires_at.to_date.to_fs %> we will not be able to proceed with your application.
 
 ## What you need to do
 

--- a/app/views/teacher_mailer/consent_requested.text.erb
+++ b/app/views/teacher_mailer/consent_requested.text.erb
@@ -15,7 +15,7 @@ Download each document then:
 
 [Sign in to access your documents](<%= new_teacher_session_url %>)
 
-You need to sign and upload these documents by <%= @expires_at.to_fs(:date) %> so that we can proceed with your application.
+You need to sign and upload these documents by <%= @expires_at.to_date.to_fs %> so that we can proceed with your application.
 
 ## Why we need your written consent
 

--- a/app/views/teacher_mailer/further_information_reminder.text.erb
+++ b/app/views/teacher_mailer/further_information_reminder.text.erb
@@ -6,7 +6,7 @@ Dear <%= application_form_full_name(@application_form) %>,
 
 # What happens next
 
-You must respond to this request by <%= @further_information_request.expires_at.to_date.to_fs(:long_ordinal_uk) %> otherwise your QTS application will be declined.
+You must respond to this request by <%= @further_information_request.expires_at.to_date.to_fs %> otherwise your QTS application will be declined.
 
 Once you respond with all of the information we’ve requested, the assessor will be able to continue reviewing your application.
 

--- a/app/views/teacher_mailer/references_reminder.text.erb
+++ b/app/views/teacher_mailer/references_reminder.text.erb
@@ -3,7 +3,7 @@ Dear <%= application_form_full_name(@application_form) %>,
 ## We’re still waiting for a response from one or more of the references you provided to verify your work history.
 
 <% if @number_of_reminders_sent == 0 %>
-We contacted your references on <%= @reference_requests.first.requested_at.to_date.to_fs(:long_ordinal_uk) %> but have not received a response from:
+We contacted your references on <%= @reference_requests.first.requested_at.to_date.to_fs %> but have not received a response from:
 <% elsif @number_of_reminders_sent == 1 %>
 The following references have just 2 weeks to respond to the reference request.
 <% end %>
@@ -12,6 +12,6 @@ The following references have just 2 weeks to respond to the reference request.
 - <%= reference_request.work_history.contact_name %> — <%= reference_request.work_history.school_name %>
 <% end %>
 
-They need to respond by <%= @reference_requests.first.expires_at.to_date.to_fs(:long_ordinal_uk) %>. If your references do not respond, and, as a result, we cannot verify your work history, we may not be able to award you QTS. You should contact your reference to remind them about the request.
+They need to respond by <%= @reference_requests.first.expires_at.to_date.to_fs %>. If your references do not respond, and, as a result, we cannot verify your work history, we may not be able to award you QTS. You should contact your reference to remind them about the request.
 
 <%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/references_requested.text.erb
+++ b/app/views/teacher_mailer/references_requested.text.erb
@@ -2,7 +2,7 @@ Dear <%= application_form_full_name(@application_form) %>,
 
 We’ve contacted the references you provided to verify the work history information you gave as part of your QTS application.
 
-They need to respond by <%= @reference_requests.first.expires_at.to_date.to_fs(:long_ordinal_uk) %>. If your references do not respond, and, as a result, we cannot verify your work history, we may not be able to award you QTS.
+They need to respond by <%= @reference_requests.first.expires_at.to_date.to_fs %>. If your references do not respond, and, as a result, we cannot verify your work history, we may not be able to award you QTS.
 
 Contact them to make sure they have received the request. They may need to check their junk email folder.
 

--- a/app/views/teaching_authority_mailer/application_submitted.text.erb
+++ b/app/views/teaching_authority_mailer/application_submitted.text.erb
@@ -4,14 +4,14 @@ We can confirm that the following person has made an application to us for quali
 
 <%= application_form_full_name(@application_form) %>
 
-Date of birth: <%= @application_form.date_of_birth.to_fs(:long_ordinal_uk) %>
+Date of birth: <%= @application_form.date_of_birth.to_fs %>
 
 The applicant has provided us with the following details about their teaching qualification:
 
 Title: <%= @qualification.title %>
 Institution studied at: <%= @qualification.institution_name %>
-Date started: <%= @qualification.start_date.to_fs(:long_ordinal_uk) %>
-Date ended: <%= @qualification.complete_date.to_fs(:long_ordinal_uk) %>
+Date started: <%= @qualification.start_date.to_fs %>
+Date ended: <%= @qualification.complete_date.to_fs %>
 
 They’ve told us that they’re qualified to teach children <%= @application_form.subjects.to_sentence %> from age <%= @application_form.age_range_min %> to <%= @application_form.age_range_max %> years old.
 

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-Date::DATE_FORMATS[:long_ordinal_uk] = "%-d %B %Y"
+Date::DATE_FORMATS[:default] = "%-d %B %Y"
 Date::DATE_FORMATS[:month_and_year] = "%B %Y"
 
-Time::DATE_FORMATS[:date] = "%e %B %Y"
-Time::DATE_FORMATS[:date_and_time] = "%e %B %Y at %l:%M %P"
+Time::DATE_FORMATS[:default] = "%-d %B %Y at %l:%M %P"

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe ApplicationFormHelper do
             },
             actions: [],
           },
-          { key: { text: "Created on" }, value: { text: " 1 January 2020" } },
+          { key: { text: "Created on" }, value: { text: "1 January 2020" } },
           {
             key: {
               text: "Working days since submission",


### PR DESCRIPTION
This refactors how we format dates and times to have a default formatter (for dates and times) and any additional custom formatting where necessary. This reduces the need to pick a formatter, instead we can use `to_fs` without any arguments.