### PR TITLE
Add suitability records section to header

### DIFF
--- a/app/controllers/assessor_interface/suitability_records_controller.rb
+++ b/app/controllers/assessor_interface/suitability_records_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module AssessorInterface
+  class SuitabilityRecordsController < BaseController
+    def index
+      authorize %i[assessor_interface suitability_record]
+    end
+  end
+end

--- a/app/policies/assessor_interface/suitability_record_policy.rb
+++ b/app/policies/assessor_interface/suitability_record_policy.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AssessorInterface::SuitabilityRecordPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def create?
+    user.assess_permission
+  end
+
+  def update?
+    user.assess_permission
+  end
+
+  def destroy?
+    user.assess_permission
+  end
+
+  alias_method :archive?, :destroy?
+end

--- a/app/views/assessor_interface/suitability_records/index.html.erb
+++ b/app/views/assessor_interface/suitability_records/index.html.erb
@@ -1,0 +1,5 @@
+<% title = "Suitability records" %>
+
+<% content_for :page_title, title %>
+
+<h1 class="govuk-heading-xl"><%= title %></h1>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -12,6 +12,11 @@
          href: main_app.assessor_interface_application_forms_path,
          active: current_page?(main_app.assessor_interface_application_forms_path)
        ) %>
+
+      <% if FeatureFlags::FeatureFlag.active?(:suitability) %>
+        <% header.with_navigation_item(text: "Suitability records", href: main_app.assessor_interface_suitability_records_path) %>
+      <% end %>
+
       <% header.with_navigation_item(text: "Support console", href: main_app.support_interface_root_path) %>
       <% header.with_navigation_item(text: "Sign out", href: main_app.destroy_staff_session_path) %>
     <% end %>

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -21,6 +21,10 @@ feature_flags:
     author: Richard Pattinson
     description: Allow users to sign in using accounts in Active Directory.
 
+  suitability:
+    author: Thomas Leese
+    description: Enable suitability records and matching.
+
   teacher_applications:
     author: Thomas Leese
     description: >

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -203,6 +203,10 @@ Rails.application.routes.draw do
     get "/application/documents/:document_id/uploads/:id",
         to: "uploads#show",
         as: :application_form_document_upload
+
+    resources :suitability_records,
+              path: "/suitability-records",
+              only: %i[index]
   end
 
   namespace :eligibility_interface, path: "/eligibility" do

--- a/db/scripts/sanitise.sql
+++ b/db/scripts/sanitise.sql
@@ -14,17 +14,17 @@ SET
   alternative_given_names = '',
   alternative_family_name = '',
   registration_number = '';
-  
+
 -- AssessmentSectionFailureReason
 
 UPDATE "selected_failure_reasons"
 SET
-  assessor_feedback = CASE WHEN assessor_feedback IS NULL THEN NULL ELSE '[sanitised]' END; 
+  assessor_feedback = CASE WHEN assessor_feedback IS NULL THEN NULL ELSE '[sanitised]' END;
 
 -- AssessmentSection
 -- no update required
 
--- Assessment 
+-- Assessment
 -- no update required
 
 -- Countries
@@ -37,13 +37,13 @@ SET
 -- clear these as the scheduled jobs might run against them
 DELETE FROM "dqt_trn_requests";
 
--- EligibilityCheck 
+-- EligibilityCheck
 -- no update required
 
 -- Features
 -- make sure the service open flag defaults to off
 UPDATE "feature_flags_features"
-  SET active = false 
+  SET active = false
   WHERE name like 'service_open';
 
 -- FurtherInformationRequestItem
@@ -61,7 +61,7 @@ SET
 UPDATE "notes"
 SET
   text = CASE WHEN text IS NULL THEN NULL ELSE '[sanitised]' END;
-  
+
 -- Qualification
 UPDATE "qualifications"
 SET
@@ -86,6 +86,23 @@ DELETE FROM "sessions";
 -- Staff
 DELETE FROM "staff";
 
+-- SuitabilityRecord
+
+UPDATE "suitability_records"
+SET
+    date_of_birth = '2000-01-01',
+    note = '[sanitised]',
+    archive_note = CASE WHEN archive_note = '' THEN '' ELSE '[sanitised]' END;
+
+UPDATE "suitability_record_emails"
+SET
+    value = CASE WHEN value IS NULL THEN NULL ELSE CONCAT('teacher', id, '@example.com') END,
+    canonical = CASE WHEN canonical IS NULL THEN NULL ELSE CONCAT('teacher', id, '@example.com') END;
+
+UPDATE "suitability_record_names"
+SET
+    value = CONCAT('Applicant ', id);
+
 -- Teacher
 UPDATE "teachers"
 SET
@@ -109,4 +126,3 @@ SET
   job  = '[sanitised]',
   contact_email  = 'sanitised@example.com',
   contact_name  = '[sanitised]';
-

--- a/lib/tasks/review_app.rake
+++ b/lib/tasks/review_app.rake
@@ -7,7 +7,8 @@ namespace :review_app do
       raise "THIS TASK CANNOT BE RUN IN PRODUCTION"
     end
 
-    FeatureFlags::FeatureFlag.activate(:personas)
-    FeatureFlags::FeatureFlag.activate(:teacher_applications)
+    %i[personas suitability teacher_applications].each do |feature|
+      FeatureFlags::FeatureFlag.activate(feature)
+    end
   end
 end

--- a/spec/policies/assessor_interface/application_form_policy_spec.rb
+++ b/spec/policies/assessor_interface/application_form_policy_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe AssessorInterface::ApplicationFormPolicy do
   end
 
   describe "#withdraw?" do
-    subject(:rollback?) { policy.withdraw? }
+    subject(:withdraw?) { policy.withdraw? }
 
     it_behaves_like "a policy method requiring the withdraw permission"
   end

--- a/spec/policies/assessor_interface/suitability_record_policy_spec.rb
+++ b/spec/policies/assessor_interface/suitability_record_policy_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::SuitabilityRecordPolicy do
+  subject(:policy) { described_class.new(user, record) }
+
+  let(:record) { nil }
+  let(:user) { nil }
+
+  it_behaves_like "a policy"
+
+  describe "#index?" do
+    subject(:index?) { policy.index? }
+
+    it_behaves_like "a policy method with permission"
+  end
+
+  describe "#show?" do
+    subject(:show?) { policy.show? }
+
+    it_behaves_like "a policy method without permission"
+  end
+
+  describe "#create?" do
+    subject(:create?) { policy.create? }
+
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+
+  describe "#new?" do
+    subject(:new?) { policy.new? }
+
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+
+  describe "#update?" do
+    subject(:update?) { policy.update? }
+
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+
+  describe "#edit?" do
+    subject(:edit?) { policy.edit? }
+
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+
+  describe "#destroy?" do
+    subject(:destroy?) { policy.destroy? }
+
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+
+  describe "#archive?" do
+    subject(:archive?) { policy.archive? }
+
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/suitability_records.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/suitability_records.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class SuitabilityRecords < SitePrism::Page
+      set_url "/assessor/suitability-records"
+
+      element :heading, "h1"
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -238,6 +238,11 @@ module PageHelpers
       PageObjects::AssessorInterface::SendSignedConsentDocuments.new
   end
 
+  def assessor_suitability_records_page
+    @assessor_suitability_records_page ||=
+      PageObjects::AssessorInterface::SuitabilityRecords.new
+  end
+
   def assessor_timeline_page
     @assessor_timeline_page ||= PageObjects::AssessorInterface::Timeline.new
   end

--- a/spec/system/assessor_interface/suitability_spec.rb
+++ b/spec/system/assessor_interface/suitability_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assessor suitability", type: :system do
+  before { given_suitability_is_enabled }
+  after { given_suitability_is_disabled }
+
+  it "add suitability records" do
+    given_i_am_authorized_as_a_user(assessor)
+
+    when_i_visit_the(:assessor_suitability_records_page)
+    then_i_see_the_suitability_records
+  end
+
+  def given_suitability_is_enabled
+    FeatureFlags::FeatureFlag.deactivate(:suitability)
+  end
+
+  def given_suitability_is_disabled
+    FeatureFlags::FeatureFlag.deactivate(:suitability)
+  end
+
+  def then_i_see_the_suitability_records
+    expect(assessor_suitability_records_page.heading).to be_visible
+  end
+
+  def assessor
+    @assessor ||= create(:staff, :with_assess_permission)
+  end
+end


### PR DESCRIPTION
This starts the work on the suitability records by adding a link in the main navigation bar to where the suitability records section of the site will live.