### PR TITLE
Upgrade actions/cache on github actions

### DIFF
--- a/.github/actions/prepare-app-env/action.yml
+++ b/.github/actions/prepare-app-env/action.yml
@@ -41,7 +41,7 @@ runs:
 
     - name: Set up yarn cache
       if: ${{ inputs.skip-node == 'false' }}
-      uses: actions/cache@v2.1.7
+      uses: actions/cache@v4
       with:
         path: ${{ steps.yarn-cache.outputs.dir }}
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
Starting February 1st, 2025, Github are closing down v1-v2 of [actions/cache](https://github.com/actions/cache) (read more about it in this [changelog announcement](https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/)) as well as all previous versions of the [@actions/cache package](https://github.com/actions/toolkit/tree/main/packages/cache) in [actions/toolkit](https://github.com/actions/toolkit/). Attempting to use a version of the @actions/cache package or actions/cache after the announced deprecation date will result in a workflow failure. If you are pinned to a specific version or SHA of the cache action, your workflows will also fail after February 1st.

This PR updates the version to V4

