### PR TITLE
[AQTS-812] Fix typo on English language certificate content

### DIFF
--- a/app/views/shared/_english_language_approved_providers.html.erb
+++ b/app/views/shared/_english_language_approved_providers.html.erb
@@ -8,7 +8,7 @@
   </p>
 
   <p class="govuk-body">
-    See the list of <%= govuk_link_to "approved providers (opens in new tab)",
+    See the list of <%= govuk_link_to "approved providers",
                                       reduced_evidence_accepted ? "https://register.ofqual.gov.uk/Search?category=Qualifications&query=ESOl" : english_language_guidance_path,
                                       new_tab: true %>.
   </p>

--- a/app/views/shared/eligible_region_content_components/_english_language.html.erb
+++ b/app/views/shared/eligible_region_content_components/_english_language.html.erb
@@ -30,7 +30,7 @@
   <p class="govuk-body">You’ll need a Secure English Language Test (SELT) at level B2 from an approved provider.</p>
 <% else %>
   <p class="govuk-body">
-    If you cannot provide one of the documents described in 1,2 or 3, you'll need a <%= govuk_link_to "B2 level", "https://www.coe.int/en/web/common-european-framework-reference-languages/table-1-cefr-3.3-common-reference-levels-global-scale", new_tab: true %> Secure English Language Test (SELT) from on approved provider. We accept the following approved providers and tests:
+    If you cannot provide one of the documents described in 1,2 or 3, you'll need a <%= govuk_link_to "B2 level", "https://www.coe.int/en/web/common-european-framework-reference-languages/table-1-cefr-3.3-common-reference-levels-global-scale", new_tab: true %> Secure English Language Test (SELT) from an approved provider. We accept the following approved providers and tests:
   </p>
 
   <ul class="govuk-list govuk-list--bullet">

--- a/app/views/teacher_interface/work_histories/add_another.html.erb
+++ b/app/views/teacher_interface/work_histories/add_another.html.erb
@@ -63,7 +63,7 @@
   <% if @years_count == 0 && @months_count < 9 %>
     <%= govuk_details(summary_text: "I do not have more than 9 months of teaching experience") do %>
       <p class="govuk-body">QTS requires a minimum of 9 months of active teaching experience. We can keep your application open for 6 months, so you can continue later, if you gain enough experience in that time.</p>
-      <p class="govuk-body">Alternatively, you can <%= govuk_link_to "explore other ways to teach in England (opens in new tab)", "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas", new_tab: true %>.</p>
+      <p class="govuk-body">Alternatively, you can <%= govuk_link_to "explore other ways to teach in England", "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas", new_tab: true %>.</p>
     <% end %>
   <% end %>
 

--- a/app/views/teacher_interface/work_histories/requirements_unmet.html.erb
+++ b/app/views/teacher_interface/work_histories/requirements_unmet.html.erb
@@ -4,7 +4,7 @@
 <h1 class="govuk-heading-l">Your work experience does not meet all of the requirements for QTS</h1>
 
 <p class="govuk-body">
-  You can <%= govuk_link_to "explore other ways to teach in England (opens in new tab)", "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas", new_tab: true %>.
+  You can <%= govuk_link_to "explore other ways to teach in England", "https://getintoteaching.education.gov.uk/non-uk-teachers/teach-in-england-if-you-trained-overseas", new_tab: true %>.
 </p>
 
 <%= render "shared/help_us_to_improve_this_service" %>


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-812

1. Fix typo.
2. Remove unnecessary (opens in new tab) text as the `govuk_link_to` helper with `new_tab: true` already handles that.