### PR TITLE
AQTS-410 DEV Eligibility criteria has changed banner is showing on applications where the prelim check has changed since submission

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -260,8 +260,7 @@ class ApplicationForm < ApplicationRecord
 
   def submitted_under_old_criteria?
     created_under_old_regulations? ||
-      subject_limited != country.subject_limited ||
-      requires_preliminary_check != region.requires_preliminary_check
+      subject_limited != country.subject_limited
   end
 
   def reminder_email_names

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -259,8 +259,7 @@ class ApplicationForm < ApplicationRecord
   end
 
   def submitted_under_old_criteria?
-    created_under_old_regulations? ||
-      subject_limited != country.subject_limited
+    created_under_old_regulations? || subject_limited != country.subject_limited
   end
 
   def reminder_email_names

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -495,13 +495,5 @@ RSpec.describe ApplicationForm, type: :model do
 
       it { is_expected.to be true }
     end
-
-    context "when requires preliminary check doesn't match the country" do
-      let(:application_form) do
-        create(:application_form, :requires_preliminary_check)
-      end
-
-      it { is_expected.to be true }
-    end
   end
 end


### PR DESCRIPTION
Fix incorrect banner display by removing preliminary check condition from submitted_under_old_criteria? method. The banner should not trigger based on changes to the preliminary check status, only subject restriction changes.

https://dfedigital.atlassian.net/browse/AQTS-410

