### PR TITLE
Add missing test variables.yml file

### DIFF
--- a/terraform/application/config/test/variables.tfvars.json
+++ b/terraform/application/config/test/variables.tfvars.json
@@ -1,7 +1,6 @@
 {
   "app_environment": "test",
   "cluster": "test",
-  "dqt_api_url": "https://test.teacher-qualifications-api.education.gov.uk",
   "enable_monitoring": false,
   "external_hostname": "test.apply-for-qts-in-england.education.gov.uk",
   "namespace": "tra-test",

--- a/terraform/application/config/test/variables.yml
+++ b/terraform/application/config/test/variables.yml
@@ -1,0 +1,2 @@
+---
+DQT_API_URL: https://test.teacher-qualifications-api.education.gov.uk


### PR DESCRIPTION
Fix: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/actions/runs/11438983071/job/31832650742

Terraform was refactored to configure environment variables using a yaml file, but the test environment was missed