### PR TITLE
Update publication extract calculation

### DIFF
--- a/app/lib/analytics/publication_extract.rb
+++ b/app/lib/analytics/publication_extract.rb
@@ -24,14 +24,7 @@ class Analytics::PublicationExtract
           .where(assessment: { induction_required: true })
           .count
 
-      percent_induction_required =
-        (
-          if awards.empty?
-            0
-          else
-            ((induction_required.to_f / awards.count) * 100).round
-          end
-        )
+      percent_induction_required = percent_of(induction_required, awards.count)
 
       {
         country_name: CountryName.from_country(country),
@@ -87,5 +80,11 @@ class Analytics::PublicationExtract
       start_date,
       end_date,
     )
+  end
+
+  def percent_of(numerator, denominator)
+    return 0 if numerator.zero? || denominator.zero?
+
+    ((numerator.to_f / denominator) * 100).round
   end
 end

--- a/app/lib/analytics/publication_extract.rb
+++ b/app/lib/analytics/publication_extract.rb
@@ -41,19 +41,6 @@ class Analytics::PublicationExtract
         withdrawn: withdraws.count,
         awaiting_decision:
           submissions.count - awards.count - declines.count - withdraws.count,
-        awardees_with_only_ebacc_subject_or_subjects:
-          awards.count do |application_form|
-            has_only_ebacc_subjects?(application_form)
-          end,
-        awardees_with_no_ebacc_subjects:
-          awards.count do |application_form|
-            has_no_ebacc_subjects?(application_form)
-          end,
-        awardees_with_a_mix_of_subjects_at_least_one_is_ebacc:
-          awards.count do |application_form|
-            !has_only_ebacc_subjects?(application_form) &&
-              !has_no_ebacc_subjects?(application_form)
-          end,
         induction_required:,
         percent_induction_required:,
       }
@@ -99,14 +86,6 @@ class Analytics::PublicationExtract
       start_date,
       end_date,
     )
-  end
-
-  def has_only_ebacc_subjects?(application_form)
-    Subject.find(application_form.assessment.subjects).all?(&:ebacc?)
-  end
-
-  def has_no_ebacc_subjects?(application_form)
-    Subject.find(application_form.assessment.subjects).none?(&:ebacc?)
   end
 
   def requires_induction?(application_form)

--- a/app/lib/analytics/publication_extract.rb
+++ b/app/lib/analytics/publication_extract.rb
@@ -20,7 +20,8 @@ class Analytics::PublicationExtract
 
       induction_required =
         awards
-          .select { |application_form| requires_induction?(application_form) }
+          .joins(:assessment)
+          .where(assessment: { induction_required: true })
           .count
 
       percent_induction_required =
@@ -86,9 +87,5 @@ class Analytics::PublicationExtract
       start_date,
       end_date,
     )
-  end
-
-  def requires_induction?(application_form)
-    application_form.assessment.induction_required
   end
 end

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -203,6 +203,18 @@ class ApplicationForm < ApplicationRecord
     submitted_at.present?
   end
 
+  def awarded?
+    awarded_at.present?
+  end
+
+  def declined?
+    declined_at.present?
+  end
+
+  def withdrawn?
+    withdrawn_at.present?
+  end
+
   def to_param
     reference
   end


### PR DESCRIPTION
This updates the publication extract according to the new calculations where we only consider the submitted applications on a certain date range, regardless of when they transitioned to a different state.