### PR TITLE
Set Sidekiq log level to warning 

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
+  config.log_level = Sidekiq.server? ? :warn : :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,9 +2,6 @@
 
 url = ENV.fetch("REDIS_URL", "redis://localhost:6379/1")
 
-Sidekiq.configure_server do |config|
-  config.redis = { url: }
-  config.logger.level = Logger::WARN
-end
+Sidekiq.configure_server { |config| config.redis = { url: } }
 
 Sidekiq.configure_client { |config| config.redis = { url: } }


### PR DESCRIPTION
This sets the global log level configuration to warning if we're running as the Sidekiq service. This allows us to reduce the number of generic logs related to when runs are run (which we have access to anyway via the dashboard) and instead focus on logging which might require investigation.

The previous attempt (#2282) didn't work as Rails uses a separate logger to the Sidekiq one.