### PR TITLE
Set Sidekiq log level to warning

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,6 +2,9 @@
 
 url = ENV.fetch("REDIS_URL", "redis://localhost:6379/1")
 
-Sidekiq.configure_server { |config| config.redis = { url: } }
+Sidekiq.configure_server do |config|
+  config.redis = { url: }
+  config.logger.level = Logger::WARN
+end
 
 Sidekiq.configure_client { |config| config.redis = { url: } }


### PR DESCRIPTION
This sets the log level for Sidekiq to warning to avoid sending lots of unnecessary generic logging, when we can track these in other ways via the Sidekiq dashboard. Instead, we only need to send logs about errors or problems that might need attention.