### PR TITLE
[AQTS-821] Introduce a view only page for applications that have been submitted

### DIFF
--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -51,6 +51,9 @@ module TeacherInterface
       @view_object = ApplicationFormViewObject.new(application_form:)
     end
 
+    def answers
+    end
+
     def edit
       @view_object = ApplicationFormViewObject.new(application_form:)
 

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -13,7 +13,8 @@ module TeacherInterface
     before_action -> { authenticate_or_redirect(:teacher) }
 
     skip_before_action :track_history, only: :show
-    before_action :redirect_unless_draft_or_additional_information
+    before_action :redirect_unless_draft_or_additional_information,
+                  except: :show
     before_action :load_application_form
     before_action :load_document
     before_action :load_upload, only: %i[delete destroy show]

--- a/app/views/assessor_interface/assessment_sections/_work_history_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_work_history_summary.html.erb
@@ -8,7 +8,8 @@
 <% else %>
   <%= render "shared/application_form/work_history_summary",
              work_histories: application_form.work_histories.order_by_user,
-             highlighted_contact_emails: highlighted_work_history_contact_emails %>
+             highlighted_contact_emails: highlighted_work_history_contact_emails,
+             changeable: true %>
 <% end %>
 
 <% unless application_form.created_under_old_regulations? %>

--- a/app/views/shared/application_form/_work_history_summary.html.erb
+++ b/app/views/shared/application_form/_work_history_summary.html.erb
@@ -68,5 +68,6 @@
       } : nil,
     },
     delete_link_to:,
+    changeable:,
   )) %>
 <% end %>

--- a/app/views/teacher_interface/application_forms/answers.html.erb
+++ b/app/views/teacher_interface/application_forms/answers.html.erb
@@ -1,7 +1,7 @@
-<% content_for :page_title, "View your answers" %>
+<% content_for :page_title, "View your submitted application" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
-<h1 class="govuk-heading-xl">View the answers you submitted to us</h1>
+<h1 class="govuk-heading-xl">View your submitted application</h1>
 
 <section id="app-application-form-about-you">
   <h2 class="govuk-heading-m">About you</h2>

--- a/app/views/teacher_interface/application_forms/answers.html.erb
+++ b/app/views/teacher_interface/application_forms/answers.html.erb
@@ -1,0 +1,54 @@
+<% content_for :page_title, "View your answers" %>
+<% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
+
+<h1 class="govuk-heading-xl">View the answers you submitted to us</h1>
+
+<section id="app-application-form-about-you">
+  <h2 class="govuk-heading-m">About you</h2>
+  <%= render "shared/application_form/personal_information_summary", application_form: @application_form, changeable: false %>
+  <% if @application_form.requires_passport_as_identity_proof? %>
+    <%= render "shared/application_form/passport_document_summary", application_form: @application_form, changeable: false %>
+  <% else %>
+    <%= render "shared/application_form/identification_document_summary", application_form: @application_form, changeable: false %>
+  <% end %>
+</section>
+
+<section id="app-application-form-who-you-can-teach">
+  <h2 class="govuk-heading-m">Who you can teach</h2>
+  <%= render "shared/application_form/qualifications_summary", application_form: @application_form, qualifications: @application_form.qualifications.order_by_user, changeable: false %>
+  <%= render "shared/application_form/age_range_summary", application_form: @application_form, changeable: false %>
+  <%= render "shared/application_form/subjects_summary", application_form: @application_form, changeable: false %>
+</section>
+
+<% unless @application_form.created_under_old_regulations? %>
+  <section id="app-application-form-your-english-language-proficiency">
+    <h2 class="govuk-heading-m">Your English language proficiency</h2>
+    <%= render "shared/application_form/english_language_summary", application_form: @application_form, changeable: false %>
+  </section>
+<% end %>
+
+<% if @application_form.needs_work_history %>
+  <section id="app-application-form-work-history">
+    <h2 class="govuk-heading-m">Your work history</h2>
+
+    <%= render "shared/application_form/work_history_summary",
+               work_histories: @application_form.work_histories.order_by_user,
+               highlighted_contact_emails: [],
+               changeable: false %>
+  </section>
+<% end %>
+
+<% if @application_form.needs_written_statement || @application_form.needs_registration_number %>
+  <section id="app-application-form-proof-of-recognition">
+    <h2 class="govuk-heading-m">Proof that you’re recognised as a teacher</h2>
+    <% if @application_form.needs_registration_number %>
+      <%= render "shared/application_form/registration_number_summary", application_form: @application_form, changeable: false %>
+    <% end %>
+    <% if @application_form.needs_written_statement %>
+      <%= render "shared/application_form/written_statement_summary", application_form: @application_form, changeable: false %>
+    <% end %>
+  </section>
+<% end %>
+
+<h2 class="govuk-heading-m">How we handle your data</h2>
+<p class="govuk-body">You can read about the data we collect from you, how we use it and how it’s stored, in our <%= govuk_link_to "privacy policy", "https://www.gov.uk/government/publications/privacy-information-education-providers-workforce-including-teachers/5a254207-a566-44f7-ac77-6ba59fd26e04#using-your-data-when-you-use-the-apply-for-qualified-teacher-status-qts-in-england-service" %>.</p>

--- a/app/views/teacher_interface/application_forms/edit.html.erb
+++ b/app/views/teacher_interface/application_forms/edit.html.erb
@@ -33,7 +33,8 @@
 
     <%= render "shared/application_form/work_history_summary",
                work_histories: @application_form.work_histories.order_by_user,
-               highlighted_contact_emails: [] %>
+               highlighted_contact_emails: [],
+               changeable: true %>
   </section>
 <% end %>
 

--- a/app/views/teacher_interface/work_histories/check_collection.html.erb
+++ b/app/views/teacher_interface/work_histories/check_collection.html.erb
@@ -6,7 +6,8 @@
 
 <%= render "shared/application_form/work_history_summary",
            work_histories: @work_histories,
-           highlighted_contact_emails: [] %>
+           highlighted_contact_emails: [],
+           changeable: true %>
 
 <% if @came_from_add_another %>
   <%= govuk_button_link_to "Continue", %i[teacher_interface application_form] %>

--- a/app/views/teacher_interface/work_histories/check_member.html.erb
+++ b/app/views/teacher_interface/work_histories/check_member.html.erb
@@ -6,7 +6,8 @@
 
 <%= render "shared/application_form/work_history_summary",
            work_histories: [@work_history],
-           highlighted_contact_emails: [] %>
+           highlighted_contact_emails: [],
+           changeable: true %>
 
 <% if @next_work_history %>
   <%= govuk_button_link_to "Continue", [:school, :teacher_interface, :application_form, @next_work_history] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -282,6 +282,8 @@ Rails.application.routes.draw do
     root to: redirect("/teacher/application")
 
     resource :application_form, path: "/application", except: %i[destroy] do
+      get "/answers", to: "application_forms#answers"
+
       resource :personal_information,
                controller: :personal_information,
                only: %i[show] do

--- a/spec/controllers/teacher_interface/uploads_controller_spec.rb
+++ b/spec/controllers/teacher_interface/uploads_controller_spec.rb
@@ -54,7 +54,19 @@ RSpec.describe TeacherInterface::UploadsController, type: :controller do
     let(:document) { create(:document, documentable: application_form) }
     let(:upload) { create(:upload, :clean, document:) }
 
-    include_examples "redirect unless application form is draft"
+    context "with a submitted application form" do
+      before { application_form.update!(submitted_at: Time.zone.now) }
+
+      it "renders the upload" do
+        perform
+        expect(response.status).to eq(200)
+      end
+
+      it "sends the blob stream" do
+        perform
+        expect(response.body).to eq(upload.attachment.blob.download)
+      end
+    end
 
     context "when the upload is present and user is authenticated" do
       it "renders the upload" do

--- a/spec/support/autoload/page_objects/teacher_interface/view_your_answers.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/view_your_answers.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class ViewYourAnswers < SitePrism::Page
+      set_url "/teacher/application/answers"
+
+      element :heading, "h1", match: :first
+
+      section :about_you, "#app-application-form-about-you" do
+        section :personal_information_summary_list,
+                GovukSummaryList,
+                "#app-check-your-answers-summary-personal-information"
+        section :identification_document_summary_list,
+                GovukSummaryList,
+                "#app-check-your-answers-summary-identity-document"
+        section :passport_document_summary_list,
+                GovukSummaryList,
+                "#app-check-your-answers-summary-passport-document"
+      end
+
+      section :who_you_can_teach, "#app-application-form-who-you-can-teach" do
+        sections :qualification_summary_lists,
+                 GovukSummaryList,
+                 ".govuk-summary-card" \
+                   ":not(#app-check-your-answers-summary-age-range)" \
+                   ":not(#app-check-your-answers-summary-subjects)",
+                 match: :first
+        section :age_range_summary_list,
+                GovukSummaryList,
+                "#app-check-your-answers-summary-age-range"
+        section :subjects_summary_list,
+                GovukSummaryList,
+                "#app-check-your-answers-summary-subjects"
+      end
+
+      section :your_english_language_proficiency,
+              "#app-application-form-your-english-language-proficiency" do
+        section :english_language_proficiency_summary_list,
+                GovukSummaryList,
+                "#app-check-your-answers-summary-english-language"
+      end
+
+      section :work_history, "section#app-application-form-work-history" do
+        section :add_summary_list,
+                GovukSummaryList,
+                "#app-check-your-answers-summary-add-work-history"
+        sections :work_history_summary_lists,
+                 GovukSummaryList,
+                 ".govuk-summary-card:not(#app-check-your-answers-summary-add-work-history)"
+      end
+
+      section :proof_of_recognition,
+              "section#app-application-form-proof-of-recognition" do
+        section :registration_number_summary_list,
+                GovukSummaryList,
+                "#app-check-your-answers-summary-registration-number"
+        section :written_statement_summary_list,
+                GovukSummaryList,
+                "#app-check-your-answers-summary-written-statement"
+      end
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -482,6 +482,11 @@ module PageHelpers
       PageObjects::TeacherInterface::CheckYourAnswers.new
   end
 
+  def teacher_view_answers_page
+    @teacher_view_answers_page =
+      PageObjects::TeacherInterface::ViewYourAnswers.new
+  end
+
   def teacher_check_your_uploads_page
     @teacher_check_your_uploads_page =
       PageObjects::TeacherInterface::CheckYourUploads.new

--- a/spec/system/teacher_interface/view_answers_spec.rb
+++ b/spec/system/teacher_interface/view_answers_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Teacher application view answers", type: :system do
+  let(:teacher) { create(:teacher) }
+  let(:application_form) do
+    create(
+      :application_form,
+      :with_personal_information,
+      :with_identification_document,
+      :with_age_range,
+      :with_subjects,
+      :with_registration_number,
+      :with_work_history,
+      :with_written_statement,
+      :with_teaching_qualification,
+      :submitted,
+      teacher:,
+    )
+  end
+
+  it "shows all the sections" do
+    given_i_am_authorized_as_a_user(teacher)
+    given_there_is_an_application_form
+
+    when_i_visit_the(:teacher_view_answers_page)
+
+    then_i_see_the_view_your_answers_title
+    and_i_see_about_you_summary
+    and_i_see_who_you_can_teach_summary
+    and_i_see_your_english_proficiency_summary
+    and_i_see_your_work_history_summary
+    and_i_see_your_proof_of_recognition_summary
+  end
+
+  context "when the applicant has uploaded passport to prove identity" do
+    let(:application_form) do
+      create(
+        :application_form,
+        :with_personal_information,
+        :with_passport_document,
+        :with_age_range,
+        :with_subjects,
+        :with_registration_number,
+        :with_work_history,
+        :with_written_statement,
+        :with_teaching_qualification,
+        :submitted,
+        teacher:,
+        requires_passport_as_identity_proof: true,
+      )
+    end
+
+    it "shows passport document summary instead of identity document" do
+      given_i_am_authorized_as_a_user(teacher)
+      given_there_is_an_application_form
+
+      when_i_visit_the(:teacher_view_answers_page)
+
+      then_i_see_the_upload_your_passport_instead_of_identity
+    end
+  end
+
+  def then_i_see_the_view_your_answers_title
+    expect(teacher_view_answers_page.heading).to have_content(
+      "View the answers you submitted to us",
+    )
+  end
+
+  def and_i_see_about_you_summary
+    expect(teacher_view_answers_page.about_you).to be_present
+    expect(
+      teacher_view_answers_page.about_you.personal_information_summary_list,
+    ).to be_present
+    expect(
+      teacher_view_answers_page.about_you.identification_document_summary_list,
+    ).to be_present
+  end
+
+  def then_i_see_the_upload_your_passport_instead_of_identity
+    expect(teacher_view_answers_page.about_you).to be_present
+    expect(
+      teacher_view_answers_page.about_you.personal_information_summary_list,
+    ).to be_present
+    expect(
+      teacher_view_answers_page.about_you.passport_document_summary_list,
+    ).to be_present
+
+    expect(teacher_view_answers_page.about_you).to have_content(
+      "Upload your passport",
+    )
+    expect(teacher_view_answers_page.about_you).not_to have_content(
+      "Upload your identity document",
+    )
+  end
+
+  def and_i_see_who_you_can_teach_summary
+    expect(teacher_view_answers_page.who_you_can_teach).to be_present
+    expect(
+      teacher_view_answers_page.who_you_can_teach.qualification_summary_lists,
+    ).to be_present
+    expect(
+      teacher_view_answers_page.who_you_can_teach.age_range_summary_list,
+    ).to be_present
+    expect(
+      teacher_view_answers_page.who_you_can_teach.subjects_summary_list,
+    ).to be_present
+  end
+
+  def and_i_see_your_english_proficiency_summary
+    expect(
+      teacher_view_answers_page.your_english_language_proficiency,
+    ).to be_present
+  end
+
+  def and_i_see_your_work_history_summary
+    expect(teacher_view_answers_page.work_history).to be_present
+  end
+
+  def and_i_see_your_proof_of_recognition_summary
+    expect(teacher_view_answers_page.proof_of_recognition).to be_present
+    expect(
+      teacher_view_answers_page.proof_of_recognition.registration_number_summary_list,
+    ).to be_present
+    expect(
+      teacher_view_answers_page.proof_of_recognition.written_statement_summary_list,
+    ).to be_present
+  end
+
+  def given_there_is_an_application_form
+    application_form
+  end
+end

--- a/spec/system/teacher_interface/view_answers_spec.rb
+++ b/spec/system/teacher_interface/view_answers_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe "Teacher application view answers", type: :system do
 
   def then_i_see_the_view_your_answers_title
     expect(teacher_view_answers_page.heading).to have_content(
-      "View the answers you submitted to us",
+      "View your submitted application",
     )
   end
 


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-821

This PR introduces a read only view of the applicants submission after they have submitted their application. This allows them to review the information they have submitted as it is not currently available. This page is currently only accessible via direct URL link. In the future, we may decide to allow easies access to this page.

