### PR TITLE
[AQTS-688] [DO NOT MERGE] Chages to DQT copy updates to TRS

### DIFF
--- a/app/components/status_tag/component.rb
+++ b/app/components/status_tag/component.rb
@@ -46,6 +46,7 @@ module StatusTag
       overdue_lops: "pink",
       overdue_reference: "pink",
       potential_duplicate_in_dqt: "pink",
+      potential_duplicate_in_trs: "pink",
       pre_assessment: "pink",
       preliminary_check: "pink",
       received: "purple",

--- a/app/jobs/update_trs_trn_request_job.rb
+++ b/app/jobs/update_trs_trn_request_job.rb
@@ -15,12 +15,12 @@ class UpdateTRSTRNRequestJob < ApplicationJob
       trs_trn_request.update!(potential_duplicate:)
     end
 
-    ApplicationFormStatusUpdater.call(application_form:, user: "DQT")
+    ApplicationFormStatusUpdater.call(application_form:, user: "TRS")
 
     unless potential_duplicate
       AwardQTS.call(
         application_form:,
-        user: "DQT",
+        user: "TRS",
         trn: response[:trn],
         access_your_teaching_qualifications_url:
           response[:access_your_teaching_qualifications_link],

--- a/app/lib/application_form_status_updater.rb
+++ b/app/lib/application_form_status_updater.rb
@@ -109,7 +109,7 @@ class ApplicationFormStatusUpdater
         %w[awarded]
       elsif trs_trn_request.present?
         if trs_trn_request.potential_duplicate?
-          %w[potential_duplicate_in_dqt]
+          %w[potential_duplicate_in_trs]
         else
           %w[awarded_pending_checks]
         end

--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -36,7 +36,7 @@ class AssessmentFactory
       (:name_change_document_present if application_form.has_alternative_name),
       :duplicate_application,
       :applicant_already_qts,
-      :applicant_already_dqt,
+      :applicant_already_trs,
     ].compact
 
     failure_reasons = [
@@ -55,7 +55,7 @@ class AssessmentFactory
       ),
       FailureReasons::DUPLICATE_APPLICATION,
       FailureReasons::APPLICANT_ALREADY_QTS,
-      FailureReasons::APPLICANT_ALREADY_DQT,
+      FailureReasons::APPLICANT_ALREADY_TRS,
     ].compact
 
     if suitability_active?

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -42,6 +42,7 @@ class FailureReasons
     ADDITIONAL_DEGREE_TRANSCRIPT_ILLEGIBLE =
       "additional_degree_transcript_illegible",
     APPLICANT_ALREADY_DQT = "applicant_already_dqt",
+    APPLICANT_ALREADY_TRS = "applicant_already_trs",
     APPLICATION_AND_QUALIFICATION_NAMES_DO_NOT_MATCH =
       "application_and_qualification_names_do_not_match",
     DEGREE_CERTIFICATE_ILLEGIBLE = "degree_certificate_illegible",

--- a/app/views/assessor_interface/application_forms/show.html.erb
+++ b/app/views/assessor_interface/application_forms/show.html.erb
@@ -18,9 +18,9 @@
 
 <% if (duplicate_matches = @view_object.duplicate_matches).present? %>
   <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
-    <% notification_banner.with_heading(text: "Application details match DQT record(s)") %>
+    <% notification_banner.with_heading(text: "Application details match TRS record(s)") %>
 
-    <p class="govuk-body">The surname and date of birth used in this application matches the following records found in the Database of Qualified Teachers (DQT):</p>
+    <p class="govuk-body">The surname and date of birth used in this application matches the following records found in the Teaching Record System (TRS):</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <% duplicate_matches.each do |match| %>

--- a/app/views/assessor_interface/application_forms/status.html.erb
+++ b/app/views/assessor_interface/application_forms/status.html.erb
@@ -26,7 +26,7 @@
 <% elsif @view_object.application_form.declined_at.present? %>
   <p class="govuk-body">The application will be deleted after 90 days unless the applicant chooses to appeal.</p>
 <% elsif @view_object.application_form.trs_trn_request.present? %>
-  <p class="govuk-body">This status will appear while the award is reconciled with the information in the Database of Qualified Teachers (DQT).</p>
+  <p class="govuk-body">This status will appear while the award is reconciled with the information in the Teaching Record System (TRS).</p>
   <p class="govuk-body">Once these checks are complete, the status will change to ‘Awarded’ and the applicant will receive the email telling them they’ve been awarded QTS.</p>
 <% end %>
 

--- a/app/views/shared/_age_range_subjects_form_fields.html.erb
+++ b/app/views/shared/_age_range_subjects_form_fields.html.erb
@@ -3,7 +3,7 @@
 
   <ul class="govuk-list govuk-list--bullet">
     <li>based on evidence, you do not agree with the age range the applicant has submitted</li>
-    <li>the 'To' age is greater than 19 and will not be accepted by DQT</li>
+    <li>the 'To' age is greater than 19 and will not be accepted by TRS</li>
   </ul>
 
   <%= f.govuk_number_field :age_range_min, width: 3 %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -100,7 +100,8 @@ en:
 
       checks:
         age_range_subjects_matches: that the age range and subjects information the applicant has entered matches the qualifications they’ve provided
-        applicant_already_dqt: applicant does not already appear in DQT
+        applicant_already_dqt: applicant does not already appear in TRS
+        applicant_already_trs: applicant does not already appear in TRS
         applicant_already_qts: applicant does not already hold QTS and induction exemption
         authorisation_to_teach: confirmation that authorisation to teach has never been suspended, barred, cancelled, revoked or restricted, and there are no sanctions present
         confirm_age_range_subjects: confirmation of the age ranges and subjects the applicant is qualified to teach
@@ -144,6 +145,7 @@ en:
           additional_degree_transcript_illegible: An additional degree transcript (or translation) is illegible or in a format that we cannot accept.
           age_range: The age range the applicant is qualified to teach does not fall within the requirements of QTS.
           applicant_already_dqt: There’s a potential existing match for this applicant. We need to ask for an additional identifier.
+          applicant_already_trs: There’s a potential existing match for this applicant. We need to ask for an additional identifier.
           applicant_already_qts: The applicant already holds QTS and induction exemption.
           application_and_qualification_names_do_not_match: The name on the online application form is different from 1 or more qualification documents, but no evidence of change of name was provided.
           authorisation_to_teach: Sanctions or restrictions were detected on professional record.
@@ -273,6 +275,8 @@ en:
             age_range_notes:
               blank: Enter a note to the applicant
             applicant_already_dqt_notes:
+              blank: Enter a note to the applicant
+            applicant_already_trs_notes:
               blank: Enter a note to the applicant
             applicant_already_qts_notes:
               blank: Enter a note to the applicant

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -25,6 +25,7 @@ en:
       overdue_lops: Overdue LoPS
       overdue_reference: Overdue reference
       potential_duplicate_in_dqt: Potential duplication in DQT
+      potential_duplicate_in_trs: Potential duplication in TRS
       pre_assessment: Pre-assessment
       preliminary_check: Preliminary check
       received: Received

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -8,6 +8,7 @@ en:
             additional_degree_transcript_illegible: Your additional degree transcript (or translation) is illegible or in a format we cannot accept.
             age_range: The age range you are qualified to teach does not fall within the requirements of QTS.
             applicant_already_dqt: Your details have been matched with someone who already has QTS and is registered in our database for qualified teachers.
+            applicant_already_trs: Your details have been matched with someone who already has QTS and is registered in our database for qualified teachers.
             applicant_already_qts: You already hold QTS and induction exemption.
             application_and_qualification_names_do_not_match: The name on the application form is different from 1 or more qualification documents, but no evidence of change of name has been provided.
             authorisation_to_teach: Sanctions or restrictions were detected on your professional record.
@@ -87,6 +88,7 @@ en:
         failure_reason:
           age_range: Tell us more about the age range you can teach
           applicant_already_dqt: Additional personal information
+          applicant_already_trs: Additional personal information
           english_language_unverifiable_reference_number: Tell us more about your English language proficiency
           qualifications_dont_match_other_details: Tell us more about your qualifications
           qualifications_dont_match_subjects: Tell us more about the subjects you can teach

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -192,10 +192,10 @@ FactoryBot.define do
       statuses { %w[awarded_pending_checks] }
     end
 
-    trait :potential_duplicate_in_dqt do
+    trait :potential_duplicate_in_trs do
       submitted
       review_stage
-      statuses { %w[potential_duplicate_in_dqt] }
+      statuses { %w[potential_duplicate_in_trs] }
     end
 
     trait :awarded do

--- a/spec/jobs/update_trstrn_request_job_spec.rb
+++ b/spec/jobs/update_trstrn_request_job_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe UpdateTRSTRNRequestJob, type: :job do
 
         it "changes the state" do
           expect { perform }.to change(application_form, :statuses).to(
-            %w[potential_duplicate_in_dqt],
+            %w[potential_duplicate_in_trs],
           )
         end
 
@@ -237,7 +237,7 @@ RSpec.describe UpdateTRSTRNRequestJob, type: :job do
 
         it "changes the state" do
           expect { perform }.to change(application_form, :statuses).to(
-            %w[potential_duplicate_in_dqt],
+            %w[potential_duplicate_in_trs],
           )
         end
 

--- a/spec/lib/application_form_status_updater_spec.rb
+++ b/spec/lib/application_form_status_updater_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe ApplicationFormStatusUpdater do
 
       include_examples "changes action required by", "assessor"
       include_examples "changes stage", "review"
-      include_examples "changes statuses", %w[potential_duplicate_in_dqt]
+      include_examples "changes statuses", %w[potential_duplicate_in_trs]
     end
 
     context "with a withdrawn_at date" do

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe AssessmentFactory do
               identification_document_present
               duplicate_application
               applicant_already_qts
-              applicant_already_dqt
+              applicant_already_trs
             ],
           )
           expect(section.failure_reasons).to eq(
@@ -64,7 +64,7 @@ RSpec.describe AssessmentFactory do
               identification_document_mismatch
               duplicate_application
               applicant_already_qts
-              applicant_already_dqt
+              applicant_already_trs
               suitability
               suitability_previously_declined
               fraud

--- a/spec/lib/trs/country_code_spec.rb
+++ b/spec/lib/trs/country_code_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe TRS::CountryCode do
   describe "#for_code" do
-    subject(:dqt_code) { described_class.for_code(code) }
+    subject(:trs_code) { described_class.for_code(code) }
 
     let(:code) { "US" }
 

--- a/spec/lib/trs/subject_spec.rb
+++ b/spec/lib/trs/subject_spec.rb
@@ -4,13 +4,13 @@ require "rails_helper"
 
 RSpec.describe TRS::Subject do
   describe "#for" do
-    subject(:dqt_code) { described_class.for(value) }
+    subject(:trs_code) { described_class.for(value) }
 
-    shared_examples "DQT code" do |value|
+    shared_examples "TRS code" do |value|
       let(:value) { value }
       it { is_expected.not_to be_nil }
     end
 
-    Subject.all.map { |subject| it_behaves_like "DQT code", subject.value }
+    Subject.all.map { |subject| it_behaves_like "TRS code", subject.value }
   end
 end

--- a/spec/services/award_qts_spec.rb
+++ b/spec/services/award_qts_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe AwardQTS do
 
   context "with a potential duplicate in QTS application form" do
     let(:application_form) do
-      create(:application_form, :potential_duplicate_in_dqt, teacher:)
+      create(:application_form, :potential_duplicate_in_trs, teacher:)
     end
 
     before { create(:trs_trn_request, application_form:) }

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
   it "does not allow any access if assessor is archived" do
     given_i_am_authorized_as_an_archived_assessor_user
     given_there_is_an_awardable_application_form
-    given_i_can_request_dqt_api
+    given_i_can_request_trs_api
 
     when_i_visit_the(
       :assessor_complete_assessment_page,
@@ -23,7 +23,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
   it "award" do
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_awardable_application_form
-    given_i_can_request_dqt_api
+    given_i_can_request_trs_api
 
     when_i_visit_the(
       :assessor_complete_assessment_page,
@@ -268,7 +268,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
     )
   end
 
-  def given_i_can_request_dqt_api
+  def given_i_can_request_trs_api
     uri_template =
       Addressable::Template.new(
         "https://test-teacher-qualifications-api.education.gov.uk/v2/trn-requests/{request_id}",

--- a/spec/system/assessor_interface/duplicate_applicant_application_form_spec.rb
+++ b/spec/system/assessor_interface/duplicate_applicant_application_form_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe "Assessor views duplicate applicant's application form",
   it "displays information about the duplicate applicant" do
     given_i_am_authorized_as_an_assessor_user
     given_there_is_an_application_form
-    and_the_applicant_matches_a_record_in_dqt
+    and_the_applicant_matches_a_record_in_trs
 
     when_i_visit_the(:assessor_application_page, reference:)
     then_i_see_the_application
-    and_i_see_the_warning_of_an_existing_record_in_dqt
+    and_i_see_the_warning_of_an_existing_record_in_trs
   end
 
   private
@@ -30,14 +30,14 @@ RSpec.describe "Assessor views duplicate applicant's application form",
     )
   end
 
-  def and_i_see_the_warning_of_an_existing_record_in_dqt
+  def and_i_see_the_warning_of_an_existing_record_in_trs
     expect(assessor_application_page).to have_content(
-      "Application details match DQT record(s)",
+      "Application details match TRS record(s)",
     )
     expect(assessor_application_page).to have_content("John Smith, TRN 7654322")
   end
 
-  def and_the_applicant_matches_a_record_in_dqt
+  def and_the_applicant_matches_a_record_in_trs
     application_form.update!(trs_match:)
   end
 


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-688

This PR updates any copy related to referring to TRS as DQT. As the TRS team handles migration of DQT to TRS, we are making changes to our system to be more consistent with the language used. 

Note: This work to go in February 2025 as DQT migration fully happens.

Steps for PR:
1. Merge this PR.
2. Update all existing application forms with statuses for potential dqt duplicate to be the new one.
3. Update all existing FI request items for duplicates to now be the new value.
4. Remove any old DQT related keys that can be deleted.