### PR TITLE
Add redirect filter on check email page

### DIFF
--- a/config/initializers/filter_logging.rb
+++ b/config/initializers/filter_logging.rb
@@ -27,3 +27,5 @@ Rails.application.config.filter_parameters += %i[
   current_sign_in_ip
   last_sign_in_ip
 ]
+
+Rails.application.config.filter_redirect << %r{/teacher/check_email}


### PR DESCRIPTION
This page includes the email address as a query parameter so we want to ensure it doesn't appear in any logs.