### PR TITLE
Add rspec retry due to a lot of flaky failures due to timeouts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,9 @@ group :test do
   gem "pry"
   gem "rspec"
   gem "rspec-rails"
+  gem "rspec-retry",
+      git: "https://github.com/DFE-Digital/rspec-retry.git",
+      branch: "main"
   gem "shoulda-matchers"
   gem "site_prism"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,14 @@ GIT
     govuk_feature_flags (0.1.0)
       rails (>= 7.0.4)
 
+GIT
+  remote: https://github.com/DFE-Digital/rspec-retry.git
+  revision: 306b42b8d5853303982e1a165e82d04744c20ea3
+  branch: main
+  specs:
+    rspec-retry (0.7.0)
+      rspec-core (> 3.3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -725,6 +733,7 @@ DEPENDENCIES
   rmagick
   rspec
   rspec-rails
+  rspec-retry!
   rubocop-govuk
   ruby-vips
   sentry-rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,7 +15,24 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+require "rspec/retry"
+require "rspec/core/formatters/base_text_formatter"
+
 RSpec.configure do |config|
+  # RSpec-retry configuration, retry and log any indeterminate tests.
+  if ENV["CI"]
+    reporter = RSpec::Core::Reporter.new(config)
+    formatter =
+      RSpec::Core::Formatters::BaseTextFormatter.new(
+        File.open("tmp/rspec-retry-flakey-specs.log", "ab"),
+      )
+    reporter.register_listener(formatter, "message")
+    config.retry_reporter = reporter
+
+    config.around { |ex| ex.run_with_retry retry: 3 }
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
We keep seeing very regular flaky system specs due to `Ferrum::ProcessTimeoutError`. 

This PR introduces [rspec-retry](https://github.com/DFE-Digital/rspec-retry) to improve this temporarily