### PR TITLE
[AQTS-759] Updating or Submitting a draft application when passport has expired

### DIFF
--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -9,7 +9,11 @@ class TeacherInterface::ApplicationFormViewObject
 
   attr_reader :application_form
 
-  delegate :assessment, :country, :region, :teacher, to: :application_form
+  delegate :assessment, :country, :region, :teacher, :passport_document_status, to: :application_form
+
+  def passport_document_status_in_progress?
+    passport_document_status == "in_progress"
+  end
 
   def requires_passport_as_identity_proof?
     application_form.requires_passport_as_identity_proof

--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -9,7 +9,12 @@ class TeacherInterface::ApplicationFormViewObject
 
   attr_reader :application_form
 
-  delegate :assessment, :country, :region, :teacher, :passport_document_status, to: :application_form
+  delegate :assessment,
+           :country,
+           :region,
+           :teacher,
+           :passport_document_status,
+           to: :application_form
 
   def passport_document_status_in_progress?
     passport_document_status == "in_progress"

--- a/app/views/teacher_interface/application_forms/show/_draft.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_draft.html.erb
@@ -13,7 +13,7 @@
   </div>
 <% end %>
 
-<% if view_object.passport_expiry_date_expired? %>
+<% if view_object.passport_expiry_date_expired? && view_object.passport_document_status_in_progress? %>
   <div class="moj-interruption-card">
     <div class="moj-interruption-card__content">
       <h1 class="govuk-heading-m moj-interruption-card__heading">Your passport has expired</h1>
@@ -80,7 +80,7 @@
 
 <div class="govuk-button-group">
   <% if view_object.can_submit? %>
-    <%= govuk_button_link_to t("teacher_interface.application_forms.show.draft.check"), edit_teacher_interface_application_form_path %>
+    <%= govuk_button_link_to t("teacher_interface.application_forms.show.draft.check"), edit_teacher_interface_application_form_path, class: "check-your-answers" %>
   <% end %>
 
   <% if FeatureFlags::FeatureFlag.active?(:gov_one_applicant_login) %>

--- a/spec/support/autoload/page_objects/teacher_interface/application.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/application.rb
@@ -9,7 +9,7 @@ module PageObjects
       element :content_title, "app-task-list_section"
       element :app_task_list, ".app-task-list"
 
-      element :check_answers, ".govuk-button:not(.govuk-button--secondary)"
+      element :check_answers, ".govuk-button.check-your-answers"
       element :save_and_sign_out, ".govuk-button.govuk-button--secondary"
       element :start_now_button, ".govuk-button:not(.govuk-button--secondary)"
 


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-759

Attempting to submit a draft application when passport has already expired will result in a redirect and a status update to them show the applicant that they need to update their passport details.

![Screenshot 2025-02-05 at 13 26 08](https://github.com/user-attachments/assets/b41c70c1-2fca-4eb1-9023-dfba53439b64)
