### PR TITLE
[AQTS-760] Passport changes for assessment pages (Personal information section)

### DIFF
--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -93,6 +93,8 @@ class FailureReasons
     IDENTIFICATION_DOCUMENT_ILLEGIBLE => :identification,
     IDENTIFICATION_DOCUMENT_MISMATCH => :name_change,
     NAME_CHANGE_DOCUMENT_ILLEGIBLE => :name_change,
+    PASSPORT_DOCUMENT_ILLEGIBLE => :passport,
+    PASSPORT_DOCUMENT_MISMATCH => :name_change,
     QUALIFICATIONS_DONT_MATCH_SUBJECTS => :qualification_document,
     QUALIFIED_TO_TEACH => :written_statement,
     REGISTRATION_NUMBER_ALTERNATIVE => :written_statement,

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -124,6 +124,10 @@ class FailureReasons
     failure_reason.to_s == FailureReasons::FRAUD
   end
 
+  def self.passport_expired?(failure_reason)
+    failure_reason.to_s == FailureReasons::PASSPORT_DOCUMENT_EXPIRED
+  end
+
   def self.requires_note?(failure_reason)
     suitability?(failure_reason) || fraud?(failure_reason) ||
       further_information?(failure_reason)

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -7,8 +7,11 @@ class FailureReasons
     AUTHORISATION_TO_TEACH = "authorisation_to_teach",
     CONFIRM_AGE_RANGE_SUBJECTS = "confirm_age_range_subjects",
     DUPLICATE_APPLICATION = "duplicate_application",
+    PASSPORT_DOCUMENT_EXPIRED = "passport_document_expired",
     EL_EXEMPTION_BY_CITIZENSHIP_ID_UNCONFIRMED =
       "english_language_exemption_by_citizenship_not_confirmed",
+    EL_EXEMPTION_BY_CITIZENSHIP_PASSPORT_UNCONFIRMED =
+      "english_language_exemption_by_citizenship_not_confirmed_via_passport",
     EL_EXEMPTION_BY_QUALIFICATION_DOCUMENTS_UNCONFIRMED =
       "english_language_exemption_by_qualification_not_confirmed",
     EL_GRADE_BELOW_B2 = "english_language_not_achieved_b2",
@@ -54,6 +57,8 @@ class FailureReasons
     IDENTIFICATION_DOCUMENT_EXPIRED = "identification_document_expired",
     IDENTIFICATION_DOCUMENT_ILLEGIBLE = "identification_document_illegible",
     IDENTIFICATION_DOCUMENT_MISMATCH = "identification_document_mismatch",
+    PASSPORT_DOCUMENT_ILLEGIBLE = "passport_document_illegible",
+    PASSPORT_DOCUMENT_MISMATCH = "passport_document_mismatch",
     NAME_CHANGE_DOCUMENT_ILLEGIBLE = "name_change_document_illegible",
     QUALIFICATIONS_DONT_MATCH_OTHER_DETAILS =
       "qualifications_dont_match_other_details",

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -163,7 +163,9 @@ module AssessorInterface
 
     def build_key(failure_reason, key_section)
       key =
-        if FailureReasons.fraud?(failure_reason)
+        if FailureReasons.passport_expired?(failure_reason)
+          "passport_expired"
+        elsif FailureReasons.fraud?(failure_reason)
           "fraud"
         elsif FailureReasons.suitability?(failure_reason)
           "suitability"

--- a/app/view_objects/assessor_interface/further_information_request_view_object.rb
+++ b/app/view_objects/assessor_interface/further_information_request_view_object.rb
@@ -96,7 +96,11 @@ class AssessorInterface::FurtherInformationRequestViewObject
         "teacher_interface.further_information_request.show.failure_reason.#{item.failure_reason_key}",
       )
     when "document"
-      "Upload your #{I18n.t("document.document_type.#{item.document.document_type}")} document"
+      if item.document.document_type == "passport"
+        "Upload your #{I18n.t("document.document_type.#{item.document.document_type}")}"
+      else
+        "Upload your #{I18n.t("document.document_type.#{item.document.document_type}")} document"
+      end
     when "work_history_contact"
       "Please provide new contact information for your work history contact"
     end

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -87,7 +87,11 @@ module TeacherInterface
       when "work_history_contact"
         "Add work history details"
       when "document"
-        "Upload your #{I18n.t("document.document_type.#{item.document.document_type}")} document"
+        if item.document.document_type == "passport"
+          "Upload your #{I18n.t("document.document_type.#{item.document.document_type}")}"
+        else
+          "Upload your #{I18n.t("document.document_type.#{item.document.document_type}")} document"
+        end
       end
     end
   end

--- a/app/views/assessor_interface/assessment_sections/_form.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_form.html.erb
@@ -2,6 +2,12 @@
   <%= f.govuk_error_summary %>
 
   <% if view_object.show_english_language_exemption_checkbox? %>
+    <% if view_object.assessment_section.personal_information? %>
+      <% english_language_section_passed_label = t("#{view_object.assessment_section.key}_#{view_object.application_form.requires_passport_as_identity_proof? ? 'passport' : 'id'}", scope: %i[assessor_interface assessment_sections english_language_proficiency passed]) %>
+    <% else %>
+      <% english_language_section_passed_label = t(view_object.assessment_section.key, scope: %i[assessor_interface assessment_sections english_language_proficiency passed]) %>
+    <% end %>
+
     <%= f.govuk_check_box :english_language_section_passed,
                           true,
                           false,
@@ -9,7 +15,7 @@
                           link_errors: true,
                           small: true,
                           label: {
-                            text: t(view_object.assessment_section.key, scope: %i[assessor_interface assessment_sections english_language_proficiency passed]),
+                            text: english_language_section_passed_label,
                             size: "s",
                           },
                           disabled: view_object.disable_form? %>

--- a/app/views/assessor_interface/assessment_sections/_personal_information_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_personal_information_summary.html.erb
@@ -1,5 +1,9 @@
 <%= render "shared/application_form/personal_information_summary", application_form:, changeable: false %>
-<%= render "shared/application_form/identification_document_summary", application_form:, changeable: false %>
+<% if application_form.requires_passport_as_identity_proof %>
+  <%= render "shared/application_form/passport_document_summary", application_form:, changeable: false %>
+<% else %>
+  <%= render "shared/application_form/identification_document_summary", application_form:, changeable: false %>
+<% end %>
 
 <% if application_form.english_language_citizenship_exempt %>
   <%= govuk_accordion do |accordion| %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -171,7 +171,7 @@ en:
           name_change_document_illegible: The evidence of change of name is illegible or in a format that we cannot accept.
           not_qualified_to_teach_mainstream: Applicant is not qualified to teach in mainstream education.
           passport_document_expired: The passport had already expired when the application was submitted.
-          passport_document_illegible: There is a problem with the passport. For example, it's incorrect, illegible, or incomplete.
+          passport_document_illegible: There is a problem with the passport. For example, it’s incorrect, illegible, or incomplete.
           passport_document_mismatch: The name on the online application form is different from the passport, but no evidence of change of name was provided.
           qualifications_dont_match_other_details: Uploaded qualifications do not match other details entered, for example, name of qualification, name of institution or dates.
           qualifications_dont_match_subjects: Subjects entered are acceptable for QTS, but the uploaded qualifications do not match them.

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -115,6 +115,8 @@ en:
         has_teacher_qualification_transcript: teaching qualification transcript is present (and translation if required)
         has_university_degree_certificate: university degree qualification certificate is present (and translation if required)
         has_university_degree_transcript: university degree transcript is present (and translation if required)
+        expiry_date_valid: the expiry date on the uploaded passport file matches the expiry date the applicant entered
+        passport_document_valid: the uploaded passport was valid and in date when the application was created
         identification_document_present: a valid ID document is present
         name_change_document_present: evidence of name change is present (if the name entered on the form is different to the name on their ID)
         qualifications_meet_level_6_or_equivalent: applicant holds qualifications that meet the required academic level (level 6 qualification or higher)
@@ -152,6 +154,7 @@ en:
           degree_transcript_illegible: The university degree transcript (or translation) is illegible or in a format that we cannot accept.
           duplicate_application: There’s already another in-flight application for this applicant.
           english_language_exemption_by_citizenship_not_confirmed: The applicant’s ID does not confirm English language exemption by birth/citizenship.
+          english_language_exemption_by_citizenship_not_confirmed_via_passport: The applicant’s passport does not confirm English language exemption by birth/citizenship.
           english_language_exemption_by_qualification_not_confirmed: The applicant’s qualification documents do not confirm English language exemption by country of study.
           english_language_moi_invalid_format: The applicant’s Medium of instruction (MOI) document is illegible or in a format that we cannot accept.
           english_language_moi_not_taught_in_english: The applicant’s MOI does not show that they were taught exclusively in English.
@@ -167,6 +170,9 @@ en:
           identification_document_mismatch: The name on the online application form is different from the ID document, but no evidence of change of name was provided.
           name_change_document_illegible: The evidence of change of name is illegible or in a format that we cannot accept.
           not_qualified_to_teach_mainstream: Applicant is not qualified to teach in mainstream education.
+          passport_document_expired: The passport had already expired when the application was submitted.
+          passport_document_illegible: There is a problem with the passport. For example, it's incorrect, illegible, or incomplete.
+          passport_document_mismatch: The name on the online application form is different from the passport, but no evidence of change of name was provided.
           qualifications_dont_match_other_details: Uploaded qualifications do not match other details entered, for example, name of qualification, name of institution or dates.
           qualifications_dont_match_subjects: Subjects entered are acceptable for QTS, but the uploaded qualifications do not match them.
           qualified_to_teach: We were not provided with sufficient evidence to confirm qualification to teach at state or government schools.
@@ -206,7 +212,8 @@ en:
 
       english_language_proficiency:
         passed:
-          personal_information: This applicant has indicated English language exemption by birth/citizenship. I have checked their ID for evidence of this.
+          personal_information_passport: This applicant has indicated English language exemption by birth/citizenship. I have checked their passport for evidence of this.
+          personal_information_id: This applicant has indicated English language exemption by birth/citizenship. I have checked their ID for evidence of this.
           qualifications: This applicant has indicated English language exemption by country of study. I have checked their qualification documents for evidence of this.
 
     further_information_requests:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -13,6 +13,7 @@ en:
           decline: As this reason triggers a decline, you do not need to add a note, but you can use the space below to add anything you feel might be helpful, if you want to.
           document: This FI reason asks the applicant to upload a file. Use this space to give them clear instructions on what they need to provide.
           fraud: This reason triggers a decline. As you are declining an applicant because of potential fraud, you must enter the additional content agreed by the suitability panel.
+          passport_expired: As this reason triggers a decline, you do not need to add a note, but you can use the space below to add anything you feel might be helpful, if you want to.
           suitability: This reason triggers a decline. As you are declining an applicant because of suitability reasons, you must enter the additional content agreed by the suitability panel.
           text: This FI allows the applicant to send us a typed response. Use this space to give them clear instructions on what they need to provide.
       assessor_interface_create_note_form:
@@ -98,6 +99,7 @@ en:
           decline: Note to the applicant (optional)
           document: Note to the applicant
           fraud: Note to the applicant (mandatory)
+          passport_expired: Note to the applicant (optional)
           suitability: Note to the applicant (mandatory)
           text: Note to the applicant
         induction_required_options:
@@ -310,6 +312,7 @@ en:
           decline: "Example: We declined this QTS application as you already have another application in progress."
           document: "Example: The right-hand section of your teaching qualification document is missing, please take a new image and upload it."
           fraud: "Example: We declined this QTS application as you already have another application in progress."
+          passport_expired: "Example: We declined this QTS application as your passport had already expired when you submitted your application. We can only accept valid, in-date passports to verify your identity."
           suitability: "Example: We declined this QTS application as you already have another application in progress."
           text: "Example: The right-hand section of your teaching qualification document is missing, please take a new image and upload it."
     legend:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -16,6 +16,7 @@ en:
             degree_transcript_illegible: Your university degree transcript (or translation) is illegible or in a format we cannot accept.
             duplicate_application: You already have an application in progress.
             english_language_exemption_by_citizenship_not_confirmed: Your ID does not confirm English language exemption by birth or citizenship.
+            english_language_exemption_by_citizenship_not_confirmed_via_passport: Your passport does not confirm English language exemption by birth or citizenship.
             english_language_exemption_by_qualification_not_confirmed: Your qualification documents do not confirm English language exemption by country of study.
             english_language_moi_invalid_format: Your Medium of instruction (MOI) document is illegible or in a format that we cannot accept.
             english_language_moi_not_taught_in_english: Your medium of instruction (MOI) does not show that you were taught exclusively in English.
@@ -33,6 +34,9 @@ en:
             name_change_document_illegible: The evidence for your name change is illegible or in a format we cannot accept.
             not_qualified_to_teach_mainstream: You are not qualified to teach in mainstream education.
             professional_standing_request_expired: Your application has been declined as we did not receive your %{certificate_name} from %{teaching_authority_name} within 180 days.
+            passport_document_expired: Your passport document has expired.
+            passport_document_illegible: Your passport is illegible or in a format we cannot accept.
+            passport_document_mismatch: Your name on the online application form is different from the passport, but no evidence of change of name has been provided.
             qualifications_dont_match_other_details: Your uploaded qualifications do not match other details entered, for example, name of qualification, name of institution, or dates.
             qualifications_dont_match_subjects: The subjects you entered are acceptable for QTS, but the uploaded qualifications do not match them.
             qualified_to_teach: We were not provided with sufficient evidence to confirm qualification to teach at state or government schools.

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -34,9 +34,9 @@ en:
             name_change_document_illegible: The evidence for your name change is illegible or in a format we cannot accept.
             not_qualified_to_teach_mainstream: You are not qualified to teach in mainstream education.
             professional_standing_request_expired: Your application has been declined as we did not receive your %{certificate_name} from %{teaching_authority_name} within 180 days.
-            passport_document_expired: Your passport document has expired.
-            passport_document_illegible: Your passport is illegible or in a format we cannot accept.
-            passport_document_mismatch: Your name on the online application form is different from the passport, but no evidence of change of name has been provided.
+            passport_document_expired: Your passport had already expired when the application was submitted.
+            passport_document_illegible: There is a problem with your passport. For example, it's incorrect, illegible, or incomplete.
+            passport_document_mismatch: Your name on the online application form is different from your passport, but no evidence of change of name has been provided.
             qualifications_dont_match_other_details: Your uploaded qualifications do not match other details entered, for example, name of qualification, name of institution, or dates.
             qualifications_dont_match_subjects: The subjects you entered are acceptable for QTS, but the uploaded qualifications do not match them.
             qualified_to_teach: We were not provided with sufficient evidence to confirm qualification to teach at state or government schools.

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -35,7 +35,7 @@ en:
             not_qualified_to_teach_mainstream: You are not qualified to teach in mainstream education.
             professional_standing_request_expired: Your application has been declined as we did not receive your %{certificate_name} from %{teaching_authority_name} within 180 days.
             passport_document_expired: Your passport had already expired when the application was submitted.
-            passport_document_illegible: There is a problem with your passport. For example, it's incorrect, illegible, or incomplete.
+            passport_document_illegible: There is a problem with your passport. For example, it’s incorrect, illegible, or incomplete.
             passport_document_mismatch: Your name on the online application form is different from your passport, but no evidence of change of name has been provided.
             qualifications_dont_match_other_details: Your uploaded qualifications do not match other details entered, for example, name of qualification, name of institution, or dates.
             qualifications_dont_match_subjects: The subjects you entered are acceptable for QTS, but the uploaded qualifications do not match them.

--- a/spec/factories/further_information_request_items.rb
+++ b/spec/factories/further_information_request_items.rb
@@ -46,6 +46,13 @@ FactoryBot.define do
       end
     end
 
+    trait :with_passport_document_response do
+      information_type { "document" }
+      failure_reason_key { "passport_document_illegible" }
+
+      after(:create) { |item| create(:document, :passport, documentable: item) }
+    end
+
     trait :with_work_history_contact_response do
       information_type { "work_history_contact" }
       failure_reason_key { "school_details_cannot_be_verified" }

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe AssessmentFactory do
       age_range_min: 7,
       age_range_max: 11,
       requires_passport_as_identity_proof:,
-      english_language_citizenship_exempt:
+      english_language_citizenship_exempt:,
     )
   end
 

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -13,8 +13,13 @@ RSpec.describe AssessmentFactory do
       needs_registration_number: false,
       age_range_min: 7,
       age_range_max: 11,
+      requires_passport_as_identity_proof:,
+      english_language_citizenship_exempt:
     )
   end
+
+  let(:requires_passport_as_identity_proof) { false }
+  let(:english_language_citizenship_exempt) { false }
 
   before { FeatureFlags::FeatureFlag.activate(:suitability) }
 
@@ -80,6 +85,17 @@ RSpec.describe AssessmentFactory do
             expect(section.checks).to include("name_change_document_present")
             expect(section.failure_reasons).to include(
               "name_change_document_illegible",
+            )
+          end
+        end
+
+        context "with english language citizenship exemption" do
+          let(:english_language_citizenship_exempt) { true }
+
+          it "has the english exemption by citizenship unconfirmed failure reason" do
+            section = sections.personal_information.first
+            expect(section.failure_reasons).to include(
+              "english_language_exemption_by_citizenship_not_confirmed",
             )
           end
         end
@@ -447,6 +463,69 @@ RSpec.describe AssessmentFactory do
                 fraud
               ],
             )
+          end
+        end
+      end
+    end
+
+    context "with application form requiring passport as identity proof" do
+      let(:requires_passport_as_identity_proof) { true }
+
+      describe "sections" do
+        subject(:sections) { call.sections }
+
+        describe "personal information section" do
+          it "is created" do
+            expect(sections.personal_information.count).to eq(1)
+          end
+
+          it "has the right checks and failure reasons" do
+            section = sections.personal_information.first
+            expect(section.checks).to eq(
+              %w[
+                expiry_date_valid
+                passport_document_valid
+                duplicate_application
+                applicant_already_qts
+                applicant_already_dqt
+              ],
+            )
+            expect(section.failure_reasons).to eq(
+              %w[
+                passport_document_expired
+                passport_document_illegible
+                passport_document_mismatch
+                duplicate_application
+                applicant_already_qts
+                applicant_already_dqt
+                suitability
+                suitability_previously_declined
+                fraud
+              ],
+            )
+          end
+
+          context "with a name change document" do
+            before { application_form.update!(has_alternative_name: true) }
+
+            it "has the right checks and failure reasons" do
+              section = sections.personal_information.first
+              expect(section.checks).to include("name_change_document_present")
+              expect(section.failure_reasons).to include(
+                "name_change_document_illegible",
+              )
+            end
+          end
+
+          context "with english language citizenship exemption (via passport)" do
+            let(:english_language_citizenship_exempt) { true }
+
+            it "has the english exemption by citizenship unconfirmed failure reason" do
+              section = sections.personal_information.first
+              expect(section.failure_reasons).to include(
+                "english_language_exemption_by_citizenship_not_confirmed_via_passport",
+              )
+            end
           end
         end
       end

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -70,6 +70,16 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
       end
     end
 
+    context "with a passport expired failure reason" do
+      let(:failure_reason) { FailureReasons::PASSPORT_DOCUMENT_EXPIRED }
+
+      it do
+        expect(subject).to eq(
+          "helpers.label.assessor_interface_assessment_section_form.failure_reason_notes.passport_expired",
+        )
+      end
+    end
+
     context "with a text failure reason" do
       let(:failure_reason) { "there-once-was-a-cat-with-a-hungry-belly" }
 
@@ -114,6 +124,16 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
       end
     end
 
+    context "with a passport expired failure reason" do
+      let(:failure_reason) { FailureReasons::PASSPORT_DOCUMENT_EXPIRED }
+
+      it do
+        expect(subject).to eq(
+          "helpers.hint.assessor_interface_assessment_section_form.failure_reason_notes.passport_expired",
+        )
+      end
+    end
+
     context "with a text failure reason" do
       let(:failure_reason) { "soon-may-the-kitty-man-come" }
 
@@ -144,6 +164,16 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
       it do
         expect(subject).to eq(
           "helpers.placeholder.assessor_interface_assessment_section_form.failure_reason_notes.decline",
+        )
+      end
+    end
+
+    context "with a passport expired failure reason" do
+      let(:failure_reason) { FailureReasons::PASSPORT_DOCUMENT_EXPIRED }
+
+      it do
+        expect(subject).to eq(
+          "helpers.placeholder.assessor_interface_assessment_section_form.failure_reason_notes.passport_expired",
         )
       end
     end

--- a/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
@@ -78,6 +78,56 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
         ],
       )
     end
+
+    context "when the document item is passport" do
+      let!(:document_item) do
+        create(
+          :further_information_request_item,
+          :with_passport_document_response,
+          :completed,
+          further_information_request:,
+        )
+      end
+
+      it do
+        expect(subject).to eq(
+          [
+            {
+              heading:
+                "Subjects entered are acceptable for QTS, but the uploaded qualifications do not match them.",
+              description: text_item.failure_reason_assessor_feedback,
+              check_your_answers: {
+                id: "further-information-requested-#{text_item.id}",
+                model: text_item,
+                title: "Further information requested",
+                fields: {
+                  text_item.id => {
+                    title: "Tell us more about the subjects you can teach",
+                    value: text_item.response,
+                  },
+                },
+              },
+            },
+            {
+              heading:
+                "There is a problem with the passport. For example, it's incorrect, illegible, or incomplete.",
+              description: document_item.failure_reason_assessor_feedback,
+              check_your_answers: {
+                id: "further-information-requested-#{document_item.id}",
+                model: document_item,
+                title: "Further information requested",
+                fields: {
+                  document_item.id => {
+                    title: "Upload your passport",
+                    value: document_item.document,
+                  },
+                },
+              },
+            },
+          ],
+        )
+      end
+    end
   end
 
   describe "#can_update?" do

--- a/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
             },
             {
               heading:
-                "There is a problem with the passport. For example, it's incorrect, illegible, or incomplete.",
+                "There is a problem with the passport. For example, it’s incorrect, illegible, or incomplete.",
               description: document_item.failure_reason_assessor_feedback,
               check_your_answers: {
                 id: "further-information-requested-#{document_item.id}",

--- a/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/further_information_request_view_object_spec.rb
@@ -153,5 +153,45 @@ RSpec.describe TeacherInterface::FurtherInformationRequestViewObject do
         },
       )
     end
+
+    context "when the document item is passport" do
+      let!(:document_item) do
+        create(
+          :further_information_request_item,
+          :with_passport_document_response,
+          :completed,
+          further_information_request:,
+        )
+      end
+
+      it do
+        expect(subject).to eq(
+          {
+            text_item.id => {
+              title: "Tell us more about the subjects you can teach",
+              href: [
+                :edit,
+                :teacher_interface,
+                :application_form,
+                further_information_request,
+                text_item,
+              ],
+              value: text_item.response,
+            },
+            document_item.id => {
+              title: "Upload your passport",
+              href: [
+                :edit,
+                :teacher_interface,
+                :application_form,
+                further_information_request,
+                document_item,
+              ],
+              value: document_item.document,
+            },
+          },
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-760

Changes: Assessment factory updates based on whether the application provided passport as proof of identity.

This change ensures that if an application has passport uploaded as a way to verify identity, the assessment sections and checks in place clearly show that.

As well as content changes across assessment, FI and declines, we also introduce a new decline reason if the passport has been expired.

Example:
![Screenshot 2025-01-20 at 17 35 32](https://github.com/user-attachments/assets/513d21c8-a19c-4f3f-a962-55d5727cb3dd)


For existing applications that uploaded ID, the page will look as it did before:
![Screenshot 2025-01-20 at 17 35 42](https://github.com/user-attachments/assets/028f4662-815c-4f03-bbf3-9ee06664aef8)
