### PR TITLE
Check assessment subjects rather than applicant subjects

### DIFF
--- a/app/lib/analytics/publication_extract.rb
+++ b/app/lib/analytics/publication_extract.rb
@@ -18,7 +18,10 @@ class Analytics::PublicationExtract
       declines = declined_application_forms(country)
       withdraws = withdrawn_application_forms(country)
 
-      submissions_with_subjects = submissions.where.not(subjects: [])
+      submissions_with_subjects =
+        submissions.select do |application_form|
+          application_form.assessment&.subjects.present?
+        end
 
       induction_required =
         awards


### PR DESCRIPTION
We need to check the subjects that the assessors are selecting rather than ones provided by the applicant.