### PR TITLE
Fix flaky date formatting test

### DIFF
--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     it "describes the event" do
       expect(component.text).to include(
         "Further information requested on " \
-          "#{timeline_event.requestable.created_at.strftime("%e %B %Y at %l:%M %P")} has been received.",
+          "#{timeline_event.requestable.created_at.strftime("%-d %B %Y at %l:%M %P")} has been received.",
       )
     end
 
@@ -339,7 +339,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     it "describes the event" do
       expect(component.text).to include(
         "Further information requested on " \
-          "#{timeline_event.requestable.created_at.strftime("%e %B %Y at %l:%M %P")} has expired. " \
+          "#{timeline_event.requestable.created_at.strftime("%-d %B %Y at %l:%M %P")} has expired. " \
           "Application has been declined.",
       )
     end


### PR DESCRIPTION
This test works until the day of the month is only a single character where we're checking for an empty space before the day which doesn't exist.