### PR TITLE
[AQTS-699] Removing `expire_after` from our session store

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,5 +2,4 @@
 
 Rails.application.config.session_store :active_record_store,
                                        key: "_session_id",
-                                       secure: Rails.env.production?,
-                                       expire_after: 20.hours
+                                       secure: Rails.env.production?


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-699

We have come across a scenario where when browsers are fully closed and re-opened, user sessions on our service are retained (given that it's reopened before the authentication has timed out. Timeouts are set to 1 hour of inactivity for teachers and 20 minutes for staff).

This PR ensures that when browsers are fully closed, the session is not retained. This is done by removing the expiry_after on the session_store. 

This also does mean that sessions do not expire while the same browser is running. However, this is not an issue since the teacher/staff sessions timeout automatically based on the timeout setting for each of those models. However, session data such as eligibility criteria entered and assessor filters will just be retained until the window is closed. 