### PR TITLE
[2152] Use testing terraform modules in preproduction

### DIFF
--- a/terraform/application/config/preproduction/Terrafile
+++ b/terraform/application/config/preproduction/Terrafile
@@ -1,3 +1,3 @@
 dfe-terraform-modules:
   source: https://github.com/DFE-Digital/terraform-modules
-  version: stable
+  version: testing


### PR DESCRIPTION
## Description
Fix for https://github.com/DFE-Digital/apply-for-qualified-teacher-status/actions/runs/11895091096/job/33150995864

The service account name fix is required as the preproduction environment name is too long