### PR TITLE
[AQTS-585][AQTS-591] Submission and LoPS request journeys (Nigeria, Hong Kong & Alberta, Canada)

### DIFF
--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -30,6 +30,7 @@ module AssessorInterface
         if assessment_section.preliminary?
           if assessment.all_preliminary_sections_passed?
             request_professional_standing
+            send_initial_checks_passed_email
             unassign_assessor
           else
             redirect_to [
@@ -98,6 +99,14 @@ module AssessorInterface
       RequestRequestable.call(requestable:, user: current_staff)
 
       ApplicationFormStatusUpdater.call(application_form:, user: current_staff)
+    end
+
+    def send_initial_checks_passed_email
+      DeliverEmail.call(
+        application_form:,
+        mailer: TeacherMailer,
+        action: :initial_checks_passed,
+      )
     end
 
     def unassign_assessor

--- a/app/controllers/assessor_interface/assessment_sections_controller.rb
+++ b/app/controllers/assessor_interface/assessment_sections_controller.rb
@@ -30,7 +30,6 @@ module AssessorInterface
         if assessment_section.preliminary?
           if assessment.all_preliminary_sections_passed?
             request_professional_standing
-            send_initial_checks_passed_email
             unassign_assessor
           else
             redirect_to [
@@ -99,14 +98,6 @@ module AssessorInterface
       RequestRequestable.call(requestable:, user: current_staff)
 
       ApplicationFormStatusUpdater.call(application_form:, user: current_staff)
-    end
-
-    def send_initial_checks_passed_email
-      DeliverEmail.call(
-        application_form:,
-        mailer: TeacherMailer,
-        action: :initial_checks_passed,
-      )
     end
 
     def unassign_assessor

--- a/app/lib/country_name.rb
+++ b/app/lib/country_name.rb
@@ -17,6 +17,14 @@ class CountryName
         from_country(region.country, with_definite_article:)
     end
 
+    def from_region_with_country(region, with_definite_article: false)
+      if region.name.presence
+        "#{region.name.presence}, #{from_code(region.country.code, with_definite_article:)}"
+      else
+        from_region(region, with_definite_article:)
+      end
+    end
+
     def from_eligibility_check(eligibility_check, with_definite_article: false)
       if eligibility_check.region.present?
         from_country(eligibility_check.region.country, with_definite_article:)

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -118,14 +118,6 @@ class TeacherMailer < ApplicationMailer
     )
   end
 
-  def initial_checks_passed
-    view_mail(
-      GOVUK_NOTIFY_TEMPLATE_ID,
-      to: teacher.email,
-      subject: I18n.t("mailer.teacher.initial_checks_passed.subject"),
-    )
-  end
-
   def initial_checks_required
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,

--- a/app/mailers/teacher_mailer.rb
+++ b/app/mailers/teacher_mailer.rb
@@ -126,6 +126,14 @@ class TeacherMailer < ApplicationMailer
     )
   end
 
+  def initial_checks_required
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: teacher.email,
+      subject: I18n.t("mailer.teacher.initial_checks_required.subject"),
+    )
+  end
+
   def professional_standing_received
     view_mail(
       GOVUK_NOTIFY_TEMPLATE_ID,
@@ -133,6 +141,18 @@ class TeacherMailer < ApplicationMailer
       subject:
         I18n.t(
           "mailer.teacher.professional_standing_received.subject",
+          certificate: region_certificate_name(region),
+        ),
+    )
+  end
+
+  def professional_standing_requested
+    view_mail(
+      GOVUK_NOTIFY_TEMPLATE_ID,
+      to: teacher.email,
+      subject:
+        I18n.t(
+          "mailer.teacher.professional_standing_requested.subject",
           certificate: region_certificate_name(region),
         ),
     )

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -38,6 +38,16 @@ class ProfessionalStandingRequest < ApplicationRecord
     end
   end
 
+  def after_requested(*)
+    if should_send_emails?
+      DeliverEmail.call(
+        application_form:,
+        mailer: TeacherMailer,
+        action: :professional_standing_requested,
+      )
+    end
+  end
+
   def after_received(*)
     if should_send_emails?
       DeliverEmail.call(

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -38,16 +38,6 @@ class ProfessionalStandingRequest < ApplicationRecord
     end
   end
 
-  def after_requested(*)
-    if should_send_emails?
-      DeliverEmail.call(
-        application_form:,
-        mailer: TeacherMailer,
-        action: :initial_checks_passed,
-      )
-    end
-  end
-
   def after_received(*)
     if should_send_emails?
       DeliverEmail.call(

--- a/app/models/professional_standing_request.rb
+++ b/app/models/professional_standing_request.rb
@@ -45,6 +45,14 @@ class ProfessionalStandingRequest < ApplicationRecord
         mailer: TeacherMailer,
         action: :professional_standing_requested,
       )
+
+      if region.teaching_authority_requires_submission_email
+        DeliverEmail.call(
+          application_form:,
+          mailer: TeachingAuthorityMailer,
+          action: :application_submitted,
+        )
+      end
     end
   end
 
@@ -65,7 +73,7 @@ class ProfessionalStandingRequest < ApplicationRecord
     end
   end
 
-  delegate :teacher, to: :application_form
+  delegate :teacher, :region, to: :application_form
 
   private
 

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -33,11 +33,13 @@ class SubmitApplicationForm
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end
 
-    DeliverEmail.call(
-      application_form:,
-      mailer: TeacherMailer,
-      action: :application_received,
-    )
+    unless application_form.teaching_authority_provides_written_statement
+      DeliverEmail.call(
+        application_form:,
+        mailer: TeacherMailer,
+        action: :application_received,
+      )
+    end
 
     if region.teaching_authority_requires_submission_email
       DeliverEmail.call(
@@ -61,7 +63,13 @@ class SubmitApplicationForm
 
     requestable = ProfessionalStandingRequest.create!(assessment:)
 
-    unless application_form.requires_preliminary_check
+    if application_form.requires_preliminary_check
+      DeliverEmail.call(
+        application_form:,
+        mailer: TeacherMailer,
+        action: :initial_checks_required,
+      )
+    else
       RequestRequestable.call(requestable:, user:)
     end
   end

--- a/app/services/submit_application_form.rb
+++ b/app/services/submit_application_form.rb
@@ -41,14 +41,6 @@ class SubmitApplicationForm
       )
     end
 
-    if region.teaching_authority_requires_submission_email
-      DeliverEmail.call(
-        application_form:,
-        mailer: TeachingAuthorityMailer,
-        action: :application_submitted,
-      )
-    end
-
     UpdateDQTMatchJob.set(wait: 5.minutes).perform_later(application_form)
   end
 

--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -139,6 +139,12 @@ class TeacherInterface::ApplicationFormViewObject
       !further_information_request.received?
   end
 
+  def preliminary_check_pending?
+    return false if assessment.nil?
+
+    requires_preliminary_check && !assessment.all_preliminary_sections_passed?
+  end
+
   def request_professional_standing_certificate?
     teaching_authority_provides_written_statement &&
       professional_standing_request&.requested? &&
@@ -159,6 +165,12 @@ class TeacherInterface::ApplicationFormViewObject
     return false if assessment.nil? || consent_requests.empty?
 
     consent_requests.all?(&:received?)
+  end
+
+  def letter_of_professional_standing_received?
+    return false if assessment.nil? || professional_standing_request.nil?
+
+    professional_standing_request.received?
   end
 
   def show_work_history_under_submission_banner?

--- a/app/views/shared/eligible_region_content_components/_proof_of_recognition.html.erb
+++ b/app/views/shared/eligible_region_content_components/_proof_of_recognition.html.erb
@@ -26,22 +26,38 @@
   <% if region.status_check_written? || region.sanction_check_written? %>
     <% if teaching_authority_provides_written_statement %>
       <p class="govuk-body">
-        You’ll need to provide <%= region_certificate_phrase(region) %> from <%= region_teaching_authority_name_phrase(region) %>.
-      </p>
-
-      <p class="govuk-body">
-        You should request it by emailing <%= region_teaching_authority_emails_phrase(region) %>.
-      </p>
-
-      <p class="govuk-body">
-        You cannot send this document yourself – instead, you must contact <%= region_teaching_authority_name_phrase(region) %> and ask them to send it directly to us at <%= govuk_link_to t("service.email.verification"), email_path("verification") %>.
+        To prove you are recognised as a teacher in <%= CountryName.from_region_with_country(region, with_definite_article: true) %>,
+        you’ll need to get <%= region_certificate_phrase(region) %> from <%= region_teaching_authority_name_phrase(region) %>.
       </p>
 
       <% if region.requires_preliminary_check %>
         <p class="govuk-body govuk-!-font-weight-bold">
-          Do not request this document yet – we’ll carry out some checks on your application first. If your application passes these checks, we’ll then email you and ask you to request the document.
+          Do not request your <%= region_certificate_name(region) %> yet
+        </p>
+
+        <p class="govuk-body">
+          We will need to carry out initial checks on your application.
+          If these checks are passed we will email you and ask you to request your <%= region_certificate_name(region) %>.
+        </p>
+
+        <p class="govuk-body">
+          Once we have asked you to, you must email <%= region_teaching_authority_emails_phrase(region) %>
+          and ask them to send your <%= region_certificate_name(region) %> directly to us at <%= govuk_link_to t("service.email.verification"), email_path("verification") %>.
+        </p>
+      <% else %>
+        <p class="govuk-body">
+          Do this after you have submitted your application, as you will need your application reference number.
+        </p>
+
+        <p class="govuk-body">
+          Once you have submitted your application you must email <%= region_teaching_authority_emails_phrase(region) %>
+          and ask them to send your <%= region_certificate_name(region) %> directly to us at <%= govuk_link_to t("service.email.verification"), email_path("verification") %>.
         </p>
       <% end %>
+
+      <p class="govuk-body">
+        You cannot send it yourself.
+      </p>
     <% else %>
       <p class="govuk-body">
         <% if region.written_statement_optional %>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -8,6 +8,8 @@
   <%= render "teacher_interface/application_forms/show/awarded", view_object: @view_object %>
 <% elsif @view_object.request_further_information? %>
   <%= render "teacher_interface/application_forms/show/further_information_requested", view_object: @view_object %>
+<% elsif @view_object.preliminary_check_pending? %>
+  <%= render "teacher_interface/application_forms/show/preliminary_check_pending", view_object: @view_object %>
 <% elsif @view_object.request_professional_standing_certificate? %>
   <%= render "teacher_interface/application_forms/show/request_professional_standing_certificate", view_object: @view_object %>
 <% elsif @view_object.request_qualification_consent? %>

--- a/app/views/teacher_interface/application_forms/show.html.erb
+++ b/app/views/teacher_interface/application_forms/show.html.erb
@@ -8,7 +8,7 @@
   <%= render "teacher_interface/application_forms/show/awarded", view_object: @view_object %>
 <% elsif @view_object.request_further_information? %>
   <%= render "teacher_interface/application_forms/show/further_information_requested", view_object: @view_object %>
-<% elsif @view_object.preliminary_check_pending? %>
+<% elsif @view_object.teaching_authority_provides_written_statement? && @view_object.preliminary_check_pending? %>
   <%= render "teacher_interface/application_forms/show/preliminary_check_pending", view_object: @view_object %>
 <% elsif @view_object.request_professional_standing_certificate? %>
   <%= render "teacher_interface/application_forms/show/request_professional_standing_certificate", view_object: @view_object %>

--- a/app/views/teacher_interface/application_forms/show/_preliminary_check_pending.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_preliminary_check_pending.html.erb
@@ -1,0 +1,21 @@
+<h2 class="govuk-heading-l">
+  Application submitted
+</h2>
+
+<h2 class="govuk-heading-m">
+  Application reference number: <strong><%= view_object.application_form.reference %></strong>
+</h2>
+
+<h2 class="govuk-heading-m">What happens next</h2>
+
+<p class="govuk-body">
+  We need to carry out some initial checks on your application. We will email you to let you know if your application passes these initial checks.
+</p>
+
+<p class="govuk-body">
+  If initial checks are passed you will need to request <%= region_certificate_phrase(view_object.region) %> from <%= region_teaching_authority_name_phrase(view_object.region) %>.
+</p>
+
+<p class="govuk-body">
+  Do not request your <%= region_certificate_name(view_object.region) %> until you have received confirmation from us. You do not need to contact us. 
+</p>

--- a/app/views/teacher_interface/application_forms/show/_request_professional_standing_certificate.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_request_professional_standing_certificate.html.erb
@@ -1,13 +1,30 @@
-<h2 class="govuk-heading-m">
-  You should now request your <%= region_certificate_name(view_object.region) %>
+<h2 class="govuk-heading-l">
+  <% if view_object.application_form.requires_preliminary_check? && view_object.application_form.assessment.all_preliminary_sections_passed? %>
+    Your application has passed initial checks
+  <% else %>
+    Application submitted
+  <% end %>
 </h2>
 
+<h2 class="govuk-heading-m">
+  Application reference number: <strong><%= view_object.application_form.reference %></strong>
+</h2>
+
+<%= govuk_warning_text(text: "Your application cannot proceed until we receive your #{region_certificate_name(view_object.region)}.") %>
+
+<h2 class="govuk-heading-m">What you need to do</h2>
+
 <p class="govuk-body">
-  You should now request your <%= region_certificate_name(view_object.region) %> from <%= region_teaching_authority_name_phrase(view_object.region) %>.
+  You must now get your <%= region_certificate_name(view_object.region) %> from <%= region_teaching_authority_name_phrase(view_object.region) %>.
 </p>
 
 <p class="govuk-body">
-  Contact them directly and instruct them to send the document to <%= govuk_link_to t("service.email.verification"), email_path("verification") %>.
+  Email <%= region_teaching_authority_emails_phrase(view_object.region) %> and ask them to send your
+  <%= region_certificate_name(view_object.region) %> directly to us at <%= govuk_link_to t("service.email.verification"), email_path("verification") %>.
+</p>
+
+<p class="govuk-body">
+  You cannot send it yourself.
 </p>
 
 <% if view_object.region.teaching_authority_requires_submission_email %>
@@ -15,10 +32,6 @@
     Once you’ve submitted your application, we’ll notify <%= region_teaching_authority_name_phrase(view_object.region) %> that you’ve applied for QTS. You do not need to contact us to get written confirmation of this.
   </p>
 <% end %>
-
-<h2 class="govuk-heading-m">
-  Important information about your <%= region_certificate_name(view_object.region) %>
-</h2>
 
 <% if view_object.region.status_check_written? %>
   <% if view_object.region.status_information.present? %>
@@ -48,4 +61,12 @@
   <%= raw GovukMarkdown.render(view_object.region.country.other_information) %>
 <% end %>
 
-<p class="govuk-body">Once you’re satisfied that you understand your next steps, you can close this page.</p>
+<h2 class="govuk-heading-m">What happens next</h2>
+
+<p class="govuk-body">
+  Once the <%= region_certificate_name(view_object.region) %> is received and checked, your application will be assessed by a trained assessor. They will check all the information you have submitted. Some information may need verification by third parties.
+</p>
+
+<p class="govuk-body">
+  If we need more information, we will email you. You do not need to contact us.
+</p>

--- a/app/views/teacher_interface/application_forms/show/_submitted.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_submitted.html.erb
@@ -1,6 +1,7 @@
 <% further_information_submitted = view_object.further_information_request&.received? %>
 <% qualification_consent_submitted = view_object.qualification_consent_submitted? %>
 <% teaching_authority_provides_written_statement = view_object.teaching_authority_provides_written_statement? %>
+<% letter_of_professional_standing_received = view_object.letter_of_professional_standing_received? %>
 
 <% title_text = if qualification_consent_submitted
                   "Consent documents successfully submitted"
@@ -26,8 +27,12 @@
   <p class="govuk-body">The assessor will continue to review your QTS application once they’ve checked that the further information you’ve provided can be accepted.</p>
   <p class="govuk-body">You can now close this page.</p>
 <% else %>
-  <p class="govuk-body">We’ve received your application for QTS and we’ve sent you a confirmation email.</p>
-  <p class="govuk-body">Keep the email safe, as you may need your application reference number for future correspondence about your application.</p>
+  <% if letter_of_professional_standing_received %>
+    <p class="govuk-body">We’ve received and checked your  <%= region_certificate_name(view_object.region) %> from <%= region_teaching_authority_name_phrase(view_object.region) %>. This has been attached to your application.</p>
+  <% else %>
+    <p class="govuk-body">We’ve received your application for QTS and we’ve sent you a confirmation email.</p>
+    <p class="govuk-body">Keep the email safe, as you may need your application reference number for future correspondence about your application.</p>
+  <% end %>
 
   <h2 class="govuk-heading-m">What happens next</h2>
   <p class="govuk-body">Your application will be assessed by a trained assessor. They will check all the information you have submitted. Some information may need verification by third parties.</p>

--- a/app/views/teacher_mailer/application_received.text.erb
+++ b/app/views/teacher_mailer/application_received.text.erb
@@ -6,13 +6,7 @@ Dear <%= application_form_full_name(@application_form) %>,
 
 # What happens next
 
-<% if @application_form.teaching_authority_provides_written_statement %>
-We are waiting to receive the written evidence you’ve requested from your teaching authority.
-
-Once the written evidence is received and checked, your application will be assessed by a trained assessor. They will check all the information you have submitted. Some information may need verification by third parties.
-<% else %>
 Your application will be assessed by a trained assessor. They will check all the information you have submitted. Some information may need verification by third parties.
-<% end %>
 
 If we need more information, we will email you. You do not need to contact us.
 
@@ -23,7 +17,7 @@ Your teaching qualifications and experience will be assessed against strict requ
 We assess 90 per cent of applications within 12 months.
 
 Information correct as of July 2024. Timelines are based on total applications completed since February 2023.
- 
+
 It may take longer if we need to ask for further information or if external factors, or third parties, cause delays. This includes waiting for references, or verification of qualifications or professional standing. The time it takes to assess applications is regularly reviewed and subject to change.
 
 We will contact you with a decision about your QTS application when the assessment and all verifications have been completed. We will not be able to give individual updates on the status of your application while it is being assessed.

--- a/app/views/teacher_mailer/initial_checks_required.text.erb
+++ b/app/views/teacher_mailer/initial_checks_required.text.erb
@@ -1,0 +1,15 @@
+Dear <%= application_form_full_name(@application_form) %>,
+
+# We’ve received your application for qualfied teacher status (QTS) in England
+
+<%= render "shared/teacher_mailer/reference_number" %>
+
+# What happens next
+
+We need to carry out some initial checks on your application. We will email you to let you know if your application passes these initial checks.
+
+If initial checks are passed you will need to request a <%= region_certificate_name(@application_form.region) %> from <%= region_teaching_authority_name_phrase(@application_form.region) %>.
+
+Do not request your <%= region_certificate_name(@application_form.region) %> until you have received confirmation from us. You do not need to contact us.
+
+<%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/professional_standing_received.text.erb
+++ b/app/views/teacher_mailer/professional_standing_received.text.erb
@@ -1,16 +1,26 @@
 Dear <%= application_form_full_name(@application_form) %>,
 
-# We’ve received your <%= region_certificate_name(@application_form.region) %>
+We’ve received and checked your <%= region_certificate_name(@application_form.region) %> from <%= region_teaching_authority_name_phrase(@application_form.region) %>. This has been attached to your application.
 
-We have received your <%= region_certificate_name(@application_form.region) %> from <%= region_teaching_authority_name_phrase(@application_form.region) %> and attached it to your application.
+<%= render "shared/teacher_mailer/reference_number" %>
 
 # What happens next
 
-Your application will be entered into a queue and assigned a QTS assessor. This can take several weeks.
+Your application will be assessed by a trained assessor. They will check all the information you have submitted. Some information may need verification by third parties.
 
-Once assigned, an assessor will review your application. If we need more information, we'll email you.
+If we need more information, we will email you. You do not need to contact us.
 
-We will contact you with a decision about your QTS application when the assessment and all verifications have been completed.
+# How long will it take?
+
+Your teaching qualifications and experience will be assessed against strict requirements. These requirements are mandatory and must be met in full. The process is designed to ensure we only award QTS to the highest quality teachers. Your application will be assessed as soon as possible, but it can take time.
+
+We assess 90 per cent of applications within 12 months.
+
+Information correct as of July 2024. Timelines are based on total applications completed since February 2023.
+
+It may take longer if we need to ask for further information or if external factors, or third parties, cause delays. This includes waiting for references, or verification of qualifications or professional standing. The time it takes to assess applications is regularly reviewed and subject to change.
+
+We will contact you with a decision about your QTS application when the assessment and all verifications have been completed. We will not be able to give individual updates on the status of your application while it is being assessed.
 
 <%= render "shared/teacher_mailer/any_questions_contact" %>
 

--- a/app/views/teacher_mailer/professional_standing_requested.text.erb
+++ b/app/views/teacher_mailer/professional_standing_requested.text.erb
@@ -1,0 +1,53 @@
+Dear <%= application_form_full_name(@application_form) %>,
+
+<% if @application_form.requires_preliminary_check %>
+# Your application has passed initial checks
+<% else %>
+# We’ve received your application for qualfied teacher status (QTS) in England
+<% end %>
+
+<%= render "shared/teacher_mailer/reference_number" %>
+
+You must now get your <%= region_certificate_name(@application_form.region) %> from <%= region_teaching_authority_name_phrase(@application_form.region) %>. Your application cannot progress until we have received it.
+
+# What you need to do
+
+Email <%= region_teaching_authority_emails_phrase(@application_form.region) %> and ask them to send your <%= region_certificate_name(@application_form.region) %> directly to us at [<%= t("service.email.verification") %>](mailto:<%= t("service.email.verification") %>).
+
+You cannot send it yourself.
+
+<% if @application_form.region.status_check_online? %>
+<% if @application_form.region.status_information.present? %>
+<%= @application_form.region.status_information %>
+<% end %>
+
+<% if @application_form.region.country.status_information.present? %>
+<%= @application_form.region.country.status_information %>
+<% end %>
+<% end %>
+
+<% if @application_form.region.sanction_check_online? %>
+<% if @application_form.region.sanction_information.present? %>
+<%= @application_form.region.sanction_information %>
+<% end %>
+
+<% if @application_form.region.country.sanction_information.present? %>
+<%= @application_form.region.country.sanction_information %>
+<% end %>
+<% end %>
+
+<% if @application_form.region.other_information.present? %>
+<%= @application_form.region.other_information %>
+<% end %>
+
+<% if @application_form.region.country.other_information.present? %>
+<%= @application_form.region.country.other_information %>
+<% end %>
+
+# What happens next
+
+Once the <%= region_certificate_name(@application_form.region) %> is received and checked, your application will be assessed by a trained assessor. They will check all the information you have submitted. Some information may need verification by third parties.
+
+<%= render "shared/teacher_mailer/any_questions_contact" %>
+
+<%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teacher_mailer/professional_standing_requested.text.erb
+++ b/app/views/teacher_mailer/professional_standing_requested.text.erb
@@ -12,7 +12,7 @@ You must now get your <%= region_certificate_name(@application_form.region) %> f
 
 # What you need to do
 
-Email <%= region_teaching_authority_emails_phrase(@application_form.region) %> and ask them to send your <%= region_certificate_name(@application_form.region) %> directly to us at [<%= t("service.email.verification") %>](mailto:<%= t("service.email.verification") %>).
+Email <%= @application_form.region.teaching_authority_emails.map { |email| "[#{email}](mailto:#{email})" }.to_sentence %> and ask them to send your <%= region_certificate_name(@application_form.region) %> directly to us at [<%= t("service.email.verification") %>](mailto:<%= t("service.email.verification") %>).
 
 You cannot send it yourself.
 

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -34,8 +34,6 @@ en:
         subject: "Your QTS application: More information needed"
       further_information_reminder:
         subject: "Your QTS application: information still needed"
-      initial_checks_passed:
-        subject: "Your QTS application: Initial checks passed"
       initial_checks_required:
         subject: "Your QTS application: Initial checks required"
       professional_standing_received:

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -36,8 +36,12 @@ en:
         subject: "Your QTS application: information still needed"
       initial_checks_passed:
         subject: "Your QTS application: Initial checks passed"
+      initial_checks_required:
+        subject: "Your QTS application: Initial checks required"
       professional_standing_received:
         subject: "Your QTS application: %{certificate} received"
+      professional_standing_requested:
+        subject: "Your QTS application: Request your %{certificate}"
       references_requested:
         subject: We’ve contacted your references – QTS application
       references_reminder:

--- a/spec/lib/country_name_spec.rb
+++ b/spec/lib/country_name_spec.rb
@@ -59,6 +59,29 @@ RSpec.describe CountryName do
     end
   end
 
+  describe "#from_region_with_country" do
+    subject(:name) do
+      described_class.from_region_with_country(region, with_definite_article:)
+    end
+
+    let(:region) { create(:region, :national, country:) }
+    let(:with_definite_article) { false }
+
+    it { is_expected.to eq("United States") }
+
+    context "with definite article" do
+      let(:with_definite_article) { true }
+
+      it { is_expected.to eq("the United States") }
+    end
+
+    context "with a region name" do
+      before { region.update!(name: "California") }
+
+      it { is_expected.to eq("California, United States") }
+    end
+  end
+
   describe "#from_eligibility_check" do
     subject(:name) do
       described_class.from_eligibility_check(

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -515,6 +515,36 @@ RSpec.describe TeacherMailer, type: :mailer do
     end
   end
 
+  describe "#initial_checks_required" do
+    subject(:mail) do
+      described_class.with(application_form:).initial_checks_required
+    end
+
+    describe "#subject" do
+      subject { mail.subject }
+
+      it { is_expected.to eq("Your QTS application: Initial checks required") }
+    end
+
+    describe "#to" do
+      subject(:to) { mail.to }
+
+      it { is_expected.to eq(["teacher@example.com"]) }
+    end
+
+    describe "#body" do
+      subject(:body) { mail.body }
+
+      it { is_expected.to include("Dear First Last") }
+
+      it do
+        expect(subject).to include(
+          "We need to carry out some initial checks on your application",
+        )
+      end
+    end
+  end
+
   describe "#professional_standing_received" do
     subject(:mail) do
       described_class.with(application_form:).professional_standing_received
@@ -546,6 +576,50 @@ RSpec.describe TeacherMailer, type: :mailer do
           "We have received your Letter of Professional Standing from the teaching " \
             "authority and attached it to your application.",
         )
+      end
+    end
+  end
+
+  describe "#professional_standing_requested" do
+    subject(:mail) do
+      described_class.with(application_form:).professional_standing_requested
+    end
+
+    describe "#subject" do
+      subject { mail.subject }
+
+      it do
+        expect(subject).to eq(
+          "Your QTS application: Request your Letter of Professional Standing",
+        )
+      end
+    end
+
+    describe "#to" do
+      subject(:to) { mail.to }
+
+      it { is_expected.to eq(["teacher@example.com"]) }
+    end
+
+    describe "#body" do
+      subject(:body) { mail.body }
+
+      it { is_expected.to include("Dear First Last") }
+
+      it do
+        expect(subject).to include(
+          "We’ve received your application for qualfied teacher status (QTS) in England",
+        )
+      end
+
+      context "when the application had required preliminary checks" do
+        before { application_form.update!(requires_preliminary_check: true) }
+
+        it do
+          expect(subject).to include(
+            "Your application has passed initial checks",
+          )
+        end
       end
     end
   end

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -252,36 +252,6 @@ RSpec.describe TeacherMailer, type: :mailer do
             "information you have submitted.",
         )
       end
-
-      context "if the teaching authority provides the written statement" do
-        before do
-          application_form.update!(
-            teaching_authority_provides_written_statement: true,
-          )
-        end
-
-        it do
-          expect(subject).to include(
-            "Once the written evidence is received and checked, your application " \
-              "will be assessed by a trained assessor.",
-          )
-        end
-      end
-
-      context "if the teaching authority does not provide the written statement" do
-        before do
-          application_form.update!(
-            teaching_authority_provides_written_statement: false,
-          )
-        end
-
-        it do
-          expect(subject).to include(
-            "Your application will be assessed by a trained assessor. They will check all the " \
-              "information you have submitted.",
-          )
-        end
-      end
     end
   end
 
@@ -573,8 +543,8 @@ RSpec.describe TeacherMailer, type: :mailer do
 
       it do
         expect(subject).to include(
-          "We have received your Letter of Professional Standing from the teaching " \
-            "authority and attached it to your application.",
+          "We’ve received and checked your Letter of Professional Standing from the teaching " \
+            "authority. This has been attached to your application.",
         )
       end
     end

--- a/spec/models/professional_standing_request_spec.rb
+++ b/spec/models/professional_standing_request_spec.rb
@@ -67,6 +67,134 @@ RSpec.describe ProfessionalStandingRequest, type: :model do
     end
   end
 
+  describe "#after_requested" do
+    subject(:after_requested) do
+      professional_standing_request.after_requested(user:)
+    end
+
+    let(:user) { create(:staff) }
+
+    let(:professional_standing_request) do
+      create(
+        :professional_standing_request,
+        assessment:
+          create(
+            :assessment,
+            application_form:
+              create(
+                :application_form,
+                :with_teaching_qualification,
+                declined ? :declined : :submitted,
+                teaching_authority_provides_written_statement:,
+                date_of_birth: 30.years.ago.to_date,
+              ),
+          ),
+      )
+    end
+
+    describe "when teaching authority provides the written statement and application form is declined" do
+      let(:teaching_authority_provides_written_statement) { true }
+      let(:declined) { true }
+
+      it "doesn't send an email" do
+        expect { after_requested }.not_to have_enqueued_mail(
+          TeacherMailer,
+          :professional_standing_requested,
+        )
+      end
+
+      it "doesn't send an email to teaching authority" do
+        expect { after_requested }.not_to have_enqueued_mail(
+          TeachingAuthorityMailer,
+          :application_submitted,
+        )
+      end
+    end
+
+    describe "when teaching authority provides the written statement and application form is not declined" do
+      let(:teaching_authority_provides_written_statement) { true }
+      let(:declined) { false }
+
+      it "sends an email" do
+        expect { after_requested }.to have_enqueued_mail(
+          TeacherMailer,
+          :professional_standing_requested,
+        )
+      end
+
+      it "doesn't send an email to teaching authority" do
+        expect { after_requested }.not_to have_enqueued_mail(
+          TeachingAuthorityMailer,
+          :application_submitted,
+        )
+      end
+
+      context "when teaching authority requires the email" do
+        before do
+          professional_standing_request
+            .assessment
+            .application_form
+            .region
+            .update!(
+            teaching_authority_requires_submission_email: true,
+            teaching_authority_emails: ["test@ta.example"],
+          )
+        end
+
+        it "queues an email job for teaching authority mailer" do
+          expect { after_requested }.to have_enqueued_mail(
+            TeachingAuthorityMailer,
+            :application_submitted,
+          ).with(
+            params: {
+              application_form:
+                professional_standing_request.assessment.application_form,
+            },
+            args: [],
+          )
+        end
+      end
+    end
+
+    describe "when teaching authority doesn't provide the written statement and application form is declined" do
+      let(:teaching_authority_provides_written_statement) { false }
+      let(:declined) { true }
+
+      it "doesn't send an email" do
+        expect { after_requested }.not_to have_enqueued_mail(
+          TeacherMailer,
+          :professional_standing_requested,
+        )
+      end
+
+      it "doesn't send an email to teaching authority" do
+        expect { after_requested }.not_to have_enqueued_mail(
+          TeachingAuthorityMailer,
+          :application_submitted,
+        )
+      end
+    end
+
+    describe "when teaching authority doesn't provide the written statement and application form is not declined" do
+      let(:teaching_authority_provides_written_statement) { false }
+      let(:declined) { false }
+
+      it "doesn't send an email" do
+        expect { after_requested }.not_to have_enqueued_mail(
+          TeacherMailer,
+          :professional_standing_requested,
+        )
+      end
+
+      it "doesn't send an email to teaching authority" do
+        expect { after_requested }.not_to have_enqueued_mail(
+          TeachingAuthorityMailer,
+          :application_submitted,
+        )
+      end
+    end
+  end
+
   describe "#after_received" do
     subject(:after_received) do
       professional_standing_request.after_received(user:)

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -259,23 +259,6 @@ RSpec.describe SubmitApplicationForm do
       )
     end
 
-    context "when teaching authority requires the email" do
-      let(:region) do
-        create(
-          :region,
-          teaching_authority_emails: ["authority@example.com"],
-          teaching_authority_requires_submission_email: true,
-        )
-      end
-
-      it "queues an email job for teaching authority mailer" do
-        expect { call }.to have_enqueued_mail(
-          TeachingAuthorityMailer,
-          :application_submitted,
-        ).with(params: { application_form: }, args: [])
-      end
-    end
-
     context "when teaching authority provides the written statement" do
       before do
         region.update!(requires_preliminary_check: false)

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe SubmitApplicationForm do
     end
   end
 
-  describe "sending application submitted email" do
+  describe "sending application submitted email to teaching authority" do
     it "doesn't queue an email job" do
       expect { call }.not_to have_enqueued_mail(
         TeachingAuthorityMailer,
@@ -232,11 +232,35 @@ RSpec.describe SubmitApplicationForm do
         )
       end
 
-      it "enqueues an initial checks email job" do
-        expect { call }.to have_enqueued_mail(
-          TeacherMailer,
-          :initial_checks_passed,
-        ).with(params: { application_form: }, args: [])
+      it "generates a professional standing request" do
+        expect {
+          call
+        }.to change(ProfessionalStandingRequest, :count).by(1)
+      end
+
+      it "marks the professional standing request as requested" do
+        call
+
+        expect(
+          application_form.assessment.reload.professional_standing_request.requested_at
+        ).not_to be_nil
+      end
+
+      context "with the application form a requiring preliminary check" do
+        before do
+          region.update!(requires_preliminary_check: true)
+          application_form.update!(
+            requires_preliminary_check: true,
+          )
+        end
+
+        it "does not mark the professional standing request as requested" do
+          call
+
+          expect(
+            application_form.assessment.reload.professional_standing_request.requested_at
+          ).to be_nil
+        end
       end
     end
   end

--- a/spec/services/submit_application_form_spec.rb
+++ b/spec/services/submit_application_form_spec.rb
@@ -233,32 +233,36 @@ RSpec.describe SubmitApplicationForm do
       end
 
       it "generates a professional standing request" do
-        expect {
-          call
-        }.to change(ProfessionalStandingRequest, :count).by(1)
+        expect { call }.to change(ProfessionalStandingRequest, :count).by(1)
       end
 
       it "marks the professional standing request as requested" do
         call
 
         expect(
-          application_form.assessment.reload.professional_standing_request.requested_at
+          application_form
+            .assessment
+            .reload
+            .professional_standing_request
+            .requested_at,
         ).not_to be_nil
       end
 
       context "with the application form a requiring preliminary check" do
         before do
           region.update!(requires_preliminary_check: true)
-          application_form.update!(
-            requires_preliminary_check: true,
-          )
+          application_form.update!(requires_preliminary_check: true)
         end
 
         it "does not mark the professional standing request as requested" do
           call
 
           expect(
-            application_form.assessment.reload.professional_standing_request.requested_at
+            application_form
+              .assessment
+              .reload
+              .professional_standing_request
+              .requested_at,
           ).to be_nil
         end
       end

--- a/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
+++ b/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Assessor pre-assessment tasks", type: :system do
     and_i_choose_yes_to_both_questions
     then_i_see_the(:assessor_application_page, reference:)
     and_i_see_a_completed_preliminary_check_task
-    and_the_teacher_receives_a_checks_passed_email
+    and_the_teacher_receives_a_request_your_lops_email
     and_the_assessor_is_unassigned
 
     when_i_visit_the(:assessor_application_page, reference:)
@@ -142,10 +142,10 @@ RSpec.describe "Assessor pre-assessment tasks", type: :system do
     ).to have_content("Waiting on")
   end
 
-  def and_the_teacher_receives_a_checks_passed_email
+  def and_the_teacher_receives_a_request_your_lops_email
     expect(TeacherMailer.deliveries.count).to eq(1)
     expect(TeacherMailer.deliveries.first.subject).to eq(
-      I18n.t("mailer.teacher.initial_checks_passed.subject"),
+      "Your QTS application: Request your Letter of Professional Standing",
     )
   end
 

--- a/spec/system/teacher_interface/submitting_spec.rb
+++ b/spec/system/teacher_interface/submitting_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Teacher submitting", type: :system do
       when_i_confirm_i_have_no_sanctions
       then_i_see_the(:teacher_submitted_application_page)
       and_i_see_the_submitted_application_information_with_preliminary_check_pending
-      and_i_receive_an_application_email_to_request_lops
+      and_i_receive_an_application_email_for_initial_checks_required
     end
   end
 
@@ -175,7 +175,17 @@ RSpec.describe "Teacher submitting", type: :system do
     expect(message).not_to be_nil
 
     expect(message.subject).to eq(
-      "Your QTS application: Awaiting Letter of Professional Standing",
+      "Your QTS application: Request your Letter of Professional Standing",
+    )
+    expect(message.to).to include("teacher@example.com")
+  end
+
+  def and_i_receive_an_application_email_for_initial_checks_required
+    message = ActionMailer::Base.deliveries.last
+    expect(message).not_to be_nil
+
+    expect(message.subject).to eq(
+      "Your QTS application: Initial checks required",
     )
     expect(message.to).to include("teacher@example.com")
   end

--- a/spec/system/teacher_interface/submitting_spec.rb
+++ b/spec/system/teacher_interface/submitting_spec.rb
@@ -3,6 +3,22 @@
 require "rails_helper"
 
 RSpec.describe "Teacher submitting", type: :system do
+  let(:application_form) do
+    create(
+      :application_form,
+      :with_personal_information,
+      :with_identification_document,
+      :with_teaching_qualification,
+      :with_age_range,
+      :with_subjects,
+      :with_english_language_provider,
+      :with_work_history,
+      :with_written_statement,
+      :with_registration_number,
+      teacher:,
+    )
+  end
+
   before do
     given_i_am_authorized_as_a_user(teacher)
     given_there_is_an_application_form
@@ -19,6 +35,73 @@ RSpec.describe "Teacher submitting", type: :system do
     then_i_see_the(:teacher_submitted_application_page)
     and_i_see_the_submitted_application_information
     and_i_receive_an_application_email
+  end
+
+  context "when from country requiring written statement from teaching authority" do
+    let(:application_form) do
+      create(
+        :application_form,
+        :teaching_authority_provides_written_statement,
+        :with_personal_information,
+        :with_identification_document,
+        :with_teaching_qualification,
+        :with_age_range,
+        :with_subjects,
+        :with_english_language_provider,
+        :with_work_history,
+        :with_written_statement,
+        :with_registration_number,
+        teacher:,
+      )
+    end
+
+    it "submits" do
+      when_i_visit_the(:teacher_application_page)
+      then_i_see_the(:teacher_application_page)
+
+      when_i_click_check_your_answers
+      then_i_see_the(:teacher_check_your_answers_page)
+
+      when_i_confirm_i_have_no_sanctions
+      then_i_see_the(:teacher_submitted_application_page)
+      and_i_see_the_submitted_application_information_with_lops_pending
+      and_i_receive_an_application_email_to_request_lops
+    end
+  end
+
+  context "when from country requiring written statement from teaching authority and preliminary check" do
+    let(:application_form) do
+      create(
+        :application_form,
+        :teaching_authority_provides_written_statement,
+        :requires_preliminary_check,
+        :with_personal_information,
+        :with_identification_document,
+        :with_teaching_qualification,
+        :with_age_range,
+        :with_subjects,
+        :with_english_language_provider,
+        :with_work_history,
+        :with_written_statement,
+        :with_registration_number,
+        teacher:,
+      )
+    end
+
+    before { application_form.region.update(requires_preliminary_check: true) }
+
+    it "submits" do
+      when_i_visit_the(:teacher_application_page)
+      then_i_see_the(:teacher_application_page)
+
+      when_i_click_check_your_answers
+      then_i_see_the(:teacher_check_your_answers_page)
+
+      when_i_confirm_i_have_no_sanctions
+      then_i_see_the(:teacher_submitted_application_page)
+      and_i_see_the_submitted_application_information_with_preliminary_check_pending
+      and_i_receive_an_application_email_to_request_lops
+    end
   end
 
   def given_there_is_an_application_form
@@ -54,6 +137,31 @@ RSpec.describe "Teacher submitting", type: :system do
     )
   end
 
+  def and_i_see_the_submitted_application_information_with_lops_pending
+    expect(teacher_submitted_application_page).to have_content(
+      "Application submitted",
+    )
+    expect(teacher_submitted_application_page).to have_content(
+      "Application reference number: #{application_form.reference}",
+    )
+    expect(teacher_submitted_application_page).to have_content(
+      "You must now get your Letter of Professional Standing from the teaching authority.",
+    )
+  end
+
+  def and_i_see_the_submitted_application_information_with_preliminary_check_pending
+    expect(teacher_submitted_application_page).to have_content(
+      "Application submitted",
+    )
+    expect(teacher_submitted_application_page).to have_content(
+      "Application reference number: #{application_form.reference}",
+    )
+    expect(teacher_submitted_application_page).to have_content(
+      "We need to carry out some initial checks on your application. " \
+        "We will email you to let you know if your application passes these initial checks.",
+    )
+  end
+
   def and_i_receive_an_application_email
     message = ActionMailer::Base.deliveries.last
     expect(message).not_to be_nil
@@ -62,24 +170,17 @@ RSpec.describe "Teacher submitting", type: :system do
     expect(message.to).to include("teacher@example.com")
   end
 
-  def teacher
-    @teacher ||= create(:teacher, email: "teacher@example.com")
+  def and_i_receive_an_application_email_to_request_lops
+    message = ActionMailer::Base.deliveries.last
+    expect(message).not_to be_nil
+
+    expect(message.subject).to eq(
+      "Your QTS application: Awaiting Letter of Professional Standing",
+    )
+    expect(message.to).to include("teacher@example.com")
   end
 
-  def application_form
-    @application_form ||=
-      create(
-        :application_form,
-        :with_personal_information,
-        :with_identification_document,
-        :with_teaching_qualification,
-        :with_age_range,
-        :with_subjects,
-        :with_english_language_provider,
-        :with_work_history,
-        :with_written_statement,
-        :with_registration_number,
-        teacher:,
-      )
+  def teacher
+    @teacher ||= create(:teacher, email: "teacher@example.com")
   end
 end

--- a/spec/system/teacher_interface/submitting_spec.rb
+++ b/spec/system/teacher_interface/submitting_spec.rb
@@ -88,7 +88,12 @@ RSpec.describe "Teacher submitting", type: :system do
       )
     end
 
-    before { application_form.region.update(requires_preliminary_check: true) }
+    before do
+      application_form.region.update(
+        teaching_authority_provides_written_statement: true,
+        requires_preliminary_check: true,
+      )
+    end
 
     it "submits" do
       when_i_visit_the(:teacher_application_page)

--- a/spec/views/shared/eligible_region_content_spec.rb
+++ b/spec/views/shared/eligible_region_content_spec.rb
@@ -164,4 +164,55 @@ RSpec.describe "Eligible region content", type: :view do
       end
     end
   end
+
+  context "with letter of professional standing provided by teaching authority" do
+    let(:region) do
+      create(
+        :region,
+        :written_checks,
+        teaching_authority_provides_written_statement: true,
+      )
+    end
+
+    it do
+      expect(subject).to match(/To prove you are recognised as a teacher in/)
+      expect(subject).to match(/You cannot send it yourself./)
+
+      expect(subject).to match(
+        /Do this after you have submitted your application, as you will need your application reference number./,
+      )
+
+      expect(subject).not_to match(
+        /Do not request your Letter of Professional Standing/,
+      )
+      expect(subject).not_to match(
+        /We will need to carry out initial checks on your application./,
+      )
+    end
+
+    context "when the region requires preliminary checks" do
+      let(:region) do
+        create :region,
+               :written_checks,
+               :requires_preliminary_check,
+               teaching_authority_provides_written_statement: true
+      end
+
+      it do
+        expect(subject).to match(/To prove you are recognised as a teacher in/)
+        expect(subject).to match(/You cannot send it yourself./)
+
+        expect(subject).to match(
+          /Do not request your Letter of Professional Standing/,
+        )
+        expect(subject).to match(
+          /We will need to carry out initial checks on your application./,
+        )
+
+        expect(subject).not_to match(
+          /Do this after you have submitted your application, as you will need your application reference number./,
+        )
+      end
+    end
+  end
 end

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
     end
 
     it do
-      is_expected.to match(
+      expect(subject).to match(
         /We need your written consent to verify some of your qualifications/,
       )
     end
@@ -56,7 +56,7 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
     let(:application_form) { create(:application_form) }
 
     it do
-      is_expected.to match(/Applications must be completed within 6 months/)
+      expect(subject).to match(/Applications must be completed within 6 months/)
     end
   end
 

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -94,6 +94,9 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
       end
 
       before do
+        application_form.region.update!(
+          teaching_authority_provides_written_statement: true,
+        )
         create(
           :assessment_section,
           :preliminary,
@@ -136,6 +139,26 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
         )
       end
     end
+  end
+
+  context "when requiring preliminary check" do
+    let(:application_form) do
+      create :application_form,
+             :with_assessment,
+             :requires_preliminary_check,
+             :submitted
+    end
+
+    before do
+      create(
+        :assessment_section,
+        :preliminary,
+        assessment: application_form.assessment,
+      )
+    end
+
+    it { is_expected.to match(/Application received/) }
+    it { is_expected.to match(/We’ve received your application for QTS/) }
   end
 
   context "when from ineligible country" do

--- a/spec/views/teacher_interface/application_forms_show_spec.rb
+++ b/spec/views/teacher_interface/application_forms_show_spec.rb
@@ -15,14 +15,17 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
 
   context "when request further information" do
     let(:application_form) { create(:application_form, :submitted) }
-    let!(:further_information_request) do
-      create(:requested_further_information_request, application_form:)
+
+    context "with the requested consent request not received" do
+      before do
+        create(:requested_further_information_request, application_form:)
+      end
+
+      it { is_expected.to match(/We need some more information/) }
     end
 
-    it { is_expected.to match(/We need some more information/) }
-
     context "with the requested consent request received" do
-      let!(:further_information_request) do
+      before do
         create(:received_further_information_request, application_form:)
       end
 
@@ -33,20 +36,18 @@ RSpec.describe "teacher_interface/application_forms/show.html.erb",
   context "when request qualification consent" do
     let(:application_form) { create(:application_form, :submitted) }
 
-    let!(:consent_request) do
-      create :requested_consent_request, application_form:
-    end
+    context "with the requested consent request not received" do
+      before { create :requested_consent_request, application_form: }
 
-    it do
-      expect(subject).to match(
-        /We need your written consent to verify some of your qualifications/,
-      )
+      it do
+        expect(subject).to match(
+          /We need your written consent to verify some of your qualifications/,
+        )
+      end
     end
 
     context "with the requested consent request received" do
-      let!(:consent_request) do
-        create :received_consent_request, application_form:
-      end
+      before { create :received_consent_request, application_form: }
 
       it { is_expected.to match(/Consent documents successfully submitted/) }
     end


### PR DESCRIPTION
1. Update the UI and copy for applicants requiring Letter of Professional Standing (Alberta Canada, Hong Kong and Nigeria) in addition to any one of the requiring preliminary checks (Nigeria).
2. Remove a bug where "initial checks passed" email was sent to countries who didn't require any checks.
3. Update the email journey and copy for LoPS and Preliminary check journey.


https://dfedigital.atlassian.net/browse/AQTS-585
https://dfedigital.atlassian.net/browse/AQTS-591