### PR TITLE
[2041] Enable federated auth for Bigquery in test

### DIFF
--- a/terraform/application/config/test/variables.tfvars.json
+++ b/terraform/application/config/test/variables.tfvars.json
@@ -4,5 +4,6 @@
   "enable_monitoring": false,
   "external_hostname": "test.apply-for-qts-in-england.education.gov.uk",
   "namespace": "tra-test",
-  "uploads_storage_environment_tag": "Test"
+  "uploads_storage_environment_tag": "Test",
+  "bigquery_federated_auth": true
 }


### PR DESCRIPTION
## Description
Review apps have been tested with federated auth. Now we can migrate the test environment.
Check if there is any data loss or errors when the change happens.

