### PR TITLE
Revert "Bump ruby-vips from 2.2.1 to 2.2.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,9 +226,7 @@ GEM
       concurrent-ruby (~> 1.1)
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.16.3)
     fugit (1.11.0)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -305,7 +303,6 @@ GEM
       base64
     language_server-protocol (3.17.0.3)
     libreconv (0.9.5)
-    logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -535,9 +532,8 @@ GEM
       rexml
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
-    ruby-vips (2.2.2)
+    ruby-vips (2.2.1)
       ffi (~> 1.12)
-      logger
     ruby2_keywords (0.0.5)
     semantic_logger (4.16.0)
       concurrent-ruby (~> 1.0)


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-qualified-teacher-status#2316