### PR TITLE
Increase tag maximum width

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -71,6 +71,10 @@ ul.autocomplete__menu {
   margin-bottom: 0;
 }
 
+.govuk-tag {
+  max-width: 230px;
+}
+
 .app-table__center_right {
   text-align: right;
   vertical-align: middle;


### PR DESCRIPTION
A number of our tags are slightly wider than the 160px maximum with set by the GOV.UK Design System, so we are going to increase this slightly to improve readability.

## Screenshots

### Before

![Screenshot 2024-04-25 at 16 28 12](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/ed9a4a3b-9a2b-4256-b950-80f81f01e245)

### After

![Screenshot 2024-04-25 at 16 30 34](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/assets/510498/8d6f100c-0430-4ba2-8328-5d4a96036abc)