### PR TITLE
[2041] Authenticate to Google in delete review app workflow

### DIFF
--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -19,6 +19,11 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - uses: google-github-actions/auth@v2
+        with:
+          project_id: apply-for-qts-in-england
+          workload_identity_provider: projects/385922361840/locations/global/workloadIdentityPools/apply-for-qualified-teacher-sta3/providers/apply-for-qualified-teacher-sta3
+
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.5.0


### PR DESCRIPTION
# Description
Terraform now connects to Google in case bigquery is used
Fix for: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/actions/runs/11687279915/job/32546929223