### PR TITLE
AQTS 689 fix for smoke test 4

### DIFF
--- a/spec/system/smoke_spec.rb
+++ b/spec/system/smoke_spec.rb
@@ -55,7 +55,7 @@ describe "Smoke test", :js, :smoke_test, type: :system do
     # dev & test environments have this feature enabled currently but production does
     # not. We can remove this conditional when the feature is released
     if page.has_content?("Have you used the service before?")
-      if FeatureFlags::FeatureFlag.active?(:gov_one_applicant_login)
+      if page.has_content?("No, I need to check my eligibility")
         choose "No, I need to check my eligibility", visible: false
       else
         choose "No, I need to check if I can apply", visible: false


### PR DESCRIPTION
Another attempt at fixing the failing smoke test