### PR TITLE
AQTS 738 manually restore preprod

### DIFF
--- a/.github/workflows/database.yaml
+++ b/.github/workflows/database.yaml
@@ -100,32 +100,3 @@ jobs:
           backup-file: ${{ env.BACKUP_FILE }}.sql
           db-server-name: ${{ inputs.db-server }}
           slack-webhook: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}
-
-      - name: Install postgres client
-        if: github.event_name == 'schedule'
-        uses: DFE-Digital/github-actions/install-postgres-client@master
-        with:
-          version: 14
-
-      - name: Sanitise dump
-        if: github.event_name == 'schedule'
-        run: |
-          gzip -d --to-stdout ${BACKUP_FILE}.sql.gz | psql -d postgres
-          psql -d postgres -f db/scripts/sanitise.sql
-          pg_dump -E utf8 --compress=1 --clean --if-exists --no-owner --verbose --no-password -f ${SANITISED_FILE_NAME}.sql.gz
-        env:
-          PGUSER: postgres
-          PGPASSWORD: postgres
-          PGHOST: localhost
-          PGPORT: 5432
-
-      - name: Upload sanitised backup to Azure Storage
-        if: github.event_name == 'schedule'
-        run: |
-          STORAGE_CONN_STR=$(az storage account show-connection-string -g ${{ env.RESOURCE_GROUP_NAME }} -n ${{ env.STORAGE_ACCOUNT_NAME }} --query 'connectionString')
-          echo "::add-mask::$STORAGE_CONN_STR"
-
-          az storage blob upload --container-name database-backup \
-            --file ${SANITISED_FILE_NAME}.sql.gz --name ${SANITISED_FILE_NAME}.sql.gz --overwrite \
-            --connection-string "${STORAGE_CONN_STR}"
-          rm ${SANITISED_FILE_NAME}.sql.gz

--- a/.github/workflows/database.yaml
+++ b/.github/workflows/database.yaml
@@ -101,112 +101,31 @@ jobs:
           db-server-name: ${{ inputs.db-server }}
           slack-webhook: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}
 
-  #     - name: Install postgres client
-  #       if: github.event_name == 'schedule'
-  #       uses: DFE-Digital/github-actions/install-postgres-client@master
-  #       with:
-  #         version: 14
+      - name: Install postgres client
+        if: github.event_name == 'schedule'
+        uses: DFE-Digital/github-actions/install-postgres-client@master
+        with:
+          version: 14
 
-  #     - name: Sanitise dump
-  #       if: github.event_name == 'schedule'
-  #       run: |
-  #         gzip -d --to-stdout ${BACKUP_FILE}.sql.gz | psql -d postgres
-  #         psql -d postgres -f db/scripts/sanitise.sql
-  #         pg_dump -E utf8 --compress=1 --clean --if-exists --no-owner --verbose --no-password -f ${SANITISED_FILE_NAME}.sql.gz
-  #       env:
-  #         PGUSER: postgres
-  #         PGPASSWORD: postgres
-  #         PGHOST: localhost
-  #         PGPORT: 5432
+      - name: Sanitise dump
+        if: github.event_name == 'schedule'
+        run: |
+          gzip -d --to-stdout ${BACKUP_FILE}.sql.gz | psql -d postgres
+          psql -d postgres -f db/scripts/sanitise.sql
+          pg_dump -E utf8 --compress=1 --clean --if-exists --no-owner --verbose --no-password -f ${SANITISED_FILE_NAME}.sql.gz
+        env:
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGHOST: localhost
+          PGPORT: 5432
 
-  #     - name: Upload sanitised backup to Azure Storage
-  #       if: github.event_name == 'schedule'
-  #       run: |
-  #         STORAGE_CONN_STR=$(az storage account show-connection-string -g ${{ env.RESOURCE_GROUP_NAME }} -n ${{ env.STORAGE_ACCOUNT_NAME }} --query 'connectionString')
-  #         echo "::add-mask::$STORAGE_CONN_STR"
+      - name: Upload sanitised backup to Azure Storage
+        if: github.event_name == 'schedule'
+        run: |
+          STORAGE_CONN_STR=$(az storage account show-connection-string -g ${{ env.RESOURCE_GROUP_NAME }} -n ${{ env.STORAGE_ACCOUNT_NAME }} --query 'connectionString')
+          echo "::add-mask::$STORAGE_CONN_STR"
 
-  #         az storage blob upload --container-name database-backup \
-  #           --file ${SANITISED_FILE_NAME}.sql.gz --name ${SANITISED_FILE_NAME}.sql.gz --overwrite \
-  #           --connection-string "${STORAGE_CONN_STR}"
-  #         rm ${SANITISED_FILE_NAME}.sql.gz
-
-  # restore-preproduction:
-  #   name: Restore preproduction
-  #   needs: [backup]
-  #   if: ${{ github.event_name == 'schedule' }}
-  #   runs-on: ubuntu-latest
-  #   environment: production
-  #   env:
-  #     GLOBAL_CONFIG: preprod
-
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-
-  #     - name: Set environment variables
-  #       run: |
-  #         source global_config/${GLOBAL_CONFIG}.sh
-  #         tf_vars_file=${TF_VARS_PATH}/${CONFIG}/variables.tfvars.json
-  #         APP_ENVIRONMENT=$(jq -r '.app_environment' ${tf_vars_file})
-  #         echo "APP_NAME=${SERVICE_NAME}-${APP_ENVIRONMENT}-web" >> $GITHUB_ENV
-  #         echo "SANITISED_FILE_NAME=afqts_sanitised_$(date +"%F").sql.gz" >> $GITHUB_ENV
-  #         echo "CLUSTER_RG=s189t01-tsc-ts-rg" >> $GITHUB_ENV
-  #         echo "CLUSTER_NAME=s189t01-tsc-test-aks" >> $GITHUB_ENV
-  #         echo "RESOURCE_GROUP_NAME=s189p01-afqts-pd-rg" >> $GITHUB_ENV
-  #         echo "STORAGE_ACCOUNT_NAME=s189p01afqtsdbbkppdsa" >> $GITHUB_ENV
-
-  #     # Download backup from production storage account
-  #     - uses: azure/login@v2
-  #       with:
-  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-  #     - name: Set Connection String
-  #       run: |
-  #         STORAGE_CONN_STR=$(az storage account show-connection-string -g ${RESOURCE_GROUP_NAME} -n ${STORAGE_ACCOUNT_NAME} --query 'connectionString')
-  #         echo "::add-mask::$STORAGE_CONN_STR"
-  #         echo "AZURE_STORAGE_CONNECTION_STRING=$STORAGE_CONN_STR" >> $GITHUB_ENV
-
-  #     - name: Download Backup from Azure Storage
-  #       run: |
-  #         az config set extension.use_dynamic_install=yes_without_prompt
-  #         az config set core.only_show_errors=true
-  #         az storage azcopy blob download --container database-backup \
-  #           --source ${SANITISED_FILE_NAME} --destination ${SANITISED_FILE_NAME}
-
-  #     # Restore backup to preproduction database
-  #     - uses: azure/login@v2
-  #       with:
-  #         creds: ${{ secrets.AZURE_CREDENTIALS_PREPRODUCTION }}
-
-  #     - name: Setup postgres client
-  #       uses: DFE-Digital/github-actions/install-postgres-client@master
-  #       with:
-  #         version: 14
-
-  #     - name: Install kubectl
-  #       uses: DFE-Digital/github-actions/set-kubectl@master
-
-  #     - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
-  #       with:
-  #         azure-credentials: ${{ secrets.AZURE_CREDENTIALS_PREPRODUCTION }}
-
-  #     - name: K8 setup
-  #       run: |
-  #         az aks get-credentials --overwrite-existing -g ${CLUSTER_RG} -n ${CLUSTER_NAME}
-  #         kubelogin convert-kubeconfig -l spn
-  #         # install konduit
-  #         curl -s https://raw.githubusercontent.com/DFE-Digital/teacher-services-cloud/master/scripts/konduit.sh -o ./konduit.sh
-  #         chmod +x ./konduit.sh
-
-  #     - name: Restore backup to aks env database
-  #       run: |
-  #         ./konduit.sh -i ${SANITISED_FILE_NAME} -c -t 7200 -x ${APP_NAME} -- psql
-
-  #     - name: Restore Summary
-  #       if: success()
-  #       run: |
-  #         NOW=$(TZ=Europe/London date +"%F %R")
-  #         echo "RESTORE SUCCESSFUL!" >> $GITHUB_STEP_SUMMARY
-  #         echo "APP: ${APP_NAME}" >> $GITHUB_STEP_SUMMARY
-  #         echo "BACKUP FILE RESTORED: ${STORAGE_ACCOUNT_NAME} / database-backup / ${SANITISED_FILE_NAME}" >> $GITHUB_STEP_SUMMARY
-  #         echo "AT: ${NOW}" >> $GITHUB_STEP_SUMMARY
+          az storage blob upload --container-name database-backup \
+            --file ${SANITISED_FILE_NAME}.sql.gz --name ${SANITISED_FILE_NAME}.sql.gz --overwrite \
+            --connection-string "${STORAGE_CONN_STR}"
+          rm ${SANITISED_FILE_NAME}.sql.gz

--- a/.github/workflows/database.yaml
+++ b/.github/workflows/database.yaml
@@ -101,112 +101,112 @@ jobs:
           db-server-name: ${{ inputs.db-server }}
           slack-webhook: ${{ steps.key-vault-secrets.outputs.SLACK_WEBHOOK }}
 
-      - name: Install postgres client
-        if: github.event_name == 'schedule'
-        uses: DFE-Digital/github-actions/install-postgres-client@master
-        with:
-          version: 14
+  #     - name: Install postgres client
+  #       if: github.event_name == 'schedule'
+  #       uses: DFE-Digital/github-actions/install-postgres-client@master
+  #       with:
+  #         version: 14
 
-      - name: Sanitise dump
-        if: github.event_name == 'schedule'
-        run: |
-          gzip -d --to-stdout ${BACKUP_FILE}.sql.gz | psql -d postgres
-          psql -d postgres -f db/scripts/sanitise.sql
-          pg_dump -E utf8 --compress=1 --clean --if-exists --no-owner --verbose --no-password -f ${SANITISED_FILE_NAME}.sql.gz
-        env:
-          PGUSER: postgres
-          PGPASSWORD: postgres
-          PGHOST: localhost
-          PGPORT: 5432
+  #     - name: Sanitise dump
+  #       if: github.event_name == 'schedule'
+  #       run: |
+  #         gzip -d --to-stdout ${BACKUP_FILE}.sql.gz | psql -d postgres
+  #         psql -d postgres -f db/scripts/sanitise.sql
+  #         pg_dump -E utf8 --compress=1 --clean --if-exists --no-owner --verbose --no-password -f ${SANITISED_FILE_NAME}.sql.gz
+  #       env:
+  #         PGUSER: postgres
+  #         PGPASSWORD: postgres
+  #         PGHOST: localhost
+  #         PGPORT: 5432
 
-      - name: Upload sanitised backup to Azure Storage
-        if: github.event_name == 'schedule'
-        run: |
-          STORAGE_CONN_STR=$(az storage account show-connection-string -g ${{ env.RESOURCE_GROUP_NAME }} -n ${{ env.STORAGE_ACCOUNT_NAME }} --query 'connectionString')
-          echo "::add-mask::$STORAGE_CONN_STR"
+  #     - name: Upload sanitised backup to Azure Storage
+  #       if: github.event_name == 'schedule'
+  #       run: |
+  #         STORAGE_CONN_STR=$(az storage account show-connection-string -g ${{ env.RESOURCE_GROUP_NAME }} -n ${{ env.STORAGE_ACCOUNT_NAME }} --query 'connectionString')
+  #         echo "::add-mask::$STORAGE_CONN_STR"
 
-          az storage blob upload --container-name database-backup \
-            --file ${SANITISED_FILE_NAME}.sql.gz --name ${SANITISED_FILE_NAME}.sql.gz --overwrite \
-            --connection-string "${STORAGE_CONN_STR}"
-          rm ${SANITISED_FILE_NAME}.sql.gz
+  #         az storage blob upload --container-name database-backup \
+  #           --file ${SANITISED_FILE_NAME}.sql.gz --name ${SANITISED_FILE_NAME}.sql.gz --overwrite \
+  #           --connection-string "${STORAGE_CONN_STR}"
+  #         rm ${SANITISED_FILE_NAME}.sql.gz
 
-  restore-preproduction:
-    name: Restore preproduction
-    needs: [backup]
-    if: ${{ github.event_name == 'schedule' }}
-    runs-on: ubuntu-latest
-    environment: production
-    env:
-      GLOBAL_CONFIG: preprod
+  # restore-preproduction:
+  #   name: Restore preproduction
+  #   needs: [backup]
+  #   if: ${{ github.event_name == 'schedule' }}
+  #   runs-on: ubuntu-latest
+  #   environment: production
+  #   env:
+  #     GLOBAL_CONFIG: preprod
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
 
-      - name: Set environment variables
-        run: |
-          source global_config/${GLOBAL_CONFIG}.sh
-          tf_vars_file=${TF_VARS_PATH}/${CONFIG}/variables.tfvars.json
-          APP_ENVIRONMENT=$(jq -r '.app_environment' ${tf_vars_file})
-          echo "APP_NAME=${SERVICE_NAME}-${APP_ENVIRONMENT}-web" >> $GITHUB_ENV
-          echo "SANITISED_FILE_NAME=afqts_sanitised_$(date +"%F").sql.gz" >> $GITHUB_ENV
-          echo "CLUSTER_RG=s189t01-tsc-ts-rg" >> $GITHUB_ENV
-          echo "CLUSTER_NAME=s189t01-tsc-test-aks" >> $GITHUB_ENV
-          echo "RESOURCE_GROUP_NAME=s189p01-afqts-pd-rg" >> $GITHUB_ENV
-          echo "STORAGE_ACCOUNT_NAME=s189p01afqtsdbbkppdsa" >> $GITHUB_ENV
+  #     - name: Set environment variables
+  #       run: |
+  #         source global_config/${GLOBAL_CONFIG}.sh
+  #         tf_vars_file=${TF_VARS_PATH}/${CONFIG}/variables.tfvars.json
+  #         APP_ENVIRONMENT=$(jq -r '.app_environment' ${tf_vars_file})
+  #         echo "APP_NAME=${SERVICE_NAME}-${APP_ENVIRONMENT}-web" >> $GITHUB_ENV
+  #         echo "SANITISED_FILE_NAME=afqts_sanitised_$(date +"%F").sql.gz" >> $GITHUB_ENV
+  #         echo "CLUSTER_RG=s189t01-tsc-ts-rg" >> $GITHUB_ENV
+  #         echo "CLUSTER_NAME=s189t01-tsc-test-aks" >> $GITHUB_ENV
+  #         echo "RESOURCE_GROUP_NAME=s189p01-afqts-pd-rg" >> $GITHUB_ENV
+  #         echo "STORAGE_ACCOUNT_NAME=s189p01afqtsdbbkppdsa" >> $GITHUB_ENV
 
-      # Download backup from production storage account
-      - uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
+  #     # Download backup from production storage account
+  #     - uses: azure/login@v2
+  #       with:
+  #         creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Set Connection String
-        run: |
-          STORAGE_CONN_STR=$(az storage account show-connection-string -g ${RESOURCE_GROUP_NAME} -n ${STORAGE_ACCOUNT_NAME} --query 'connectionString')
-          echo "::add-mask::$STORAGE_CONN_STR"
-          echo "AZURE_STORAGE_CONNECTION_STRING=$STORAGE_CONN_STR" >> $GITHUB_ENV
+  #     - name: Set Connection String
+  #       run: |
+  #         STORAGE_CONN_STR=$(az storage account show-connection-string -g ${RESOURCE_GROUP_NAME} -n ${STORAGE_ACCOUNT_NAME} --query 'connectionString')
+  #         echo "::add-mask::$STORAGE_CONN_STR"
+  #         echo "AZURE_STORAGE_CONNECTION_STRING=$STORAGE_CONN_STR" >> $GITHUB_ENV
 
-      - name: Download Backup from Azure Storage
-        run: |
-          az config set extension.use_dynamic_install=yes_without_prompt
-          az config set core.only_show_errors=true
-          az storage azcopy blob download --container database-backup \
-            --source ${SANITISED_FILE_NAME} --destination ${SANITISED_FILE_NAME}
+  #     - name: Download Backup from Azure Storage
+  #       run: |
+  #         az config set extension.use_dynamic_install=yes_without_prompt
+  #         az config set core.only_show_errors=true
+  #         az storage azcopy blob download --container database-backup \
+  #           --source ${SANITISED_FILE_NAME} --destination ${SANITISED_FILE_NAME}
 
-      # Restore backup to preproduction database
-      - uses: azure/login@v2
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS_PREPRODUCTION }}
+  #     # Restore backup to preproduction database
+  #     - uses: azure/login@v2
+  #       with:
+  #         creds: ${{ secrets.AZURE_CREDENTIALS_PREPRODUCTION }}
 
-      - name: Setup postgres client
-        uses: DFE-Digital/github-actions/install-postgres-client@master
-        with:
-          version: 14
+  #     - name: Setup postgres client
+  #       uses: DFE-Digital/github-actions/install-postgres-client@master
+  #       with:
+  #         version: 14
 
-      - name: Install kubectl
-        uses: DFE-Digital/github-actions/set-kubectl@master
+  #     - name: Install kubectl
+  #       uses: DFE-Digital/github-actions/set-kubectl@master
 
-      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
-        with:
-          azure-credentials: ${{ secrets.AZURE_CREDENTIALS_PREPRODUCTION }}
+  #     - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+  #       with:
+  #         azure-credentials: ${{ secrets.AZURE_CREDENTIALS_PREPRODUCTION }}
 
-      - name: K8 setup
-        run: |
-          az aks get-credentials --overwrite-existing -g ${CLUSTER_RG} -n ${CLUSTER_NAME}
-          kubelogin convert-kubeconfig -l spn
-          # install konduit
-          curl -s https://raw.githubusercontent.com/DFE-Digital/teacher-services-cloud/master/scripts/konduit.sh -o ./konduit.sh
-          chmod +x ./konduit.sh
+  #     - name: K8 setup
+  #       run: |
+  #         az aks get-credentials --overwrite-existing -g ${CLUSTER_RG} -n ${CLUSTER_NAME}
+  #         kubelogin convert-kubeconfig -l spn
+  #         # install konduit
+  #         curl -s https://raw.githubusercontent.com/DFE-Digital/teacher-services-cloud/master/scripts/konduit.sh -o ./konduit.sh
+  #         chmod +x ./konduit.sh
 
-      - name: Restore backup to aks env database
-        run: |
-          ./konduit.sh -i ${SANITISED_FILE_NAME} -c -t 7200 -x ${APP_NAME} -- psql
+  #     - name: Restore backup to aks env database
+  #       run: |
+  #         ./konduit.sh -i ${SANITISED_FILE_NAME} -c -t 7200 -x ${APP_NAME} -- psql
 
-      - name: Restore Summary
-        if: success()
-        run: |
-          NOW=$(TZ=Europe/London date +"%F %R")
-          echo "RESTORE SUCCESSFUL!" >> $GITHUB_STEP_SUMMARY
-          echo "APP: ${APP_NAME}" >> $GITHUB_STEP_SUMMARY
-          echo "BACKUP FILE RESTORED: ${STORAGE_ACCOUNT_NAME} / database-backup / ${SANITISED_FILE_NAME}" >> $GITHUB_STEP_SUMMARY
-          echo "AT: ${NOW}" >> $GITHUB_STEP_SUMMARY
+  #     - name: Restore Summary
+  #       if: success()
+  #       run: |
+  #         NOW=$(TZ=Europe/London date +"%F %R")
+  #         echo "RESTORE SUCCESSFUL!" >> $GITHUB_STEP_SUMMARY
+  #         echo "APP: ${APP_NAME}" >> $GITHUB_STEP_SUMMARY
+  #         echo "BACKUP FILE RESTORED: ${STORAGE_ACCOUNT_NAME} / database-backup / ${SANITISED_FILE_NAME}" >> $GITHUB_STEP_SUMMARY
+  #         echo "AT: ${NOW}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sanitise-and-restore-production-database.yaml
+++ b/.github/workflows/sanitise-and-restore-production-database.yaml
@@ -1,4 +1,4 @@
-name: Sync Preproduction with Sanitised Backup
+name: Sanitise and Restore Production Database
 
 on:
   workflow_dispatch:
@@ -21,6 +21,10 @@ jobs:
     env:
       GLOBAL_CONFIG: production
       BACKUP_FILE: ${{ inputs.backup-file }}
+    
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
     
       - name: Install postgres client
         uses: DFE-Digital/github-actions/install-postgres-client@master
@@ -48,8 +52,8 @@ jobs:
             --connection-string "${STORAGE_CONN_STR}"
           rm ${SANITISED_FILE_NAME}.sql.gz
 
-  sync-preprod:
-    name: Sync Preproduction with Sanitised Backup
+  restore-preproduction:
+    name: Restore preproduction
     needs: sanitise-backup
     runs-on: ubuntu-latest
     environment: production

--- a/.github/workflows/sanitise-and-restore-production-database.yaml
+++ b/.github/workflows/sanitise-and-restore-production-database.yaml
@@ -100,12 +100,6 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Set Connection String
-        run: |
-          STORAGE_CONN_STR=$(az storage account show-connection-string -g ${RESOURCE_GROUP_NAME} -n ${STORAGE_ACCOUNT_NAME} --query 'connectionString')
-          echo "::add-mask::$STORAGE_CONN_STR"
-          echo "AZURE_STORAGE_CONNECTION_STRING=$STORAGE_CONN_STR" >> $GITHUB_ENV
-
       - name: Download Backup from Azure Storage
         run: |
           az config set extension.use_dynamic_install=yes_without_prompt

--- a/.github/workflows/sanitise-and-restore-production-database.yaml
+++ b/.github/workflows/sanitise-and-restore-production-database.yaml
@@ -26,9 +26,23 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Set environment variables
+        run: |
+          source global_config/${GLOBAL_CONFIG}.sh
+          echo "SANITISED_FILE_NAME=afqts_sanitised_$(date +"%F").sql.gz" >> $GITHUB_ENV
+          echo "RESOURCE_GROUP_NAME=s189p01-afqts-pd-rg" >> $GITHUB_ENV
+          echo "STORAGE_ACCOUNT_NAME=s189p01afqtsdbbkppdsa" >> $GITHUB_ENV
+
       - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Download Production Backup from Azure Storage
+        run: |
+          az config set extension.use_dynamic_install=yes_without_prompt
+          az config set core.only_show_errors=true
+          az storage azcopy blob download --container database-backup \
+            --source ${BACKUP_FILE} --destination ${BACKUP_FILE}
 
       - name: Install postgres client
         uses: DFE-Digital/github-actions/install-postgres-client@master
@@ -37,7 +51,7 @@ jobs:
 
       - name: Sanitise dump
         run: |
-          gzip -d --to-stdout ${BACKUP_FILE}.sql.gz | psql -d postgres
+          gzip -d --to-stdout ${BACKUP_FILE} | psql -d postgres
           psql -d postgres -f db/scripts/sanitise.sql
           pg_dump -E utf8 --compress=1 --clean --if-exists --no-owner --verbose --no-password -f ${SANITISED_FILE_NAME}.sql.gz
         env:
@@ -60,7 +74,7 @@ jobs:
     name: Restore preproduction
     needs: sanitise-backup
     runs-on: ubuntu-latest
-    environment: production
+    environment: preproduction
     env:
       GLOBAL_CONFIG: preprod
       BACKUP_FILE: ${{ inputs.backup-file }}

--- a/.github/workflows/sanitise-and-restore-production-database.yaml
+++ b/.github/workflows/sanitise-and-restore-production-database.yaml
@@ -21,11 +21,11 @@ jobs:
     env:
       GLOBAL_CONFIG: production
       BACKUP_FILE: ${{ inputs.backup-file }}
-    
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-    
+
       - name: Install postgres client
         uses: DFE-Digital/github-actions/install-postgres-client@master
         with:

--- a/.github/workflows/sanitise-and-restore-production-database.yaml
+++ b/.github/workflows/sanitise-and-restore-production-database.yaml
@@ -26,6 +26,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
       - name: Install postgres client
         uses: DFE-Digital/github-actions/install-postgres-client@master
         with:

--- a/.github/workflows/sync-preprod-with-sanitised-prod-backup.yaml
+++ b/.github/workflows/sync-preprod-with-sanitised-prod-backup.yaml
@@ -14,6 +14,40 @@ env:
   TF_VARS_PATH: terraform/application/config
 
 jobs:
+  sanitise-backup:
+    name: Sanitise Backup
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      GLOBAL_CONFIG: production
+      BACKUP_FILE: ${{ inputs.backup-file }}
+    
+      - name: Install postgres client
+        uses: DFE-Digital/github-actions/install-postgres-client@master
+        with:
+          version: 14
+
+      - name: Sanitise dump
+        run: |
+          gzip -d --to-stdout ${BACKUP_FILE}.sql.gz | psql -d postgres
+          psql -d postgres -f db/scripts/sanitise.sql
+          pg_dump -E utf8 --compress=1 --clean --if-exists --no-owner --verbose --no-password -f ${SANITISED_FILE_NAME}.sql.gz
+        env:
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGHOST: localhost
+          PGPORT: 5432
+
+      - name: Upload sanitised backup to Azure Storage
+        run: |
+          STORAGE_CONN_STR=$(az storage account show-connection-string -g ${{ env.RESOURCE_GROUP_NAME }} -n ${{ env.STORAGE_ACCOUNT_NAME }} --query 'connectionString')
+          echo "::add-mask::$STORAGE_CONN_STR"
+
+          az storage blob upload --container-name database-backup \
+            --file ${SANITISED_FILE_NAME}.sql.gz --name ${SANITISED_FILE_NAME}.sql.gz --overwrite \
+            --connection-string "${STORAGE_CONN_STR}"
+          rm ${SANITISED_FILE_NAME}.sql.gz
+
   sync-preprod:
     name: Sync Preproduction with Sanitised Backup
     runs-on: ubuntu-latest
@@ -42,32 +76,6 @@ jobs:
       - uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: Install postgres client
-        uses: DFE-Digital/github-actions/install-postgres-client@master
-        with:
-          version: 14
-
-      - name: Sanitise dump
-        run: |
-          gzip -d --to-stdout ${BACKUP_FILE}.sql.gz | psql -d postgres
-          psql -d postgres -f db/scripts/sanitise.sql
-          pg_dump -E utf8 --compress=1 --clean --if-exists --no-owner --verbose --no-password -f ${SANITISED_FILE_NAME}.sql.gz
-        env:
-          PGUSER: postgres
-          PGPASSWORD: postgres
-          PGHOST: localhost
-          PGPORT: 5432
-
-      - name: Upload sanitised backup to Azure Storage
-        run: |
-          STORAGE_CONN_STR=$(az storage account show-connection-string -g ${{ env.RESOURCE_GROUP_NAME }} -n ${{ env.STORAGE_ACCOUNT_NAME }} --query 'connectionString')
-          echo "::add-mask::$STORAGE_CONN_STR"
-
-          az storage blob upload --container-name database-backup \
-            --file ${SANITISED_FILE_NAME}.sql.gz --name ${SANITISED_FILE_NAME}.sql.gz --overwrite \
-            --connection-string "${STORAGE_CONN_STR}"
-          rm ${SANITISED_FILE_NAME}.sql.gz
 
       - name: Set Connection String
         run: |

--- a/.github/workflows/sync-preprod-with-sanitised-prod-backup.yaml
+++ b/.github/workflows/sync-preprod-with-sanitised-prod-backup.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       backup-file:
-        description: Name of the sanitized backup file to restore (e.g., afqts_sanitised_2023-10-07.sql.gz)
+        description: Name of the prod backup file to sanitise and restore on preproduction (e.g., afqts_pd_2025-01-10.sql.gz)
         required: true
         type: string
 

--- a/.github/workflows/sync-preprod-with-sanitised-prod-backup.yaml
+++ b/.github/workflows/sync-preprod-with-sanitised-prod-backup.yaml
@@ -1,0 +1,121 @@
+name: Sync Preproduction with Sanitised Backup
+
+on:
+  workflow_dispatch:
+    inputs:
+      backup-file:
+        description: Name of the sanitized backup file to restore (e.g., afqts_sanitised_2023-10-07.sql.gz)
+        required: true
+        type: string
+
+env:
+  SERVICE_NAME: apply-for-qts
+  SERVICE_SHORT: afqts
+  TF_VARS_PATH: terraform/application/config
+
+jobs:
+  sync-preprod:
+    name: Sync Preproduction with Sanitised Backup
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      GLOBAL_CONFIG: preprod
+      BACKUP_FILE: ${{ inputs.backup-file }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set environment variables
+        run: |
+          source global_config/${GLOBAL_CONFIG}.sh
+          tf_vars_file=${TF_VARS_PATH}/${CONFIG}/variables.tfvars.json
+          APP_ENVIRONMENT=$(jq -r '.app_environment' ${tf_vars_file})
+          echo "APP_NAME=${SERVICE_NAME}-${APP_ENVIRONMENT}-web" >> $GITHUB_ENV
+          echo "SANITISED_FILE_NAME=afqts_sanitised_$(date +"%F").sql.gz" >> $GITHUB_ENV
+          echo "CLUSTER_RG=s189t01-tsc-ts-rg" >> $GITHUB_ENV
+          echo "CLUSTER_NAME=s189t01-tsc-test-aks" >> $GITHUB_ENV
+          echo "RESOURCE_GROUP_NAME=s189p01-afqts-pd-rg" >> $GITHUB_ENV
+          echo "STORAGE_ACCOUNT_NAME=s189p01afqtsdbbkppdsa" >> $GITHUB_ENV
+
+      # Download backup from production storage account
+      - uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Install postgres client
+        uses: DFE-Digital/github-actions/install-postgres-client@master
+        with:
+          version: 14
+
+      - name: Sanitise dump
+        run: |
+          gzip -d --to-stdout ${BACKUP_FILE}.sql.gz | psql -d postgres
+          psql -d postgres -f db/scripts/sanitise.sql
+          pg_dump -E utf8 --compress=1 --clean --if-exists --no-owner --verbose --no-password -f ${SANITISED_FILE_NAME}.sql.gz
+        env:
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGHOST: localhost
+          PGPORT: 5432
+
+      - name: Upload sanitised backup to Azure Storage
+        run: |
+          STORAGE_CONN_STR=$(az storage account show-connection-string -g ${{ env.RESOURCE_GROUP_NAME }} -n ${{ env.STORAGE_ACCOUNT_NAME }} --query 'connectionString')
+          echo "::add-mask::$STORAGE_CONN_STR"
+
+          az storage blob upload --container-name database-backup \
+            --file ${SANITISED_FILE_NAME}.sql.gz --name ${SANITISED_FILE_NAME}.sql.gz --overwrite \
+            --connection-string "${STORAGE_CONN_STR}"
+          rm ${SANITISED_FILE_NAME}.sql.gz
+
+      - name: Set Connection String
+        run: |
+          STORAGE_CONN_STR=$(az storage account show-connection-string -g ${RESOURCE_GROUP_NAME} -n ${STORAGE_ACCOUNT_NAME} --query 'connectionString')
+          echo "::add-mask::$STORAGE_CONN_STR"
+          echo "AZURE_STORAGE_CONNECTION_STRING=$STORAGE_CONN_STR" >> $GITHUB_ENV
+
+      - name: Download Backup from Azure Storage
+        run: |
+          az config set extension.use_dynamic_install=yes_without_prompt
+          az config set core.only_show_errors=true
+          az storage azcopy blob download --container database-backup \
+            --source ${SANITISED_FILE_NAME} --destination ${SANITISED_FILE_NAME}
+
+      # Restore backup to preproduction database
+      - uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS_PREPRODUCTION }}
+
+      - name: Setup postgres client
+        uses: DFE-Digital/github-actions/install-postgres-client@master
+        with:
+          version: 14
+
+      - name: Install kubectl
+        uses: DFE-Digital/github-actions/set-kubectl@master
+
+      - uses: DFE-Digital/github-actions/set-kubelogin-environment@master
+        with:
+          azure-credentials: ${{ secrets.AZURE_CREDENTIALS_PREPRODUCTION }}
+
+      - name: K8 setup
+        run: |
+          az aks get-credentials --overwrite-existing -g ${CLUSTER_RG} -n ${CLUSTER_NAME}
+          kubelogin convert-kubeconfig -l spn
+          # install konduit
+          curl -s https://raw.githubusercontent.com/DFE-Digital/teacher-services-cloud/master/scripts/konduit.sh -o ./konduit.sh
+          chmod +x ./konduit.sh
+
+      - name: Restore backup to aks env database
+        run: |
+          ./konduit.sh -i ${SANITISED_FILE_NAME} -c -t 7200 -x ${APP_NAME} -- psql
+
+      - name: Restore Summary
+        if: success()
+        run: |
+          NOW=$(TZ=Europe/London date +"%F %R")
+          echo "RESTORE SUCCESSFUL!" >> $GITHUB_STEP_SUMMARY
+          echo "APP: ${APP_NAME}" >> $GITHUB_STEP_SUMMARY
+          echo "BACKUP FILE RESTORED: ${STORAGE_ACCOUNT_NAME} / database-backup / ${SANITISED_FILE_NAME}" >> $GITHUB_STEP_SUMMARY
+          echo "AT: ${NOW}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/sync-preprod-with-sanitised-prod-backup.yaml
+++ b/.github/workflows/sync-preprod-with-sanitised-prod-backup.yaml
@@ -1,4 +1,4 @@
-name: Sanitise and Restore Production Database
+name: Sync PreProd with Sanitised Prod Backup
 
 on:
   workflow_dispatch:

--- a/.github/workflows/sync-preprod-with-sanitised-prod-backup.yaml
+++ b/.github/workflows/sync-preprod-with-sanitised-prod-backup.yaml
@@ -50,6 +50,7 @@ jobs:
 
   sync-preprod:
     name: Sync Preproduction with Sanitised Backup
+    needs: sanitise-backup
     runs-on: ubuntu-latest
     environment: production
     env:


### PR DESCRIPTION
https://dfedigital.atlassian.net/jira/software/projects/AQTS/boards/207?assignee=5e8313e39126d30c24f0ec5a&selectedIssue=AQTS-738

This ticket will remove the scheduled backup of the database to preprod following sanitisation. So that this functionality can be manually triggered only. 

Workflow Description
This workflow takes a production database backup file, sanitizes it, and restores it to the preproduction environment.

Required Input:
  backup-file: The name of the production backup file (e.g., afqts_pd_2025-01-10.sql.gz)

Process:
 1. Downloads the specified production backup from Azure Storage
 2. Runs sanitization scripts to remove sensitive data
 3. Uploads the sanitized backup to Azure Storage
 4. Restores the sanitized backup to the preproduction database
