### PR TITLE
[AQTS-600] Assessor interface age range validations

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
@@ -59,9 +59,11 @@ module AssessorInterface
           assessment:,
           age_range_min: assessment.age_range_min,
           age_range_max: assessment.age_range_max,
+          age_range_note: assessment.age_range_note,
           subject_1: assessment.subjects.first,
           subject_2: assessment.subjects.second,
           subject_3: assessment.subjects.third,
+          subjects_note: assessment.subjects_note,
         )
     end
 

--- a/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
+++ b/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
@@ -67,7 +67,7 @@ module AssessorInterface::AgeRangeSubjectsForm
 
   private
 
-  delegate :application_form, to: :assessment, allow_nil: true
+  delegate :application_form, to: :assessment
 
   def age_range_changed_from_application_form?
     return unless assessment

--- a/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
+++ b/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
@@ -19,6 +19,7 @@ module AssessorInterface::AgeRangeSubjectsForm
               presence: true,
               numericality: {
                 only_integer: true,
+                less_than_or_equal_to: 19,
                 greater_than_or_equal_to: :age_range_min,
                 allow_nil: true,
               }

--- a/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
+++ b/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
@@ -8,6 +8,7 @@ module AssessorInterface::AgeRangeSubjectsForm
     attribute :age_range_max, :integer
     attribute :age_range_note, :string
 
+    validates :age_range_note, presence: true, if: :age_range_changed_from_application_form?
     validates :age_range_min,
               presence: true,
               numericality: {
@@ -60,5 +61,16 @@ module AssessorInterface::AgeRangeSubjectsForm
     end
 
     true
+  end
+
+  private
+
+  delegate :application_form, to: :assessment, allow_nil: true
+
+  def age_range_changed_from_application_form?
+    return unless assessment
+
+    application_form.age_range_min != age_range_min ||
+      application_form.age_range_max != age_range_max
   end
 end

--- a/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
+++ b/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
@@ -8,7 +8,9 @@ module AssessorInterface::AgeRangeSubjectsForm
     attribute :age_range_max, :integer
     attribute :age_range_note, :string
 
-    validates :age_range_note, presence: true, if: :age_range_changed_from_application_form?
+    validates :age_range_note,
+              presence: true,
+              if: :age_range_changed_from_application_form?
     validates :age_range_min,
               presence: true,
               numericality: {

--- a/app/views/shared/_age_range_subjects_form_fields.html.erb
+++ b/app/views/shared/_age_range_subjects_form_fields.html.erb
@@ -1,5 +1,7 @@
 <%= f.govuk_fieldset legend: { text: "What age range is the applicant qualified to teach?" } do %>
-  <p class="govuk-body">Based on the evidence the applicant has provided, you can either copy the age range they entered if you agree, or enter a new range.</p>
+  <p class="govuk-body">You can edit the age range below if:</p>
+  <p class="govuk-body">- based on evidence, you do not agree with the age range the applicant has submitted</p>
+  <p class="govuk-body">- the 'To' age is greater than 19 and will not be accepted by DQT</p>
 
   <%= f.govuk_number_field :age_range_min, width: 3 %>
   <%= f.govuk_number_field :age_range_max, width: 3 %>

--- a/app/views/shared/_age_range_subjects_form_fields.html.erb
+++ b/app/views/shared/_age_range_subjects_form_fields.html.erb
@@ -1,7 +1,10 @@
 <%= f.govuk_fieldset legend: { text: "What age range is the applicant qualified to teach?" } do %>
   <p class="govuk-body">You can edit the age range below if:</p>
-  <p class="govuk-body">- based on evidence, you do not agree with the age range the applicant has submitted</p>
-  <p class="govuk-body">- the 'To' age is greater than 19 and will not be accepted by DQT</p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li>based on evidence, you do not agree with the age range the applicant has submitted</li>
+    <li>the 'To' age is greater than 19 and will not be accepted by DQT</li>
+  </ul>
 
   <%= f.govuk_number_field :age_range_min, width: 3 %>
   <%= f.govuk_number_field :age_range_max, width: 3 %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -348,6 +348,11 @@ en:
               blank: Enter a note to the applicant
             written_statement_recent_notes:
               blank: Enter a note to the applicant
+        assessor_interface/check_age_range_subjects_form:
+          attributes:
+            age_range_max:
+              less_than_or_equal_to: We cannot accept an age greater than 19
+              greater_than_or_equal_to: ‘To’ must be greater than ‘From’
         assessor_interface/confirm_age_range_subjects_form:
           attributes:
             age_range_min:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -350,15 +350,24 @@ en:
               blank: Enter a note to the applicant
         assessor_interface/check_age_range_subjects_form:
           attributes:
+            age_range_min:
+              blank: Enter the minimum age
             age_range_max:
+              blank: Enter the maximum age
               less_than_or_equal_to: We cannot accept an age greater than 19
               greater_than_or_equal_to: ‘To’ must be greater than ‘From’
+            age_range_note:
+              blank: Explain why you have entered a new age range
         assessor_interface/confirm_age_range_subjects_form:
           attributes:
             age_range_min:
               blank: Enter the minimum age
             age_range_max:
               blank: Enter the maximum age
+              less_than_or_equal_to: We cannot accept an age greater than 19
+              greater_than_or_equal_to: ‘To’ must be greater than ‘From’
+            age_range_note:
+              blank: Explain why you have entered a new age range
             subject_1:
               blank: Enter the subject
         assessor_interface/consent_method_form:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -92,7 +92,7 @@ en:
       assessor_interface_assessment_section_form:
         age_range_max: To
         age_range_min: From
-        age_range_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> If you''ve entered a new range please explain why (optional)'
+        age_range_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> If you''ve entered a new range please explain why'
         failure_reason_notes:
           decline: Note to the applicant (optional)
           document: Note to the applicant
@@ -112,7 +112,7 @@ en:
       assessor_interface_confirm_age_range_subjects_form:
         age_range_min: From
         age_range_max: To
-        age_range_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> If you''ve entered a new range please explain why (optional)'
+        age_range_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> If you''ve entered a new range please explain why'
         subject_1: Subject 1
         subject_2: Subject 2 (optional)
         subject_3: Subject 3 (optional)

--- a/spec/forms/assessor_interface/check_age_range_subjects_form_spec.rb
+++ b/spec/forms/assessor_interface/check_age_range_subjects_form_spec.rb
@@ -27,12 +27,4 @@ RSpec.describe AssessorInterface::CheckAgeRangeSubjectsForm, type: :model do
     it { is_expected.to validate_presence_of(:user) }
     it { is_expected.to allow_values(true, false).for(:passed) }
   end
-
-  describe "#save" do
-    subject(:save) { form.save }
-
-    describe "when invalid attributes" do
-      it { is_expected.to be false }
-    end
-  end
 end

--- a/spec/forms/assessor_interface/check_age_range_subjects_form_spec.rb
+++ b/spec/forms/assessor_interface/check_age_range_subjects_form_spec.rb
@@ -21,10 +21,4 @@ RSpec.describe AssessorInterface::CheckAgeRangeSubjectsForm, type: :model do
     let(:assessment) { assessment_section.assessment }
     let(:attributes) { { passed: true } }
   end
-
-  describe "validations" do
-    it { is_expected.to validate_presence_of(:assessment_section) }
-    it { is_expected.to validate_presence_of(:user) }
-    it { is_expected.to allow_values(true, false).for(:passed) }
-  end
 end

--- a/spec/forms/assessor_interface/confirm_age_range_subjects_form_spec.rb
+++ b/spec/forms/assessor_interface/confirm_age_range_subjects_form_spec.rb
@@ -17,12 +17,4 @@ RSpec.describe AssessorInterface::ConfirmAgeRangeSubjectsForm, type: :model do
     it { is_expected.to validate_presence_of(:assessment) }
     it { is_expected.to validate_presence_of(:user) }
   end
-
-  describe "#save" do
-    subject(:save) { form.save }
-
-    describe "when invalid attributes" do
-      it { is_expected.to be false }
-    end
-  end
 end

--- a/spec/support/shared_examples/age_range_subjects_form.rb
+++ b/spec/support/shared_examples/age_range_subjects_form.rb
@@ -1,38 +1,47 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples_for "an age range subjects form" do
+  it { is_expected.to validate_presence_of(:age_range_min) }
+  it { is_expected.to validate_presence_of(:age_range_max) }
+
   describe "validations" do
-    it { is_expected.to validate_presence_of(:age_range_min) }
-    it { is_expected.to validate_presence_of(:age_range_max) }
+    let(:age_range_subjects_attributes) do
+      {
+        age_range_min: "5",
+        age_range_max: "16",
+        subject_1: "Subject",
+        subject_1_raw: "Subject",
+      }
+    end
 
     context "with a minimum too low" do
-      let(:age_range_subjects_attributes) { { age_range_min: "1" } }
+      before { age_range_subjects_attributes[:age_range_min] = "-1" }
 
       it { is_expected.to be_invalid }
     end
 
-    context "with a minimum too high" do
-      let(:age_range_subjects_attributes) { { age_range_min: "20" } }
+    context "with a minimum between 0 and 19" do
+      before { age_range_subjects_attributes[:age_range_min] = "8" }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "with a maximum lower than the minimum" do
+      before { age_range_subjects_attributes[:age_range_max] = "4" }
 
       it { is_expected.to be_invalid }
     end
 
-    context "when minimum is set" do
-      context "with a maximum too low" do
-        let(:age_range_subjects_attributes) do
-          { age_range_min: "7", age_range_max: "1" }
-        end
+    context "with a maximum greater than min but below 20" do
+      before { age_range_subjects_attributes[:age_range_max] = "19" }
 
-        it { is_expected.to be_invalid }
-      end
+      it { is_expected.to be_valid }
+    end
 
-      context "with a maximum too high" do
-        let(:age_range_subjects_attributes) do
-          { age_range_min: "7", age_range_max: "20" }
-        end
+    context "with a maximum too high" do
+      before { age_range_subjects_attributes[:age_range_max] = "20" }
 
-        it { is_expected.to be_invalid }
-      end
+      it { is_expected.to be_invalid }
     end
 
     it { is_expected.not_to validate_presence_of(:age_range_note) }

--- a/spec/support/shared_examples/age_range_subjects_form.rb
+++ b/spec/support/shared_examples/age_range_subjects_form.rb
@@ -9,9 +9,23 @@ RSpec.shared_examples_for "an age range subjects form" do
       {
         age_range_min: "5",
         age_range_max: "16",
+        age_range_note: "Note",
         subject_1: "Subject",
         subject_1_raw: "Subject",
       }
+    end
+
+    before do
+      assessment.application_form.update(age_range_min: 5, age_range_max: 16)
+    end
+
+    context "when the minimum has changed but a note has not been added" do
+      before do
+        age_range_subjects_attributes[:age_range_min] = "6"
+        age_range_subjects_attributes[:age_range_note] = ""
+      end
+
+      it { is_expected.to be_invalid }
     end
 
     context "with a minimum too low" do
@@ -24,6 +38,15 @@ RSpec.shared_examples_for "an age range subjects form" do
       before { age_range_subjects_attributes[:age_range_min] = "8" }
 
       it { is_expected.to be_valid }
+    end
+
+    context "when the maximum has changed but a note has not been added" do
+      before do
+        age_range_subjects_attributes[:age_range_max] = "18"
+        age_range_subjects_attributes[:age_range_note] = ""
+      end
+
+      it { is_expected.to be_invalid }
     end
 
     context "with a maximum lower than the minimum" do
@@ -56,6 +79,10 @@ RSpec.shared_examples_for "an age range subjects form" do
   describe "#save" do
     subject(:save) { form.save }
 
+    before do
+      assessment.application_form.update(age_range_min: 5, age_range_max: 16)
+    end
+
     describe "when invalid attributes" do
       it { is_expected.to be false }
     end
@@ -63,8 +90,8 @@ RSpec.shared_examples_for "an age range subjects form" do
     describe "with valid attributes and no note" do
       let(:age_range_subjects_attributes) do
         {
-          age_range_min: "7",
-          age_range_max: "11",
+          age_range_min: "5",
+          age_range_max: "16",
           subject_1: "Subject",
           subject_1_raw: "Subject",
         }
@@ -75,8 +102,8 @@ RSpec.shared_examples_for "an age range subjects form" do
       it "sets the attributes" do
         save # rubocop:disable Rails/SaveBang
 
-        expect(assessment.age_range_min).to eq(7)
-        expect(assessment.age_range_max).to eq(11)
+        expect(assessment.age_range_min).to eq(5)
+        expect(assessment.age_range_max).to eq(16)
         expect(assessment.age_range_note).to be_blank
 
         expect(assessment.subjects).to eq(%w[Subject])

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -217,6 +217,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
         :assessment,
         age_range_max: 11,
         age_range_min: 8,
+        age_range_note: "Explanation",
         application_form:,
         subjects: %w[mathematics],
       )


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/AQTS-600

This PR updates the copy for the ‘Verify age range and subjects’ page to meet new content requirements. Additionally, validation has been added to ensure that ages greater than 19 cannot be submitted and improved error messages.

1. Updating the copy on the age range subjects page.
2. Updating the validation for age range "To" to be no more than 19.
3. Updating the age range note to be present if it has been updated during the assessment.
4. Bug fix to ensure that any age range note and subject notes are visible on the award review of the age range and subjects.

![Screenshot 2024-10-08 at 14 18 18](https://github.com/user-attachments/assets/bb808525-3f2f-4eca-96cf-f1cc2a81b24a)
![Screenshot 2024-10-08 at 14 18 47](https://github.com/user-attachments/assets/0318604c-45c4-447b-ac85-c0556e6157d2)
![Screenshot 2024-10-08 at 14 22 18](https://github.com/user-attachments/assets/5c68f244-ead9-4f31-81e3-9e3da5140780)