### PR TITLE
AQTS-613 Support console validation for teaching authority email

### DIFF
--- a/app/forms/support_interface/region_form.rb
+++ b/app/forms/support_interface/region_form.rb
@@ -35,7 +35,7 @@ class SupportInterface::RegionForm
             presence: {
               message: "You must provide an email for the teaching authority.",
             },
-            if: -> { teaching_authority_requires_submission_email }
+            if: :teaching_authority_requires_submission_email
   validates :teaching_authority_name,
             format: {
               without: /\Athe.*\z/i,

--- a/app/forms/support_interface/region_form.rb
+++ b/app/forms/support_interface/region_form.rb
@@ -31,7 +31,11 @@ class SupportInterface::RegionForm
   validates :requires_preliminary_check, inclusion: { in: [true, false] }
   validates :sanction_check, inclusion: { in: %w[online written none] }
   validates :status_check, inclusion: { in: %w[online written none] }
-  validates :teaching_authority_emails_string, presence: true
+  validates :teaching_authority_emails_string,
+            presence: {
+              message: "You must provide an email for the teaching authority.",
+            },
+            if: -> { teaching_authority_requires_submission_email }
   validates :teaching_authority_name,
             format: {
               without: /\Athe.*\z/i,

--- a/app/forms/support_interface/region_form.rb
+++ b/app/forms/support_interface/region_form.rb
@@ -31,6 +31,7 @@ class SupportInterface::RegionForm
   validates :requires_preliminary_check, inclusion: { in: [true, false] }
   validates :sanction_check, inclusion: { in: %w[online written none] }
   validates :status_check, inclusion: { in: %w[online written none] }
+  validates :teaching_authority_emails_string, presence: true
   validates :teaching_authority_name,
             format: {
               without: /\Athe.*\z/i,

--- a/spec/forms/support_interface/region_form_spec.rb
+++ b/spec/forms/support_interface/region_form_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SupportInterface::RegionForm, type: :model do
+  describe "#valid?" do
+    subject(:valid) { form.valid? }
+
+    let(:region) { create(:region) }
+    let(:form) do
+      described_class.new(
+        teaching_authority_emails_string:,
+        region:,
+        teaching_authority_requires_submission_email:,
+        all_sections_necessary: true,
+        requires_preliminary_check: false,
+        sanction_check: "none",
+        status_check: "none",
+        teaching_authority_provides_written_statement: false,
+        written_statement_optional: true,
+      )
+    end
+
+    context "when teaching authority requires submission email" do
+      let(:teaching_authority_requires_submission_email) { true }
+
+      context "when teaching authority emails string is blank" do
+        let(:teaching_authority_emails_string) { "" }
+
+        it { is_expected.to be_falsey }
+
+        it "adds an error to the teaching_authority_emails_string field" do
+          subject
+          expect(form.errors[:teaching_authority_emails_string]).to include(
+            "You must provide an email for the teaching authority.",
+          )
+        end
+      end
+
+      context "when teaching authority emails string is not blank" do
+        let(:teaching_authority_emails_string) do
+          "test@test.com, test2@test.com"
+        end
+
+        it { is_expected.to be_truthy }
+      end
+    end
+
+    context "when teaching authority does not require submission email" do
+      let(:teaching_authority_requires_submission_email) { false }
+
+      context "when teaching authority emails string is blank" do
+        let(:teaching_authority_emails_string) { "" }
+
+        it { is_expected.to be_truthy }
+      end
+
+      context "when teaching authority emails string is not blank" do
+        let(:teaching_authority_emails_string) do
+          "test@test.com, test2@test.com"
+        end
+
+        it { is_expected.to be_truthy }
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/AQTS-613

Currently we can save the regions page in the support console without an email address if we have selected to automatically send emails to the teaching authority upon submission. This pr is to add validation to ensure an email is present when saving.