### PR TITLE
Add validation on minimum file size

### DIFF
--- a/app/validators/file_upload_validator.rb
+++ b/app/validators/file_upload_validator.rb
@@ -25,6 +25,8 @@ class FileUploadValidator < ActiveModel::EachValidator
     if uploaded_file.size >= MAX_FILE_SIZE
       record.errors.add attribute, :file_size_too_big
     end
+
+    record.errors.add attribute, :file_size_too_small if uploaded_file.size <= 1
   end
 
   def validate_content_type(record, attribute, uploaded_file)

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -426,7 +426,6 @@ en:
             original_attachment:
               blank: Upload the required consent document
               encrypted_pdf: The selected file is security protected
-              file_size_too_big: Files must be smaller than 50MB
               invalid_content_type: Files must be in PDF, JPG, PNG, DOCX or DOC format
               mismatch_content_type: Files must have matching file type and file name. For example, if the upload is called example.doc, it must be a DOC file.
         assessor_interface/verify_professional_standing_form:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,7 +69,8 @@ en:
     messages:
       comparison: can't be before start date
       encrypted_pdf: file is encrypted
-      file_size_too_big: file size is too large
+      file_size_too_big: Files must be smaller than 50 MB
+      file_size_too_small: Files must be bigger than 0 MB
       future: can't be in the future
       invalid_content_type: is not in the correct format
       mismatch_content_type: file format doesn't match extension

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -387,13 +387,11 @@ en:
             original_attachment:
               blank: Select a file to upload
               encrypted_pdf: The selected file is security protected
-              file_size_too_big: Files must be smaller than 50MB
               invalid_content_type: Files must be in PDF, JPG, PNG, DOCX or DOC format
               mismatch_content_type: Files must have matching file type and file name. For example, if the upload is called example.doc, it must be a DOC file.
             translated_attachment:
               blank: Select a translation to upload
               encrypted_pdf: The selected file is security protected
-              file_size_too_big: Files must be smaller than 50MB
               invalid_content_type: Files must be in PDF, JPG, PNG, DOCX or DOC format
               mismatch_content_type: Files must have matching file type and file name. For example, if the upload is called example.doc, it must be a DOC file.
         teacher_interface/work_history_form:

--- a/spec/validators/file_upload_validator_spec.rb
+++ b/spec/validators/file_upload_validator_spec.rb
@@ -45,4 +45,12 @@ RSpec.describe FileUploadValidator do
 
     it { is_expected.not_to be_valid }
   end
+
+  context "with a small file" do
+    let(:file) { fixture_file_upload("upload.pdf", "application/pdf") }
+
+    before { allow(file).to receive(:size).and_return(1) }
+
+    it { is_expected.not_to be_valid }
+  end
 end


### PR DESCRIPTION
We're seeing some files being uploaded empty and we think this could be due to applicants uploading these files, so we expect this validation will fix this problem.