### PR TITLE
Remove the sanitized file once sanitized file is restored to preprod

### DIFF
--- a/.github/workflows/sync-preprod-with-sanitised-prod-backup.yaml
+++ b/.github/workflows/sync-preprod-with-sanitised-prod-backup.yaml
@@ -110,6 +110,10 @@ jobs:
         run: |
           ./konduit.sh -n ${{ env.NAMESPACE }} -i ${SANITISED_FILE_NAME} -c -t 7200 -x ${APP_NAME} -- psql
 
+      - name: Remove the sanitized file
+        run: |
+          rm ${SANITISED_FILE_NAME}
+
       - name: Restore Summary
         if: success()
         run: |


### PR DESCRIPTION
As per moving the sync of preprod [sync with the latest sanitised prod backup](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/2599/files), we want to ensure we delete the sanitised file before the job ends.