### PR TITLE
Preproduction Maintenance Page

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -8,6 +8,7 @@ on:
         type: choice
         options:
           - test
+          - preproduction
           - production
       mode:
         required: true

--- a/maintenance_page/manifests/preproduction/ingress_internal_to_main.yml
+++ b/maintenance_page/manifests/preproduction/ingress_internal_to_main.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: apply-for-qts-preproduction-web.test.teacherservices.cloud
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: apply-for-qts-preproduction-web.test.teacherservices.cloud
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: apply-for-qts-preproduction-web
+                port:
+                  number: 80

--- a/maintenance_page/manifests/preproduction/ingress_internal_to_maintenance.yml
+++ b/maintenance_page/manifests/preproduction/ingress_internal_to_maintenance.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: apply-for-qts-preproduction-web.test.teacherservices.cloud
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: apply-for-qts-preproduction-web.test.teacherservices.cloud
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: apply-for-qts-maintenance
+                port:
+                  number: 80

--- a/maintenance_page/manifests/preproduction/ingress_maintenance.yml
+++ b/maintenance_page/manifests/preproduction/ingress_maintenance.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: apply-for-qts-maintenance.test.teacherservices.cloud
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: apply-for-qts-maintenance.test.teacherservices.cloud
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: apply-for-qts-maintenance
+                port:
+                  number: 80

--- a/maintenance_page/manifests/preproduction/ingress_temp_to_main.yml
+++ b/maintenance_page/manifests/preproduction/ingress_temp_to_main.yml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: apply-for-qts-temp.test.teacherservices.cloud
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: apply-for-qts-temp.test.teacherservices.cloud
+      http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: apply-for-qts-preproduction-web
+                port:
+                  number: 80


### PR DESCRIPTION
### Context

Show a friendly message to users when the service is down in preproduction

### Changes proposed in this pull request

- following process [Maintenance page](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/documentation/maintenance-page.md)
- Configure the maintenance page based on [the template](https://github.com/DFE-Digital/teacher-services-cloud/tree/main/templates/new_service/maintenance_page) for production and a test environment.
- Configure the [maintenance page workflow](https://github.com/DFE-Digital/teacher-services-cloud/blob/main/templates/new_service/.github/workflows/maintenance.yml).
- Test the maintenance page in a test environment.

### Guidance to review

i retested the workflow against preproduction you can see the actions:

 gh workflow run "Set maintenance mode" -r "preproduction" -f environment=preproduction -f mode=enable

https://github.com/DFE-Digital/apply-for-qualified-teacher-status/actions/runs/11615356532  enable maintenance 

 gh workflow run "Set maintenance mode" -r "preproduction" -f environment=preproduction -f mode=disable

https://github.com/DFE-Digital/apply-for-qualified-teacher-status/actions/runs/11615404254 disable maintence 

### Link to Trello card
[AFQTS: maintenance page  for preprod](https://trello.com/c/uZrV9NaF/2119-afqts-maintenance-page-for-preprod)

### Checklist

- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
