### PR TITLE
Delete consent requests if necessary

### DIFF
--- a/app/forms/assessor_interface/consent_method_form.rb
+++ b/app/forms/assessor_interface/consent_method_form.rb
@@ -14,7 +14,15 @@ class AssessorInterface::ConsentMethodForm
 
   def save
     return false if invalid?
+
     qualification_request.update!(consent_method:)
+
+    unless qualification_request.consent_method_signed?
+      ConsentRequest.destroy_by(
+        qualification: qualification_request.qualification,
+      )
+    end
+
     true
   end
 end


### PR DESCRIPTION
If the consent method has been changed from signed to unsigned, we may have a consent request that we need to delete.