### PR TITLE
[AQTS-625] Validation for referee email address in CMS, FI & draft application when you save and continue

### DIFF
--- a/app/forms/assessor_interface/work_history_contact_form.rb
+++ b/app/forms/assessor_interface/work_history_contact_form.rb
@@ -11,6 +11,8 @@ class AssessorInterface::WorkHistoryContactForm
 
   validates :work_history, :user, presence: true
 
+  validates :email, valid_for_notify: true
+
   def save
     return false if invalid?
 

--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -54,7 +54,8 @@ class FurtherInformationRequestItem < ApplicationRecord
     (text? && response.present?) || (document? && document.completed?) ||
       (
         work_history_contact? && contact_name.present? &&
-          contact_job.present? && contact_email.present?
+          contact_job.present? && contact_email.present? &&
+          contact_email.match?(ValidForNotifyValidator::EMAIL_REGEX)
       )
   end
 

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -70,7 +70,9 @@ class WorkHistory < ApplicationRecord
     end
 
     unless application_form.reduced_evidence_accepted?
-      return false unless contact_email.match?(ValidForNotifyValidator::EMAIL_REGEX)
+      unless contact_email.match?(ValidForNotifyValidator::EMAIL_REGEX)
+        return false
+      end
 
       values += [contact_name, contact_email]
     end

--- a/app/models/work_history.rb
+++ b/app/models/work_history.rb
@@ -70,6 +70,8 @@ class WorkHistory < ApplicationRecord
     end
 
     unless application_form.reduced_evidence_accepted?
+      return false unless contact_email.match?(ValidForNotifyValidator::EMAIL_REGEX)
+
       values += [contact_name, contact_email]
     end
 

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -2,7 +2,9 @@
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
 
 <%= form_with model: @form, url: [:teacher_interface, :application_form, @further_information_request, @further_information_request_item], method: :put do |f| %>
-  <%= f.govuk_error_summary %>
+  <% if f.object.present? %>
+    <%= f.govuk_error_summary %>
+  <% end %>
 
   <h1 class="govuk-heading-l">Further information required</h1>
 

--- a/app/views/teacher_interface/further_information_request_items/edit.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/edit.html.erb
@@ -2,6 +2,8 @@
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_further_information_request_path(@further_information_request)) %>
 
 <%= form_with model: @form, url: [:teacher_interface, :application_form, @further_information_request, @further_information_request_item], method: :put do |f| %>
+  <%= f.govuk_error_summary %>
+
   <h1 class="govuk-heading-l">Further information required</h1>
 
   <h2 class="govuk-heading-s">Notes from the assessor</h2>

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -274,6 +274,14 @@ en:
           attributes:
             has_work_history:
               inclusion: Select whether you have worked professionally as a teacher
+        teacher_interface/further_information_request_item_work_history_contact_form:
+          attributes:
+            contact_name:
+              blank: Enter this person’s full name
+            contact_job:
+              blank: Enter this person’s job title
+            contact_email:
+              blank: Enter this person’s email address
         teacher_interface/name_and_date_of_birth_form:
           attributes:
             date_of_birth:

--- a/spec/models/further_information_request_item_spec.rb
+++ b/spec/models/further_information_request_item_spec.rb
@@ -90,6 +90,52 @@ RSpec.describe FurtherInformationRequestItem do
         it { is_expected.to eq("completed") }
       end
     end
+
+    context "with contact work history contact" do
+      before do
+        further_information_request_item.work_history_contact!
+        further_information_request_item.work_history = create(:work_history)
+      end
+
+      context "without any entries" do
+        it { is_expected.to eq("not_started") }
+      end
+
+      context "with partially being filled out" do
+        before do
+          further_information_request_item.update!(
+            contact_name: "name",
+            contact_job: "job",
+          )
+        end
+
+        it { is_expected.to eq("not_started") }
+      end
+
+      context "with all contact information provided but an invalid email" do
+        before do
+          further_information_request_item.update!(
+            contact_name: "name",
+            contact_job: "job",
+            contact_email: "INVALID",
+          )
+        end
+
+        it { is_expected.to eq("not_started") }
+      end
+
+      context "with all contact information provided and a valid email" do
+        before do
+          further_information_request_item.update!(
+            contact_name: "name",
+            contact_job: "job",
+            contact_email: "referee@job.com",
+          )
+        end
+
+        it { is_expected.to eq("completed") }
+      end
+    end
   end
 
   describe "#is_teaching?" do

--- a/spec/models/work_history_spec.rb
+++ b/spec/models/work_history_spec.rb
@@ -131,5 +131,28 @@ RSpec.describe WorkHistory, type: :model do
         it { is_expected.to be true }
       end
     end
+
+    context "without a valid contact email" do
+      let(:application_form) { create(:application_form) }
+
+      let(:work_history) do
+        build(
+          :work_history,
+          :completed,
+          application_form:,
+          contact_email: "INVALID",
+        )
+      end
+
+      it { is_expected.to be false }
+
+      context "with a reduced evidence application form" do
+        let(:application_form) do
+          create(:application_form, reduced_evidence_accepted: true)
+        end
+
+        it { is_expected.to be true }
+      end
+    end
   end
 end


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/AQTS-625

1. Ensuring work history referee email is validated on all assessor interfaces. This includes work history referee updates by admins and also at the final review stage.
2. Ensure work history contact email is validation while the applicant is filling out their draft application and if they decide to click "Save and come back later", the Work histories section does not move to complete if the email is invalid and instead it moves to "In progress".
3. Ensure work history contact email is validation while the applicant is filling out their response to further information request for referee details and if they decide to click "Save and come back later", the FI does not move to complete if the email is invalid and instead it moved to "Not Started".
