### PR TITLE
Rename qualifications information column

### DIFF
--- a/app/controllers/support_interface/countries_controller.rb
+++ b/app/controllers/support_interface/countries_controller.rb
@@ -15,15 +15,16 @@ module SupportInterface
       @form =
         CountryForm.new(
           country:,
-          subject_limited: country.subject_limited,
           eligibility_enabled: country.eligibility_enabled,
           eligibility_skip_questions: country.eligibility_skip_questions,
           has_regions: country.regions.count > 1,
           other_information: country.other_information,
-          qualifications_information: country.qualifications_information,
           region_names: country.regions.pluck(:name).join("\n"),
           sanction_information: country.sanction_information,
           status_information: country.status_information,
+          subject_limited: country.subject_limited,
+          teaching_qualification_information:
+            country.teaching_qualification_information,
         )
     end
 
@@ -59,13 +60,13 @@ module SupportInterface
     def country_params
       params.require(:support_interface_country_form).permit(
         :eligibility_enabled,
+        :eligibility_route,
         :has_regions,
         :other_information,
-        :qualifications_information,
         :region_names,
         :sanction_information,
         :status_information,
-        :eligibility_route,
+        :teaching_qualification_information,
       )
     end
   end

--- a/app/controllers/support_interface/regions_controller.rb
+++ b/app/controllers/support_interface/regions_controller.rb
@@ -33,9 +33,7 @@ class SupportInterface::RegionsController < SupportInterface::BaseController
   def region_params
     params.require(:region).permit(
       :all_sections_necessary,
-      :work_history_section_to_omit,
       :other_information,
-      :qualifications_information,
       :requires_preliminary_check,
       :sanction_check,
       :sanction_information,
@@ -49,6 +47,8 @@ class SupportInterface::RegionsController < SupportInterface::BaseController
       :teaching_authority_provides_written_statement,
       :teaching_authority_requires_submission_email,
       :teaching_authority_websites_string,
+      :teaching_qualification_information,
+      :work_history_section_to_omit,
       :written_statement_optional,
     )
   end

--- a/app/forms/support_interface/country_form.rb
+++ b/app/forms/support_interface/country_form.rb
@@ -8,15 +8,15 @@ class SupportInterface::CountryForm
   attr_accessor :country
   validates :country, presence: true
 
-  attribute :subject_limited, :boolean
   attribute :eligibility_enabled, :boolean
   attribute :eligibility_skip_questions, :boolean
   attribute :has_regions, :boolean
   attribute :other_information, :string
-  attribute :qualifications_information, :string
   attribute :region_names, :string
   attribute :sanction_information, :string
   attribute :status_information, :string
+  attribute :subject_limited, :boolean
+  attribute :teaching_qualification_information, :string
 
   validates :eligibility_enabled, inclusion: { in: [true, false] }
   validates :eligibility_skip_questions, inclusion: { in: [true, false] }
@@ -53,16 +53,16 @@ class SupportInterface::CountryForm
     if has_regions
       country.assign_attributes(
         other_information:,
-        qualifications_information:,
         sanction_information:,
         status_information:,
+        teaching_qualification_information:,
       )
     else
       country.assign_attributes(
         other_information: "",
-        qualifications_information: "",
         sanction_information: "",
         status_information: "",
+        teaching_qualification_information: "",
       )
     end
   end

--- a/app/lib/configuration_sync/exporter.rb
+++ b/app/lib/configuration_sync/exporter.rb
@@ -33,10 +33,11 @@ class ConfigurationSync::Exporter
       eligibility_enabled: country.eligibility_enabled,
       eligibility_skip_questions: country.eligibility_skip_questions,
       other_information: country.other_information,
-      qualifications_information: country.qualifications_information,
       sanction_information: country.sanction_information,
       status_information: country.status_information,
       subject_limited: country.subject_limited,
+      teaching_qualification_information:
+        country.teaching_qualification_information,
     }
   end
 
@@ -61,7 +62,6 @@ class ConfigurationSync::Exporter
       country_code: region.country.code,
       name: region.name,
       other_information: region.other_information,
-      qualifications_information: region.qualifications_information,
       reduced_evidence_accepted: region.reduced_evidence_accepted,
       sanction_check: region.sanction_check,
       sanction_information: region.sanction_information,
@@ -78,6 +78,8 @@ class ConfigurationSync::Exporter
       teaching_authority_requires_submission_email:
         region.teaching_authority_requires_submission_email,
       teaching_authority_websites: region.teaching_authority_websites,
+      teaching_qualification_information:
+        region.teaching_qualification_information,
       written_statement_optional: region.written_statement_optional,
     }
   end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -33,7 +33,4 @@ class Country < ApplicationRecord
     YAML.load(File.read("lib/countries-in-european-economic-area.yaml"))
 
   validates :code, inclusion: { in: CODES }
-
-  alias_attribute :teaching_qualification_information,
-                  :qualifications_information
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -2,17 +2,17 @@
 #
 # Table name: countries
 #
-#  id                         :bigint           not null, primary key
-#  code                       :string           not null
-#  eligibility_enabled        :boolean          default(TRUE), not null
-#  eligibility_skip_questions :boolean          default(FALSE), not null
-#  other_information          :text             default(""), not null
-#  qualifications_information :text             default(""), not null
-#  sanction_information       :string           default(""), not null
-#  status_information         :string           default(""), not null
-#  subject_limited            :boolean          default(FALSE), not null
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
+#  id                                 :bigint           not null, primary key
+#  code                               :string           not null
+#  eligibility_enabled                :boolean          default(TRUE), not null
+#  eligibility_skip_questions         :boolean          default(FALSE), not null
+#  other_information                  :text             default(""), not null
+#  sanction_information               :string           default(""), not null
+#  status_information                 :string           default(""), not null
+#  subject_limited                    :boolean          default(FALSE), not null
+#  teaching_qualification_information :text             default(""), not null
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
 #
 # Indexes
 #

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -60,9 +60,6 @@ class Region < ApplicationRecord
             }
   validates :teaching_authority_online_checker_url, url: { allow_blank: true }
 
-  alias_attribute :teaching_qualification_information,
-                  :qualifications_information
-
   def checks_available?
     !sanction_check_none? && !status_check_none?
   end

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -6,7 +6,6 @@
 #  application_form_skip_work_history            :boolean          default(FALSE), not null
 #  name                                          :string           default(""), not null
 #  other_information                             :text             default(""), not null
-#  qualifications_information                    :text             default(""), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  requires_preliminary_check                    :boolean          default(FALSE), not null
 #  sanction_check                                :string           default("none"), not null
@@ -21,6 +20,7 @@
 #  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
 #  teaching_authority_requires_submission_email  :boolean          default(FALSE), not null
 #  teaching_authority_websites                   :text             default([]), not null, is an Array
+#  teaching_qualification_information            :text             default(""), not null
 #  written_statement_optional                    :boolean          default(FALSE), not null
 #  created_at                                    :datetime         not null
 #  updated_at                                    :datetime         not null

--- a/app/views/shared/support_interface/_country_region_information_fields.html.erb
+++ b/app/views/shared/support_interface/_country_region_information_fields.html.erb
@@ -3,7 +3,7 @@
 <%= f.govuk_fieldset legend: { text: "Proof of qualifications", size: "s" } do %>
   <p class="govuk-body">Example: ‘We cannot accept the National Certificate in Education (NCE) or the Teachers Certificate Grade II from Nigeria, as these do not meet the required level.’</p>
 
-  <%= f.govuk_text_area :qualifications_information, label: { text: "For the teaching qualification" }, rows: 5 %>
+  <%= f.govuk_text_area :teaching_qualification_information, label: { text: "For the teaching qualification" }, rows: 5 %>
 <% end %>
 
 <%= f.govuk_fieldset legend: { text: "Proof that you’re recognised as a teacher", size: "s" } do %>

--- a/app/views/support_interface/countries/preview.html.erb
+++ b/app/views/support_interface/countries/preview.html.erb
@@ -48,9 +48,9 @@
   <%= raw GovukMarkdown.render(@country.other_information) %>
 <% end %>
 
-<% if @country.qualifications_information_changed? %>
-  <h3 class="govuk-heading-s">Qualifications information</h3>
-  <%= raw GovukMarkdown.render(@country.qualifications_information) %>
+<% if @country.teaching_qualification_information %>
+  <h3 class="govuk-heading-s">Teaching qualification information</h3>
+  <%= raw GovukMarkdown.render(@country.teaching_qualification_information) %>
 <% end %>
 
 <% if @country.eligibility_skip_questions_changed? || @country.subject_limited_changed? %>
@@ -68,13 +68,13 @@
 
 <%= form_with model: @form, url: [:support_interface, @country], method: :put do |f| %>
   <%= f.hidden_field :eligibility_enabled, value: @form.eligibility_enabled %>
+  <%= f.hidden_field :eligibility_route, value: @form.eligibility_route %>
   <%= f.hidden_field :eligibility_skip_questions, value: @form.eligibility_skip_questions %>
   <%= f.hidden_field :has_regions, value: @form.has_regions %>
   <%= f.hidden_field :other_information, value: @form.other_information %>
-  <%= f.hidden_field :qualifications_information, value: @form.qualifications_information %>
   <%= f.hidden_field :region_names, value: @form.region_names %>
   <%= f.hidden_field :sanction_information, value: @form.sanction_information %>
   <%= f.hidden_field :status_information, value: @form.status_information %>
-  <%= f.hidden_field :eligibility_route, value: @form.eligibility_route %>
+  <%= f.hidden_field :teaching_qualification_information, value: @form.teaching_qualification_information %>
   <%= f.govuk_submit "Save", name: "preview", value: "false" %>
 <% end %>

--- a/app/views/support_interface/regions/preview.html.erb
+++ b/app/views/support_interface/regions/preview.html.erb
@@ -13,7 +13,6 @@
 <%= form_with model: [:support_interface, @region] do |f| %>
   <%= f.hidden_field :application_form_skip_work_history, value: @region.application_form_skip_work_history %>
   <%= f.hidden_field :other_information, value: @region.other_information %>
-  <%= f.hidden_field :qualifications_information, value: @region.qualifications_information %>
   <%= f.hidden_field :reduced_evidence_accepted, value: @region.reduced_evidence_accepted %>
   <%= f.hidden_field :requires_preliminary_check, value: @region.requires_preliminary_check %>
   <%= f.hidden_field :sanction_check, value: @region.sanction_check %>
@@ -28,6 +27,7 @@
   <%= f.hidden_field :teaching_authority_provides_written_statement, value: @region.teaching_authority_provides_written_statement %>
   <%= f.hidden_field :teaching_authority_requires_submission_email, value: @region.teaching_authority_requires_submission_email %>
   <%= f.hidden_field :teaching_authority_websites_string, value: @region.teaching_authority_websites_string %>
+  <%= f.hidden_field :teaching_qualification_information, value: @region.teaching_qualification_information %>
   <%= f.hidden_field :written_statement_optional, value: @region.written_statement_optional %>
   <%= f.govuk_submit "Save", name: "preview", value: "false" %>
 <% end %>

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -112,11 +112,11 @@
     - eligibility_skip_questions
     - id
     - other_information
-    - qualifications_information
     - sanction_information
     - status_information
-    - updated_at
     - subject_limited
+    - teaching_qualification_information
+    - updated_at
   :documents:
     - available
     - created_at
@@ -282,7 +282,6 @@
     - id
     - name
     - other_information
-    - qualifications_information
     - reduced_evidence_accepted
     - requires_preliminary_check
     - sanction_check
@@ -297,6 +296,7 @@
     - teaching_authority_provides_written_statement
     - teaching_authority_requires_submission_email
     - teaching_authority_websites
+    - teaching_qualification_information
     - updated_at
     - written_statement_optional
   :reminder_emails:

--- a/db/migrate/20240528121209_rename_qualifications_information.rb
+++ b/db/migrate/20240528121209_rename_qualifications_information.rb
@@ -1,0 +1,10 @@
+class RenameQualificationsInformation < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :countries,
+                  :qualifications_information,
+                  :teaching_qualification_information
+    rename_column :regions,
+                  :qualifications_information,
+                  :teaching_qualification_information
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_26_085949) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_28_121209) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -176,7 +176,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_26_085949) do
     t.string "status_information", default: "", null: false
     t.string "sanction_information", default: "", null: false
     t.boolean "eligibility_enabled", default: true, null: false
-    t.text "qualifications_information", default: "", null: false
+    t.text "teaching_qualification_information", default: "", null: false
     t.boolean "eligibility_skip_questions", default: false, null: false
     t.boolean "subject_limited", default: false, null: false
     t.index ["code"], name: "index_countries_on_code", unique: true
@@ -385,7 +385,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_26_085949) do
     t.string "status_information", default: "", null: false
     t.string "sanction_information", default: "", null: false
     t.boolean "teaching_authority_provides_written_statement", default: false, null: false
-    t.text "qualifications_information", default: "", null: false
+    t.text "teaching_qualification_information", default: "", null: false
     t.boolean "application_form_skip_work_history", default: false, null: false
     t.boolean "reduced_evidence_accepted", default: false, null: false
     t.boolean "teaching_authority_requires_submission_email", default: false, null: false

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -2,17 +2,17 @@
 #
 # Table name: countries
 #
-#  id                         :bigint           not null, primary key
-#  code                       :string           not null
-#  eligibility_enabled        :boolean          default(TRUE), not null
-#  eligibility_skip_questions :boolean          default(FALSE), not null
-#  other_information          :text             default(""), not null
-#  qualifications_information :text             default(""), not null
-#  sanction_information       :string           default(""), not null
-#  status_information         :string           default(""), not null
-#  subject_limited            :boolean          default(FALSE), not null
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
+#  id                                 :bigint           not null, primary key
+#  code                               :string           not null
+#  eligibility_enabled                :boolean          default(TRUE), not null
+#  eligibility_skip_questions         :boolean          default(FALSE), not null
+#  other_information                  :text             default(""), not null
+#  sanction_information               :string           default(""), not null
+#  status_information                 :string           default(""), not null
+#  subject_limited                    :boolean          default(FALSE), not null
+#  teaching_qualification_information :text             default(""), not null
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
 #
 # Indexes
 #

--- a/spec/factories/regions.rb
+++ b/spec/factories/regions.rb
@@ -6,7 +6,6 @@
 #  application_form_skip_work_history            :boolean          default(FALSE), not null
 #  name                                          :string           default(""), not null
 #  other_information                             :text             default(""), not null
-#  qualifications_information                    :text             default(""), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  requires_preliminary_check                    :boolean          default(FALSE), not null
 #  sanction_check                                :string           default("none"), not null
@@ -21,6 +20,7 @@
 #  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
 #  teaching_authority_requires_submission_email  :boolean          default(FALSE), not null
 #  teaching_authority_websites                   :text             default([]), not null, is an Array
+#  teaching_qualification_information            :text             default(""), not null
 #  written_statement_optional                    :boolean          default(FALSE), not null
 #  created_at                                    :datetime         not null
 #  updated_at                                    :datetime         not null

--- a/spec/lib/configuration_sync/exporter_spec.rb
+++ b/spec/lib/configuration_sync/exporter_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe ConfigurationSync::Exporter do
         "eligibility_enabled" => true,
         "eligibility_skip_questions" => false,
         "other_information" => "",
-        "qualifications_information" => "",
         "sanction_information" => "",
         "status_information" => "",
         "subject_limited" => false,
+        "teaching_qualification_information" => "",
       },
     )
   end
@@ -60,7 +60,6 @@ RSpec.describe ConfigurationSync::Exporter do
         "country_code" => "FR",
         "name" => "Region",
         "other_information" => "",
-        "qualifications_information" => "",
         "reduced_evidence_accepted" => false,
         "sanction_check" => "none",
         "sanction_information" => "",
@@ -74,6 +73,7 @@ RSpec.describe ConfigurationSync::Exporter do
         "teaching_authority_provides_written_statement" => false,
         "teaching_authority_requires_submission_email" => false,
         "teaching_authority_websites" => [],
+        "teaching_qualification_information" => "",
         "written_statement_optional" => false,
       },
     )

--- a/spec/lib/configuration_sync/importer_spec.rb
+++ b/spec/lib/configuration_sync/importer_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe ConfigurationSync::Importer do
             "eligibility_enabled": true,
             "eligibility_skip_questions": false,
             "other_information": "",
-            "qualifications_information": "",
             "sanction_information": "",
             "status_information": "",
-            "subject_limited": false
+            "subject_limited": false,
+            "teaching_qualification_information": ""
           }
         ],
         "english_language_providers": [
@@ -39,7 +39,6 @@ RSpec.describe ConfigurationSync::Importer do
             "country_code": "FR",
             "name": "Region",
             "other_information": "",
-            "qualifications_information": "",
             "reduced_evidence_accepted": false,
             "sanction_check": "none",
             "sanction_information": "",
@@ -53,6 +52,7 @@ RSpec.describe ConfigurationSync::Importer do
             "teaching_authority_provides_written_statement": false,
             "teaching_authority_requires_submission_email": false,
             "teaching_authority_websites": [],
+            "teaching_qualification_information": "",
             "written_statement_optional": false
           }
         ]

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -2,17 +2,17 @@
 #
 # Table name: countries
 #
-#  id                         :bigint           not null, primary key
-#  code                       :string           not null
-#  eligibility_enabled        :boolean          default(TRUE), not null
-#  eligibility_skip_questions :boolean          default(FALSE), not null
-#  other_information          :text             default(""), not null
-#  qualifications_information :text             default(""), not null
-#  sanction_information       :string           default(""), not null
-#  status_information         :string           default(""), not null
-#  subject_limited            :boolean          default(FALSE), not null
-#  created_at                 :datetime         not null
-#  updated_at                 :datetime         not null
+#  id                                 :bigint           not null, primary key
+#  code                               :string           not null
+#  eligibility_enabled                :boolean          default(TRUE), not null
+#  eligibility_skip_questions         :boolean          default(FALSE), not null
+#  other_information                  :text             default(""), not null
+#  sanction_information               :string           default(""), not null
+#  status_information                 :string           default(""), not null
+#  subject_limited                    :boolean          default(FALSE), not null
+#  teaching_qualification_information :text             default(""), not null
+#  created_at                         :datetime         not null
+#  updated_at                         :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/region_spec.rb
+++ b/spec/models/region_spec.rb
@@ -6,7 +6,6 @@
 #  application_form_skip_work_history            :boolean          default(FALSE), not null
 #  name                                          :string           default(""), not null
 #  other_information                             :text             default(""), not null
-#  qualifications_information                    :text             default(""), not null
 #  reduced_evidence_accepted                     :boolean          default(FALSE), not null
 #  requires_preliminary_check                    :boolean          default(FALSE), not null
 #  sanction_check                                :string           default("none"), not null
@@ -21,6 +20,7 @@
 #  teaching_authority_provides_written_statement :boolean          default(FALSE), not null
 #  teaching_authority_requires_submission_email  :boolean          default(FALSE), not null
 #  teaching_authority_websites                   :text             default([]), not null, is an Array
+#  teaching_qualification_information            :text             default(""), not null
 #  written_statement_optional                    :boolean          default(FALSE), not null
 #  created_at                                    :datetime         not null
 #  updated_at                                    :datetime         not null

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -7,13 +7,13 @@ module SystemHelpers
   def given_an_eligible_eligibility_check(country_check:)
     country = create(:country, :with_national_region, code: "GB-SCT")
     country.regions.first.update!(
-      qualifications_information: "Qualifications information",
-      requires_preliminary_check: true,
-      status_check: country_check,
-      sanction_check: country_check,
-      status_information: "Status information",
-      sanction_information: "Sanction information",
       other_information: "Other teaching authority information.",
+      requires_preliminary_check: true,
+      sanction_check: country_check,
+      sanction_information: "Sanction information",
+      status_check: country_check,
+      status_information: "Status information",
+      teaching_qualification_information: "Qualifications information",
     )
 
     visit "/eligibility/start"

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_other_information
     when_i_fill_sanction_information
     when_i_fill_status_information
-    when_i_fill_qualifications_information
+    when_i_fill_teaching_qualification_information
     when_i_fill_regions
     and_i_click_preview
     then_i_see_country_changes_preview
@@ -42,7 +42,7 @@ RSpec.describe "Countries support", type: :system do
     when_i_fill_teaching_authority_online_checker_url
     when_i_fill_teaching_authority_websites
     when_i_select_yes_teaching_authority_requires_submission_email
-    when_i_fill_qualifications_information
+    when_i_fill_teaching_qualification_information
     when_i_check_written_statement_optional
     when_i_check_requires_preliminary_check
     and_i_click_preview
@@ -193,11 +193,11 @@ RSpec.describe "Countries support", type: :system do
            visible: :all
   end
 
-  def when_i_fill_qualifications_information
-    fill_in "region-qualifications-information-field",
+  def when_i_fill_teaching_qualification_information
+    fill_in "region-teaching-qualification-information-field",
             with: "Qualifications information"
   rescue Capybara::ElementNotFound
-    fill_in "support-interface-country-form-qualifications-information-field",
+    fill_in "support-interface-country-form-teaching-qualification-information-field",
             with: "Qualifications information"
   end
 

--- a/spec/views/shared/eligible_region_content_spec.rb
+++ b/spec/views/shared/eligible_region_content_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe "Eligible region content", type: :view do
       create(
         :region,
         country: create(:country, code: "FR"),
-        status_check: :written,
         sanction_check: :written,
-        status_information: "Status information",
         sanction_information: "Sanction information",
+        status_check: :written,
+        status_information: "Status information",
         teaching_authority_address: "address",
         teaching_authority_certificate: "certificate",
-        qualifications_information: "qualifications info",
+        teaching_qualification_information: "qualifications info",
       )
     end
 


### PR DESCRIPTION
This renames the column from qualifications information to teaching qualification information to make it clear what this content relates to and where it's used.