### PR TITLE
[AQTS-633] If user has no account and attempts to sign in they should go through eligibility check

### DIFF
--- a/app/models/eligibility_check.rb
+++ b/app/models/eligibility_check.rb
@@ -141,6 +141,10 @@ class EligibilityCheck < ApplicationRecord
     touch(:completed_at)
   end
 
+  def completed?
+    completed_at.present?
+  end
+
   def status
     return :country if country_code.blank?
 

--- a/app/services/find_or_create_teacher_from_gov_one.rb
+++ b/app/services/find_or_create_teacher_from_gov_one.rb
@@ -5,10 +5,10 @@ class FindOrCreateTeacherFromGovOne
 
   attr_reader :teacher
 
-  def initialize(email:, gov_one_id:, eligibility_check_id:)
+  def initialize(email:, gov_one_id:, eligibility_check:)
     @email = email
     @gov_one_id = gov_one_id
-    @eligibility_check_id = eligibility_check_id
+    @eligibility_check = eligibility_check
   end
 
   def call
@@ -27,7 +27,7 @@ class FindOrCreateTeacherFromGovOne
 
   private
 
-  attr_reader :email, :gov_one_id, :eligibility_check_id
+  attr_reader :email, :gov_one_id, :eligibility_check
 
   def find_or_create_teacher!
     @teacher =
@@ -46,10 +46,6 @@ class FindOrCreateTeacherFromGovOne
   def valid_eligibility_check?
     eligibility_check.present? && eligibility_check.region.present? &&
       eligibility_check.country.eligibility_enabled?
-  end
-
-  def eligibility_check
-    @eligibility_check ||= EligibilityCheck.find_by(id: eligibility_check_id)
   end
 
   def teacher_requires_application_form?

--- a/spec/models/eligibility_check_spec.rb
+++ b/spec/models/eligibility_check_spec.rb
@@ -241,6 +241,20 @@ RSpec.describe EligibilityCheck, type: :model do
     it { is_expected.to eq([complete_check]) }
   end
 
+  describe "#completed?" do
+    context "when completed_at is set" do
+      let(:eligibility_check) { create(:eligibility_check, :complete) }
+
+      it { expect(eligibility_check.completed?).to be true }
+    end
+
+    context "when completed_at is nil" do
+      let(:eligibility_check) { create(:eligibility_check) }
+
+      it { expect(eligibility_check.completed?).to be false }
+    end
+  end
+
   describe "#eligible" do
     subject(:eligible) { described_class.eligible }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,6 +18,7 @@ require "site_prism/all_there"
 require "validate_url/rspec_matcher"
 require "view_component/test_helpers"
 require "webmock/rspec"
+require "support/set_session_helpers"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/requests/teachers/omniauth_callbacks/gov_one_spec.rb
+++ b/spec/requests/teachers/omniauth_callbacks/gov_one_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe "/teacher/auth/gov_one/callback", type: :request do
-  subject(:gov_one_callback) { get "/teacher/auth/gov_one/callback" }
+  subject(:gov_one_callback) do
+    get "/teacher/auth/gov_one/callback" }
+  end
 
   let(:omniauth_hash) do
     OmniAuth::AuthHash.new(
@@ -22,47 +24,93 @@ RSpec.describe "/teacher/auth/gov_one/callback", type: :request do
 
   before { OmniAuth.config.mock_auth[:default] = omniauth_hash }
 
-  it "generates a new teacher record" do
-    expect { gov_one_callback }.to change(Teacher, :count).by(1)
+  context "when the user is new and has a completed eligibility_check_id in session" do
+    before { set_session({ eligibility_check_id: eligibility_check.id }) }
+
+    context "with the teacher being eligible" do
+      let(:eligibility_check) do
+        create :eligibility_check, :complete, :eligible
+      end
+
+      it "generates a new teacher record" do
+        expect { gov_one_callback }.to change(Teacher, :count).by(1)
+      end
+
+      it "redirects the teacher to the teacher interface" do
+        gov_one_callback
+
+        expect(response).to redirect_to(teacher_interface_root_path)
+      end
+
+      it "sets the id_token session" do
+        gov_one_callback
+
+        expect(request.session[:id_token]).to eq("99999")
+      end
+    end
+
+    context "with the teacher being ineligible" do
+      let(:eligibility_check) do
+        create :eligibility_check, :complete, :ineligible
+      end
+
+      it "does not generate a new teacher record with an application" do
+        expect { gov_one_callback }.not_to change(Teacher, :count)
+      end
+
+      it "redirects the teacher to eligibility countries selection" do
+        gov_one_callback
+
+        expect(response).to redirect_to(eligibility_interface_countries_path)
+      end
+
+      it "does not set the id_token session" do
+        gov_one_callback
+
+        expect(request.session[:id_token]).to be_nil
+      end
+    end
   end
 
-  it "redirects the teacher to the teacher interface" do
-    gov_one_callback
+  context "when the user is new and has an incompleted eligibility_check_id in session" do
+    let(:eligibility_check) { create :eligibility_check }
 
-    expect(response).to redirect_to(teacher_interface_root_path)
+    before { set_session({ eligibility_check_id: eligibility_check.id }) }
+
+    it "does not generate a new teacher record with an application" do
+      expect { gov_one_callback }.not_to change(Teacher, :count)
+    end
+
+    it "redirects the teacher to eligibility countries selection" do
+      gov_one_callback
+
+      expect(response).to redirect_to(eligibility_interface_countries_path)
+    end
+
+    it "does not set the id_token session" do
+      gov_one_callback
+
+      expect(request.session[:id_token]).to be_nil
+    end
   end
 
-  it "sets the id_token session" do
-    gov_one_callback
-
-    expect(request.session[:id_token]).to eq("99999")
-  end
-
-  context "when there is an existing teacher for the same identity" do
+  context "when the user has an existing teacher record" do
     before { create :teacher, email:, gov_one_id: }
 
     it "does not generate a new teacher record with an application" do
       expect { gov_one_callback }.not_to change(Teacher, :count)
     end
-  end
 
-  context "when there is an existing eligibility_check_id in session" do
-    let(:eligibility_check) { create :eligibility_check, :eligible }
+    it "redirects the teacher to the teacher interface" do
+      gov_one_callback
 
-    before do
-      allow_any_instance_of(ActionDispatch::Request).to receive(:session) do
-        OpenStruct.new(id: 1, eligibility_check_id: eligibility_check.id)
-      end
+      expect(response).to redirect_to(teacher_interface_root_path)
     end
 
-    it "generates a new teacher record with an application" do
-      expect { gov_one_callback }.to change(Teacher, :count).by(1)
+    it "sets the id_token session" do
+      gov_one_callback
 
-      application = Teacher.last.application_forms.first
-      expect(application).not_to be_nil
-      expect(application.region.country.code).to eq(
-        eligibility_check.country_code,
-      )
+      expect(request.session[:id_token]).to eq("99999")
     end
   end
 
@@ -73,10 +121,16 @@ RSpec.describe "/teacher/auth/gov_one/callback", type: :request do
       expect { gov_one_callback }.not_to change(Teacher, :count)
     end
 
+    it "does not set the id_token session" do
+      gov_one_callback
+
+      expect(request.session[:id_token]).to be_nil
+    end
+
     it "redirects the user back to the sign in page" do
       gov_one_callback
 
-      expect(response).to redirect_to(new_teacher_session_path)
+      expect(response).to redirect_to(root_path)
       expect(request.flash[:alert]).to eq(
         "There was a problem signing in. Please try again.",
       )

--- a/spec/requests/teachers/omniauth_callbacks/gov_one_spec.rb
+++ b/spec/requests/teachers/omniauth_callbacks/gov_one_spec.rb
@@ -3,9 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "/teacher/auth/gov_one/callback", type: :request do
-  subject(:gov_one_callback) do
-    get "/teacher/auth/gov_one/callback" }
-  end
+  subject(:gov_one_callback) { get "/teacher/auth/gov_one/callback" }
 
   let(:omniauth_hash) do
     OmniAuth::AuthHash.new(

--- a/spec/services/find_or_create_teacher_from_gov_one_spec.rb
+++ b/spec/services/find_or_create_teacher_from_gov_one_spec.rb
@@ -4,13 +4,12 @@ require "rails_helper"
 
 RSpec.describe FindOrCreateTeacherFromGovOne do
   subject(:call) do
-    described_class.call(email:, gov_one_id:, eligibility_check_id:)
+    described_class.call(email:, gov_one_id:, eligibility_check:)
   end
 
   let(:email) { "test@example.com" }
   let(:gov_one_id) { "123456789" }
   let(:eligibility_check) { nil }
-  let(:eligibility_check_id) { eligibility_check&.id }
 
   it "creates a teacher record" do
     expect { call }.to change(Teacher, :count).by(1)

--- a/spec/support/set_session_helpers.rb
+++ b/spec/support/set_session_helpers.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Test
+  class SessionsController < ApplicationController
+    def create
+      vars = params.permit(session_vars: {})
+      vars[:session_vars].each { |var, value| session[var] = value }
+      head :created
+    end
+  end
+
+  module RequestSessionHelper
+    def set_session(vars = {})
+      post test_session_path, params: { session_vars: vars }
+      expect(response).to have_http_status(:created)
+
+      vars.each_key { |var| expect(session[var]).to be_present }
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Test::RequestSessionHelper
+
+  config.before(:all, type: :request) do
+    # https://github.com/rails/rails/blob/d15a694b40922f15c81042acaeede9e7df7bbb75/actionpack/lib/action_dispatch/routing/route_set.rb#L423
+    Rails.application.routes.send(
+      :eval_block,
+      proc do
+        namespace :test do
+          resource :session, only: %i[create]
+        end
+      end,
+    )
+  end
+end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-633

Based on the new GOV.UK One Login integration, users have the ability to sign in before having gone through the eligibility checker. This ensures that users that do not have an active application (no teacher record), are forced into the eligibility flow and can only sign into our system if they are eligible. 