### PR TITLE
[AQTS-757] Content updates regarding passport proof on eligibility criteria

### DIFF
--- a/app/views/eligibility_interface/start/show.erb
+++ b/app/views/eligibility_interface/start/show.erb
@@ -32,6 +32,9 @@
 <p class="govuk-body"><strong>You must have:</strong></p>
 
 <ul class="govuk-list govuk-list--bullet">
+  <% if FeatureFlags::FeatureFlag.active?(:use_passport_for_identity_verification) %>
+    <li>a valid passport that has not expired</li>
+  <% end %>
   <li>an undergraduate degree equal to a UK bachelor’s degree</li>
   <li>completed teacher training equal to a <%= govuk_link_to "level 6 qualification", "https://www.gov.uk/what-different-qualification-levels-mean/list-of-qualification-levels#:~:text=Level%206%20qualifications%20are%3A,graduate%20certificate" %></li>
   <li>completed all mandatory induction processes to gain full teacher registration in the country where you qualified</li>

--- a/app/views/shared/eligible_region_content_components/_english_language.html.erb
+++ b/app/views/shared/eligible_region_content_components/_english_language.html.erb
@@ -6,7 +6,11 @@
 
 <%= render "shared/english_language_exempt_countries" %>
 
-<p class="govuk-body">You’ll need to provide your passport or official identification documents for that country as proof. </p>
+<% if FeatureFlags::FeatureFlag.active?(:use_passport_for_identity_verification) %>
+  <p class="govuk-body">We will use your passport to verify your identity and check your English language ability. If you have more than one valid passport, you should only provide the one that proves you are exempt from English language requirements.</p>
+<% else %>
+  <p class="govuk-body">You’ll need to provide your passport or official identification documents for that country as proof. </p>
+<% end %>
 <p class="govuk-body">If you’re not exempt by birth or citizenship, you must be able to provide evidence of your English language ability in one of the following ways:</p>
 
 <h3 class="govuk-heading-s">2. If you studied in an exempt country</h3>
@@ -50,7 +54,12 @@
 
 <%= govuk_details(summary_text: "What if you have more than one nationality?") do %>
   <p class="govuk-body">
-    If you’re a national of more than 1 country and both are exempt from English language requirements, you can choose which of them you use to apply for QTS. Remember, you must be able to show a passport (or the recognised identity document for that country).
+    If you’re a national of more than 1 country and both are exempt from English language requirements, you can choose which of them you use to apply for QTS.
+    <% if FeatureFlags::FeatureFlag.active?(:use_passport_for_identity_verification) %>
+      Your passport will be used to verify that you are exempt.
+    <% else %>
+      Remember, you must be able to show a passport (or the recognised identity document for that country).
+    <% end %>
   </p>
 
   <p class="govuk-body">

--- a/app/views/shared/eligible_region_content_components/_proof_of_identity.html.erb
+++ b/app/views/shared/eligible_region_content_components/_proof_of_identity.html.erb
@@ -1,6 +1,6 @@
 <% if FeatureFlags::FeatureFlag.active?(:use_passport_for_identity_verification) %>
   <p class="govuk-body">You must provide a valid passport.</p>
-  <p class="govuk-body">We only accept passports because they provide the most reliable and secure way to verify an applicant's identity.</p>
+  <p class="govuk-body">We only accept passports because they provide the most reliable and secure way to verify an applicant’s identity.</p>
   <p class="govuk-body">You cannot apply for QTS with an expired passport or with any other identity document.</p>
   <%= govuk_details(summary_text: "Has your name changed?") do %>
     <p class="govuk-body">

--- a/app/views/shared/eligible_region_content_components/_proof_of_identity.html.erb
+++ b/app/views/shared/eligible_region_content_components/_proof_of_identity.html.erb
@@ -1,12 +1,24 @@
-<p class="govuk-body">You must provide one of the following:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>passport (must not have expired)</li>
-  <li>birth certificate</li>
-  <li>national identity card that shows your date of birth and nationality (must not have expired)</li>
-</ul>
-<%= govuk_details(summary_text: "Has your name changed?") do %>
-  <p class="govuk-body">
-    If the name on your proof of identity is different from that on your other documents, 
-    you need to provide evidence of your name change (for example, a marriage certificate or name change deed).
-  </p>
+<% if FeatureFlags::FeatureFlag.active?(:use_passport_for_identity_verification) %>
+  <p class="govuk-body">You must provide a valid passport.</p>
+  <p class="govuk-body">We only accept passports because they provide the most reliable and secure way to verify an applicant's identity.</p>
+  <p class="govuk-body">You cannot apply for QTS with an expired passport or with any other identity document.</p>
+  <%= govuk_details(summary_text: "Has your name changed?") do %>
+    <p class="govuk-body">
+      If the name on your passport is different from that on your other documents,
+      you need to provide evidence of your name change (for example, a marriage certificate or name change deed).
+    </p>
+  <% end %>
+<% else %>
+  <p class="govuk-body">You must provide one of the following:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>passport (must not have expired)</li>
+    <li>birth certificate</li>
+    <li>national identity card that shows your date of birth and nationality (must not have expired)</li>
+  </ul>
+  <%= govuk_details(summary_text: "Has your name changed?") do %>
+    <p class="govuk-body">
+      If the name on your proof of identity is different from that on your other documents,
+      you need to provide evidence of your name change (for example, a marriage certificate or name change deed).
+    </p>
+  <% end %>
 <% end %>


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-757

Content updates for when the passport upload for proof of identity feature is live:
1. Content around uploading passport as a way prove identity on the homepage.
2. Content around uploading passport as a way prove identity on the last page of eligibility criteria (once they are eligible). 
3. Content around how passport will be used to prove English language ability on the last page of eligibility criteria (once they are eligible). 