### PR TITLE
Downgrade pg

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,7 +377,7 @@ GEM
       ast (~> 2.4.1)
       racc
     pdf-core (0.10.0)
-    pg (1.5.7)
+    pg (1.5.6)
     pkg-config (1.5.6)
     prawn (2.5.0)
       matrix (~> 0.4)


### PR DESCRIPTION
The pg version was causing errors when running bundle install so this has been downgraded.