### PR TITLE
AQTS230 Save failed emails to MailDeliveryFailure table

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -15,16 +15,16 @@ class ApplicationMailer < Mail::Notify::Mailer
     #
     # @see https://github.com/rails/rails/issues/39018
     if respond_to?(:headers)
-      recipient_email = headers["To"].value
-      MailDeliveryFailure.create!(recipient_email:)
+      email_address = headers["To"].value
+      mailer_action_method = action_name
+      mailer_class = mailer_name
+      MailDeliveryFailure.create!(email_address:, mailer_action_method:, mailer_class:)
     end
 
     raise
   end
 
   def notify_email(headers)
-    headers =
-      headers.merge(rails_mailer: mailer_name, rails_mail_template: action_name)
     view_mail(GOVUK_NOTIFY_TEMPLATE_ID, headers)
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -27,8 +27,4 @@ class ApplicationMailer < Mail::Notify::Mailer
 
     raise
   end
-
-  def notify_email(headers)
-    view_mail(GOVUK_NOTIFY_TEMPLATE_ID, headers)
-  end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -18,7 +18,11 @@ class ApplicationMailer < Mail::Notify::Mailer
       email_address = headers["To"].value
       mailer_action_method = action_name
       mailer_class = mailer_name
-      MailDeliveryFailure.create!(email_address:, mailer_action_method:, mailer_class:)
+      MailDeliveryFailure.create!(
+        email_address:,
+        mailer_action_method:,
+        mailer_class:,
+      )
     end
 
     raise

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -8,4 +8,23 @@ class ApplicationMailer < Mail::Notify::Mailer
       "GOVUK_NOTIFY_TEMPLATE_ID_APPLICATION",
       "95adafaf-0920-4623-bddc-340853c047af",
     )
+
+    rescue_from Notifications::Client::RequestError do
+      # WARNING: this needs to be a block, otherwise the exception will not be
+      # re-raised and we will not be notified via Sentry, and the job will not retry.
+      #
+      # @see https://github.com/rails/rails/issues/39018
+      if respond_to?(:headers)
+        binding.break
+        email = Email.find(headers['email-log-id'].to_s)
+        email.update!(delivery_status: 'notify_error')
+      end
+  
+      raise
+    end
+
+    def notify_email(headers)
+      headers = headers.merge(rails_mailer: mailer_name, rails_mail_template: action_name)
+      view_mail(GOVUK_NOTIFY_TEMPLATE_ID, headers)
+    end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -9,23 +9,22 @@ class ApplicationMailer < Mail::Notify::Mailer
       "95adafaf-0920-4623-bddc-340853c047af",
     )
 
-    rescue_from Notifications::Client::RequestError do
-      # WARNING: this needs to be a block, otherwise the exception will not be
-      # re-raised and we will not be notified via Sentry, and the job will not retry.
-      #
-      # @see https://github.com/rails/rails/issues/39018
-      if respond_to?(:headers)
-        recipient_email = headers['To'].value
-        MailDeliveryFailure.create!(
-          recipient_email: recipient_email
-        )
-      end
-  
-      raise
+  rescue_from Notifications::Client::RequestError do
+    # WARNING: this needs to be a block, otherwise the exception will not be
+    # re-raised and we will not be notified via Sentry, and the job will not retry.
+    #
+    # @see https://github.com/rails/rails/issues/39018
+    if respond_to?(:headers)
+      recipient_email = headers["To"].value
+      MailDeliveryFailure.create!(recipient_email:)
     end
 
-    def notify_email(headers)
-      headers = headers.merge(rails_mailer: mailer_name, rails_mail_template: action_name)
-      view_mail(GOVUK_NOTIFY_TEMPLATE_ID, headers)
-    end
+    raise
+  end
+
+  def notify_email(headers)
+    headers =
+      headers.merge(rails_mailer: mailer_name, rails_mail_template: action_name)
+    view_mail(GOVUK_NOTIFY_TEMPLATE_ID, headers)
+  end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -15,9 +15,10 @@ class ApplicationMailer < Mail::Notify::Mailer
       #
       # @see https://github.com/rails/rails/issues/39018
       if respond_to?(:headers)
-        binding.break
-        email = Email.find(headers['email-log-id'].to_s)
-        email.update!(delivery_status: 'notify_error')
+        recipient_email = headers['To'].value
+        MailDeliveryFailure.create!(
+          recipient_email: recipient_email
+        )
       end
   
       raise

--- a/app/views/anonymous/test_notify_error.text.erb
+++ b/app/views/anonymous/test_notify_error.text.erb
@@ -1,0 +1,1 @@
+This is used by the ApplicationMailer spec.

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -13,7 +13,11 @@ RSpec.describe ApplicationMailer, type: :mailer do
         }
 
         def test_notify_error
-          view_mail("testGOVUK_NOTIFY_TEMPLATE_ID_APPLICATION", to: "test@example.com", subject: "Some subject")
+          view_mail(
+            ApplicationMailer::GOVUK_NOTIFY_TEMPLATE_ID,
+            to: "test@example.com",
+            subject: "Some subject",
+          )
         end
       end
 

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -27,7 +27,11 @@ RSpec.describe ApplicationMailer, :sidekiq do
         Notifications::Client::NotFoundError,
       )
 
-      expect(Email.last.delivery_status).to eql("notify_error")
+      failure = MailDeliveryFailure.last
+      expect(failure).not_to be_nil
+      expect(failure.email_address).to eq("test@example.com")
+      expect(failure.mailer_action_method).to eq("test_notify_error")
+      expect(failure.mailer_class).to eq("anonymous")
     end
   end
 end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ApplicationMailer, type: :mailer do
         }
 
         def test_notify_error
-          notify_email(to: "test@example.com", subject: "Some subject")
+          view_mail("testGOVUK_NOTIFY_TEMPLATE_ID_APPLICATION", to: "test@example.com", subject: "Some subject")
         end
       end
 

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,30 +1,33 @@
-require 'rails_helper'
+# frozen_string_literal: true
+
+require "rails_helper"
 
 RSpec.describe ApplicationMailer, :sidekiq do
-  describe '.rescue_from' do
-    fake_mailer = Class.new(ApplicationMailer) do
-      self.delivery_method = :notify
-      self.notify_settings = {
-        api_key: 'not-real-e1f4c969-b675-4a0d-a14d-623e7c2d3fd8-24fea27b-824e-4259-b5ce-1badafe98150',
-      }
+  describe ".rescue_from" do
+    fake_mailer =
+      Class.new(ApplicationMailer) do
+        self.delivery_method = :notify
+        self.notify_settings = {
+          api_key:
+            "not-real-e1f4c969-b675-4a0d-a14d-623e7c2d3fd8-24fea27b-824e-4259-b5ce-1badafe98150",
+        }
 
-      def test_notify_error
-        notify_email(
-          to: 'test@example.com',
-          subject: 'Some subject',
-        )
+        def test_notify_error
+          notify_email(to: "test@example.com", subject: "Some subject")
+        end
       end
-    end
 
-    it 'marks errors as failed and re-raises the error' do
-      stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/email')
-        .to_return(status: 404)
+    it "marks errors as failed and re-raises the error" do
+      stub_request(
+        :post,
+        "https://api.notifications.service.gov.uk/v2/notifications/email",
+      ).to_return(status: 404)
 
-      expect {
-        fake_mailer.test_notify_error.deliver_now
-      }.to raise_error(Notifications::Client::NotFoundError)
+      expect { fake_mailer.test_notify_error.deliver_now }.to raise_error(
+        Notifications::Client::NotFoundError,
+      )
 
-      expect(Email.last.delivery_status).to eql('notify_error')
+      expect(Email.last.delivery_status).to eql("notify_error")
     end
   end
 end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe ApplicationMailer, :sidekiq do
+RSpec.describe ApplicationMailer, type: :mailer do
   describe ".rescue_from" do
     fake_mailer =
       Class.new(ApplicationMailer) do

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationMailer, :sidekiq do
+  describe '.rescue_from' do
+    fake_mailer = Class.new(ApplicationMailer) do
+      self.delivery_method = :notify
+      self.notify_settings = {
+        api_key: 'not-real-e1f4c969-b675-4a0d-a14d-623e7c2d3fd8-24fea27b-824e-4259-b5ce-1badafe98150',
+      }
+
+      def test_notify_error
+        notify_email(
+          to: 'test@example.com',
+          subject: 'Some subject',
+        )
+      end
+    end
+
+    it 'marks errors as failed and re-raises the error' do
+      stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/email')
+        .to_return(status: 404)
+
+      expect {
+        fake_mailer.test_notify_error.deliver_now
+      }.to raise_error(Notifications::Client::NotFoundError)
+
+      expect(Email.last.delivery_status).to eql('notify_error')
+    end
+  end
+end


### PR DESCRIPTION
[ticket](https://dfedigital.atlassian.net/jira/software/projects/AQTS/boards/207?selectedIssue=AQTS-230)

MailDeliveryFailure model has been merged into the codebase, this pr will provide the functionality to create entries for the table by recording errors when sending emails.