### PR TITLE
Aqts 593 udate visa sponsorship link

### DIFF
--- a/app/forms/support_interface/region_form.rb
+++ b/app/forms/support_interface/region_form.rb
@@ -48,6 +48,7 @@ class SupportInterface::RegionForm
   validates :written_statement_optional, inclusion: { in: [true, false] }
 
   def save!
+    raise ActiveRecord::RecordInvalid, self if invalid?
     assign_region_attributes
 
     ActiveRecord::Base.transaction { region.save! }

--- a/app/views/teacher_interface/application_forms/show/_awarded.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_awarded.html.erb
@@ -34,7 +34,7 @@
 
 <h3 class="govuk-heading-m">Search for a teaching job in England</h3>
 
-<p class="govuk-body">You can search for a job in teaching through the government’s official <%= govuk_link_to "Teaching Vacancies service", "https://teaching-vacancies.service.gov.uk" %>.</p>
+<p class="govuk-body">You can search for a job in teaching through the government’s official <%= govuk_link_to "Teaching Vacancies service", "https://teaching-vacancies.service.gov.uk/jobs?visa_sponsorship_availability%5B%5D=&visa_sponsorship_availability%5B%5D=true" %>.</p>
 
 <p class="govuk-body">The service is free and is used by English schools to list their teaching roles. As well as applying for jobs you can:</p>
 

--- a/app/views/teacher_mailer/application_awarded.text.erb
+++ b/app/views/teacher_mailer/application_awarded.text.erb
@@ -35,7 +35,7 @@ The Get into Teaching website also offers [help and support](https://getintoteac
 
 ## Search for a teaching job in England
 
-You can search for a job in teaching through the government’s official [Teaching Vacancies service](https://teaching-vacancies.service.gov.uk).
+You can search for a job in teaching through the government’s official [Teaching Vacancies service](https://teaching-vacancies.service.gov.uk/jobs?visa_sponsorship_availability%5B%5D=&visa_sponsorship_availability%5B%5D=true).
 
 The service is free and is used by English schools to list their teaching roles. As well as applying for jobs you can:
 - set up job alerts

--- a/spec/forms/support_interface/region_form_spec.rb
+++ b/spec/forms/support_interface/region_form_spec.rb
@@ -153,4 +153,55 @@ RSpec.describe SupportInterface::RegionForm, type: :model do
       it { is_expected.to be_valid }
     end
   end
+
+  describe "#save" do
+    subject(:save!) { form.save! }
+
+    let(:form) do
+      described_class.new(
+        region:,
+        teaching_authority_online_checker_url:,
+        teaching_authority_name:,
+        teaching_authority_emails_string:,
+        teaching_authority_requires_submission_email:,
+        all_sections_necessary:,
+        requires_preliminary_check: false,
+        sanction_check:,
+        status_check: "none",
+        teaching_authority_provides_written_statement:,
+        written_statement_optional: true,
+        teaching_authority_websites_string: "",
+        teaching_authority_address: "",
+        other_information: "",
+        teaching_authority_certificate: "",
+        status_information: "",
+        sanction_information: "",
+        teaching_qualification_information: "",
+      )
+    end
+
+    let(:region) { create(:region) }
+    let(:teaching_authority_requires_submission_email) { false }
+    let(:teaching_authority_emails_string) { "" }
+    let(:teaching_authority_name) { "Teaching Authority" }
+    let(:teaching_authority_online_checker_url) { "" }
+    let(:all_sections_necessary) { true }
+    let(:teaching_authority_provides_written_statement) { false }
+    let(:sanction_check) { "none" }
+
+    it "updates region attributes" do
+      subject
+      expect(region).to have_attributes(
+        teaching_authority_name: "Teaching Authority",
+        teaching_authority_provides_written_statement: false,
+        teaching_authority_requires_submission_email: false,
+      )
+    end
+
+    context "when form is valid" do
+      it "returns true" do
+        expect(subject).to be true
+      end
+    end
+  end
 end

--- a/spec/forms/support_interface/region_form_spec.rb
+++ b/spec/forms/support_interface/region_form_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe SupportInterface::RegionForm, type: :model do
       let(:all_sections_necessary) { false }
 
       it do
-        subject.valid?
+        valid
         expect(subject).to validate_inclusion_of(
           :work_history_section_to_omit,
         ).in_array(%w[whole_section contact_details])
@@ -160,15 +160,15 @@ RSpec.describe SupportInterface::RegionForm, type: :model do
     let(:form) do
       described_class.new(
         region:,
-        teaching_authority_online_checker_url:,
+        teaching_authority_online_checker_url: "",
         teaching_authority_name:,
-        teaching_authority_emails_string:,
-        teaching_authority_requires_submission_email:,
-        all_sections_necessary:,
+        teaching_authority_emails_string: "",
+        teaching_authority_requires_submission_email: false,
+        all_sections_necessary: true,
         requires_preliminary_check: false,
-        sanction_check:,
+        sanction_check: "none",
         status_check: "none",
-        teaching_authority_provides_written_statement:,
+        teaching_authority_provides_written_statement: false,
         written_statement_optional: true,
         teaching_authority_websites_string: "",
         teaching_authority_address: "",
@@ -181,25 +181,34 @@ RSpec.describe SupportInterface::RegionForm, type: :model do
     end
 
     let(:region) { create(:region) }
-    let(:teaching_authority_requires_submission_email) { false }
-    let(:teaching_authority_emails_string) { "" }
     let(:teaching_authority_name) { "Teaching Authority" }
-    let(:teaching_authority_online_checker_url) { "" }
-    let(:all_sections_necessary) { true }
-    let(:teaching_authority_provides_written_statement) { false }
-    let(:sanction_check) { "none" }
 
     it "updates region attributes" do
       subject
       expect(region).to have_attributes(
+        application_form_skip_work_history: false,
+        other_information: "",
+        reduced_evidence_accepted: false,
+        requires_preliminary_check: false,
+        sanction_check: "none",
+        sanction_information: "",
+        status_check: "none",
+        status_information: "",
+        teaching_authority_address: "",
+        teaching_authority_certificate: "",
+        teaching_authority_emails: [],
         teaching_authority_name: "Teaching Authority",
+        teaching_authority_online_checker_url: "",
         teaching_authority_provides_written_statement: false,
         teaching_authority_requires_submission_email: false,
+        teaching_authority_websites: [],
+        teaching_qualification_information: "",
+        written_statement_optional: true,
       )
     end
 
     context "when form is invalid" do
-      let(:sanction_check) { "invalid" }
+      let(:teaching_authority_name) { "The Teaching Authority" }
 
       it "returns false" do
         expect { subject }.to raise_error(ActiveRecord::RecordInvalid)

--- a/spec/forms/support_interface/region_form_spec.rb
+++ b/spec/forms/support_interface/region_form_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe SupportInterface::RegionForm, type: :model do
       let(:all_sections_necessary) { false }
 
       it do
-        save!
+        subject.valid?
         expect(subject).to validate_inclusion_of(
           :work_history_section_to_omit,
         ).in_array(%w[whole_section contact_details])
@@ -198,9 +198,11 @@ RSpec.describe SupportInterface::RegionForm, type: :model do
       )
     end
 
-    context "when form is valid" do
-      it "returns true" do
-        expect(subject).to be true
+    context "when form is invalid" do
+      let(:sanction_check) { "invalid" }
+
+      it "returns false" do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
   end


### PR DESCRIPTION
This ticket changes links in the award communications, and service page to direct candidates to jobs with visa sponsorship.

https://dfedigital.atlassian.net/browse/AQTS-593