### PR TITLE
[AQTS-761][AQTS-816] Copy changes to personal information section

### DIFF
--- a/app/controllers/teacher_interface/personal_information_controller.rb
+++ b/app/controllers/teacher_interface/personal_information_controller.rb
@@ -57,6 +57,8 @@ module TeacherInterface
     end
 
     def alternative_name
+      @view_object =
+        TeacherInterface::PersonalInformationViewObject.new(application_form:)
       @form =
         AlternativeNameForm.new(
           has_alternative_name: application_form.has_alternative_name,
@@ -66,6 +68,8 @@ module TeacherInterface
     end
 
     def update_alternative_name
+      @view_object =
+        TeacherInterface::PersonalInformationViewObject.new(application_form:)
       @form =
         AlternativeNameForm.new(
           alternative_name_form_params.merge(application_form:),

--- a/app/controllers/teacher_interface/personal_information_controller.rb
+++ b/app/controllers/teacher_interface/personal_information_controller.rb
@@ -30,6 +30,8 @@ module TeacherInterface
     end
 
     def name_and_date_of_birth
+      @view_object =
+        TeacherInterface::PersonalInformationViewObject.new(application_form:)
       @form =
         NameAndDateOfBirthForm.new(
           given_names: application_form.given_names,
@@ -39,6 +41,8 @@ module TeacherInterface
     end
 
     def update_name_and_date_of_birth
+      @view_object =
+        TeacherInterface::PersonalInformationViewObject.new(application_form:)
       @form =
         NameAndDateOfBirthForm.new(
           name_and_date_of_birth_form_params.merge(application_form:),

--- a/app/forms/teacher_interface/alternative_name_form.rb
+++ b/app/forms/teacher_interface/alternative_name_form.rb
@@ -8,7 +8,18 @@ module TeacherInterface
     attribute :alternative_family_name, :string
 
     validates :application_form, presence: true
-    validates :has_alternative_name, inclusion: { in: [true, false] }
+    validates :has_alternative_name,
+              inclusion: {
+                in: [true, false],
+                message: :inclusion_passport,
+              },
+              if: :requires_passport_as_identity_proof
+    validates :has_alternative_name,
+              inclusion: {
+                in: [true, false],
+                message: :inclusion_id_documents,
+              },
+              unless: :requires_passport_as_identity_proof
     validates :alternative_given_names,
               presence: true,
               if: :has_alternative_name
@@ -22,6 +33,12 @@ module TeacherInterface
         alternative_given_names:,
         alternative_family_name:,
       )
+    end
+
+    private
+
+    def requires_passport_as_identity_proof
+      application_form&.requires_passport_as_identity_proof?
     end
   end
 end

--- a/app/forms/teacher_interface/name_and_date_of_birth_form.rb
+++ b/app/forms/teacher_interface/name_and_date_of_birth_form.rb
@@ -11,8 +11,30 @@ module TeacherInterface
     attribute :date_of_birth
 
     validates :application_form, presence: true
-    validates :given_names, presence: true
-    validates :family_name, presence: true
+    validates :given_names,
+              presence: {
+                message: :blank_passport,
+              },
+              if: :requires_passport_as_identity_proof
+
+    validates :given_names,
+              presence: {
+                message: :blank_id_documents,
+              },
+              unless: :requires_passport_as_identity_proof
+
+    validates :family_name,
+              presence: {
+                message: :blank_passport,
+              },
+              if: :requires_passport_as_identity_proof
+
+    validates :family_name,
+              presence: {
+                message: :blank_id_documents,
+              },
+              unless: :requires_passport_as_identity_proof
+
     validates :date_of_birth, date: true
     validate :date_of_birth_valid
 
@@ -30,6 +52,12 @@ module TeacherInterface
       elsif date < 100.years.ago
         errors.add(:date_of_birth, :too_old)
       end
+    end
+
+    private
+
+    def requires_passport_as_identity_proof
+      application_form&.requires_passport_as_identity_proof?
     end
   end
 end

--- a/app/view_objects/teacher_interface/personal_information_view_object.rb
+++ b/app/view_objects/teacher_interface/personal_information_view_object.rb
@@ -7,6 +7,30 @@ class TeacherInterface::PersonalInformationViewObject
 
   attr_reader :application_form
 
+  def given_names_hint
+    if requires_passport_as_identity_proof?
+      I18n.t(
+        "helpers.hint.teacher_interface_name_and_date_of_birth_form.given_names_passport",
+      )
+    else
+      I18n.t(
+        "helpers.hint.teacher_interface_name_and_date_of_birth_form.given_names_id_documents",
+      )
+    end
+  end
+
+  def family_name_hint
+    if requires_passport_as_identity_proof?
+      I18n.t(
+        "helpers.hint.teacher_interface_name_and_date_of_birth_form.family_name_passport",
+      )
+    else
+      I18n.t(
+        "helpers.hint.teacher_interface_name_and_date_of_birth_form.family_name_id_documents",
+      )
+    end
+  end
+
   def alternative_name_legend
     if requires_passport_as_identity_proof?
       I18n.t(

--- a/app/view_objects/teacher_interface/personal_information_view_object.rb
+++ b/app/view_objects/teacher_interface/personal_information_view_object.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class TeacherInterface::PersonalInformationViewObject
+  def initialize(application_form:)
+    @application_form = application_form
+  end
+
+  attr_reader :application_form
+
+  def alternative_name_legend
+    if requires_passport_as_identity_proof?
+      I18n.t(
+        "helpers.legend.teacher_interface_alternative_name_form.has_alternative_name_passport",
+      )
+    else
+      I18n.t(
+        "helpers.legend.teacher_interface_alternative_name_form.has_alternative_name_id_documents",
+      )
+    end
+  end
+
+  def alternative_name_hint
+    if requires_passport_as_identity_proof?
+      I18n.t(
+        "helpers.hint.teacher_interface_alternative_name_form.has_alternative_name_passport",
+      )
+    else
+      I18n.t(
+        "helpers.hint.teacher_interface_alternative_name_form.has_alternative_name_id_documents",
+      )
+    end
+  end
+
+  private
+
+  def requires_passport_as_identity_proof?
+    application_form.requires_passport_as_identity_proof
+  end
+end

--- a/app/views/shared/application_form/_personal_information_summary.html.erb
+++ b/app/views/shared/application_form/_personal_information_summary.html.erb
@@ -14,7 +14,8 @@
       href: %i[name_and_date_of_birth teacher_interface application_form personal_information]
     },
     has_alternative_name: {
-      title: "Name appears differently on your passport or qualifications?",
+      title: application_form.requires_passport_as_identity_proof? ?
+        "Name appears differently on your passport or qualifications?": "Name appears differently on your ID documents or qualifications?",
       href: %i[alternative_name teacher_interface application_form personal_information]
     },
     alternative_given_names: application_form.has_alternative_name? ? {

--- a/app/views/shared/application_form/_personal_information_summary.html.erb
+++ b/app/views/shared/application_form/_personal_information_summary.html.erb
@@ -7,19 +7,22 @@
       href: %i[name_and_date_of_birth teacher_interface application_form personal_information]
     },
     family_name: {
+      title: "Surname",
       href: %i[name_and_date_of_birth teacher_interface application_form personal_information]
     },
     date_of_birth: {
       href: %i[name_and_date_of_birth teacher_interface application_form personal_information]
     },
     has_alternative_name: {
-      title: "Name appears differently on your ID documents or qualifications?",
+      title: "Name appears differently on your passport or qualifications?",
       href: %i[alternative_name teacher_interface application_form personal_information]
     },
     alternative_given_names: application_form.has_alternative_name? ? {
+      title: "Alternate given names",
       href: %i[alternative_name teacher_interface application_form personal_information]
     } : nil,
     alternative_family_name: application_form.has_alternative_name? ? {
+      title: "Alternate surname",
       href: %i[alternative_name teacher_interface application_form personal_information]
     } : nil,
     name_change_document: application_form.has_alternative_name? ? {

--- a/app/views/teacher_interface/personal_information/alternative_name.html.erb
+++ b/app/views/teacher_interface/personal_information/alternative_name.html.erb
@@ -1,10 +1,10 @@
 <% content_for :page_title, title_with_error_prefix(t("application_form.tasks.sections.about_you"), error: @form.errors.any?) %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
-<span class="govuk-caption-l"><%= t("application_form.tasks.sections.about_you") %></span>
-
 <%= form_with model: @form, url: [:alternative_name, :teacher_interface, :application_form, :personal_information] do |f| %>
   <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l"><%= t("application_form.tasks.sections.about_you") %></span>
 
   <%= f.govuk_radio_buttons_fieldset :has_alternative_name, legend: { size: "l", tag: "h1" } do %>
     <%= f.govuk_radio_button :has_alternative_name, :true, link_errors: true do %>

--- a/app/views/teacher_interface/personal_information/alternative_name.html.erb
+++ b/app/views/teacher_interface/personal_information/alternative_name.html.erb
@@ -6,7 +6,7 @@
 
   <span class="govuk-caption-l"><%= t("application_form.tasks.sections.about_you") %></span>
 
-  <%= f.govuk_radio_buttons_fieldset :has_alternative_name, legend: { size: "l", tag: "h1" } do %>
+  <%= f.govuk_radio_buttons_fieldset :has_alternative_name, legend: { size: "l", tag: "h1", text: @view_object.alternative_name_legend }, hint: { text: @view_object.alternative_name_hint } do %>
     <%= f.govuk_radio_button :has_alternative_name, :true, link_errors: true do %>
       <%= f.govuk_text_field :alternative_given_names %>
       <%= f.govuk_text_field :alternative_family_name %>

--- a/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
+++ b/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
@@ -1,11 +1,11 @@
 <% content_for :page_title, title_with_error_prefix(t("application_form.tasks.sections.about_you"), error: @form.errors.any?) %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
-<span class="govuk-caption-l"><%= t("application_form.tasks.sections.about_you") %></span>
-<h1 class="govuk-heading-l">Personal information</h1>
-
 <%= form_with model: @form, url: [:name_and_date_of_birth, :teacher_interface, :application_form, :personal_information] do |f| %>
   <%= f.govuk_error_summary %>
+
+  <span class="govuk-caption-l"><%= t("application_form.tasks.sections.about_you") %></span>
+  <h1 class="govuk-heading-l">Personal information</h1>
 
   <%= f.govuk_text_field :given_names,
                          label: { text: "Given names", size: "m" },

--- a/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
+++ b/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
@@ -9,11 +9,11 @@
 
   <%= f.govuk_text_field :given_names,
                          label: { text: "Given names", size: "m" },
-                         hint: { text: "Enter your full name apart from your family name" } %>
+                         hint: { text: "Enter your given names as they appear on your passport." } %>
 
   <%= f.govuk_text_field :family_name,
-                         label: { text: "Family name", size: "m" },
-                         hint: { text: "Enter just your family name" } %>
+                         label: { text: "Surname", size: "m" },
+                         hint: { text: "Enter your surname as it appears on your passport." } %>
 
   <%= f.govuk_date_field :date_of_birth,
                          date_of_birth: true,

--- a/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
+++ b/app/views/teacher_interface/personal_information/name_and_date_of_birth.html.erb
@@ -9,11 +9,11 @@
 
   <%= f.govuk_text_field :given_names,
                          label: { text: "Given names", size: "m" },
-                         hint: { text: "Enter your given names as they appear on your passport." } %>
+                         hint: { text: @view_object.given_names_hint } %>
 
   <%= f.govuk_text_field :family_name,
                          label: { text: "Surname", size: "m" },
-                         hint: { text: "Enter your surname as it appears on your passport." } %>
+                         hint: { text: @view_object.family_name_hint } %>
 
   <%= f.govuk_date_field :date_of_birth,
                          date_of_birth: true,

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -39,7 +39,8 @@ en:
       teacher_interface_add_another_upload_form:
         add_another: If your document has several pages, you can upload them here. Otherwise, select ‘No’ and then ‘Continue’.
       teacher_interface_alternative_name_form:
-        has_alternative_name: If your name appears differently on your passport or qualifications you need to upload proof of your name change, for example, your marriage or civil partnership certificate.
+        has_alternative_name_passport: If your name appears differently on your passport or qualifications you need to upload proof of your name change, for example, your marriage or civil partnership certificate.
+        has_alternative_name_id_documents: If your name appears differently on your ID documents or qualifications you need to upload proof of your name change, for example, your marriage or civil partnership certificate.
       teacher_interface_english_language_proof_method_form:
         proof_method: There are 2 ways you can do this.
         proof_method_options:
@@ -342,7 +343,8 @@ en:
       teacher_interface_add_another_work_history_form:
         add_another: Add another role?
       teacher_interface_alternative_name_form:
-        has_alternative_name: Does your name appear differently on your passport or qualifications?
+        has_alternative_name_passport: Does your name appear differently on your passport or qualifications?
+        has_alternative_name_id_documents: Does your name appear differently on your ID documents or qualifications?
       teacher_interface_document_available_form:
         available: Have you completed your induction period in Northern Ireland?
       teacher_interface_english_language_proof_method_form:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -52,6 +52,11 @@ en:
         registration_number: Your teacher license number is made up of 2 letters, 6 numbers and a final 4 numbers. For example, PT/123456/1234.
       teacher_interface_has_work_history_form:
         has_work_history: If you’re a recent university graduate, or you've just completed your teaching qualification, you may not have held a professional teaching position yet.
+      teacher_interface_name_and_date_of_birth_form:
+        given_names_passport: Enter your given names as they appear on your passport.
+        given_names_id_documents: Enter your given names as they appear on your ID documents.
+        family_name_passport: Enter your surname as it appears on your passport.
+        family_name_id_documents: Enter your surname as it appears on your ID documents.
       teacher_interface_new_session_form:
         email: We need to send you an email with a link so that you can sign into the Apply for QTS in England service. Please enter the email address you used to register.
       teacher_interface_reference_request_additional_information_response_form:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -40,8 +40,6 @@ en:
         add_another: If your document has several pages, you can upload them here. Otherwise, select ‘No’ and then ‘Continue’.
       teacher_interface_alternative_name_form:
         has_alternative_name: If your name appears differently on your ID documents or qualifications you need to upload proof of your name change, for example, your marriage or civil partnership certificate.
-        alternative_given_names: Enter your full name apart from your family name
-        alternative_family_name: Enter just your family name
       teacher_interface_english_language_proof_method_form:
         proof_method: There are 2 ways you can do this.
         proof_method_options:
@@ -200,9 +198,9 @@ en:
       teacher_interface_alternative_name_form:
         has_alternative_name_options:
           true: Yes – I’ll upload another document to prove this
-          false: "No"
+          false: No - my name does not appear differently
         alternative_given_names: Alternate given names
-        alternative_family_name: Alternate family name
+        alternative_family_name: Alternate surname
       teacher_interface_age_range_form:
         minimum: <span class="govuk-visually-hidden">Age</span> From
         maximum: <span class="govuk-visually-hidden">Age</span> To
@@ -344,7 +342,7 @@ en:
       teacher_interface_add_another_work_history_form:
         add_another: Add another role?
       teacher_interface_alternative_name_form:
-        has_alternative_name: Does your name appear differently on your ID documents or qualifications?
+        has_alternative_name: Does your name appear differently on your passport or qualifications?
       teacher_interface_document_available_form:
         available: Have you completed your induction period in Northern Ireland?
       teacher_interface_english_language_proof_method_form:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -39,7 +39,7 @@ en:
       teacher_interface_add_another_upload_form:
         add_another: If your document has several pages, you can upload them here. Otherwise, select ‘No’ and then ‘Continue’.
       teacher_interface_alternative_name_form:
-        has_alternative_name: If your name appears differently on your ID documents or qualifications you need to upload proof of your name change, for example, your marriage or civil partnership certificate.
+        has_alternative_name: If your name appears differently on your passport or qualifications you need to upload proof of your name change, for example, your marriage or civil partnership certificate.
       teacher_interface_english_language_proof_method_form:
         proof_method: There are 2 ways you can do this.
         proof_method_options:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -75,7 +75,7 @@ en:
         citizenship:
           heading: Were you born in or hold citizenship of any of the countries below?
           description: If you were born in, or hold citizenship of any of the following countries, you’re exempt from English language requirements.
-          evidence: You’ll need to provide a passport or other official form of identification. You can do this in the ‘About you’ section of the application form.
+          evidence: Assessors will use your passport to verify that you are exempt.
         qualification:
           heading: Was your teaching qualification or university degree taught in any of the following countries?
           description: If your teaching qualification or university degree was taught in any of the following countries, you’re exempt from English language requirements.

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -301,9 +301,11 @@ en:
               too_young: You must be 18 or over to use this service
               too_old: Your date of birth cannot be that far in the past
             given_names:
-              blank: Enter your given names as they appear on your passport
+              blank_passport: Enter your given names as they appear on your passport
+              blank_id_documents: Enter your given names as it appears on your ID documents
             family_name:
-              blank: Enter your surname as it appears on your passport
+              blank_passport: Enter your surname as it appears on your passport
+              blank_id_documents: Enter your surname as it appears on your ID documents
         teacher_interface/new_session_form:
           attributes:
             sign_in_or_sign_up:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -226,9 +226,9 @@ en:
             alternative_given_names:
               blank: Enter your alternate given names
             alternative_family_name:
-              blank: Enter your alternate family name
+              blank: Enter your alternate surname
             has_alternative_name:
-              inclusion: Tell us whether you have an alternative name
+              inclusion: Select if your name appears differently on your passport or qualifications
         teacher_interface/add_another_qualification_form:
           attributes:
             add_another:
@@ -300,9 +300,9 @@ en:
               too_young: You must be 18 or over to use this service
               too_old: Your date of birth cannot be that far in the past
             given_names:
-              blank: Enter your given names
+              blank: Enter your given names as they appear on your passport
             family_name:
-              blank: Enter your family name
+              blank: Enter your surname as it appears on your passport
         teacher_interface/new_session_form:
           attributes:
             sign_in_or_sign_up:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -228,7 +228,8 @@ en:
             alternative_family_name:
               blank: Enter your alternate surname
             has_alternative_name:
-              inclusion: Select if your name appears differently on your passport or qualifications
+              inclusion_passport: Select if your name appears differently on your passport or qualifications
+              inclusion_id_documents: Select if your name appears differently on your ID documents or qualifications
         teacher_interface/add_another_qualification_form:
           attributes:
             add_another:

--- a/spec/forms/teacher_interface/name_and_date_of_birth_form_spec.rb
+++ b/spec/forms/teacher_interface/name_and_date_of_birth_form_spec.rb
@@ -12,7 +12,9 @@ RSpec.describe TeacherInterface::NameAndDateOfBirthForm, type: :model do
     )
   end
 
-  let(:application_form) { build(:application_form) }
+  let(:application_form) do
+    build(:application_form, requires_passport_as_identity_proof: false)
+  end
 
   describe "validations" do
     let(:given_names) { "" }
@@ -20,8 +22,19 @@ RSpec.describe TeacherInterface::NameAndDateOfBirthForm, type: :model do
     let(:date_of_birth) { "" }
 
     it { is_expected.to validate_presence_of(:application_form) }
-    it { is_expected.to validate_presence_of(:given_names) }
-    it { is_expected.to validate_presence_of(:family_name) }
+
+    it do
+      expect(subject).to validate_presence_of(:given_names).with_message(
+        "Enter your given names as it appears on your ID documents",
+      )
+    end
+
+    it do
+      expect(subject).to validate_presence_of(:family_name).with_message(
+        "Enter your surname as it appears on your ID documents",
+      )
+    end
+
     it { is_expected.to validate_presence_of(:date_of_birth) }
 
     context "when date of birth is more than 18 years ago but less than 100 years ago" do

--- a/spec/system/teacher_interface/personal_information_spec.rb
+++ b/spec/system/teacher_interface/personal_information_spec.rb
@@ -199,6 +199,11 @@ RSpec.describe "Teacher personal information", type: :system do
   end
 
   def application_form
-    @application_form ||= create(:application_form, teacher:)
+    @application_form ||=
+      create(
+        :application_form,
+        teacher:,
+        requires_passport_as_identity_proof: true,
+      )
   end
 end

--- a/spec/system/teacher_interface/personal_information_spec.rb
+++ b/spec/system/teacher_interface/personal_information_spec.rb
@@ -140,16 +140,12 @@ RSpec.describe "Teacher personal information", type: :system do
 
     alternative_given_names_row =
       teacher_check_personal_information_page.summary_list.rows[4]
-    expect(alternative_given_names_row.key.text).to eq(
-      "Alternate given names",
-    )
+    expect(alternative_given_names_row.key.text).to eq("Alternate given names")
     expect(alternative_given_names_row.value.text).to eq("Jonathan")
 
     alternative_family_name_row =
       teacher_check_personal_information_page.summary_list.rows[5]
-    expect(alternative_family_name_row.key.text).to eq(
-      "Alternate surname",
-    )
+    expect(alternative_family_name_row.key.text).to eq("Alternate surname")
     expect(alternative_family_name_row.value.text).to eq("Smithe")
 
     name_change_document_row =

--- a/spec/system/teacher_interface/personal_information_spec.rb
+++ b/spec/system/teacher_interface/personal_information_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "Teacher personal information", type: :system do
 
     family_name_row =
       teacher_check_personal_information_page.summary_list.rows[1]
-    expect(family_name_row.key.text).to eq("Family name")
+    expect(family_name_row.key.text).to eq("Surname")
     expect(family_name_row.value.text).to eq("Smith")
 
     date_of_birth_row =
@@ -134,21 +134,21 @@ RSpec.describe "Teacher personal information", type: :system do
     has_alternative_name_row =
       teacher_check_personal_information_page.summary_list.rows[3]
     expect(has_alternative_name_row.key.text).to eq(
-      "Name appears differently on your ID documents or qualifications?",
+      "Name appears differently on your passport or qualifications?",
     )
     expect(has_alternative_name_row.value.text).to eq("Yes")
 
     alternative_given_names_row =
       teacher_check_personal_information_page.summary_list.rows[4]
     expect(alternative_given_names_row.key.text).to eq(
-      "Alternative given names",
+      "Alternate given names",
     )
     expect(alternative_given_names_row.value.text).to eq("Jonathan")
 
     alternative_family_name_row =
       teacher_check_personal_information_page.summary_list.rows[5]
     expect(alternative_family_name_row.key.text).to eq(
-      "Alternative family name",
+      "Alternate surname",
     )
     expect(alternative_family_name_row.value.text).to eq("Smithe")
 
@@ -172,7 +172,7 @@ RSpec.describe "Teacher personal information", type: :system do
 
     family_name_row =
       teacher_check_personal_information_page.summary_list.rows.second
-    expect(family_name_row.key.text).to eq("Family name")
+    expect(family_name_row.key.text).to eq("Surname")
     expect(family_name_row.value.text).to eq("Smith")
 
     date_of_birth_row =
@@ -183,7 +183,7 @@ RSpec.describe "Teacher personal information", type: :system do
     has_alternative_name_row =
       teacher_check_personal_information_page.summary_list.rows.fourth
     expect(has_alternative_name_row.key.text).to eq(
-      "Name appears differently on your ID documents or qualifications?",
+      "Name appears differently on your passport or qualifications?",
     )
     expect(has_alternative_name_row.value.text).to eq("No")
   end

--- a/spec/view_objects/teacher_interface/personal_information_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/personal_information_view_object_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::PersonalInformationViewObject do
+  subject(:view_object) { described_class.new(application_form:) }
+
+  let(:requires_passport_as_identity_proof) { false }
+  let(:application_form) do
+    create(:application_form, requires_passport_as_identity_proof:)
+  end
+
+  describe "#alternative_name_legend" do
+    it "returns the content with ID documents" do
+      expect(view_object.alternative_name_legend).to eq(
+        "Does your name appear differently on your ID documents or qualifications?",
+      )
+    end
+
+    context "when the application form requires passport upload" do
+      let(:requires_passport_as_identity_proof) { true }
+
+      it "returns the content with passport" do
+        expect(view_object.alternative_name_legend).to eq(
+          "Does your name appear differently on your passport or qualifications?",
+        )
+      end
+    end
+  end
+
+  describe "#alternative_name_hint" do
+    it "returns the content with ID documents" do
+      expect(view_object.alternative_name_hint).to eq(
+        "If your name appears differently on your ID documents or qualifications you" \
+          " need to upload proof of your name change, for example, your marriage or civil partnership certificate.",
+      )
+    end
+
+    context "when the application form requires passport upload" do
+      let(:requires_passport_as_identity_proof) { true }
+
+      it "returns the content with passport" do
+        expect(view_object.alternative_name_hint).to eq(
+          "If your name appears differently on your passport or qualifications you" \
+            " need to upload proof of your name change, for example, your marriage or civil partnership certificate.",
+        )
+      end
+    end
+  end
+end

--- a/spec/view_objects/teacher_interface/personal_information_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/personal_information_view_object_spec.rb
@@ -10,6 +10,42 @@ RSpec.describe TeacherInterface::PersonalInformationViewObject do
     create(:application_form, requires_passport_as_identity_proof:)
   end
 
+  describe "#given_names_hint" do
+    it "returns the content with ID documents" do
+      expect(view_object.given_names_hint).to eq(
+        "Enter your given names as they appear on your ID documents.",
+      )
+    end
+
+    context "when the application form requires passport upload" do
+      let(:requires_passport_as_identity_proof) { true }
+
+      it "returns the content with passport" do
+        expect(view_object.given_names_hint).to eq(
+          "Enter your given names as they appear on your passport.",
+        )
+      end
+    end
+  end
+
+  describe "#family_name_hint" do
+    it "returns the content with ID documents" do
+      expect(view_object.family_name_hint).to eq(
+        "Enter your surname as it appears on your ID documents.",
+      )
+    end
+
+    context "when the application form requires passport upload" do
+      let(:requires_passport_as_identity_proof) { true }
+
+      it "returns the content with passport" do
+        expect(view_object.family_name_hint).to eq(
+          "Enter your surname as it appears on your passport.",
+        )
+      end
+    end
+  end
+
   describe "#alternative_name_legend" do
     it "returns the content with ID documents" do
       expect(view_object.alternative_name_legend).to eq(


### PR DESCRIPTION
Tickets: https://dfedigital.atlassian.net/browse/AQTS-816 & https://dfedigital.atlassian.net/browse/AQTS-761

Content updates on application form (including CMS content changes while reviewing) of personal information.

Content around passport is only for applications that go through uploading their passport, while existing applications will retain their original content. 

Content on the first form of personal information remains the same for all.

![Screenshot 2025-02-03 at 11 18 01](https://github.com/user-attachments/assets/f4dfacce-2395-4897-9f65-42c59534bff0)
![Screenshot 2025-02-03 at 11 17 52](https://github.com/user-attachments/assets/ecbc2899-a26d-4723-a6e9-69210bd3cc67)
![Screenshot 2025-02-03 at 11 17 34](https://github.com/user-attachments/assets/a38398af-89be-4eac-9073-07f5cedce678)
![Screenshot 2025-02-03 at 11 17 23](https://github.com/user-attachments/assets/395bf513-d6f3-4098-a0fb-1c390561d553)
