### PR TITLE
[AQTS-641] Remove OLI content from start page

### DIFF
--- a/app/views/eligibility_interface/start/show.erb
+++ b/app/views/eligibility_interface/start/show.erb
@@ -49,22 +49,11 @@
 
 <p class="govuk-body">If you trained in England or Wales, or have not yet qualified, learn more about <%= govuk_link_to "other routes to getting QTS", "https://www.gov.uk/government/publications/apply-for-qualified-teacher-status-qts-if-you-teach-outside-the-uk/routes-to-qualified-teacher-status-qts-for-teachers-and-those-with-teaching-experience-outside-the-uk#routes-to-qts" %>.</p>
 
-<% if FeatureFlags::FeatureFlag.active?(:gov_one_applicant_login) %>
-  <p class="govuk-body">You need a GOV.UK One Login to use this service. You can create one if you do not already have one.</p>
-<% end %>
-
 <%= govuk_start_button(text: "Check you’re eligible", href: eligibility_interface_start_path, as_button: true) %>
 
 <% if FeatureFlags::FeatureFlag.active?(:teacher_applications) %>
-  <% if FeatureFlags::FeatureFlag.active?(:gov_one_applicant_login) %>
-    <p class="govuk-body">
-      Find out more about
-      <%= govuk_link_to "using a GOV.UK One Login", "https://www.gov.uk/using-your-gov-uk-one-login", new_tab: true %>.
-    </p>
-  <% else %>
-    <p class="govuk-body">
-      If you’ve already started your application using this service, you can
-      <%= govuk_link_to "sign in to continue working on it", :create_or_new_teacher_session %>.
-    </p>
-  <% end %>
+  <p class="govuk-body">
+    If you’ve already started your application using this service, you can
+    <%= govuk_link_to "sign in to continue working on it", :create_or_new_teacher_session %>.
+  </p>
 <% end %>

--- a/spec/views/eligibility_interface/start/show_spec.rb
+++ b/spec/views/eligibility_interface/start/show_spec.rb
@@ -23,14 +23,6 @@ RSpec.describe "eligibility_interface/start/show.html.erb", type: :view do
     )
   end
 
-  it do
-    expect(subject).not_to match(
-      /You need a GOV.UK One Login to use this service./,
-    )
-  end
-
-  it { expect(subject).not_to match(/using a GOV.UK One Login/) }
-
   context "with GOV.UK One Login enabled" do
     around do |example|
       FeatureFlags::FeatureFlag.activate(:gov_one_applicant_login)
@@ -40,14 +32,6 @@ RSpec.describe "eligibility_interface/start/show.html.erb", type: :view do
 
     it do
       expect(subject).to match(
-        /You need a GOV.UK One Login to use this service./,
-      )
-    end
-
-    it { expect(subject).to match(/using a GOV.UK One Login/) }
-
-    it do
-      expect(subject).not_to match(
         /If you’ve already started your application using this service, you can/,
       )
     end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-641

![Screenshot 2024-10-25 at 09 44 31](https://github.com/user-attachments/assets/030f5c0a-a986-42b7-b079-9af684a1040a)

Content around GOV.UK One Login on landing page to revert back to what it previously was