### PR TITLE
[AQTS-671] TRS QTS PUT endpoint

### DIFF
--- a/app/lib/trs/client/v3/update_qts_request.rb
+++ b/app/lib/trs/client/v3/update_qts_request.rb
@@ -18,7 +18,7 @@ class TRS::Client::V3::UpdateQTSRequest
         req.body = body
       end
 
-    response.body.transform_keys { |key| key.underscore.to_sym }
+    response.body
   end
 
   private

--- a/app/lib/trs/client/v3/update_qts_request.rb
+++ b/app/lib/trs/client/v3/update_qts_request.rb
@@ -26,7 +26,7 @@ class TRS::Client::V3::UpdateQTSRequest
   attr_reader :application_form
 
   def trn
-    application_form.trn
+    application_form.teacher.trn
   end
 
   def reference

--- a/app/lib/trs/client/v3/update_qts_request.rb
+++ b/app/lib/trs/client/v3/update_qts_request.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class TRS::Client::V3::UpdateQTSRequest
+  include ServicePattern
+  include TRS::Client::Connection
+
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+  def call
+    path = "/v3/persons/#{trn}/professional-statuses/#{reference}"
+    body = TRS::V3::QTSRequestParams.call(application_form:)
+    response =
+      connection.put(path) do |req|
+        # TODO: Temporary API version and will need to change once in production
+        req.headers["X-Api-Version"] = "Next"
+        req.body = body
+      end
+
+    response.body.transform_keys { |key| key.underscore.to_sym }
+  end
+
+  private
+
+  attr_reader :application_form
+
+  def trn
+    application_form.trn
+  end
+
+  def reference
+    application_form.reference
+  end
+end

--- a/app/lib/trs/v3/qts_request_params.rb
+++ b/app/lib/trs/v3/qts_request_params.rb
@@ -7,8 +7,10 @@ module TRS
 
       AWARDED_QTS_STATUS = "Approved"
 
-      SCOTLAND_RECOGNITION_ROUTE_TYPE_ID = "52835b1f-1f2e-4665-abc6-7fb1ef0a80bb"
-      NORTHERN_IRELAND_RECOGNITION_ROUTE_TYPE_ID = "3604ef30-8f11-4494-8b52-a2f9c5371e03"
+      SCOTLAND_RECOGNITION_ROUTE_TYPE_ID =
+        "52835b1f-1f2e-4665-abc6-7fb1ef0a80bb"
+      NORTHERN_IRELAND_RECOGNITION_ROUTE_TYPE_ID =
+        "3604ef30-8f11-4494-8b52-a2f9c5371e03"
       ALL_RECOGNITION_ROUTE_TYPE_ID = "6f27bdeb-d00a-4ef9-b0ea-26498ce64713"
 
       def initialize(application_form:)
@@ -49,7 +51,11 @@ module TRS
       end
 
       def age_range
-        { type: "Range", from: assessment.age_range_min, to: assessment.age_range_max }
+        {
+          type: "Range",
+          from: assessment.age_range_min,
+          to: assessment.age_range_max,
+        }
       end
 
       def exempt_from_induction

--- a/app/lib/trs/v3/qts_request_params.rb
+++ b/app/lib/trs/v3/qts_request_params.rb
@@ -13,7 +13,7 @@ module TRS
 
       def call
         {
-          routeType: "", # TODO: Something like "Apply for QTS" TBC.
+          routeType: route_type,
           startDate: teaching_qualification.start_date.iso8601,
           endDate: teaching_qualification.complete_date.iso8601,
           subjects:,
@@ -55,6 +55,21 @@ module TRS
       def induction_exemption_reasons
         # TODO: List of potential reasons to be provided.
         # This must be provided if exemptFromInduction is true
+      end
+
+      def route_type
+        # TODO: The value returned will be either an enum or GUID. TBD
+        if CountryCode.scotland?(country_code)
+          "Scotland R"
+        elsif CountryCode.northern_ireland?(country_code)
+          "NI R"
+        else
+          "Apply for QTS"
+        end
+      end
+
+      def country_code
+        @country_code ||= application_form.region.country.code
       end
     end
   end

--- a/app/lib/trs/v3/qts_request_params.rb
+++ b/app/lib/trs/v3/qts_request_params.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module TRS
+  module V3
+    class QTSRequestParams
+      include ServicePattern
+
+      def initialize(application_form:)
+        @application_form = application_form
+        @teacher = application_form.teacher
+        @assessment = application_form.assessment
+      end
+
+      def call
+        {
+          routeType: "", # TODO: Something like "Apply for QTS" TBC.
+          startDate: teaching_qualification.start_date.iso8601,
+          endDate: teaching_qualification.complete_date.iso8601,
+          subjects:,
+          ageRange: age_range,
+          degreeType: nil,
+          trainingCountryCode:
+            CountryCode.for_code(
+              teaching_qualification.institution_country_code,
+            ),
+          providerUkprn: nil,
+          routeStatus: "Awarded", # TODO: TBC
+          exemptFromInduction: exempt_from_induction,
+          inductionExemptionReasons: induction_exemption_reasons,
+        }
+      end
+
+      private
+
+      attr_reader :application_form, :teacher, :assessment
+
+      def teaching_qualification
+        @teaching_qualification ||= application_form.teaching_qualification
+      end
+
+      def subjects
+        assessment.subjects.map { |value| Subject.for(value) }
+      end
+
+      def age_range
+        { from: assessment.age_range_min, to: assessment.age_range_max }
+      end
+
+      def exempt_from_induction
+        return true if application_form.created_under_old_regulations?
+
+        !assessment.induction_required
+      end
+
+      def induction_exemption_reasons
+        # TODO: List of potential reasons to be provided.
+        # This must be provided if exemptFromInduction is true
+      end
+    end
+  end
+end

--- a/spec/lib/trs/client/v3/update_qts_request_spec.rb
+++ b/spec/lib/trs/client/v3/update_qts_request_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TRS::Client::V3::UpdateQTSRequest do
+  subject(:call) { described_class.call(application_form:) }
+
+  let(:application_form) { create(:application_form, teacher:) }
+  let(:teacher) { create(:teacher, trn: "12345") }
+
+  before do
+    allow(TRS::V3::QTSRequestParams).to receive(:call).with(
+      application_form:,
+    ).and_return("body")
+  end
+
+  context "with a successful response" do
+    before do
+      stub_request(
+        :put,
+        "https://test-teacher-qualifications-api.education.gov.uk/v3/persons/#{teacher.trn}/professional-statuses/#{application_form.reference}",
+      ).with(
+        body: "body",
+        headers: {
+          "X-Api-Version" => "Next",
+          "Authorization" => "Bearer test-api-key",
+          "Content-Type" => "application/json",
+        },
+      ).to_return(
+        status: 200,
+        body: "",
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+    end
+
+    it { expect(subject).to be_nil }
+  end
+
+  context "with a failure response" do
+    before do
+      stub_request(
+        :put,
+        "https://test-teacher-qualifications-api.education.gov.uk/v3/persons/#{teacher.trn}/professional-statuses/#{application_form.reference}",
+      ).with(
+        body: "body",
+        headers: {
+          "X-Api-Version" => "Next",
+          "Authorization" => "Bearer test-api-key",
+          "Content-Type" => "application/json",
+        },
+      ).to_return(
+        status: 400,
+        body: nil,
+        headers: {
+          "Content-Type" => "application/json",
+        },
+      )
+    end
+
+    it "raises an error" do
+      expect { call }.to raise_error(Faraday::BadRequestError)
+    end
+  end
+end

--- a/spec/lib/trs/v3/qts_request_params_spec.rb
+++ b/spec/lib/trs/v3/qts_request_params_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TRS::V3::QTSRequestParams do
+  describe "#call" do
+    subject(:call) { described_class.call(application_form:) }
+
+    let(:teacher) { create(:teacher, email: "teacher@example.com") }
+
+    let(:region) { create(:region, :in_country, country_code: "FR") }
+
+    let(:application_form) do
+      create(
+        :application_form,
+        :awarded,
+        teacher:,
+        created_at: Date.new(2024, 1, 1),
+        submitted_at: Date.new(2024, 1, 1),
+        date_of_birth: Date.new(1960, 1, 1),
+        given_names: "Given",
+        family_name: "Family",
+        region:,
+        teaching_qualification_part_of_degree: true,
+      )
+    end
+
+    before do
+      create(
+        :assessment,
+        :award,
+        recommended_at: Date.new(2024, 1, 7),
+        application_form:,
+        age_range_min: 7,
+        age_range_max: 11,
+        subjects: %w[physics french_language],
+        induction_required: false,
+      )
+
+      create(
+        :qualification,
+        :completed,
+        application_form:,
+        start_date: Date.new(1990, 1, 1),
+        complete_date: Date.new(1995, 1, 1),
+        certificate_date: Date.new(1996, 1, 1),
+        title: "Master of Physics and French",
+        institution_country_code: region.country.code,
+      )
+    end
+
+    it do
+      expect(subject).to eq(
+        {
+          routeTypeId: "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+          status: "Approved",
+          awardedDate: application_form.awarded_at.to_date.iso8601,
+          trainingStartDate: "1990-01-01",
+          trainingEndDate: "1995-01-01",
+          trainingSubjectReferences: %w[100425 100321],
+          trainingAgeSpecialism: {
+            type: "Range",
+            from: 7,
+            to: 11,
+          },
+          degreeTypeId: nil,
+          trainingCountryReference: "FR",
+          trainingProviderUkprn: nil,
+          isExemptFromInduction: true,
+        },
+      )
+    end
+
+    context "when the applicant has been trained in Scotland" do
+      let(:region) { create(:region, :in_country, country_code: "GB-SCT") }
+
+      it do
+        expect(subject).to eq(
+          {
+            routeTypeId: "52835b1f-1f2e-4665-abc6-7fb1ef0a80bb",
+            status: "Approved",
+            awardedDate: application_form.awarded_at.to_date.iso8601,
+            trainingStartDate: "1990-01-01",
+            trainingEndDate: "1995-01-01",
+            trainingSubjectReferences: %w[100425 100321],
+            trainingAgeSpecialism: {
+              type: "Range",
+              from: 7,
+              to: 11,
+            },
+            degreeTypeId: nil,
+            trainingCountryReference: "XH",
+            trainingProviderUkprn: nil,
+            isExemptFromInduction: true,
+          },
+        )
+      end
+    end
+
+    context "when the applicant has been trained in Northern Ireland" do
+      let(:region) { create(:region, :in_country, country_code: "GB-NIR") }
+
+      it do
+        expect(subject).to eq(
+          {
+            routeTypeId: "3604ef30-8f11-4494-8b52-a2f9c5371e03",
+            status: "Approved",
+            awardedDate: application_form.awarded_at.to_date.iso8601,
+            trainingStartDate: "1990-01-01",
+            trainingEndDate: "1995-01-01",
+            trainingSubjectReferences: %w[100425 100321],
+            trainingAgeSpecialism: {
+              type: "Range",
+              from: 7,
+              to: 11,
+            },
+            degreeTypeId: nil,
+            trainingCountryReference: "XG",
+            trainingProviderUkprn: nil,
+            isExemptFromInduction: true,
+          },
+        )
+      end
+    end
+
+    context "when the applicant is not exempt from induction" do
+      before { application_form.assessment.update!(induction_required: true) }
+
+      it do
+        expect(subject).to eq(
+          {
+            routeTypeId: "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+            status: "Approved",
+            awardedDate: application_form.awarded_at.to_date.iso8601,
+            trainingStartDate: "1990-01-01",
+            trainingEndDate: "1995-01-01",
+            trainingSubjectReferences: %w[100425 100321],
+            trainingAgeSpecialism: {
+              type: "Range",
+              from: 7,
+              to: 11,
+            },
+            degreeTypeId: nil,
+            trainingCountryReference: "FR",
+            trainingProviderUkprn: nil,
+            isExemptFromInduction: false,
+          },
+        )
+      end
+
+      context "with the application form created under old regulations" do
+        before { application_form.update!(created_at: Date.new(2023, 1, 1)) }
+
+        it do
+          expect(subject).to eq(
+            {
+              routeTypeId: "6f27bdeb-d00a-4ef9-b0ea-26498ce64713",
+              status: "Approved",
+              awardedDate: application_form.awarded_at.to_date.iso8601,
+              trainingStartDate: "1990-01-01",
+              trainingEndDate: "1995-01-01",
+              trainingSubjectReferences: %w[100425 100321],
+              trainingAgeSpecialism: {
+                type: "Range",
+                from: 7,
+                to: 11,
+              },
+              degreeTypeId: nil,
+              trainingCountryReference: "FR",
+              trainingProviderUkprn: nil,
+              isExemptFromInduction: true,
+            },
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-671

This work implements the client for the QTS award endpoint for [TRS](https://github.com/DFE-Digital/teaching-record-system)

This specific endpoint will be dependent on a TRN number already allocated to a teacher record before a request can be sent. 

The flow that we will implement will be initially making a request using the [TRN allocation endpoint](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/blob/main/app/lib/trs/client/v3/create_trn_request.rb) and then using the new QTS professional statuses award endpoint implemented in the PR for the TRN record.

