### PR TITLE
DFE analytics terraform module

### DIFF
--- a/.github/actions/deploy-environment/action.yml
+++ b/.github/actions/deploy-environment/action.yml
@@ -37,6 +37,11 @@ runs:
       with:
         azure-credentials: ${{ inputs.azure-credentials }}
 
+    - uses: google-github-actions/auth@v2
+      with:
+        project_id: apply-for-qts-in-england
+        workload_identity_provider: projects/385922361840/locations/global/workloadIdentityPools/apply-for-qualified-teacher-sta3/providers/apply-for-qualified-teacher-sta3
+
     - name: Apply Terraform
       id: apply-terraform
       shell: bash

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,6 +177,10 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'deploy')
     environment: review
+    permissions:
+      id-token: write
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v4
 
@@ -210,6 +214,9 @@ jobs:
       url: ${{ steps.deploy.outputs.url }}
     outputs:
       environment_name: ${{ matrix.environment }}
+    permissions:
+      id-token: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -230,6 +237,9 @@ jobs:
       name: production
       url: ${{ steps.deploy.outputs.url }}
     concurrency: deploy_production
+    permissions:
+      id-token: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4

--- a/config/initializers/dfe_analytics.rb
+++ b/config/initializers/dfe_analytics.rb
@@ -13,4 +13,6 @@ DfE::Analytics.configure do |config|
       disabled_by_default = Rails.env.development?
       ENV.fetch("BIGQUERY_DISABLE", disabled_by_default.to_s) != "true"
     end
+
+  config.azure_federated_auth = ENV.include? "GOOGLE_CLOUD_CREDENTIALS"
 end

--- a/docs/setting-up-analytics.md
+++ b/docs/setting-up-analytics.md
@@ -27,6 +27,8 @@ in the free tier
 
 ## 3. Create a data set and table
 
+Update: The [dfe_analytics](https://github.com/DFE-Digital/terraform-modules/tree/main/aks/dfe_analytics) terraform module now automates these steps.
+
 You should create separate data sets for each environment (dev/preprod/prod).
 
 1. Select the BigQuery instance
@@ -189,6 +191,8 @@ If you edit as text, you can paste this:
 
 ## 4. Create custom roles
 
+Update: The [dfe_analytics](https://github.com/DFE-Digital/terraform-modules/tree/main/aks/dfe_analytics) terraform module now automates these steps.
+
 1. Go to IAM and Admin settings > Roles
 1. Click on "+ Create role"
 1. Create the 3 roles outlined below
@@ -321,12 +325,16 @@ If you edit as text, you can paste this:
 
 ## 5. Create an appender service account
 
+Update: The [dfe_analytics](https://github.com/DFE-Digital/terraform-modules/tree/main/aks/dfe_analytics) terraform module now automates these steps.
+
 1. Go to [IAM and Admin settings > Create service account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts/create?supportedpurview=project)
 1. Name it like "Appender NAME_OF_SERVICE ENVIRONMENT", so "Appender Apply Local"
 1. Add a description, like "Used when developing locally."
 1. Grant the service account access to the project, use the "BigQuery Appender Custom" role you set up earlier
 
 ## 6. Get an API JSON key :key:
+
+Update: The [dfe_analytics](https://github.com/DFE-Digital/terraform-modules/tree/main/aks/dfe_analytics) terraform module now automates these steps.
 
 1. Access the service account you previously setup
 1. Go to the keys tab, click on "Add key > Create new key"
@@ -335,6 +343,8 @@ If you edit as text, you can paste this:
 The full contents of this JSON file is your `BIGQUERY_API_JSON_KEY`.
 
 ## 6. Set up environment variables
+
+Update: The [dfe_analytics](https://github.com/DFE-Digital/terraform-modules/tree/main/aks/dfe_analytics) terraform module now automates these steps.
 
 Putting the previous things together, to finish setting up `dfe-analytics`, you
 need these environment variables:

--- a/terraform/application/.terraform.lock.hcl
+++ b/terraform/application/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/eppo/environment" {
   constraints = "1.3.5"
   hashes = [
     "h1:1Af95/IhzW16rbX8kSApfrAi8vwc5+7uVbCeyVaGw2E=",
+    "h1:J0rtl6GrLyBKYz6PQ5BXsyYfjHbgMEoAHEQQ3u0vPBc=",
     "h1:pceowuRAKcjLd+g4noIJdX6CBIWavlM4BvRTsGfH0uQ=",
     "zh:00e7a6bf7f0f09cc4871d7f4fee2c943ce61c05b9802365a97703d6c2e63e3dc",
     "zh:018d92e621177d053ed5c32e8220efa8c019852c4d60cc7539683bac28470d9b",
@@ -27,10 +28,11 @@ provider "registry.terraform.io/eppo/environment" {
 
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.116.0"
-  constraints = "3.116.0"
+  constraints = ">= 3.0.0, 3.116.0"
   hashes = [
     "h1:2QbjtN4oMXzdA++Nvrj/wSmWZTPgXKOSFGGQCLEMrb4=",
     "h1:BCR3NIorFSvGG3v/+JOiiw3VM4PkChLO4m84wzD9NDo=",
+    "h1:SJM/KQDW9blKFmLMaupsZVYtcZ0fYpjLHEriMgCBGCY=",
     "zh:02b6606aff025fc2a962b3e568e000300abe959adac987183c24dac8eb057f4d",
     "zh:2a23a8ce24ff9e885925ffee0c3ea7eadba7a702541d05869275778aa47bdea7",
     "zh:57d10746384baeca4d5c56e88872727cdc150f437b8c5e14f0542127f7475e24",
@@ -46,12 +48,34 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.6.0"
+  constraints = "6.6.0"
+  hashes = [
+    "h1:bNj7UyO9+IdcTbkZJgjULH89DrJSaBCRw89zt6g8ajg=",
+    "h1:mllWOZFO8u2kD2kRTdDDAa8Jt+vb8Uxhf6C0lwLxoz8=",
+    "zh:0c181f9b9f0ab81731e5c4c2d20b6d342244506687437dad94e279ef2a588f68",
+    "zh:12a4c333fc0ba670e87f09eb574e4b7da90381f9929ef7c866048b6841cc8a6a",
+    "zh:15c277c2052df89429051350df4bccabe4cf46068433d4d8c673820d9756fc00",
+    "zh:35d1663c81b81cd98d768fa7b80874b48c51b27c036a3c598a597f653374d3c8",
+    "zh:56b268389758d544722a342da4174c486a40ffa2a49b45a06111fe31c6c9c867",
+    "zh:abd3ea8c3a62928ba09ba7eb42b52f53e682bd65e92d573f1739596b5a9a67b1",
+    "zh:be55a328d61d9db58690db74ed43614111e1105e5e52cee15acaa062df4e233e",
+    "zh:ce2317ce9fd02cf14323f9e061c43a415b4ae9b3f96046460d0e6b6529a5aa6c",
+    "zh:d54a6d8e031c824f1de21b93c3e01ed7fec134b4ae55223d08868c6168c98e47",
+    "zh:d8c6e33b5467c6eb5a970adb251c4c8194af12db5388cff9d4b250294eae4daa",
+    "zh:f49e4cc9c0b55b3bec7da64dd698298345634a5df372228ee12aa45e57982f64",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.32.0"
   constraints = "2.32.0"
   hashes = [
     "h1:3j4XBR5UWQA7xXaiEnzZp0bHbcwOhWetHYKTWIrUTI0=",
     "h1:Cj3RHyw3wE3AkNlCtSNrZfjFNkShvaZR0K/K3pJlYJU=",
+    "h1:HqeU0sZBh+2loFYqPMFx7jJamNUPEykyqJ9+CkMCYE0=",
     "zh:0e715d7fb13a8ad569a5fdc937b488590633f6942e986196fdb17cd7b8f7720e",
     "zh:495fc23acfe508ed981e60af9a3758218b0967993065e10a297fdbc210874974",
     "zh:4b930a8619910ef528bc90dae739cb4236b9b76ce41367281e3bc3cf586101c7",
@@ -70,6 +94,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.6.3"
   hashes = [
+    "h1:Fnaec9vA8sZ8BXVlN3Xn9Jz3zghSETIKg7ch8oXhxno=",
     "h1:f6jXn4MCv67kgcofx9D49qx1ZEBv8oyvwKDMPBr0A24=",
     "h1:zG9uFP8l9u+yGZZvi5Te7PV62j50azpgwPunq2vTm1E=",
     "zh:04ceb65210251339f07cd4611885d242cd4d0c7306e86dda9785396807c00451",
@@ -91,6 +116,7 @@ provider "registry.terraform.io/statuscakedev/statuscake" {
   version     = "2.2.2"
   constraints = "2.2.2"
   hashes = [
+    "h1:OoqL/K/eNLahbfMwJvYZHo9kacafjtrJKhd6cLrubZ4=",
     "h1:nVaJkDBk4sv0yWFzg3p+yeJGzE8mB4KJv3Q6/UgU164=",
     "h1:wFoZJfmNvG6XTf65NLai67geSHqYV1Tilx7OITrHilE=",
     "zh:0916313344c579d6e05d70f88129a10fe48f7dabe0e61cad17874d6c496f288d",

--- a/terraform/application/application.tf
+++ b/terraform/application/application.tf
@@ -19,9 +19,9 @@ module "application_configuration" {
     {
       HOSTING_ENVIRONMENT = local.environment
 
-      BIGQUERY_PROJECT_ID = "apply-for-qts-in-england"
-      BIGQUERY_DATASET    = "events_${var.app_environment}"
-      BIGQUERY_TABLE_NAME = "events"
+      BIGQUERY_PROJECT_ID = var.bigquery_federated_auth ? module.dfe_analytics[0].bigquery_project_id : "apply-for-qts-in-england"
+      BIGQUERY_DATASET    = var.bigquery_federated_auth ? module.dfe_analytics[0].bigquery_dataset : "events_${var.app_environment}"
+      BIGQUERY_TABLE_NAME = var.bigquery_federated_auth ? module.dfe_analytics[0].bigquery_table_name : "events"
   })
 
   secret_key_vault_short = "app"
@@ -32,6 +32,8 @@ module "application_configuration" {
     AZURE_STORAGE_ACCOUNT_NAME = azurerm_storage_account.uploads.name
     AZURE_STORAGE_ACCESS_KEY   = azurerm_storage_account.uploads.primary_access_key
     AZURE_STORAGE_CONTAINER    = azurerm_storage_container.uploads.name
+
+    GOOGLE_CLOUD_CREDENTIALS = var.bigquery_federated_auth ? module.dfe_analytics[0].google_cloud_credentials : null
   }
 }
 
@@ -74,5 +76,6 @@ module "worker_application" {
   command       = ["bundle", "exec", "sidekiq", "-C", "./config/sidekiq.yml"]
   probe_command = ["pgrep", "-f", "sidekiq"]
 
-  enable_logit = var.enable_logit
+  enable_logit   = var.enable_logit
+  enable_gcp_wif = var.bigquery_federated_auth ? true : null
 }

--- a/terraform/application/config/review/variables.tfvars.json
+++ b/terraform/application/config/review/variables.tfvars.json
@@ -5,5 +5,6 @@
   "enable_logit": true,
   "enable_monitoring": false,
   "namespace": "tra-development",
-  "uploads_storage_environment_tag": "Test"
+  "uploads_storage_environment_tag": "Test",
+  "bigquery_federated_auth": true
 }

--- a/terraform/application/dfe_analytics.tf
+++ b/terraform/application/dfe_analytics.tf
@@ -1,0 +1,15 @@
+provider "google" {
+  project = "apply-for-qts-in-england"
+}
+
+module "dfe_analytics" {
+  count  = var.bigquery_federated_auth ? 1 : 0
+  source = "./vendor/modules/dfe-terraform-modules//aks/dfe_analytics"
+
+  azure_resource_prefix = var.azure_resource_prefix
+  cluster               = var.cluster
+  namespace             = var.namespace
+  service_short         = var.service_short
+  environment           = "${var.app_environment}${var.app_suffix}"
+  gcp_dataset           = "events_${var.app_environment}"
+}

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -85,6 +85,12 @@ variable "uploads_storage_account_name" {
   default = null
 }
 
+variable "bigquery_federated_auth" {
+  type        = bool
+  default     = false
+  description = "Configure environment variable to let dfe-analytics use federated authentication"
+}
+
 locals {
   environment_variables = yamldecode(file("${path.module}/config/${var.app_environment}/variables.yml"))
 }


### PR DESCRIPTION
## Description
Configure workload identity federation for Google cloud to avoid using a permanent key
Add the dfe_analytics terraform module and authorise the deployment workflow to Google cloud
Enable deferated for review app, but leave biquery disabled for review apps

## How to review
Check review app events are sent to Bigquery when bigquery is enabled

## Before merging
- Delete TEMP commit so that review apps don't use Bigquery

## After merging
- Delete BIGQUERY-API-JSON-KEY from the keyvaults