### PR TITLE
Always record assessment section timeline events

### DIFF
--- a/app/forms/assessor_interface/assessment_section_form.rb
+++ b/app/forms/assessor_interface/assessment_section_form.rb
@@ -48,7 +48,7 @@ class AssessorInterface::AssessmentSectionForm
     return false unless valid?
 
     AssessAssessmentSection.call(
-      assessment_section:,
+      assessment_section,
       user:,
       passed:
         (

--- a/app/forms/concerns/assessor_interface/updates_english_language_status.rb
+++ b/app/forms/concerns/assessor_interface/updates_english_language_status.rb
@@ -36,14 +36,15 @@ module AssessorInterface::UpdatesEnglishLanguageStatus
     private
 
     def save_english_language_status
-      return true unless update_english_language_status?
-
-      AssessAssessmentSection.call(
-        assessment_section:
+      if update_english_language_status?
+        AssessAssessmentSection.call(
           self.class.english_language_section(assessment_section.assessment),
-        user:,
-        passed: english_language_section_passed,
-      )
+          user:,
+          passed: english_language_section_passed,
+        )
+      end
+
+      true
     end
 
     def update_english_language_status?

--- a/app/lib/fake_data/application_form_generator.rb
+++ b/app/lib/fake_data/application_form_generator.rb
@@ -149,7 +149,7 @@ class FakeData::ApplicationFormGenerator
       date_generator.travel_to_next_short do
         if decline
           AssessAssessmentSection.call(
-            assessment_section:,
+            assessment_section,
             user:,
             passed: false,
             selected_failure_reasons: {
@@ -159,7 +159,7 @@ class FakeData::ApplicationFormGenerator
             },
           )
         else
-          AssessAssessmentSection.call(assessment_section:, user:, passed: true)
+          AssessAssessmentSection.call(assessment_section, user:, passed: true)
         end
       end
     end
@@ -235,7 +235,7 @@ class FakeData::ApplicationFormGenerator
           )
         end
 
-        AssessAssessmentSection.call(assessment_section:, user:, **params)
+        AssessAssessmentSection.call(assessment_section, user:, **params)
       end
     end
   end

--- a/app/services/assess_assessment_section.rb
+++ b/app/services/assess_assessment_section.rb
@@ -68,16 +68,13 @@ class AssessAssessmentSection
   end
 
   def create_timeline_event(old_status:)
-    new_status = assessment_section.status
-    return if old_status == new_status
-
     CreateTimelineEvent.call(
       "assessment_section_recorded",
       application_form:,
       user:,
       assessment_section:,
       old_value: old_status,
-      new_value: new_status,
+      new_value: assessment_section.status,
     )
   end
 

--- a/spec/forms/assessor_interface/assessment_section_form_spec.rb
+++ b/spec/forms/assessor_interface/assessment_section_form_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe AssessorInterface::AssessmentSectionForm, type: :model do
 
       it "calls the update assessment service" do
         expect(AssessAssessmentSection).to receive(:call).with(
-          assessment_section:,
+          assessment_section,
           user:,
           passed: true,
           selected_failure_reasons: {
@@ -163,7 +163,7 @@ RSpec.describe AssessorInterface::AssessmentSectionForm, type: :model do
 
       it "calls the update assessment service" do
         expect(AssessAssessmentSection).to receive(:call).with(
-          assessment_section:,
+          assessment_section,
           user:,
           passed: false,
           selected_failure_reasons: {

--- a/spec/services/assess_assessment_section_spec.rb
+++ b/spec/services/assess_assessment_section_spec.rb
@@ -134,14 +134,4 @@ RSpec.describe AssessAssessmentSection do
       expect { call }.to_not change(assessment, :started_at)
     end
   end
-
-  context "when the state is the same" do
-    before { call }
-
-    it "doesn't record a timeline event" do
-      expect { call }.to_not have_recorded_timeline_event(
-        :assessment_section_recorded,
-      )
-    end
-  end
 end


### PR DESCRIPTION
When assessment sections are assessed we want to always record a timeline event to ensure this is captured even if the status changes, but the selected failure reasons might be different.

I've also refactored the service class to make it simpler.