### PR TITLE
Point in time database restore workflow

### DIFF
--- a/.github/workflows/database-ptr.yml
+++ b/.github/workflows/database-ptr.yml
@@ -1,0 +1,69 @@
+name: Restore database from point in time to new database server
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment to restore
+        required: true
+        default: test
+        type: choice
+        options:
+          - test
+          - production
+      confirm-production:
+        description: Must be set to true if restoring production
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+      restore-time:
+        description: Restore point in time in UTC. e.g. 2024-07-24T06:00:00
+        type: string
+        required: true
+      new-db-server:
+        description: Name of the new database server. Default is <original-server-name>-ptr.
+        type: string
+
+env:
+  SERVICE_SHORT: afqts
+  TF_VARS_PATH: terraform/application/config
+
+jobs:
+  ptr-restore:
+    name: PTR Restore AKS Database
+    if: ${{ inputs.environment != 'production' || (inputs.environment == 'production' && github.event.inputs.confirm-production == 'true' ) }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    concurrency: deploy_${{ inputs.environment }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set environment variables
+        run: |
+          source global_config/${{ inputs.environment }}.sh
+          tf_vars_file=${{ env.TF_VARS_PATH }}/${{ inputs.environment }}/variables.tfvars.json
+          echo "CLUSTER=$(jq -r '.cluster' ${tf_vars_file})" >> $GITHUB_ENV
+          echo "RESOURCE_GROUP_NAME=${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-rg" >> $GITHUB_ENV
+
+          DB_SERVER="${AZURE_RESOURCE_PREFIX}-${SERVICE_SHORT}-${CONFIG_SHORT}-pg"
+          if [[ -n "${{ inputs.new-db-server }}" ]]; then
+            NEW_DB_SERVER="${{ inputs.new-db-server }}"
+          else
+            NEW_DB_SERVER="${DB_SERVER}-ptr"
+          fi
+          echo "DB_SERVER=${DB_SERVER}" >> $GITHUB_ENV
+          echo "NEW_DB_SERVER=${NEW_DB_SERVER}" >> $GITHUB_ENV
+
+      - name: Restore ${{ inputs.environment }} postgres
+        uses: DFE-Digital/github-actions/ptr-postgres@master
+        with:
+          resource-group: ${{ env.RESOURCE_GROUP_NAME }}
+          source-server: ${{ env.DB_SERVER }}
+          new-server: ${{ env.NEW_DB_SERVER }}
+          restore-time: ${{ inputs.restore-time }}
+          cluster: ${{ env.CLUSTER }}
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS}}


### PR DESCRIPTION
### Context

Ability to Restore database from point in time to new database server via a manual run of a github workflow

### Changes proposed in this pull request
add workflow than can be manually run similar to workflow in repo access-your-teaching-qualifications

### Guidance to review
test in the test environment:
- look in Azure portal  storage for environment test  for name of backup file. 
- trigger workflow manual in browser of github 
- or on a branch via command line: 
```
sudo apt install gh  (mac: brew install gh)
gh auth login
gh workflow run "Restore database from point in time to new database server" -r pit-restore-workflow -f environment=test -f restore-time=2024-10-22T06:00:00
```
reply to questions 
and see if database restored correctly   
### Link to Trello card

[AFQTS: Point in time restore workflow](https://trello.com/c/dRt0qWdG/2099-afqts-point-in-time-restore-workflow)

### Checklist

- [ x] Attach to Trello card
- [x ] Rebased main
- [ x] Cleaned commit history
- [ x] Tested by running locally
