### PR TITLE
Pin postgress version

### DIFF
--- a/terraform/application/databases.tf
+++ b/terraform/application/databases.tf
@@ -30,4 +30,5 @@ module "postgres" {
   azure_enable_monitoring  = var.enable_monitoring
   azure_extensions         = ["pg_stat_statements", "pgcrypto"]
   azure_maintenance_window = var.azure_maintenance_window
+  server_version           = "14"
 }

--- a/terraform/domains/environment_domains/.terraform.lock.hcl
+++ b/terraform/domains/environment_domains/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   constraints = "3.116.0"
   hashes = [
     "h1:BCR3NIorFSvGG3v/+JOiiw3VM4PkChLO4m84wzD9NDo=",
+    "h1:gQLNY1I5e9kcle1p/VYEWb0eteQ/t5kUfnqVu2/GBNY=",
     "zh:02b6606aff025fc2a962b3e568e000300abe959adac987183c24dac8eb057f4d",
     "zh:2a23a8ce24ff9e885925ffee0c3ea7eadba7a702541d05869275778aa47bdea7",
     "zh:57d10746384baeca4d5c56e88872727cdc150f437b8c5e14f0542127f7475e24",


### PR DESCRIPTION
### Context
We need to update the postgres version to the latest stable one - however before this we need to make sure all services pin the postgres version so it’s not updated unexpectedly

### Changes proposed in this pull request
Set Postgres server version to 14


https://trello.com/c/4PBO6Miu/834-change-default-postgres-version-to-16