### PR TITLE
[DO NOT MERGE] Removing verbose: false on sidekiq config

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,4 @@
 ---
-:verbose: false
 :concurrency: 10
 :queues:
   - default


### PR DESCRIPTION
Currently we have no logs when it comes to jobs triggered on Sidekiq. This has made it harder to confirm whether certain analytics jobs had been triggered or not.