### PR TITLE
[AQTS-817] Remove the need for taking the applicant to a specific step on english language proficiency 

### DIFF
--- a/app/controllers/teacher_interface/english_language_controller.rb
+++ b/app/controllers/teacher_interface/english_language_controller.rb
@@ -24,47 +24,10 @@ module TeacherInterface
                       application_form
                       english_language
                     ]
-      elsif application_form.english_language_citizenship_exempt.nil?
+      else
         redirect_to exemption_teacher_interface_application_form_english_language_path(
                       "citizenship",
                     )
-      elsif application_form.english_language_qualification_exempt.nil?
-        redirect_to exemption_teacher_interface_application_form_english_language_path(
-                      "qualification",
-                    )
-      elsif application_form.english_language_proof_method.blank?
-        redirect_to %i[
-                      proof_method
-                      teacher_interface
-                      application_form
-                      english_language
-                    ]
-      elsif application_form.english_language_proof_method_medium_of_instruction?
-        redirect_to [
-                      :teacher_interface,
-                      :application_form,
-                      application_form.english_language_medium_of_instruction_document,
-                    ]
-      elsif application_form.english_language_provider_other
-        redirect_to [
-                      :teacher_interface,
-                      :application_form,
-                      application_form.english_language_proficiency_document,
-                    ]
-      elsif application_form.english_language_provider.nil?
-        redirect_to %i[
-                      provider
-                      teacher_interface
-                      application_form
-                      english_language
-                    ]
-      else
-        redirect_to %i[
-                      provider_reference
-                      teacher_interface
-                      application_form
-                      english_language
-                    ]
       end
     end
 

--- a/spec/requests/teachers/english_language/show_spec.rb
+++ b/spec/requests/teachers/english_language/show_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GET /teacher/english-language", type: :request do
+  subject(:sign_up) do
+    get teacher_interface_application_form_english_language_path
+  end
+
+  let(:application_form) { create :application_form }
+
+  before { sign_in(application_form.teacher) }
+
+  it "redirects to the citizenship exemption path" do
+    sign_up
+
+    expect(response).to redirect_to(
+      exemption_teacher_interface_application_form_english_language_path(
+        "citizenship",
+      ),
+    )
+  end
+
+  context "when the English language section is complete" do
+    let(:application_form) do
+      create :application_form, :with_english_language_provider
+    end
+
+    it "redirects to the check english language proficiency path" do
+      sign_up
+
+      expect(response).to redirect_to(
+        check_teacher_interface_application_form_english_language_path,
+      )
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-817

This fixes the issue where the application task for "English language proficiency" has logic to take the applicant back to where they last left their step, however this introduces some issues where the applicant is stuck without being able to go back. 

Our "Back" button is not the appropriate fix for this and therefore we are simplifying this step to ensure this applicant is always taken to the first step of the "English language proficiency" if the step is left incomplete and they come back later. This allows the applicant to review the already submitted answers and complete this stage. This is also aligned with how the other steps work. 