### PR TITLE
Revert "[AQTS-795] Update the approved providers link for english language certificate"

### DIFF
--- a/app/views/assessor_interface/assessment_sections/_english_language_provider_details.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_english_language_provider_details.html.erb
@@ -14,7 +14,7 @@
     </p>
 
     <p class="govuk-body">
-      <%= govuk_link_to "Approved providers", "https://find-a-qualification.services.ofqual.gov.uk/qualifications?title=ESOL", new_tab: true %>
+      <%= govuk_link_to "Approved providers", "https://register.ofqual.gov.uk/Search?category=Qualifications&query=ESOl", new_tab: true %>
     </p>
   <% end %>
 <% end %>

--- a/app/views/shared/_english_language_approved_providers.html.erb
+++ b/app/views/shared/_english_language_approved_providers.html.erb
@@ -9,7 +9,7 @@
 
   <p class="govuk-body">
     See the list of <%= govuk_link_to "approved providers (opens in new tab)",
-                                      reduced_evidence_accepted ? "https://find-a-qualification.services.ofqual.gov.uk/qualifications?title=ESOL" : english_language_guidance_path,
+                                      reduced_evidence_accepted ? "https://register.ofqual.gov.uk/Search?category=Qualifications&query=ESOl" : english_language_guidance_path,
                                       new_tab: true %>.
   </p>
 <% end %>

--- a/app/views/shared/eligible_region_content_components/_english_language.html.erb
+++ b/app/views/shared/eligible_region_content_components/_english_language.html.erb
@@ -43,7 +43,7 @@
 <p class="govuk-body">The test must be awarded within the last 2 years before the date of your application.</p>
 
 <% if region.reduced_evidence_accepted %>
-  <p class="govuk-body">Find an <a href="https://find-a-qualification.services.ofqual.gov.uk/qualifications?title=ESOL" class="govuk-link">approved provider</a> if you need to get an English language certificate.</p>
+  <p class="govuk-body">Find an <a href="https://register.ofqual.gov.uk/Search?category=Qualifications&query=ESOl" class="govuk-link">approved provider</a> if you need to get an English language certificate.</p>
 <% else %>
   <p class="govuk-body">Find an <%= govuk_link_to "approved provider", english_language_guidance_path %> if you need to get an English language certificate.</p>
 <% end %>


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-qualified-teacher-status#2607

We are temporarily bringing back the broken link as we need to revisit this to get the right link.