### PR TITLE
Call after_expired after expiration

### DIFF
--- a/app/services/expire_requestable.rb
+++ b/app/services/expire_requestable.rb
@@ -13,7 +13,6 @@ class ExpireRequestable
 
     ActiveRecord::Base.transaction do
       requestable.expired!
-      requestable.after_expired(user:)
 
       CreateTimelineEvent.call(
         "requestable_expired",
@@ -24,6 +23,8 @@ class ExpireRequestable
 
       ApplicationFormStatusUpdater.call(user:, application_form:)
     end
+
+    requestable.after_expired(user:)
 
     requestable
   end


### PR DESCRIPTION
Currently we call it within a transaction, but this doens't work as some expiration triggers will send emails, and therefore try and fetch data from the database while it's still within the transaction only.