### PR TITLE
AQTS-645-support-interface-testing-part3

### DIFF
--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -24,6 +24,10 @@ FactoryBot.define do
   factory :country do
     sequence :code, Country::CODES.cycle
 
+    trait :eligibility_skip_questions do
+      eligibility_skip_questions { true }
+    end
+
     trait :subject_limited do
       subject_limited { true }
     end

--- a/spec/forms/support_interface/country_form_spec.rb
+++ b/spec/forms/support_interface/country_form_spec.rb
@@ -196,7 +196,15 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
   describe "#for_existing_country" do
     subject(:form) { described_class.for_existing_country(country) }
 
-    let(:country) { create(:country, other_information:, status_information:, sanction_information:, teaching_qualification_information:) }
+    let(:country) do
+      create(
+        :country,
+        other_information:,
+        status_information:,
+        sanction_information:,
+        teaching_qualification_information:,
+      )
+    end
     let(:other_information) { "Other information" }
     let(:status_information) { "Status information" }
     let(:sanction_information) { "Sanction information" }
@@ -205,9 +213,9 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
     end
 
     it "returns a CountryForm for the country" do
-      create(:region, name: "Madrid", country: country)
-      create(:region, name: "Barcelona", country: country)
-    
+      create(:region, name: "Madrid", country:)
+      create(:region, name: "Barcelona", country:)
+
       expect(subject).to have_attributes(
         eligibility_enabled: true,
         eligibility_route: "standard",
@@ -216,7 +224,8 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
         other_information: "Other information",
         status_information: "Status information",
         sanction_information: "Sanction information",
-        teaching_qualification_information: "Teaching qualification information"
+        teaching_qualification_information:
+          "Teaching qualification information",
       )
     end
 
@@ -240,8 +249,8 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
       let(:country) { create(:country) }
 
       it "sets has_regions to true" do
-        create(:region, name: "Madrid", country: country)
-        create(:region, name: "Barcelona", country: country)
+        create(:region, name: "Madrid", country:)
+        create(:region, name: "Barcelona", country:)
         expect(subject).to have_attributes(has_regions: true)
       end
     end

--- a/spec/forms/support_interface/country_form_spec.rb
+++ b/spec/forms/support_interface/country_form_spec.rb
@@ -197,10 +197,6 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
     subject(:form) { described_class.for_existing_country(country) }
 
     let(:country) { create(:country, other_information:, status_information:, sanction_information:, teaching_qualification_information:) }
-    let(:eligibility_route) { "standard" }
-    let(:eligibility_enabled) { true }
-    let(:has_regions) { true }
-    let(:region_names) { "Madrid\nBarcelona" }
     let(:other_information) { "Other information" }
     let(:status_information) { "Status information" }
     let(:sanction_information) { "Sanction information" }
@@ -208,31 +204,20 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
       "Teaching qualification information"
     end
 
-    context do
-      before do
-        create(:region, name: "Madrid", country:)
-        create(:region, name: "Barcelona", country:)
-      end
-
-      it "returns a CountryForm for the country" do
-        expect(subject).to have_attributes(eligibility_enabled: true)
-        expect(subject).to have_attributes(eligibility_route: "standard")
-        expect(subject).to have_attributes(has_regions: true)
-        expect(subject).to have_attributes(region_names: "Madrid\nBarcelona")
-        expect(subject).to have_attributes(
-          other_information: "Other information",
-        )
-        expect(subject).to have_attributes(
-          status_information: "Status information",
-        )
-        expect(subject).to have_attributes(
-          sanction_information: "Sanction information",
-        )
-        expect(subject).to have_attributes(
-          teaching_qualification_information:
-            "Teaching qualification information",
-        )
-      end
+    it "returns a CountryForm for the country" do
+      create(:region, name: "Madrid", country: country)
+      create(:region, name: "Barcelona", country: country)
+    
+      expect(subject).to have_attributes(
+        eligibility_enabled: true,
+        eligibility_route: "standard",
+        has_regions: true,
+        region_names: "Madrid\nBarcelona",
+        other_information: "Other information",
+        status_information: "Status information",
+        sanction_information: "Sanction information",
+        teaching_qualification_information: "Teaching qualification information"
+      )
     end
 
     context "when the country is subject limited" do
@@ -251,8 +236,18 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
       end
     end
 
+    context "when the country has regions" do
+      let(:country) { create(:country) }
+
+      it "sets has_regions to true" do
+        create(:region, name: "Madrid", country: country)
+        create(:region, name: "Barcelona", country: country)
+        expect(subject).to have_attributes(has_regions: true)
+      end
+    end
+
     context "when the country has no regions" do
-      let(:country) { create(:country, regions: []) }
+      let(:country) { create(:country) }
 
       it "sets has_regions to false" do
         expect(subject).to have_attributes(has_regions: false)

--- a/spec/forms/support_interface/country_form_spec.rb
+++ b/spec/forms/support_interface/country_form_spec.rb
@@ -192,4 +192,48 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
       end
     end
   end
+
+  describe "#for_existing_country" do
+    subject(:form) { described_class.for_existing_country(country) }
+
+    let(:country) { create(:country) }
+
+    it "returns a CountryForm" do
+      expect(subject).to be_a(described_class)
+      expect(form.eligibility_enabled).to eq(country.eligibility_enabled)
+      expect(form.eligibility_route).to eq("standard")
+      expect(form.has_regions).to eq(country.regions.count > 1)
+      expect(form.region_names).to eq(country.regions.pluck(:name).join("\n"))
+      expect(form.other_information).to eq(country.other_information)
+      expect(form.status_information).to eq(country.status_information)
+      expect(form.sanction_information).to eq(country.sanction_information)
+      expect(form.teaching_qualification_information).to eq(
+        country.teaching_qualification_information,
+      )
+    end
+
+    context "when the country is subject limited" do
+      let(:country) { create(:country, :subject_limited) }
+
+      it "sets the eligibility route to expanded" do
+        expect(form.eligibility_route).to eq("expanded")
+      end
+    end
+
+    context "when the country has eligibility skip questions" do
+      let(:country) { create(:country, :eligibility_skip_questions) }
+
+      it "sets the eligibility route to reduced" do
+        expect(form.eligibility_route).to eq("reduced")
+      end
+    end
+
+    context "when the country has no regions" do
+      let(:country) { create(:country, regions: []) }
+
+      it "sets has_regions to false" do
+        expect(form.has_regions).to be(false)
+      end
+    end
+  end
 end

--- a/spec/forms/support_interface/country_form_spec.rb
+++ b/spec/forms/support_interface/country_form_spec.rb
@@ -213,14 +213,10 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
     end
 
     it "returns a CountryForm for the country" do
-      create(:region, name: "Madrid", country:)
-      create(:region, name: "Barcelona", country:)
-
       expect(subject).to have_attributes(
         eligibility_enabled: true,
         eligibility_route: "standard",
-        has_regions: true,
-        region_names: "Madrid\nBarcelona",
+        has_regions: false,
         other_information: "Other information",
         status_information: "Status information",
         sanction_information: "Sanction information",
@@ -251,7 +247,10 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
       it "sets has_regions to true" do
         create(:region, name: "Madrid", country:)
         create(:region, name: "Barcelona", country:)
-        expect(subject).to have_attributes(has_regions: true)
+        expect(subject).to have_attributes(
+          has_regions: true,
+          region_names: "Madrid\nBarcelona",
+        )
       end
     end
 

--- a/spec/forms/support_interface/country_form_spec.rb
+++ b/spec/forms/support_interface/country_form_spec.rb
@@ -197,26 +197,49 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
     subject(:form) { described_class.for_existing_country(country) }
 
     let(:country) { create(:country) }
+    let(:eligibility_route) { "standard" }
+    let(:eligibility_enabled) { true }
+    let(:has_regions) { true }
+    let(:region_names) { "Madrid\nBarcelona" }
+    let(:other_information) { "Other information" }
+    let(:status_information) { "Status information" }
+    let(:sanction_information) { "Sanction information" }
+    let(:teaching_qualification_information) do
+      "Teaching qualification information"
+    end
 
-    it "returns a CountryForm" do
-      expect(subject).to be_a(described_class)
-      expect(form.eligibility_enabled).to eq(country.eligibility_enabled)
-      expect(form.eligibility_route).to eq("standard")
-      expect(form.has_regions).to eq(country.regions.count > 1)
-      expect(form.region_names).to eq(country.regions.pluck(:name).join("\n"))
-      expect(form.other_information).to eq(country.other_information)
-      expect(form.status_information).to eq(country.status_information)
-      expect(form.sanction_information).to eq(country.sanction_information)
-      expect(form.teaching_qualification_information).to eq(
-        country.teaching_qualification_information,
-      )
+    context do
+      before do
+        create(:region, name: "Madrid", country:)
+        create(:region, name: "Barcelona", country:)
+      end
+
+      it "returns a CountryForm for the country" do
+        expect(subject).to have_attributes(eligibility_enabled: true)
+        expect(subject).to have_attributes(eligibility_route: "standard")
+        expect(subject).to have_attributes(has_regions: true)
+        expect(subject).to have_attributes(region_names: "Madrid\nBarcelona")
+        expect(subject).to have_attributes(
+          other_information: "Other information",
+        )
+        expect(subject).to have_attributes(
+          status_information: "Status information",
+        )
+        expect(subject).to have_attributes(
+          sanction_information: "Sanction information",
+        )
+        expect(subject).to have_attributes(
+          teaching_qualification_information:
+            "Teaching qualification information",
+        )
+      end
     end
 
     context "when the country is subject limited" do
       let(:country) { create(:country, :subject_limited) }
 
       it "sets the eligibility route to expanded" do
-        expect(form.eligibility_route).to eq("expanded")
+        expect(subject).to have_attributes(eligibility_route: "expanded")
       end
     end
 
@@ -224,7 +247,7 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
       let(:country) { create(:country, :eligibility_skip_questions) }
 
       it "sets the eligibility route to reduced" do
-        expect(form.eligibility_route).to eq("reduced")
+        expect(subject).to have_attributes(eligibility_route: "reduced")
       end
     end
 
@@ -232,7 +255,7 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
       let(:country) { create(:country, regions: []) }
 
       it "sets has_regions to false" do
-        expect(form.has_regions).to be(false)
+        expect(subject).to have_attributes(has_regions: false)
       end
     end
   end

--- a/spec/forms/support_interface/country_form_spec.rb
+++ b/spec/forms/support_interface/country_form_spec.rb
@@ -217,6 +217,7 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
         eligibility_enabled: true,
         eligibility_route: "standard",
         has_regions: false,
+        region_names: "",
         other_information: "Other information",
         status_information: "Status information",
         sanction_information: "Sanction information",
@@ -242,23 +243,16 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
     end
 
     context "when the country has regions" do
-      let(:country) { create(:country) }
-
-      it "sets has_regions to true" do
+      before do
         create(:region, name: "Madrid", country:)
         create(:region, name: "Barcelona", country:)
+      end
+
+      it "sets has_regions to true" do
         expect(subject).to have_attributes(
           has_regions: true,
           region_names: "Madrid\nBarcelona",
         )
-      end
-    end
-
-    context "when the country has no regions" do
-      let(:country) { create(:country) }
-
-      it "sets has_regions to false" do
-        expect(subject).to have_attributes(has_regions: false)
       end
     end
   end

--- a/spec/forms/support_interface/country_form_spec.rb
+++ b/spec/forms/support_interface/country_form_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe SupportInterface::CountryForm, type: :model do
   describe "#for_existing_country" do
     subject(:form) { described_class.for_existing_country(country) }
 
-    let(:country) { create(:country) }
+    let(:country) { create(:country, other_information:, status_information:, sanction_information:, teaching_qualification_information:) }
     let(:eligibility_route) { "standard" }
     let(:eligibility_enabled) { true }
     let(:has_regions) { true }


### PR DESCRIPTION
https://dfedigital.atlassian.net/jira/software/projects/AQTS/boards/207?selectedIssue=AQTS-645

This pr adds in tests for the for_existing_country method in the support interface country form