### PR TITLE
Remove update assessed_at migration

### DIFF
--- a/db/migrate/20240426085949_add_assessed_at_to_assessment_sections.rb
+++ b/db/migrate/20240426085949_add_assessed_at_to_assessment_sections.rb
@@ -1,9 +1,5 @@
 class AddAssessedAtToAssessmentSections < ActiveRecord::Migration[7.1]
   def change
     add_column :assessment_sections, :assessed_at, :datetime
-
-    AssessmentSection
-      .where.not(passed: nil)
-      .update_all("assessed_at = updated_at")
   end
 end


### PR DESCRIPTION
This migration has run in all environments now so we can remove this update which might cause issues in the future if the model changes.