### PR TITLE
Add migration to add suitability decline reasons

### DIFF
--- a/app/models/assessment_section.rb
+++ b/app/models/assessment_section.rb
@@ -27,6 +27,7 @@
 class AssessmentSection < ApplicationRecord
   belongs_to :assessment
   has_many :selected_failure_reasons, dependent: :destroy
+  has_one :application_form, through: :assessment
 
   enum :key,
        {

--- a/db/migrate/20240722125405_add_suitability_failure_reasons_to_application_forms.rb
+++ b/db/migrate/20240722125405_add_suitability_failure_reasons_to_application_forms.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class AddSuitabilityFailureReasonsToApplicationForms < ActiveRecord::Migration[
+  7.1
+]
+  def change
+    AssessmentSection
+      .not_preliminary
+      .joins(:application_form)
+      .where(
+        application_form: {
+          stage: %w[pre_assessment not_started assessment],
+        },
+      )
+      .find_each do |assessment_section|
+        assessment_section.update!(
+          failure_reasons:
+            (
+              assessment_section.failure_reasons +
+                [
+                  FailureReasons::SUITABILITY,
+                  FailureReasons::SUITABILITY_PREVIOUSLY_DECLINED,
+                  FailureReasons::FRAUD,
+                ]
+            ).uniq,
+        )
+      end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_17_141207) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_22_125405) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
When we're ready to go live with the new suitability reasons we can deploy this migration to apply it to existing application forms.