### PR TITLE
Hide qualification information except on teaching qualification

### DIFF
--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -33,4 +33,7 @@ class Country < ApplicationRecord
     YAML.load(File.read("lib/countries-in-european-economic-area.yaml"))
 
   validates :code, inclusion: { in: CODES }
+
+  alias_attribute :teaching_qualification_information,
+                  :qualifications_information
 end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -60,6 +60,9 @@ class Region < ApplicationRecord
             }
   validates :teaching_authority_online_checker_url, url: { allow_blank: true }
 
+  alias_attribute :teaching_qualification_information,
+                  :qualifications_information
+
   def checks_available?
     !sanction_check_none? && !status_check_none?
   end

--- a/app/views/shared/_teaching_qualification_information.html.erb
+++ b/app/views/shared/_teaching_qualification_information.html.erb
@@ -1,0 +1,7 @@
+<% if region.teaching_qualification_information.present? %>
+  <%= raw GovukMarkdown.render(region.teaching_qualification_information) %>
+<% end %>
+
+<% if region.country.teaching_qualification_information.present? %>
+  <%= raw GovukMarkdown.render(region.country.teaching_qualification_information) %>
+<% end %>

--- a/app/views/shared/eligible_region_content_components/_proof_of_qualifications.html.erb
+++ b/app/views/shared/eligible_region_content_components/_proof_of_qualifications.html.erb
@@ -31,10 +31,4 @@
   </p>
 <% end %>
 
-<% if region.qualifications_information.present? %>
-  <%= raw GovukMarkdown.render(region.qualifications_information) %>
-<% end %>
-
-<% if region.country.qualifications_information.present? %>
-  <%= raw GovukMarkdown.render(region.country.qualifications_information) %>
-<% end %>
+<%= render "shared/teaching_qualification_information", region: %>

--- a/app/views/shared/support_interface/_country_region_information_fields.html.erb
+++ b/app/views/shared/support_interface/_country_region_information_fields.html.erb
@@ -3,7 +3,7 @@
 <%= f.govuk_fieldset legend: { text: "Proof of qualifications", size: "s" } do %>
   <p class="govuk-body">Example: ‘We cannot accept the National Certificate in Education (NCE) or the Teachers Certificate Grade II from Nigeria, as these do not meet the required level.’</p>
 
-  <%= f.govuk_text_area :qualifications_information, label: { text: "Qualifications" }, rows: 5 %>
+  <%= f.govuk_text_area :qualifications_information, label: { text: "For the teaching qualification" }, rows: 5 %>
 <% end %>
 
 <%= f.govuk_fieldset legend: { text: "Proof that you’re recognised as a teacher", size: "s" } do %>

--- a/app/views/teacher_interface/qualifications/_form.html.erb
+++ b/app/views/teacher_interface/qualifications/_form.html.erb
@@ -28,17 +28,7 @@
     <p class="govuk-body">Add any additional qualifications you have that relate to your teaching career. These must be of a <%= govuk_link_to "UK ‘level 6’ equivalent or above", "https://www.gov.uk/what-different-qualification-levels-mean/list-of-qualification-levels" %>.</p>
   <% end %>
 
-  <% if @application_form.region.qualifications_information.present? || @application_form.region.country.qualifications_information.present? %>
-    <section id="app-qualifications-information">
-      <% if @application_form.region.qualifications_information.present? %>
-        <%= raw GovukMarkdown.render(@application_form.region.qualifications_information) %>
-      <% end %>
-
-      <% if @application_form.region.country.qualifications_information.present? %>
-        <%= raw GovukMarkdown.render(@application_form.region.country.qualifications_information) %>
-      <% end %>
-    </section>
-  <% end %>
+  <%= render "shared/teaching_qualification_information", region: @application_form.region %>
 
   <%= f.govuk_fieldset legend: { text: t(qualification.locale_key, scope: %i[application_form qualifications form title]) } do %>
     <%= f.govuk_text_field :title,

--- a/app/views/teacher_interface/qualifications/_form.html.erb
+++ b/app/views/teacher_interface/qualifications/_form.html.erb
@@ -20,6 +20,8 @@
     <p class="govuk-body">If you have more than one teaching qualification enter the first one you received that qualifies you to teach. For example, if you have a bachelor’s and a master’s degree, and both qualify you to teach, enter the bachelor’s degree here.</p>
 
     <p class="govuk-body">You can add more qualifications later.</p>
+
+    <%= render "shared/teaching_qualification_information", region: @application_form.region %>
   <% elsif qualification.is_bachelor_degree? %>
     <h1 class="govuk-heading-l">Bachelor’s degree</h1>
     <p class="govuk-body">Add details of your bachelor’s degree if your teaching qualification was separate.</p>
@@ -27,8 +29,6 @@
     <h1 class="govuk-heading-l">Additional qualification</h1>
     <p class="govuk-body">Add any additional qualifications you have that relate to your teaching career. These must be of a <%= govuk_link_to "UK ‘level 6’ equivalent or above", "https://www.gov.uk/what-different-qualification-levels-mean/list-of-qualification-levels" %>.</p>
   <% end %>
-
-  <%= render "shared/teaching_qualification_information", region: @application_form.region %>
 
   <%= f.govuk_fieldset legend: { text: t(qualification.locale_key, scope: %i[application_form qualifications form title]) } do %>
     <%= f.govuk_text_field :title,

--- a/spec/support/autoload/page_objects/teacher_interface/qualification_form.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/qualification_form.rb
@@ -5,7 +5,6 @@ module PageObjects
     class QualificationForm < SitePrism::Page
       element :heading, "h1"
       element :body, ".govuk-body-l"
-      element :qualifications_information, "#app-qualifications-information"
 
       section :form, "form" do
         element :title_field,


### PR DESCRIPTION
We only want it to be shown on the form for the teaching qualification, not the bachelors degree or additional qualification as the content added to that field is irrelevant to those contexts.