### PR TITLE
Reset requested date when changing reference request email addresses

### DIFF
--- a/app/controllers/assessor_interface/reference_requests_controller.rb
+++ b/app/controllers/assessor_interface/reference_requests_controller.rb
@@ -111,13 +111,7 @@ module AssessorInterface
 
     def resend_email
       if reference_request.requested? && !reference_request.received?
-        DeliverEmail.call(
-          application_form:,
-          mailer: RefereeMailer,
-          action: :reference_requested,
-          reference_request:,
-        )
-
+        reference_request.send_requested_email
         flash[:info] = "The reference requested email has been resent."
       end
 

--- a/app/models/reference_request.rb
+++ b/app/models/reference_request.rb
@@ -109,8 +109,21 @@ class ReferenceRequest < ApplicationRecord
     )
   end
 
+  def send_requested_email
+    DeliverEmail.call(
+      application_form:,
+      mailer: RefereeMailer,
+      action: :reference_requested,
+      reference_request: self,
+    )
+  end
+
   def expires_after
     6.weeks
+  end
+
+  def after_requested(*)
+    send_requested_email
   end
 
   def after_verified(*)

--- a/app/services/update_work_history_contact.rb
+++ b/app/services/update_work_history_contact.rb
@@ -30,7 +30,13 @@ class UpdateWorkHistoryContact
     end
 
     if email.present? && (reference_request = work_history.reference_request)
-      reference_request.send_requested_email
+      RequestRequestable.call(
+        requestable: reference_request,
+        user:,
+        allow_already_requested: true,
+      )
+
+      ApplicationFormStatusUpdater.call(application_form:, user:)
 
       DeliverEmail.call(
         application_form:,

--- a/app/services/update_work_history_contact.rb
+++ b/app/services/update_work_history_contact.rb
@@ -29,12 +29,7 @@ class UpdateWorkHistoryContact
     end
 
     if email.present? && (reference_request = work_history.reference_request)
-      DeliverEmail.call(
-        application_form:,
-        mailer: RefereeMailer,
-        action: :reference_requested,
-        reference_request:,
-      )
+      reference_request.send_requested_email
 
       DeliverEmail.call(
         application_form:,

--- a/app/services/verify_assessment.rb
+++ b/app/services/verify_assessment.rb
@@ -39,7 +39,7 @@ class VerifyAssessment
       end
 
     if reference_requests.present?
-      send_reference_request_emails(reference_requests)
+      send_references_requested_email(reference_requests)
     end
 
     reference_requests
@@ -80,16 +80,7 @@ class VerifyAssessment
     end
   end
 
-  def send_reference_request_emails(reference_requests)
-    reference_requests.each do |reference_request|
-      DeliverEmail.call(
-        application_form:,
-        mailer: RefereeMailer,
-        action: :reference_requested,
-        reference_request:,
-      )
-    end
-
+  def send_references_requested_email(reference_requests)
     DeliverEmail.call(
       application_form:,
       mailer: TeacherMailer,

--- a/spec/support/shared_examples/requestable.rb
+++ b/spec/support/shared_examples/requestable.rb
@@ -117,6 +117,8 @@ RSpec.shared_examples "a requestable" do
   describe "#after_requested" do
     let(:after_requested) { subject.after_requested(user: "User") }
 
+    before { subject.requested! }
+
     it "doesn't raise an error" do
       expect { after_requested }.to_not raise_error
     end


### PR DESCRIPTION
This updates the `UpdateWorkHistoryContact` service to re-request the reference request (if there is one) so the expiration date is shifted by 6 weeks, allowing the new contact enough time to respond to the reference.