### PR TITLE
[AQTS-670] Build client to make post and get requests for TRN allocation

### DIFF
--- a/app/lib/trs/client/v3/create_trn_request.rb
+++ b/app/lib/trs/client/v3/create_trn_request.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class TRS::Client::V3::CreateTRNRequest
+  include ServicePattern
+  include TRS::Client::Connection
+
+  def initialize(request_id:, application_form:)
+    @request_id = request_id
+    @application_form = application_form
+  end
+
+  def call
+    path = "/v3/trn-requests"
+    body = TRS::V3::TRNRequestParams.call(request_id:, application_form:)
+    response =
+      connection.post(path) do |req|
+        # TODO: Temporary API version and will need to change once in production
+        req.headers["X-Api-Version"] = "Next"
+        req.body = body
+      end
+
+    response.body.transform_keys { |key| key.underscore.to_sym }
+  end
+
+  private
+
+  attr_reader :request_id, :application_form
+end

--- a/app/lib/trs/client/v3/read_trn_request.rb
+++ b/app/lib/trs/client/v3/read_trn_request.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class TRS::Client::V3::ReadTRNRequest
+  include ServicePattern
+  include TRS::Client::Connection
+
+  def initialize(request_id:)
+    @request_id = request_id
+  end
+
+  def call
+    path = "/v3/trn-requests"
+    response =
+      connection.get(path) do |req|
+        # TODO: Temporary API version and will need to change once in production
+        req.headers["X-Api-Version"] = "Next"
+        req.params["requestId"] = request_id
+      end
+
+    response.body.transform_keys { |key| key.underscore.to_sym }
+  end
+
+  private
+
+  attr_reader :request_id
+end

--- a/app/lib/trs/v3/trn_request_params.rb
+++ b/app/lib/trs/v3/trn_request_params.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module TRS
+  module V3
+    class TRNRequestParams
+      include ServicePattern
+
+      def initialize(request_id:, application_form:)
+        @request_id = request_id
+        @application_form = application_form
+        @teacher = application_form.teacher
+      end
+
+      def call
+        {
+          requestId: request_id,
+          person: {
+            firstName: application_form.given_names,
+            middleName: nil,
+            lastName: application_form.family_name,
+            dateOfBirth: application_form.date_of_birth.iso8601,
+            emailAddresses: [teacher.email],
+          },
+          identityVerified: true,
+          oneLoginUserSubject: teacher.gov_one_id,
+        }
+      end
+
+      private
+
+      attr_reader :request_id, :application_form, :teacher
+    end
+  end
+end

--- a/spec/lib/trs/client/v3/create_trn_request_spec.rb
+++ b/spec/lib/trs/client/v3/create_trn_request_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TRS::Client::V3::CreateTRNRequest do
+  subject(:call) { described_class.call(request_id:, application_form:) }
+
+  let(:request_id) { "request-id" }
+  let(:application_form) { create(:application_form) }
+
+  before do
+    allow(TRS::V3::TRNRequestParams).to receive(:call).with(
+      request_id:,
+      application_form:,
+    ).and_return("body")
+  end
+
+  context "with a successful response" do
+    before do
+      stub_request(
+        :post,
+        "https://test-teacher-qualifications-api.education.gov.uk/v3/trn-requests",
+      ).with(
+        body: "body",
+        headers: {
+          "X-Api-Version" => "Next",
+          "Authorization" => "Bearer test-api-key",
+          "Content-Type" => "application/json",
+        },
+      ).to_return(
+        status: 200,
+        body:
+          '{"requestId":"72888c5d-db14-4222-829b-7db9c2ec0dc3","status":"Completed",' \
+            '"trn":"1234567"}',
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+    end
+
+    it do
+      expect(subject).to eq(
+        {
+          request_id: "72888c5d-db14-4222-829b-7db9c2ec0dc3",
+          status: "Completed",
+          trn: "1234567",
+        },
+      )
+    end
+  end
+
+  context "with a failure response" do
+    before do
+      stub_request(
+        :post,
+        "https://test-teacher-qualifications-api.education.gov.uk/v3/trn-requests",
+      ).with(
+        body: "body",
+        headers: {
+          "X-Api-Version" => "Next",
+          "Authorization" => "Bearer test-api-key",
+          "Content-Type" => "application/json",
+        },
+      ).to_return(
+        status: 400,
+        body: nil,
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+    end
+
+    it "raises an error" do
+      expect { call }.to raise_error(Faraday::BadRequestError)
+    end
+  end
+end

--- a/spec/lib/trs/client/v3/read_trn_request_spec.rb
+++ b/spec/lib/trs/client/v3/read_trn_request_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TRS::Client::V3::ReadTRNRequest do
+  subject(:call) { described_class.call(request_id:) }
+
+  let(:request_id) { "request-id" }
+
+  context "with a successful response" do
+    before do
+      stub_request(
+        :get,
+        "https://test-teacher-qualifications-api.education.gov.uk/v3/trn-requests?requestId=request-id",
+      ).with(
+        headers: {
+          "Authorization" => "Bearer test-api-key",
+          "X-Api-Version" => "Next",
+        },
+      ).to_return(
+        status: 200,
+        body:
+          '{"requestId":"72888c5d-db14-4222-829b-7db9c2ec0dc3","status":"Completed",' \
+            '"trn":"1234567"}',
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+    end
+
+    it do
+      expect(subject).to eq(
+        {
+          request_id: "72888c5d-db14-4222-829b-7db9c2ec0dc3",
+          status: "Completed",
+          trn: "1234567",
+        },
+      )
+    end
+  end
+
+  context "with a failure response" do
+    before do
+      stub_request(
+        :get,
+        "https://test-teacher-qualifications-api.education.gov.uk/v3/trn-requests?requestId=request-id",
+      ).with(
+        headers: {
+          "Authorization" => "Bearer test-api-key",
+          "X-Api-Version" => "Next",
+        },
+      ).to_return(
+        status: 400,
+        body: nil,
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+    end
+
+    it "raises an error" do
+      expect { call }.to raise_error(Faraday::BadRequestError)
+    end
+  end
+end

--- a/spec/lib/trs/v3/trn_request_params_spec.rb
+++ b/spec/lib/trs/v3/trn_request_params_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TRS::V3::TRNRequestParams do
+  describe "#call" do
+    subject(:call) { described_class.call(request_id:, application_form:) }
+
+    let(:teacher) { create(:teacher, email: "teacher@example.com") }
+    let(:request_id) { "request-id" }
+
+    let(:application_form) do
+      create(
+        :application_form,
+        :awarded,
+        teacher:,
+        created_at: Date.new(2024, 1, 1),
+        submitted_at: Date.new(2024, 1, 1),
+        region: create(:region, :in_country, country_code: "AU"),
+        date_of_birth: Date.new(1960, 1, 1),
+        given_names: "Given",
+        family_name: "Family",
+        teaching_qualification_part_of_degree: true,
+      )
+    end
+
+    it do
+      expect(subject).to eq(
+        {
+          requestId: "request-id",
+          person: {
+            firstName: "Given",
+            lastName: "Family",
+            middleName: nil,
+            dateOfBirth: "1960-01-01",
+            emailAddresses: ["teacher@example.com"],
+          },
+          identityVerified: true,
+          oneLoginUserSubject: nil,
+        },
+      )
+    end
+
+    context "when the teacher has a GOV.UK One Login ID" do
+      let(:teacher) do
+        create(:teacher, email: "teacher@example.com", gov_one_id: "12345678")
+      end
+
+      it do
+        expect(subject).to eq(
+          {
+            requestId: "request-id",
+            person: {
+              firstName: "Given",
+              lastName: "Family",
+              middleName: nil,
+              dateOfBirth: "1960-01-01",
+              emailAddresses: ["teacher@example.com"],
+            },
+            identityVerified: true,
+            oneLoginUserSubject: "12345678",
+          },
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-670

As per documentation for the new [TRS TRN allocation API](https://github.com/DFE-Digital/teaching-record-system/blob/main/docs/api-designs/trn.md), this PR implements the 2 clients which will be used in the future alongside [setting QTS against](https://github.com/DFE-Digital/teaching-record-system/blob/main/docs/api-designs/qtls.md) a record.

This new client is not inserted into our flow yet as it can only work alongside QTS assignment. 

Future work:
1. Expect `potentialDuplicate` to be returned as part of the response for the V3 create TRN record request.
2. Implement setting QTS for TRN record once the API endpoint is ready on [TRS](https://github.com/DFE-Digital/teaching-record-system).
3. Replace the existing process with these 2 endpoints.
4. Update the API version header value for when all endpoints go into production on [TRS](https://github.com/DFE-Digital/teaching-record-system)