### PR TITLE
[AQTS-833] Updating content for assessment of level 6 teaching qualifications

### DIFF
--- a/app/lib/assessment_factory.rb
+++ b/app/lib/assessment_factory.rb
@@ -98,7 +98,6 @@ class AssessmentFactory
   def qualifications_section
     checks = [
       "qualifications_meet_level_6_or_equivalent",
-      "teaching_qualifications_completed_in_eligible_country",
       "qualified_in_mainstream_education",
       (
         if application_form.subject_limited

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -119,7 +119,7 @@ en:
         passport_document_valid: the uploaded passport was valid and in date when the application was created
         identification_document_present: a valid ID document is present
         name_change_document_present: evidence of name change is present (if the name entered on the form is different to the name on their ID)
-        qualifications_meet_level_6_or_equivalent: applicant holds qualifications that meet the required academic level (level 6 qualification or higher)
+        qualifications_meet_level_6_or_equivalent: applicant holds a level 6 qualification or higher from the country where they’re recognised as a teacher
         qualified_in_mainstream_education: they’re qualified to teach in mainstream education (not vocationally only/SEN only/early years/pre-school only)
         qualified_to_teach: the applicant is qualified to teach at state or government schools
         qualified_to_teach_children_11_to_16: the applicant is qualified to teach children aged 11-16
@@ -190,7 +190,7 @@ en:
           teaching_qualification_1_year: The teacher training course qualification did not last at least 1 academic year.
           teaching_qualification_pedagogy: The teaching qualification did not have enough focus on pedagogy.
           teaching_qualification_subjects_criteria: The applicant is not qualified to teach one of the subjects that we currently accept (Maths, Science, Biology, Chemistry, Physics, French, German, Italian, Japanese, Latin, Mandarin, Russian, Spanish).
-          teaching_qualifications_from_ineligible_country: The teaching qualifications were completed in an ineligible country.
+          teaching_qualifications_from_ineligible_country: The teaching qualifications were completed in a different country to where they are recognised as a teacher.​
           teaching_qualifications_not_at_required_level: The teaching qualifications do not meet the required academic level (level 6).
           teaching_transcript_illegible: The teaching qualification transcript (or translation) is illegible or in a format that we cannot accept.
           unrecognised_references: Application contained 1 or more references that cannot be considered.

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -54,7 +54,7 @@ en:
             teaching_qualification_1_year: Your teacher training course qualification did not last at least 1 academic year.
             teaching_qualification_pedagogy: Your teaching qualification did not have enough focus on pedagogy.
             teaching_qualification_subjects_criteria: You are not qualified to teach one of the subjects we currently accept (Maths, Science, Biology, Chemistry, Physics, French, German, Italian, Japanese, Latin, Mandarin, Russian, Spanish).
-            teaching_qualifications_from_ineligible_country: Your teaching qualifications were completed in an ineligible country.
+            teaching_qualifications_from_ineligible_country: Your teaching qualifications were completed in a different country to where you are recognised as a teacher.​
             teaching_qualifications_not_at_required_level: Your teaching qualifications do not meet the required academic level (level 6).
             teaching_transcript_illegible: Your teaching qualification transcript (or translation) is illegible or in a format we cannot accept.
             unrecognised_references: Your application contained one or more references we cannot consider.

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -112,7 +112,6 @@ RSpec.describe AssessmentFactory do
           expect(section.checks).to eq(
             %w[
               qualifications_meet_level_6_or_equivalent
-              teaching_qualifications_completed_in_eligible_country
               qualified_in_mainstream_education
               has_teacher_qualification_certificate
               has_teacher_qualification_transcript
@@ -159,7 +158,6 @@ RSpec.describe AssessmentFactory do
             expect(section.checks).to eq(
               %w[
                 qualifications_meet_level_6_or_equivalent
-                teaching_qualifications_completed_in_eligible_country
                 qualified_in_mainstream_education
                 qualified_to_teach_children_11_to_16
                 teaching_qualification_subjects_criteria


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-833

Content update for improving communication on requiring level 6 teacher training qualifications for assessors while assessing for level 6 teaching qualifications.