### PR TITLE
Add teacher license form for Ghana

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -628,6 +628,7 @@ PLATFORMS
   arm64-darwin-23
   x86_64-darwin-21
   x86_64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/teacher_interface/registration_number_controller.rb
+++ b/app/controllers/teacher_interface/registration_number_controller.rb
@@ -14,21 +14,34 @@ module TeacherInterface
           application_form:,
           registration_number: application_form.registration_number,
         )
+
+      render view_name
     end
 
     def update
       @form = RegistrationNumberForm.new(form_params.merge(application_form:))
 
-      handle_application_form_section(form: @form)
+      handle_application_form_section(
+        form: @form,
+        if_failure_then_render: view_name,
+      )
     end
 
     private
+
+    def ghana?
+      CountryCode.ghana?(application_form.country.code)
+    end
 
     def form_params
       params.require(:teacher_interface_registration_number_form).permit(
         :registration_number,
         license_number_parts: [],
       )
+    end
+
+    def view_name
+      ghana? ? :edit_ghana : :edit
     end
   end
 end

--- a/app/controllers/teacher_interface/registration_number_controller.rb
+++ b/app/controllers/teacher_interface/registration_number_controller.rb
@@ -9,7 +9,8 @@ module TeacherInterface
     before_action :load_application_form
 
     def edit
-      @form = form_class.new(
+      @form =
+        form_class.new(
           application_form:,
           registration_number: application_form.registration_number,
         )
@@ -34,7 +35,9 @@ module TeacherInterface
 
     def form_params
       if ghana?
-        params.require(:teacher_interface_ghana_registration_number_form).permit(
+        params.require(
+          :teacher_interface_ghana_registration_number_form,
+        ).permit(
           :license_number_part_one,
           :license_number_part_two,
           :license_number_part_three,

--- a/app/controllers/teacher_interface/registration_number_controller.rb
+++ b/app/controllers/teacher_interface/registration_number_controller.rb
@@ -27,6 +27,7 @@ module TeacherInterface
     def form_params
       params.require(:teacher_interface_registration_number_form).permit(
         :registration_number,
+        license_number_parts: [],
       )
     end
   end

--- a/app/controllers/teacher_interface/registration_number_controller.rb
+++ b/app/controllers/teacher_interface/registration_number_controller.rb
@@ -9,8 +9,7 @@ module TeacherInterface
     before_action :load_application_form
 
     def edit
-      @form =
-        RegistrationNumberForm.new(
+      @form = form_class.new(
           application_form:,
           registration_number: application_form.registration_number,
         )
@@ -19,7 +18,7 @@ module TeacherInterface
     end
 
     def update
-      @form = RegistrationNumberForm.new(form_params.merge(application_form:))
+      @form = form_class.new(form_params.merge(application_form:))
 
       handle_application_form_section(
         form: @form,
@@ -34,14 +33,25 @@ module TeacherInterface
     end
 
     def form_params
-      params.require(:teacher_interface_registration_number_form).permit(
-        :registration_number,
-        license_number_parts: [],
-      )
+      if ghana?
+        params.require(:teacher_interface_ghana_registration_number_form).permit(
+          :license_number_part_one,
+          :license_number_part_two,
+          :license_number_part_three,
+        )
+      else
+        params.require(:teacher_interface_registration_number_form).permit(
+          :registration_number,
+        )
+      end
     end
 
     def view_name
       ghana? ? :edit_ghana : :edit
+    end
+
+    def form_class
+      ghana? ? GhanaRegistrationNumberForm : RegistrationNumberForm
     end
   end
 end

--- a/app/forms/teacher_interface/ghana_registration_number_form.rb
+++ b/app/forms/teacher_interface/ghana_registration_number_form.rb
@@ -3,35 +3,50 @@
 module TeacherInterface
   class GhanaRegistrationNumberForm < BaseForm
     attr_accessor :application_form
-    attribute :license_number_parts, array: true
 
-    validates :application_form, :license_number_parts, presence: true
+    attribute :registration_number, :string
+    attribute :license_number_part_one, :string
+    attribute :license_number_part_two, :string
+    attribute :license_number_part_three, :string
+
+    validates :application_form, presence: true
 
     validate :license_number_parts_valid
+
+    def initialize(attributes={})
+      super
+
+      if attributes[:registration_number].present?
+        license_number_parts = attributes[:registration_number].split("/")
+
+        self.license_number_part_one = license_number_parts[0]
+        self.license_number_part_two = license_number_parts[1]
+        self.license_number_part_three = license_number_parts[2]
+      end
+    end
 
     def update_model
       application_form.update!(registration_number:)
     end
 
+    def registration_number_validator
+      RegistrationNumberValidators::Ghana.new(registration_number:)
+    end
+
     private
 
     def license_number_parts_valid
-      parts = license_number_parts.compact_blank
+      return if registration_number_validator.valid?
 
-      if parts.length == 3 && parts[0].length == 2 && parts[1].length == 6 &&
-           parts[2].length == 4
-        return
-      end
-
-      if parts.empty?
-        errors.add(:license_number_parts, :blank)
-      else
-        errors.add(:license_number_parts, :invalid)
-      end
+      errors.add(:registration_number, :invalid)
     end
 
     def registration_number
-      license_number_parts.compact_blank.join("/")
+      [
+        license_number_part_one,
+        license_number_part_two,
+        license_number_part_three,
+      ].join("/")
     end
   end
 end

--- a/app/forms/teacher_interface/ghana_registration_number_form.rb
+++ b/app/forms/teacher_interface/ghana_registration_number_form.rb
@@ -47,7 +47,7 @@ module TeacherInterface
         license_number_part_one,
         license_number_part_two,
         license_number_part_three,
-      ]
+      ].map(&:strip)
 
       return nil if registration_number_parts.compact_blank.empty?
 

--- a/app/forms/teacher_interface/ghana_registration_number_form.rb
+++ b/app/forms/teacher_interface/ghana_registration_number_form.rb
@@ -30,7 +30,9 @@ module TeacherInterface
     end
 
     def registration_number_validator
-      RegistrationNumberValidators::Ghana.new(registration_number:)
+      @registration_number_validator ||= RegistrationNumberValidators::Ghana.new(
+        registration_number:
+      )
     end
 
     private
@@ -42,11 +44,15 @@ module TeacherInterface
     end
 
     def registration_number
-      [
+      registration_number_parts = [
         license_number_part_one,
         license_number_part_two,
         license_number_part_three,
-      ].join("/")
+      ]
+
+      return nil if registration_number_parts.compact_blank.empty?
+
+      registration_number_parts.join("/")
     end
   end
 end

--- a/app/forms/teacher_interface/ghana_registration_number_form.rb
+++ b/app/forms/teacher_interface/ghana_registration_number_form.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module TeacherInterface
+  class GhanaRegistrationNumberForm < BaseForm
+    attr_accessor :application_form
+    attribute :license_number_parts, array: true
+
+    validates :application_form, :license_number_parts, presence: true
+
+    validate :license_number_parts_valid
+
+    def update_model
+      application_form.update!(registration_number:)
+    end
+
+    private
+
+    def license_number_parts_valid
+      parts = license_number_parts.compact_blank
+
+      if parts.length == 3 && parts[0].length == 2 && parts[1].length == 6 &&
+           parts[2].length == 4
+        return
+      end
+
+      if parts.empty?
+        errors.add(:license_number_parts, :blank)
+      else
+        errors.add(:license_number_parts, :invalid)
+      end
+    end
+
+    def registration_number
+      license_number_parts.compact_blank.join("/")
+    end
+  end
+end

--- a/app/forms/teacher_interface/ghana_registration_number_form.rb
+++ b/app/forms/teacher_interface/ghana_registration_number_form.rb
@@ -13,7 +13,7 @@ module TeacherInterface
 
     validate :license_number_parts_valid
 
-    def initialize(attributes={})
+    def initialize(attributes = {})
       super
 
       if attributes[:registration_number].present?
@@ -30,9 +30,8 @@ module TeacherInterface
     end
 
     def registration_number_validator
-      @registration_number_validator ||= RegistrationNumberValidators::Ghana.new(
-        registration_number:
-      )
+      @registration_number_validator ||=
+        RegistrationNumberValidators::Ghana.new(registration_number:)
     end
 
     private

--- a/app/lib/application_form_section_status_updater.rb
+++ b/app/lib/application_form_section_status_updater.rb
@@ -170,7 +170,18 @@ class ApplicationFormSectionStatusUpdater
   end
 
   def registration_number_status
-    registration_number.nil? ? :not_started : :completed
+    if CountryCode.ghana?(application_form.country.code)
+      if registration_number.present?
+        registration_number_validator ||= RegistrationNumberValidators::Ghana.new(
+          registration_number:
+        )
+        registration_number_validator.valid? ? :completed : :in_progress
+      else
+        :not_started
+      end
+    else
+      registration_number.nil? ? :not_started : :completed
+    end
   end
 
   def written_statement_status

--- a/app/lib/application_form_section_status_updater.rb
+++ b/app/lib/application_form_section_status_updater.rb
@@ -172,9 +172,8 @@ class ApplicationFormSectionStatusUpdater
   def registration_number_status
     if CountryCode.ghana?(application_form.country.code)
       if registration_number.present?
-        registration_number_validator ||= RegistrationNumberValidators::Ghana.new(
-          registration_number:
-        )
+        registration_number_validator =
+          RegistrationNumberValidators::Ghana.new(registration_number:)
         registration_number_validator.valid? ? :completed : :in_progress
       else
         :not_started

--- a/app/lib/country_code.rb
+++ b/app/lib/country_code.rb
@@ -26,6 +26,10 @@ class CountryCode
       code == "GB-NIR"
     end
 
+    def ghana?(code)
+      code == "GH"
+    end
+
     def european_economic_area?(code)
       Country::CODES_IN_EUROPEAN_ECONOMIC_AREA.include?(code)
     end

--- a/app/lib/registration_number_validators/ghana.rb
+++ b/app/lib/registration_number_validators/ghana.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module RegistrationNumberValidators
+  class Ghana
+    def initialize(registration_number:)
+      @registration_number = registration_number
+
+      registration_number_parts = registration_number.split("/")
+
+      @license_number_part_one = registration_number_parts[0]
+      @license_number_part_two = registration_number_parts[1]
+      @license_number_part_three = registration_number_parts[2]
+    end
+
+    def valid?
+      license_number_part_one_valid? &&
+      license_number_part_two_valid? &&
+      license_number_part_three_valid?
+    end
+
+    def license_number_part_one_valid?
+      license_number_part_one.to_s.length == 2 &&
+        license_number_part_one.match?(/\A[a-zA-Z]*\z/)
+    end
+
+    def license_number_part_two_valid?
+      license_number_part_two.to_s.length == 6 &&
+        license_number_part_two.match?(/^[0-9]+$/)
+    end
+
+    def license_number_part_three_valid?
+      license_number_part_three.to_s.length == 4 &&
+        license_number_part_three.match?(/^[0-9]+$/)
+    end
+
+    private
+
+    attr_reader :license_number_part_one, :license_number_part_two, :license_number_part_three
+  end
+end

--- a/app/lib/registration_number_validators/ghana.rb
+++ b/app/lib/registration_number_validators/ghana.rb
@@ -5,7 +5,7 @@ module RegistrationNumberValidators
     def initialize(registration_number:)
       @registration_number = registration_number
 
-      registration_number_parts = registration_number.split("/")
+      registration_number_parts = registration_number.to_s.split("/")
 
       @license_number_part_one = registration_number_parts[0]
       @license_number_part_two = registration_number_parts[1]

--- a/app/lib/registration_number_validators/ghana.rb
+++ b/app/lib/registration_number_validators/ghana.rb
@@ -13,9 +13,8 @@ module RegistrationNumberValidators
     end
 
     def valid?
-      license_number_part_one_valid? &&
-      license_number_part_two_valid? &&
-      license_number_part_three_valid?
+      license_number_part_one_valid? && license_number_part_two_valid? &&
+        license_number_part_three_valid?
     end
 
     def license_number_part_one_valid?
@@ -35,6 +34,8 @@ module RegistrationNumberValidators
 
     private
 
-    attr_reader :license_number_part_one, :license_number_part_two, :license_number_part_three
+    attr_reader :license_number_part_one,
+                :license_number_part_two,
+                :license_number_part_three
   end
 end

--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -206,6 +206,12 @@ class TeacherInterface::ApplicationFormViewObject
       else
         I18n.t("application_form.tasks.items.written_statement.upload")
       end
+    elsif key == :registration_number
+      if CountryCode.ghana?(application_form.country.code)
+        I18n.t("application_form.tasks.items.registration_number.ghana")
+      else
+        I18n.t("application_form.tasks.items.registration_number.other")
+      end
     else
       I18n.t("application_form.tasks.items.#{key}")
     end

--- a/app/views/shared/application_form/_registration_number_summary.html.erb
+++ b/app/views/shared/application_form/_registration_number_summary.html.erb
@@ -1,7 +1,7 @@
 <%= render(CheckYourAnswersSummary::Component.new(
   id: "registration-number",
   model: application_form,
-  title: I18n.t("application_form.tasks.items.registration_number"),
+  title: t(CountryCode.ghana?(application_form.country.code) ? "ghana" : "other", scope: %i[application_form tasks items registration_number]),
   fields: {
     registration_number: {
       href: %i[registration_number teacher_interface application_form]

--- a/app/views/teacher_interface/registration_number/edit.html.erb
+++ b/app/views/teacher_interface/registration_number/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, title_with_error_prefix(t("application_form.tasks.items.registration_number"), error: @form.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(t("application_form.tasks.items.registration_number.other"), error: @form.errors.any?) %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
 <%= form_with model: @form, url: %i[registration_number teacher_interface application_form] do |f| %>

--- a/app/views/teacher_interface/registration_number/edit_ghana.html.erb
+++ b/app/views/teacher_interface/registration_number/edit_ghana.html.erb
@@ -1,0 +1,37 @@
+<% content_for :page_title, title_with_error_prefix(t("application_form.tasks.items.registration_number.ghana"), error: @form.errors.any?) %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
+
+<%= form_with model: @form, url: %i[registration_number teacher_interface application_form] do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= f.govuk_text_field :registration_number, label: { size: "l", tag: "h1" } %>
+
+  <% if @application_form.region.status_check_online? %>
+    <% if @application_form.region.status_information.present? %>
+      <%= raw GovukMarkdown.render(@application_form.region.status_information) %>
+    <% end %>
+
+    <% if @application_form.region.country.status_information.present? %>
+      <%= raw GovukMarkdown.render(@application_form.region.country.status_information) %>
+    <% end %>
+  <% end %>
+
+  <% if @application_form.region.sanction_check_online? %>
+    <% if @application_form.region.sanction_information.present? %>
+      <%= raw GovukMarkdown.render(@application_form.region.sanction_information) %>
+    <% end %>
+
+    <% if @application_form.region.country.sanction_information.present? %>
+      <%= raw GovukMarkdown.render(@application_form.region.country.sanction_information) %>
+    <% end %>
+  <% end %>
+
+  <%= govuk_details(summary_text: "When we might need more information") do %>
+    <p>
+      If we’re unable to find you using your registration number, we may need to
+      contact you for more information as part of your application.
+    </p>
+  <% end %>
+
+  <%= render "shared/save_submit_buttons", f: %>
+<% end %>

--- a/app/views/teacher_interface/registration_number/edit_ghana.html.erb
+++ b/app/views/teacher_interface/registration_number/edit_ghana.html.erb
@@ -4,34 +4,74 @@
 <%= form_with model: @form, url: %i[registration_number teacher_interface application_form] do |f| %>
   <%= f.govuk_error_summary %>
 
-  <%= f.govuk_text_field :registration_number, label: { size: "l", tag: "h1" } %>
+  <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.present? %>">
+    <fieldset class="govuk-fieldset" aria-describedby="teacher-interface-ghana-registration-number-form-registration-number-hint">
+      <h1 class="govuk-label-wrapper">
+        <label for="teacher-interface-ghana-registration-number-form-registration-number-field" class="govuk-label govuk-label--l">
+          <%= t("helpers.label.teacher_interface_ghana_registration_number_form.registration_number") %>
+        </label>
+      </h1>
+      <div class="govuk-hint" id="teacher-interface-ghana-registration-number-form-registration-number-hint">
+        <%= t("helpers.hint.teacher_interface_ghana_registration_number_form.registration_number") %>
+      </div>
 
-  <% if @application_form.region.status_check_online? %>
-    <% if @application_form.region.status_information.present? %>
-      <%= raw GovukMarkdown.render(@application_form.region.status_information) %>
-    <% end %>
+      <% if @form.errors.present? %>
+        <p id="teacher-interface-ghana-registration-number-form-registration-number-field-error" class="govuk-error-message">
+          <span class="govuk-visually-hidden">Error:</span>
+          <%= @form.errors.first.message %>
+        </p>
+      <% end %>
 
-    <% if @application_form.region.country.status_information.present? %>
-      <%= raw GovukMarkdown.render(@application_form.region.country.status_information) %>
-    <% end %>
-  <% end %>
+      <div class="govuk-date-input">
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <input id="teacher-interface-ghana-registration-number-form-license-number-part-one"
+                   class="govuk-input govuk-date-input__input govuk-input--width-2 <%= 'govuk-input--error' if @form.errors.present? && !@form.registration_number_validator.license_number_part_one_valid? %>"
+                   name="teacher_interface_ghana_registration_number_form[license_number_part_one]"
+                   type="text" inputmode="text" value=<%= @form.license_number_part_one %>>
+          </div>
+        </div>
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <input id="teacher-interface-ghana-registration-number-form-license-number-part-two"
+                   class="govuk-input govuk-date-input__input govuk-input--width-4 <%= 'govuk-input--error' if @form.errors.present? && !@form.registration_number_validator.license_number_part_two_valid? %>"
+                   name="teacher_interface_ghana_registration_number_form[license_number_part_two]"
+                   type="text"
+                   inputmode="numeric"
+                   value=<%= @form.license_number_part_two %>>
+          </div>
+        </div>
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <input id="teacher-interface-ghana-registration-number-form-license-number-part-three"
+                   class="govuk-input govuk-date-input__input govuk-input--width-3 <%= 'govuk-input--error' if @form.errors.present? && !@form.registration_number_validator.license_number_part_three_valid? %>"
+                   name="teacher_interface_ghana_registration_number_form[license_number_part_three]"
+                   type="text"
+                   inputmode="numeric"
+                   value=<%= @form.license_number_part_three %>>
+          </div>
+        </div>
+      </div>
+    </fieldset>
+  </div>
 
-  <% if @application_form.region.sanction_check_online? %>
-    <% if @application_form.region.sanction_information.present? %>
-      <%= raw GovukMarkdown.render(@application_form.region.sanction_information) %>
-    <% end %>
+  <div class="govuk-!-padding-bottom-3"></div>
 
-    <% if @application_form.region.country.sanction_information.present? %>
-      <%= raw GovukMarkdown.render(@application_form.region.country.sanction_information) %>
-    <% end %>
-  <% end %>
+  <h2 class="govuk-heading-m">Finding and checking your teacher license number</h2>
+  <p class="govuk-body">
+    You can get your teacher license number by signing in to your <%= link_to "Teacher Portal Ghana account", "https://tpg.ntc.gov.gh/account/login/teacher" %>.</p>
+  <p class="govuk-body">You can check your number on the <%= link_to "Teacher Portal Ghana website", "https://tpg.ntc.gov.gh/public/teacher/verify-license" %>.</p>
+  <p class="govuk-body">If you cannot find your teaching license number, contact the <%= link_to "Ghana National Teaching Council", "https://ntc.gov.gh/" %>.</p>
 
-  <%= govuk_details(summary_text: "When we might need more information") do %>
-    <p>
-      If we’re unable to find you using your registration number, we may need to
-      contact you for more information as part of your application.
-    </p>
-  <% end %>
+  <div class="govuk-!-padding-bottom-3"></div>
+
+  <h2 class="govuk-heading-m">Why we need your teacher license number</h2>
+  <p class="govuk-body">
+		We use this number to verify you are registered to teach in Ghana.
+    If you do not have one, we will not be able to verify you. This means your application will be declined. We do not accept other registration or license numbers.
+  </p>
+
+  <div class="govuk-!-padding-bottom-3"></div>
 
   <%= render "shared/save_submit_buttons", f: %>
 <% end %>

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -49,7 +49,7 @@ en:
       teacher_interface_further_information_request_item_text_form:
         response: Use the text box below to respond to the assessor’s question.
       teacher_interface_ghana_registration_number_form:
-        registration_number: Your teacher license number is made up of 2 letters, 6 numbers, and a final 4 numbers. For example, PT/123456/1234.
+        registration_number: Your teacher license number is made up of 2 letters, 6 numbers and a final 4 numbers. For example, PT/123456/1234.
       teacher_interface_has_work_history_form:
         has_work_history: If you’re a recent university graduate, or you've just completed your teaching qualification, you may not have held a professional teaching position yet.
       teacher_interface_new_session_form:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -226,7 +226,7 @@ en:
       teacher_interface_further_information_request_item_text_form:
         response: Enter your response
       teacher_interface_ghana_registration_number_form:
-        registration_number: "Enter your teacher license number"
+        registration_number: Enter your teacher license number
       teacher_interface_has_work_history_form:
         has_work_history_options:
           true: "Yes"

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -49,7 +49,7 @@ en:
       teacher_interface_further_information_request_item_text_form:
         response: Use the text box below to respond to the assessor’s question.
       teacher_interface_ghana_registration_number_form:
-        license_number_parts: Your teacher license number is made up of 2 letters, 6 numbers, and a final 4 numbers. For example, PT/123456/1234.
+        registration_number: Your teacher license number is made up of 2 letters, 6 numbers, and a final 4 numbers. For example, PT/123456/1234.
       teacher_interface_has_work_history_form:
         has_work_history: If you’re a recent university graduate, or you've just completed your teaching qualification, you may not have held a professional teaching position yet.
       teacher_interface_new_session_form:
@@ -226,7 +226,7 @@ en:
       teacher_interface_further_information_request_item_text_form:
         response: Enter your response
       teacher_interface_ghana_registration_number_form:
-        license_number_parts: Enter your teacher license number
+        registration_number: "Enter your teacher license number"
       teacher_interface_has_work_history_form:
         has_work_history_options:
           true: "Yes"

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -48,6 +48,8 @@ en:
           provider: The test must have been taken within the last 2 years. We cannot accept English language tests from a provider that does not appear on the list.
       teacher_interface_further_information_request_item_text_form:
         response: Use the text box below to respond to the assessor’s question.
+      teacher_interface_ghana_registration_number_form:
+        license_number_parts: Your teacher license number is made up of 2 letters, 6 numbers, and a final 4 numbers. For example, PT/123456/1234.
       teacher_interface_has_work_history_form:
         has_work_history: If you’re a recent university graduate, or you've just completed your teaching qualification, you may not have held a professional teaching position yet.
       teacher_interface_new_session_form:
@@ -223,6 +225,8 @@ en:
           provider: Upload proof of a Secure English Language Test (SELT) at B2 level, from one of the approved providers.
       teacher_interface_further_information_request_item_text_form:
         response: Enter your response
+      teacher_interface_ghana_registration_number_form:
+        license_number_parts: Enter your teacher license number
       teacher_interface_has_work_history_form:
         has_work_history_options:
           true: "Yes"

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -323,9 +323,8 @@ en:
               blank: Confirm that you have downloaded the consent document.
         teacher_interface/ghana_registration_number_form:
           attributes:
-            license_number_parts:
-              blank: Enter your teacher license number
-              invalid: Enter your teacher license number in full. It is made up of 2 letters, 6 numbers and a final 4 numbers. For example, PT/123456/1234.
+            registration_number:
+              invalid: Enter your teacher license number. It is made up of 2 letters, 6 numbers and a final 4 numbers. For example, PT/123456/1234.
         teacher_interface/reference_request_children_response_form:
           attributes:
             children_response:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -128,7 +128,9 @@ en:
         subjects: Enter the subjects you can teach
         english_language: Verify your English language proficiency
         work_history: Add your work history
-        registration_number: Enter your registration number
+        registration_number:
+          ghana: Enter your teacher license number
+          other: Enter your registration number
         written_statement:
           upload: Upload your written statement
           provide: Provide your written statement

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -319,6 +319,11 @@ en:
           attributes:
             downloaded:
               blank: Confirm that you have downloaded the consent document.
+        teacher_interface/ghana_registration_number_form:
+          attributes:
+            license_number_parts:
+              blank: Enter your teacher license number
+              invalid: Enter your teacher license number in full. It is made up of 2 letters, 6 numbers and a final 4 numbers. For example, PT/123456/1234.
         teacher_interface/reference_request_children_response_form:
           attributes:
             children_response:

--- a/spec/forms/teacher_interface/ghana_registration_number_form_spec.rb
+++ b/spec/forms/teacher_interface/ghana_registration_number_form_spec.rb
@@ -41,6 +41,14 @@ RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
       it { is_expected.to be_invalid }
     end
 
+    context "with license number parts having spaces in the end" do
+      let(:license_number_part_one) { " PT " }
+      let(:license_number_part_two) { "123456 " }
+      let(:license_number_part_three) { " 1234" }
+
+      it { is_expected.to be_valid }
+    end
+
     context "with valid parts" do
       let(:license_number_part_one) { "PT" }
       let(:license_number_part_two) { "123456" }
@@ -59,6 +67,20 @@ RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
       let(:license_number_part_three) { "1234" }
 
       it "sets the registration number to the string" do
+        expect { save }.to change(application_form, :registration_number).to(
+          "PT/123456/1234",
+        )
+      end
+    end
+
+    context "with license number parts having spaces in the end" do
+      subject(:save) { form.save(validate: true) }
+
+      let(:license_number_part_one) { " PT " }
+      let(:license_number_part_two) { "123456 " }
+      let(:license_number_part_three) { " 1234" }
+
+      it "sets the registration number to the string without spaces" do
         expect { save }.to change(application_form, :registration_number).to(
           "PT/123456/1234",
         )

--- a/spec/forms/teacher_interface/ghana_registration_number_form_spec.rb
+++ b/spec/forms/teacher_interface/ghana_registration_number_form_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
   end
 
   describe "#save" do
-    subject(:save) { form.save(validate: true) }
-
     context "with valid parts" do
+      subject(:save) { form.save(validate: true) }
+
       let(:license_number_part_one) { 'PT' }
       let(:license_number_part_two) { '123456' }
       let(:license_number_part_three) { '1234' }
@@ -62,6 +62,48 @@ RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
         expect { save }.to change(application_form, :registration_number).to(
           "PT/123456/1234",
         )
+      end
+    end
+
+    context "with invalid parts" do
+      subject(:save) { form.save(validate: false) }
+
+      let(:license_number_part_one) { 'P2' }
+      let(:license_number_part_two) { '123%56' }
+      let(:license_number_part_three) { '1^634' }
+
+      it "sets the registration number to the string" do
+        expect { save }.to change(application_form, :registration_number).to(
+          "P2/123%56/1^634",
+        )
+      end
+
+      context "when all parts are empty" do
+        let(:license_number_part_one) { '' }
+        let(:license_number_part_two) { '' }
+        let(:license_number_part_three) { '' }
+
+        before do
+          application_form.update(registration_number: "PT/123456/1234")
+        end
+
+        it "sets the registration number to nil" do
+          expect { save }.to change(application_form, :registration_number).to(
+            nil
+          )
+        end
+      end
+
+      context "when some parts are empty" do
+        let(:license_number_part_one) { 'PT' }
+        let(:license_number_part_two) { '' }
+        let(:license_number_part_three) { '111' }
+
+        it "sets the registration number to nil" do
+          expect { save }.to change(application_form, :registration_number).to(
+            "PT//111"
+          )
+        end
       end
     end
   end

--- a/spec/forms/teacher_interface/ghana_registration_number_form_spec.rb
+++ b/spec/forms/teacher_interface/ghana_registration_number_form_spec.rb
@@ -4,13 +4,20 @@ require "rails_helper"
 
 RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
   subject(:form) do
-    described_class.new(application_form:, license_number_parts:)
+    described_class.new(
+      application_form:,
+      license_number_part_one:,
+      license_number_part_two:,
+      license_number_part_three:,
+    )
   end
 
   let(:application_form) { build(:application_form) }
 
   describe "validations" do
-    let(:license_number_parts) { [] }
+    let(:license_number_part_one) { '' }
+    let(:license_number_part_two) { '' }
+    let(:license_number_part_three) { '' }
 
     it { is_expected.to validate_presence_of(:application_form) }
 
@@ -18,14 +25,26 @@ RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
       it { is_expected.to be_invalid }
     end
 
-    context "with invalid parts" do
-      let(:license_number_parts) { %w[a b c] }
+    context "with license number parts having invalid number of characters" do
+      let(:license_number_part_one) { 'A' }
+      let(:license_number_part_two) { '1' }
+      let(:license_number_part_three) { '244444444' }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "with license number parts having invalid format of characters" do
+      let(:license_number_part_one) { '11' }
+      let(:license_number_part_two) { 'AB&DSE' }
+      let(:license_number_part_three) { '1%NB' }
 
       it { is_expected.to be_invalid }
     end
 
     context "with valid parts" do
-      let(:license_number_parts) { %w[PT 123456 1234] }
+      let(:license_number_part_one) { 'PT' }
+      let(:license_number_part_two) { '123456' }
+      let(:license_number_part_three) { '1234' }
 
       it { is_expected.to be_valid }
     end
@@ -35,7 +54,9 @@ RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
     subject(:save) { form.save(validate: true) }
 
     context "with valid parts" do
-      let(:license_number_parts) { %w[PT 123456 1234] }
+      let(:license_number_part_one) { 'PT' }
+      let(:license_number_part_two) { '123456' }
+      let(:license_number_part_three) { '1234' }
 
       it "sets the registration number to the string" do
         expect { save }.to change(application_form, :registration_number).to(

--- a/spec/forms/teacher_interface/ghana_registration_number_form_spec.rb
+++ b/spec/forms/teacher_interface/ghana_registration_number_form_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
+  subject(:form) do
+    described_class.new(application_form:, license_number_parts:)
+  end
+
+  let(:application_form) { build(:application_form) }
+
+  describe "validations" do
+    let(:license_number_parts) { [] }
+
+    it { is_expected.to validate_presence_of(:application_form) }
+
+    context "with empty parts" do
+      it { is_expected.to be_invalid }
+    end
+
+    context "with invalid parts" do
+      let(:license_number_parts) { %w[a b c] }
+
+      it { is_expected.to be_invalid }
+    end
+
+    context "with valid parts" do
+      let(:license_number_parts) { %w[PT 123456 1234] }
+
+      it { is_expected.to be_valid }
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save(validate: true) }
+
+    context "with valid parts" do
+      let(:license_number_parts) { %w[PT 123456 1234] }
+
+      it "sets the registration number to the string" do
+        expect { save }.to change(application_form, :registration_number).to(
+          "PT/123456/1234",
+        )
+      end
+    end
+  end
+end

--- a/spec/forms/teacher_interface/ghana_registration_number_form_spec.rb
+++ b/spec/forms/teacher_interface/ghana_registration_number_form_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
   let(:application_form) { build(:application_form) }
 
   describe "validations" do
-    let(:license_number_part_one) { '' }
-    let(:license_number_part_two) { '' }
-    let(:license_number_part_three) { '' }
+    let(:license_number_part_one) { "" }
+    let(:license_number_part_two) { "" }
+    let(:license_number_part_three) { "" }
 
     it { is_expected.to validate_presence_of(:application_form) }
 
@@ -26,25 +26,25 @@ RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
     end
 
     context "with license number parts having invalid number of characters" do
-      let(:license_number_part_one) { 'A' }
-      let(:license_number_part_two) { '1' }
-      let(:license_number_part_three) { '244444444' }
+      let(:license_number_part_one) { "A" }
+      let(:license_number_part_two) { "1" }
+      let(:license_number_part_three) { "244444444" }
 
       it { is_expected.to be_invalid }
     end
 
     context "with license number parts having invalid format of characters" do
-      let(:license_number_part_one) { '11' }
-      let(:license_number_part_two) { 'AB&DSE' }
-      let(:license_number_part_three) { '1%NB' }
+      let(:license_number_part_one) { "11" }
+      let(:license_number_part_two) { "AB&DSE" }
+      let(:license_number_part_three) { "1%NB" }
 
       it { is_expected.to be_invalid }
     end
 
     context "with valid parts" do
-      let(:license_number_part_one) { 'PT' }
-      let(:license_number_part_two) { '123456' }
-      let(:license_number_part_three) { '1234' }
+      let(:license_number_part_one) { "PT" }
+      let(:license_number_part_two) { "123456" }
+      let(:license_number_part_three) { "1234" }
 
       it { is_expected.to be_valid }
     end
@@ -54,9 +54,9 @@ RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
     context "with valid parts" do
       subject(:save) { form.save(validate: true) }
 
-      let(:license_number_part_one) { 'PT' }
-      let(:license_number_part_two) { '123456' }
-      let(:license_number_part_three) { '1234' }
+      let(:license_number_part_one) { "PT" }
+      let(:license_number_part_two) { "123456" }
+      let(:license_number_part_three) { "1234" }
 
       it "sets the registration number to the string" do
         expect { save }.to change(application_form, :registration_number).to(
@@ -68,9 +68,9 @@ RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
     context "with invalid parts" do
       subject(:save) { form.save(validate: false) }
 
-      let(:license_number_part_one) { 'P2' }
-      let(:license_number_part_two) { '123%56' }
-      let(:license_number_part_three) { '1^634' }
+      let(:license_number_part_one) { "P2" }
+      let(:license_number_part_two) { "123%56" }
+      let(:license_number_part_three) { "1^634" }
 
       it "sets the registration number to the string" do
         expect { save }.to change(application_form, :registration_number).to(
@@ -79,9 +79,9 @@ RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
       end
 
       context "when all parts are empty" do
-        let(:license_number_part_one) { '' }
-        let(:license_number_part_two) { '' }
-        let(:license_number_part_three) { '' }
+        let(:license_number_part_one) { "" }
+        let(:license_number_part_two) { "" }
+        let(:license_number_part_three) { "" }
 
         before do
           application_form.update(registration_number: "PT/123456/1234")
@@ -89,19 +89,19 @@ RSpec.describe TeacherInterface::GhanaRegistrationNumberForm, type: :model do
 
         it "sets the registration number to nil" do
           expect { save }.to change(application_form, :registration_number).to(
-            nil
+            nil,
           )
         end
       end
 
       context "when some parts are empty" do
-        let(:license_number_part_one) { 'PT' }
-        let(:license_number_part_two) { '' }
-        let(:license_number_part_three) { '111' }
+        let(:license_number_part_one) { "PT" }
+        let(:license_number_part_two) { "" }
+        let(:license_number_part_three) { "111" }
 
         it "sets the registration number to nil" do
           expect { save }.to change(application_form, :registration_number).to(
-            "PT//111"
+            "PT//111",
           )
         end
       end

--- a/spec/lib/application_form_section_status_updater_spec.rb
+++ b/spec/lib/application_form_section_status_updater_spec.rb
@@ -406,6 +406,29 @@ RSpec.describe ApplicationFormSectionStatusUpdater do
 
         it { is_expected.to eq("completed") }
       end
+
+      context "when the application form is from Ghana" do
+        let(:application_form) { create(:application_form, registration_number:, region: ghana_country.regions.first) }
+        let(:ghana_country) { create(:country, :with_national_region, code: "GH") }
+
+        context "without a registration/license number" do
+          let(:registration_number) { nil }
+
+          it { is_expected.to eq("not_started") }
+        end
+
+        context "without a valid registration/license number" do
+          let(:registration_number) { "P/12%3/44N" }
+
+          it { is_expected.to eq("in_progress") }
+        end
+
+        context "with a valid registration/license number" do
+          let(:registration_number) { "PT/123456/1234" }
+
+          it { is_expected.to eq("completed") }
+        end
+      end
     end
   end
 end

--- a/spec/lib/application_form_section_status_updater_spec.rb
+++ b/spec/lib/application_form_section_status_updater_spec.rb
@@ -408,8 +408,16 @@ RSpec.describe ApplicationFormSectionStatusUpdater do
       end
 
       context "when the application form is from Ghana" do
-        let(:application_form) { create(:application_form, registration_number:, region: ghana_country.regions.first) }
-        let(:ghana_country) { create(:country, :with_national_region, code: "GH") }
+        let(:application_form) do
+          create(
+            :application_form,
+            registration_number:,
+            region: ghana_country.regions.first,
+          )
+        end
+        let(:ghana_country) do
+          create(:country, :with_national_region, code: "GH")
+        end
 
         context "without a registration/license number" do
           let(:registration_number) { nil }

--- a/spec/lib/registration_number_validators/ghana_spec.rb
+++ b/spec/lib/registration_number_validators/ghana_spec.rb
@@ -3,11 +3,7 @@
 require "rails_helper"
 
 RSpec.describe RegistrationNumberValidators::Ghana, type: :model do
-  subject(:validator) do
-    described_class.new(
-      registration_number:,
-    )
-  end
+  subject(:validator) { described_class.new(registration_number:) }
 
   let(:registration_number) { "PT/123456/1234" }
 

--- a/spec/lib/registration_number_validators/ghana_spec.rb
+++ b/spec/lib/registration_number_validators/ghana_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RegistrationNumberValidators::Ghana, type: :model do
+  subject(:validator) do
+    described_class.new(
+      registration_number:,
+    )
+  end
+
+  let(:registration_number) { "PT/123456/1234" }
+
+  describe "#valid?" do
+    context "when all three parts of the license number are valid" do
+      it "returns true" do
+        expect(validator.valid?).to be(true)
+      end
+    end
+
+    context "when the first part of the license number is invalid" do
+      let(:registration_number) { "P/123456/1234" }
+
+      it "returns false" do
+        expect(validator.valid?).to be(false)
+      end
+    end
+
+    context "when the second part of the license number is invalid" do
+      let(:registration_number) { "PT/123&56/1234" }
+
+      it "returns false" do
+        expect(validator.valid?).to be(false)
+      end
+    end
+
+    context "when the third part of the license number is invalid" do
+      let(:registration_number) { "PT/123&56/1N34" }
+
+      it "returns false" do
+        expect(validator.valid?).to be(false)
+      end
+    end
+  end
+
+  describe "#license_number_part_one_valid?" do
+    context "when the first part of the license number is valid" do
+      it "returns true" do
+        expect(validator.license_number_part_one_valid?).to be(true)
+      end
+    end
+
+    context "when the first part of the license number has invalid number of characters" do
+      let(:registration_number) { "PPT/123456/1234" }
+
+      it "returns false" do
+        expect(validator.license_number_part_one_valid?).to be(false)
+      end
+    end
+
+    context "when the first part of the license number has incorrect format" do
+      let(:registration_number) { "1$/123456/1234" }
+
+      it "returns false" do
+        expect(validator.license_number_part_one_valid?).to be(false)
+      end
+    end
+  end
+
+  describe "#license_number_part_two_valid?" do
+    context "when the second part of the license number is valid" do
+      it "returns true" do
+        expect(validator.license_number_part_two_valid?).to be(true)
+      end
+    end
+
+    context "when the second part of the license number has invalid number of characters" do
+      let(:registration_number) { "PT/123456789/1234" }
+
+      it "returns false" do
+        expect(validator.license_number_part_two_valid?).to be(false)
+      end
+    end
+
+    context "when the second part of the license number has incorrect format" do
+      let(:registration_number) { "PT/12 B.5$/1234" }
+
+      it "returns false" do
+        expect(validator.license_number_part_two_valid?).to be(false)
+      end
+    end
+  end
+
+  describe "#license_number_part_three_valid?" do
+    context "when the third part of the license number is valid" do
+      it "returns true" do
+        expect(validator.license_number_part_three_valid?).to be(true)
+      end
+    end
+
+    context "when the third part of the license number has invalid number of characters" do
+      let(:registration_number) { "PT/123456/122222" }
+
+      it "returns false" do
+        expect(validator.license_number_part_three_valid?).to be(false)
+      end
+    end
+
+    context "when the third part of the license number has incorrect format" do
+      let(:registration_number) { "PT/123456/123B" }
+
+      it "returns false" do
+        expect(validator.license_number_part_three_valid?).to be(false)
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/teacher_interface/application.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/application.rb
@@ -47,6 +47,10 @@ module PageObjects
         find_task_list_item("Enter your registration number")
       end
 
+      def ghana_registration_number_task_item
+        find_task_list_item("Enter your teacher license number")
+      end
+
       def upload_written_statement_task_item
         find_task_list_item("Upload your written statement")
       end

--- a/spec/support/autoload/page_objects/teacher_interface/ghana_registration_number.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/ghana_registration_number.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class GhanaRegistrationNumber < SitePrism::Page
+      set_url "/teacher/application/registration_number"
+
+      element :heading, "h1"
+
+      section :form, "form" do
+        element :license_number_part_one_field,
+                "#teacher-interface-ghana-registration-number-form-license-number-part-one"
+        element :license_number_part_two_field,
+                "#teacher-interface-ghana-registration-number-form-license-number-part-two"
+        element :license_number_part_three_field,
+                "#teacher-interface-ghana-registration-number-form-license-number-part-three"
+        element :license_number_error_message,
+                "#teacher-interface-ghana-registration-number-form-registration-number-field-error"
+        element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
+      end
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -661,6 +661,11 @@ module PageHelpers
       PageObjects::TeacherInterface::RegistrationNumber.new
   end
 
+  def teacher_ghana_registration_number_page
+    @teacher_registration_number_page =
+      PageObjects::TeacherInterface::GhanaRegistrationNumber.new
+  end
+
   def teacher_signed_out_page
     @teacher_signed_out_page = PageObjects::TeacherInterface::SignedOut.new
   end

--- a/spec/system/teacher_interface/registration_numbers/ghana_registration_number_spec.rb
+++ b/spec/system/teacher_interface/registration_numbers/ghana_registration_number_spec.rb
@@ -43,7 +43,9 @@ RSpec.describe "Teacher Ghana registration number", type: :system do
   end
 
   def and_i_see_the_registration_number_task
-    expect(teacher_application_page.ghana_registration_number_task_item).not_to be_nil
+    expect(
+      teacher_application_page.ghana_registration_number_task_item,
+    ).not_to be_nil
   end
 
   def when_i_click_the_registration_number_task
@@ -72,17 +74,23 @@ RSpec.describe "Teacher Ghana registration number", type: :system do
 
   def and_i_see_the_completed_registration_number_task
     expect(
-      teacher_application_page.ghana_registration_number_task_item.status_tag.text,
+      teacher_application_page
+        .ghana_registration_number_task_item
+        .status_tag
+        .text,
     ).to eq("Completed")
   end
 
   def and_i_see_the_validation_failures
     expect(
-      teacher_ghana_registration_number_page.form.license_number_error_message.text,
+      teacher_ghana_registration_number_page
+        .form
+        .license_number_error_message
+        .text,
     ).to include(
       "Enter your teacher license number. " \
-      "It is made up of 2 letters, 6 numbers and a final 4 numbers. " \
-      "For example, PT/123456/1234."
+        "It is made up of 2 letters, 6 numbers and a final 4 numbers. " \
+        "For example, PT/123456/1234.",
     )
   end
 
@@ -92,7 +100,12 @@ RSpec.describe "Teacher Ghana registration number", type: :system do
 
   def application_form
     @application_form ||=
-      create(:application_form, teacher:, region: ghana_country.regions.first, needs_registration_number: true)
+      create(
+        :application_form,
+        teacher:,
+        region: ghana_country.regions.first,
+        needs_registration_number: true,
+      )
   end
 
   def ghana_country

--- a/spec/system/teacher_interface/registration_numbers/ghana_registration_number_spec.rb
+++ b/spec/system/teacher_interface/registration_numbers/ghana_registration_number_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Teacher Ghana registration number", type: :system do
+  before do
+    given_i_am_authorized_as_a_user(teacher)
+    given_an_application_form_exists
+  end
+
+  it "records" do
+    when_i_visit_the(:teacher_application_page)
+    then_i_see_the(:teacher_application_page)
+    and_i_see_the_registration_number_task
+
+    when_i_click_the_registration_number_task
+    then_i_see_the(:teacher_ghana_registration_number_page)
+
+    when_i_fill_in_the_registration_number
+    then_i_see_the(:teacher_application_page)
+    and_i_see_the_completed_registration_number_task
+  end
+
+  context "when the registration number fails validation" do
+    it "does not record" do
+      when_i_visit_the(:teacher_application_page)
+      then_i_see_the(:teacher_application_page)
+      and_i_see_the_registration_number_task
+
+      when_i_click_the_registration_number_task
+      then_i_see_the(:teacher_ghana_registration_number_page)
+
+      when_i_fill_in_the_registration_number_incorrectly
+      then_i_see_the(:teacher_ghana_registration_number_page)
+      and_i_see_the_validation_failures
+    end
+  end
+
+  private
+
+  def given_an_application_form_exists
+    application_form
+  end
+
+  def and_i_see_the_registration_number_task
+    expect(teacher_application_page.ghana_registration_number_task_item).not_to be_nil
+  end
+
+  def when_i_click_the_registration_number_task
+    teacher_application_page.ghana_registration_number_task_item.click
+  end
+
+  def when_i_fill_in_the_registration_number
+    teacher_ghana_registration_number_page.form.license_number_part_one_field.fill_in with:
+      "PT"
+    teacher_ghana_registration_number_page.form.license_number_part_two_field.fill_in with:
+      "123456"
+    teacher_ghana_registration_number_page.form.license_number_part_three_field.fill_in with:
+      "1234"
+    teacher_ghana_registration_number_page.form.continue_button.click
+  end
+
+  def when_i_fill_in_the_registration_number_incorrectly
+    teacher_ghana_registration_number_page.form.license_number_part_one_field.fill_in with:
+      "P"
+    teacher_ghana_registration_number_page.form.license_number_part_two_field.fill_in with:
+      "1"
+    teacher_ghana_registration_number_page.form.license_number_part_three_field.fill_in with:
+      "1"
+    teacher_ghana_registration_number_page.form.continue_button.click
+  end
+
+  def and_i_see_the_completed_registration_number_task
+    expect(
+      teacher_application_page.ghana_registration_number_task_item.status_tag.text,
+    ).to eq("Completed")
+  end
+
+  def and_i_see_the_validation_failures
+    expect(
+      teacher_ghana_registration_number_page.form.license_number_error_message.text,
+    ).to include(
+      "Enter your teacher license number. " \
+      "It is made up of 2 letters, 6 numbers and a final 4 numbers. " \
+      "For example, PT/123456/1234."
+    )
+  end
+
+  def teacher
+    @teacher ||= create(:teacher)
+  end
+
+  def application_form
+    @application_form ||=
+      create(:application_form, teacher:, region: ghana_country.regions.first, needs_registration_number: true)
+  end
+
+  def ghana_country
+    @ghana_country ||= create(:country, :with_national_region, code: "GH")
+  end
+end


### PR DESCRIPTION
### Description


The Registration number, also known as the license number for Ghanaian specific applicants is a 3 part alphanumeric which has a specific format. To make it easier for applicants to not make mistakes when entering this number, we have decided to change the UI with additional validations in place to guide users.

Additionally, the application form status updater has also been updated with regards to the status of the registration form. If a Ghanaian applicant, submits their teacher license/registration number and it is not valid, the status should be "in_progress", meanwhile if it is empty, it should be "not_started". If it is valid then only then it will move to "completed"

Important Design Note: 
As part of this work a new grouped input had to be introduced with inspiration taken from the GOV design systems date field. Since, this is a custom group of inputs, there are no helpers available and as a result of this, custom input fields with GOV design system classes have been used to replicate the desired design.

Ghana Specific Form:
![Screenshot 2024-09-03 at 08 43 09](https://github.com/user-attachments/assets/7aa038d2-db0e-4da4-85b0-975a0ca0e0e4)

Ghana Specific Form with Errors:
![Screenshot 2024-09-03 at 08 43 30](https://github.com/user-attachments/assets/983b9419-3544-4d8b-8e9b-929289233011)

Other:
![Screenshot 2024-09-03 at 08 42 28](https://github.com/user-attachments/assets/73319899-b65b-4035-b975-06d0b34584bb)
