### PR TITLE
Add validation on maximum age

### DIFF
--- a/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
+++ b/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
@@ -12,7 +12,9 @@ module AssessorInterface::AgeRangeSubjectsForm
               presence: true,
               numericality: {
                 only_integer: true,
-                greater_than_or_equal_to: 0,
+                greater_than_or_equal_to: 4,
+                less_than_or_equal_to: :age_range_max,
+                if: :age_range_max,
                 allow_nil: true,
               }
     validates :age_range_max,
@@ -20,6 +22,8 @@ module AssessorInterface::AgeRangeSubjectsForm
               numericality: {
                 only_integer: true,
                 greater_than_or_equal_to: :age_range_min,
+                less_than_or_equal_to: 19,
+                if: :age_range_min,
                 allow_nil: true,
               }
 

--- a/spec/support/shared_examples/age_range_subjects_form.rb
+++ b/spec/support/shared_examples/age_range_subjects_form.rb
@@ -6,29 +6,35 @@ RSpec.shared_examples_for "an age range subjects form" do
     it { is_expected.to validate_presence_of(:age_range_max) }
 
     context "with a minimum too low" do
-      let(:age_range_subjects_attributes) { { age_range_min: "1" } }
+      let(:age_range_subjects_attributes) do
+        { age_range_min: "1", age_range_max: "10" }
+      end
+
       it { is_expected.to be_invalid }
     end
 
     context "with a minimum too high" do
-      let(:age_range_subjects_attributes) { { age_range_min: "20" } }
+      let(:age_range_subjects_attributes) do
+        { age_range_min: "20", age_range_max: "10" }
+      end
+
       it { is_expected.to be_invalid }
     end
 
-    context "when minimum is set" do
-      context "with a maximum too low" do
-        let(:age_range_subjects_attributes) do
-          { age_range_min: "7", age_range_max: "1" }
-        end
-        it { is_expected.to be_invalid }
+    context "with a maximum too low" do
+      let(:age_range_subjects_attributes) do
+        { age_range_min: "7", age_range_max: "1" }
       end
 
-      context "with a maximum too high" do
-        let(:age_range_subjects_attributes) do
-          { age_range_min: "7", age_range_max: "20" }
-        end
-        it { is_expected.to be_invalid }
+      it { is_expected.to be_invalid }
+    end
+
+    context "with a maximum too high" do
+      let(:age_range_subjects_attributes) do
+        { age_range_min: "7", age_range_max: "20" }
       end
+
+      it { is_expected.to be_invalid }
     end
 
     it { is_expected.to_not validate_presence_of(:age_range_note) }


### PR DESCRIPTION
Currently we allow the assessors to choose any age range. This causes problems when the application is sent to DQT as the API requires the maximum age to be 19 or less.