### PR TITLE
Add ability to archive suitability records

### DIFF
--- a/app/controllers/assessor_interface/suitability_records_controller.rb
+++ b/app/controllers/assessor_interface/suitability_records_controller.rb
@@ -59,6 +59,16 @@ module AssessorInterface
     end
 
     def update
+      if suitability_record.archived?
+        suitability_record.update!(
+          archived_at: nil,
+          archived_by: nil,
+          archive_note: "",
+        )
+        redirect_to [:edit, :assessor_interface, suitability_record]
+        return
+      end
+
       @form =
         SuitabilityRecordForm.new(
           form_params.merge(suitability_record:, user: current_staff),
@@ -68,6 +78,23 @@ module AssessorInterface
         redirect_to action: :index
       else
         render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def archive
+      @form = ArchiveSuitabilityRecordForm.new(suitability_record:)
+    end
+
+    def destroy
+      @form =
+        ArchiveSuitabilityRecordForm.new(
+          archive_form_params.merge(suitability_record:, user: current_staff),
+        )
+
+      if @form.save
+        redirect_to action: :index
+      else
+        render :archive, status: :unprocessable_entity
       end
     end
 
@@ -83,6 +110,12 @@ module AssessorInterface
         emails: [],
         references: [],
       )
+    end
+
+    def archive_form_params
+      params.require(
+        :assessor_interface_archive_suitability_record_form,
+      ).permit(:note)
     end
 
     def suitability_record

--- a/app/forms/assessor_interface/archive_suitability_record_form.rb
+++ b/app/forms/assessor_interface/archive_suitability_record_form.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class AssessorInterface::ArchiveSuitabilityRecordForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :suitability_record, :user
+  validates :suitability_record, :user, presence: true
+
+  attribute :note
+  validates :note, presence: true
+
+  def save
+    return false if invalid?
+
+    suitability_record.update!(
+      archived_at: Time.zone.now,
+      archived_by: user,
+      archive_note: note,
+    )
+
+    true
+  end
+end

--- a/app/views/assessor_interface/suitability_records/archive.html.erb
+++ b/app/views/assessor_interface/suitability_records/archive.html.erb
@@ -1,0 +1,16 @@
+<% title = "Archive suitability record for #{@suitability_record.name}" %>
+
+<% content_for :page_title, title %>
+<% content_for :back_link_url, assessor_interface_suitability_records_path %>
+
+<%= form_with model: @form, url: [:assessor_interface, @suitability_record], method: :delete do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-l"><%= title %></h1>
+
+  <%= f.govuk_text_area :note %>
+
+  <%= f.govuk_submit "Archive record" do %>
+    <%= govuk_link_to "Cancel", %i[assessor_interface suitability_records] %>
+  <% end %>
+<% end %>

--- a/app/views/assessor_interface/suitability_records/edit.html.erb
+++ b/app/views/assessor_interface/suitability_records/edit.html.erb
@@ -40,13 +40,30 @@
       row.with_key { "Suitability reasons" }
       row.with_value { @suitability_record.note }
     end
+
+    if @suitability_record.archived?
+      summary_list.with_row do |row|
+        row.with_key { "Date archived" }
+        row.with_value { @suitability_record.archived_at.to_fs }
+      end
+
+      summary_list.with_row do |row|
+        row.with_key { "Reason for archiving" }
+        row.with_value { @suitability_record.archive_note }
+      end
+    end
   end %>
 
-  <h2 class="govuk-heading-m">Update record</h2>
+  <% if @suitability_record.archived? %>
+    <%= f.govuk_submit "Set to active", secondary: true %>
+  <% else %>
+    <h2 class="govuk-heading-m">Update record</h2>
 
-  <%= render "form_fields", f: %>
+    <%= render "form_fields", f: %>
 
-  <%= f.govuk_submit "Update record" do %>
-    <%= govuk_link_to "Cancel", %i[assessor_interface suitability_records] %>
+    <%= f.govuk_submit "Update record" do %>
+      <%= govuk_button_link_to "Archive record", [:archive, :assessor_interface, @suitability_record], secondary: true, id: "app-archive-button" %>
+      <%= govuk_link_to "Cancel", %i[assessor_interface suitability_records] %>
+    <% end %>
   <% end %>
 <% end %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -220,6 +220,10 @@ en:
             email:
               blank: Enter an email address
               inclusion: A teacher already exists with this email address
+        assessor_interface/archive_suitability_record_form:
+          attributes:
+            note:
+              blank: Briefly explain why you have archived this suitability record
         assessor_interface/assessor_assignment_form:
           attributes:
             assessor_id:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -5,6 +5,8 @@ en:
       assessor_interface_application_form_name_form:
         given_names: Type the updated given names in the text box below
         family_name: Type the updated family name in the text box below
+      assessor_interface_archive_suitability_record_form:
+        note: "Internal note: Briefly explain why this suitability record is being archived."
       assessor_interface_assessment_section_form:
         selected_failure_reasons: Select all options that are relevant to you.
         failure_reason_notes:
@@ -68,6 +70,8 @@ en:
         family_name: Change family name
       assessor_interface_application_form_email_form:
         email: New email address
+      assessor_interface_archive_suitability_record_form:
+        note: Reason for archiving
       assessor_interface_assessment_recommendation_form:
         confirmation_options:
           true: I have assessed this application based on the eligibility criteria that was in place on the date that it was submitted.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,9 +204,9 @@ Rails.application.routes.draw do
         to: "uploads#show",
         as: :application_form_document_upload
 
-    resources :suitability_records,
-              path: "/suitability-records",
-              only: %i[index new create edit update]
+    resources :suitability_records, path: "/suitability-records" do
+      get "archive", on: :member
+    end
   end
 
   namespace :eligibility_interface, path: "/eligibility" do

--- a/spec/forms/assessor_interface/archive_suitability_record_form_spec.rb
+++ b/spec/forms/assessor_interface/archive_suitability_record_form_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::ArchiveSuitabilityRecordForm, type: :model do
+  subject(:form) { described_class.new(suitability_record:, user:, note:) }
+
+  let(:suitability_record) { create(:suitability_record) }
+  let(:user) { create(:staff) }
+  let(:note) { "A note." }
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:suitability_record) }
+    it { is_expected.to validate_presence_of(:user) }
+    it { is_expected.to validate_presence_of(:note) }
+  end
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    it "updates the fields" do
+      expect(save).to be true
+
+      expect(suitability_record).to be_archived
+      expect(suitability_record.archive_note).to eq("A note.")
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/archive_suitability_record.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/archive_suitability_record.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class ArchiveSuitabilityRecord < SitePrism::Page
+      set_url "/assessor/suitability-records/{id}/archive"
+
+      section :form, "form" do
+        element :note_field,
+                "#assessor-interface-archive-suitability-record-form-note-field"
+        element :submit_button, ".govuk-button:not(.govuk-button--secondary)"
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/edit_suitability_record.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/edit_suitability_record.rb
@@ -6,6 +6,8 @@ module PageObjects
       set_url "/assessor/suitability-records/{id}/edit"
 
       element :heading, "h1"
+
+      element :archive_button, "#app-archive-button"
     end
   end
 end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -29,6 +29,11 @@ module PageHelpers
       PageObjects::AssessorInterface::Applications.new
   end
 
+  def assessor_archive_suitability_record_page
+    @assessor_archive_suitability_record_page ||=
+      PageObjects::AssessorInterface::ArchiveSuitabilityRecord.new
+  end
+
   def assessor_assessment_recommendation_review_page
     @assessor_assessment_recommendation_review_page ||=
       PageObjects::AssessorInterface::AssessmentRecommendationReview.new

--- a/spec/system/assessor_interface/suitability_spec.rb
+++ b/spec/system/assessor_interface/suitability_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Assessor suitability", type: :system do
     then_i_see_the_suitability_records
   end
 
-  it "create and edit suitability records" do
+  it "create and edit and archive suitability records" do
     given_i_am_authorized_as_a_user(assessor)
 
     when_i_visit_the(:assessor_suitability_records_page)
@@ -31,6 +31,13 @@ RSpec.describe "Assessor suitability", type: :system do
     when_i_fill_in_the_fields
     and_i_submit_the_form
     then_i_see_the_suitability_records
+
+    when_i_click_on_the_suitability_record
+    then_i_see_the(:assessor_edit_suitability_record_page)
+
+    when_i_click_archive
+    then_i_see_the(:assessor_archive_suitability_record_page)
+    and_i_submit_the_archive_form
   end
 
   def given_suitability_is_enabled
@@ -77,6 +84,16 @@ RSpec.describe "Assessor suitability", type: :system do
 
   def when_i_click_on_the_suitability_record
     assessor_suitability_records_page.records.first.heading.link.click
+  end
+
+  def when_i_click_archive
+    assessor_edit_suitability_record_page.archive_button.click
+  end
+
+  def and_i_submit_the_archive_form
+    form = assessor_archive_suitability_record_page.form
+    form.note_field.fill_in with: "A note."
+    form.submit_button.click
   end
 
   def assessor


### PR DESCRIPTION
This adds the ability to archive and unarchive suitability records as per the designs, see individual commits for more details.