### PR TITLE
[2041] Enable federated auth for Bigquery in production

### DIFF
--- a/terraform/application/config/production/variables.tfvars.json
+++ b/terraform/application/config/production/variables.tfvars.json
@@ -11,5 +11,6 @@
   "enable_monitoring": true,
   "external_hostname": "apply-for-qts-in-england.education.gov.uk",
   "namespace": "tra-production",
-  "uploads_storage_environment_tag": "Production"
+  "uploads_storage_environment_tag": "Production",
+  "bigquery_federated_auth": true
 }


### PR DESCRIPTION
# Description
Bigquery federated auth was successfully enabled in all environments. Now applying to production.