### PR TITLE
[AQTS-550] Ensure if check and select consent method is not complete, other task items do not appear

### DIFF
--- a/app/view_objects/assessor_interface/qualification_requests_view_object.rb
+++ b/app/view_objects/assessor_interface/qualification_requests_view_object.rb
@@ -49,6 +49,8 @@ module AssessorInterface
     end
 
     def individual_task_items_for(qualification_request:)
+      return [] unless all_consent_methods_selected?
+
       consent_task_items(qualification_request) +
         ecctis_task_items(qualification_request)
     end


### PR DESCRIPTION
### Description

https://dfedigital.atlassian.net/browse/AQTS-550

Currently, for applications requiring verification on a single qualification, the selection of consent method needs to happen before any other step can. However, when it comes to verification of multiple qualifications, the consent method section only needs to be partially completed (e.g. 1 consent method is selected but the others have not) for all other individual tasks to be displayed. Once any other task is complete, the consent method selection is locked and therefore cannot be completed.

This causes a few complications for admins and assessors as verification gets blocked since one of the consent methods has not yet been provided.

This ticket ensures that individual tasks are never displayed unless all consent methods for all qualification requests have been selected.