### PR TITLE
Set Rails Semantic Logger format to JSON

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,6 +75,5 @@ Rails.application.configure do
   config.logger =
     ActiveSupport::Logger.new(config.paths["log"].first, 1, 50.megabytes)
 
-  config.log_format = :color
   config.semantic_logger.backtrace_level = :debug
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,7 +52,6 @@ Rails.application.configure do
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
   config.log_level = :info
-  config.log_format = :json
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -82,7 +81,8 @@ Rails.application.configure do
     config.rails_semantic_logger.add_file_appender = false
     config.semantic_logger.add_appender(
       io: $stdout,
-      formatter: config.rails_semantic_logger.format,
+      level: config.log_level,
+      formatter: :json,
     )
   end
 


### PR DESCRIPTION
The configuration `log_format` doesn't exist and therefore it wasn't being used anywhere, instead we need to specify the logging format when we add the log appender. In production we want this to be a JSON log so it can be parsed by Logit.