### PR TITLE
Require a note after further information requests

### DIFF
--- a/app/forms/assessor_interface/assessment_declaration_decline_form.rb
+++ b/app/forms/assessor_interface/assessment_declaration_decline_form.rb
@@ -11,9 +11,7 @@ class AssessorInterface::AssessmentDeclarationDeclineForm
   attribute :recommendation_assessor_note, :string
 
   validates :declaration, presence: true
-  validates :recommendation_assessor_note,
-            presence: true,
-            if: -> { assessment.selected_failure_reasons_empty? }
+  validates :recommendation_assessor_note, presence: true, if: :note_required?
 
   def save
     return false unless valid?
@@ -23,5 +21,10 @@ class AssessorInterface::AssessmentDeclarationDeclineForm
     )
 
     true
+  end
+
+  def note_required?
+    assessment.sections.all? { _1.selected_failure_reasons.empty? } ||
+      assessment.further_information_requests.exists?(review_passed: false)
   end
 end

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -188,10 +188,6 @@ class Assessment < ApplicationRecord
     end
   end
 
-  def selected_failure_reasons_empty?
-    sections.all? { |section| section.selected_failure_reasons.empty? }
-  end
-
   def all_preliminary_sections_passed?
     sections.preliminary.all?(&:passed?)
   end

--- a/spec/forms/assessor_interface/assessment_declaration_decline_form_spec.rb
+++ b/spec/forms/assessor_interface/assessment_declaration_decline_form_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe AssessorInterface::AssessmentDeclarationDeclineForm,
         )
       end
     end
+
+    context "when further information failed" do
+      before do
+        create(:further_information_request, :review_failed, assessment:)
+      end
+
+      it { is_expected.to validate_presence_of(:recommendation_assessor_note) }
+    end
   end
 
   describe "#save" do

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -489,22 +489,4 @@ RSpec.describe Assessment, type: :model do
       it { is_expected.to include("request_further_information") }
     end
   end
-
-  describe "#selected_failure_reasons_empty?" do
-    subject(:selected_failure_reasons_empty?) do
-      assessment.selected_failure_reasons_empty?
-    end
-
-    context "with no failure reasons" do
-      it { is_expected.to be true }
-    end
-
-    context "with failure reasons" do
-      before do
-        create(:assessment_section, :declines_with_already_qts, assessment:)
-      end
-
-      it { is_expected.to be false }
-    end
-  end
 end


### PR DESCRIPTION
If declining after a further information request, we want to require that the assessors write in a recommendation note as otherwise the applicant will see no reason for their decline.