### PR TITLE
[AQTS-820] Fix missing captions not visible on some of the application tasks

### DIFF
--- a/app/controllers/teacher_interface/documents_controller.rb
+++ b/app/controllers/teacher_interface/documents_controller.rb
@@ -26,6 +26,7 @@ module TeacherInterface
     end
 
     def edit
+      @view_object = TeacherInterface::DocumentViewObject.new(document:)
       @form =
         if show_available_form?
           DocumentAvailableForm.new(document:, available: document.available)
@@ -44,6 +45,7 @@ module TeacherInterface
     end
 
     def update
+      @view_object = TeacherInterface::DocumentViewObject.new(document:)
       @form =
         if show_available_form?
           DocumentAvailableForm.new(

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -28,10 +28,12 @@ module TeacherInterface
     end
 
     def new
+      @view_object = TeacherInterface::DocumentViewObject.new(document:)
       @form = UploadForm.new(document:)
     end
 
     def create
+      @view_object = TeacherInterface::DocumentViewObject.new(document:)
       @form = UploadForm.new(upload_form_params.merge(document:))
 
       handle_application_form_section(

--- a/app/view_objects/teacher_interface/document_view_object.rb
+++ b/app/view_objects/teacher_interface/document_view_object.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class TeacherInterface::DocumentViewObject
+  def initialize(document:)
+    @document = document
+  end
+
+  attr_reader :document
+
+  def section_caption
+    if document.qualification_document? ||
+         document.qualification_certificate? ||
+         document.qualification_transcript?
+      I18n.t("application_form.tasks.sections.qualifications")
+    elsif document.name_change? || document.passport? ||
+          document.identification?
+      I18n.t("application_form.tasks.sections.about_you")
+    elsif document.medium_of_instruction? ||
+          document.english_language_proficiency?
+      I18n.t("application_form.tasks.sections.english_language")
+    elsif document.written_statement?
+      I18n.t("application_form.tasks.sections.proof_of_recognition")
+    end
+  end
+end

--- a/app/views/teacher_interface/documents/edit_uploads.html.erb
+++ b/app/views/teacher_interface/documents/edit_uploads.html.erb
@@ -10,6 +10,8 @@
 <%= form_with model: @form, url: [:teacher_interface, :application_form, @document], method: :patch do |f| %>
   <%= f.govuk_error_summary %>
 
+  <span class="govuk-caption-l"><%= @view_object.section_caption %></span>
+
   <h1 class="govuk-heading-xl"><%= title %></h1>
 
   <% if @document.for_consent_request? %>

--- a/app/views/teacher_interface/registration_number/edit.html.erb
+++ b/app/views/teacher_interface/registration_number/edit.html.erb
@@ -4,6 +4,8 @@
 <%= form_with model: @form, url: %i[registration_number teacher_interface application_form] do |f| %>
   <%= f.govuk_error_summary %>
 
+  <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.proof_of_recognition") %></span>
+
   <%= f.govuk_text_field :registration_number, label: { size: "l", tag: "h1" } %>
 
   <% if @application_form.region.status_check_online? %>

--- a/app/views/teacher_interface/registration_number/edit_ghana.html.erb
+++ b/app/views/teacher_interface/registration_number/edit_ghana.html.erb
@@ -4,6 +4,8 @@
 <%= form_with model: @form, url: %i[registration_number teacher_interface application_form] do |f| %>
   <%= f.govuk_error_summary %>
 
+  <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.proof_of_recognition") %></span>
+
   <div class="govuk-form-group <%= 'govuk-form-group--error' if @form.errors.present? %>">
     <fieldset class="govuk-fieldset" aria-describedby="teacher-interface-ghana-registration-number-form-registration-number-hint">
       <h1 class="govuk-label-wrapper">

--- a/app/views/teacher_interface/uploads/new.html.erb
+++ b/app/views/teacher_interface/uploads/new.html.erb
@@ -6,6 +6,8 @@
 <%= form_with model: @form, url: [:teacher_interface, :application_form, @document, :uploads] do |f| %>
   <%= f.govuk_error_summary %>
 
+  <span class="govuk-caption-l"><%= @view_object.section_caption %></span>
+
   <% if @document.uploads.empty? || !@document.allow_multiple_uploads? %>
     <% if @document.english_language_proficiency? %>
       <h1 class="govuk-heading-l">Upload your English language proficiency test</h1>
@@ -57,8 +59,6 @@
       <h1 class="govuk-heading-l">Upload your Medium of Instruction (MOI)</h1>
       <p class="govuk-body">This document must confirm that the primary language used to teach this qualification was English.</p>
     <% elsif @document.qualification_certificate? %>
-      <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
-
       <h1 class="govuk-heading-l">
         <% if @document.documentable.try(:institution_name).present? %>
           Upload your <%= @document.documentable.institution_name %> <%= I18n.t("document.document_type.qualification_certificate") %>
@@ -73,8 +73,6 @@
     <% elsif @document.qualification_document? %>
       <h1 class="govuk-heading-l">Upload your qualification document</h1>
     <% elsif @document.qualification_transcript? %>
-      <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.qualifications") %></span>
-
       <h1 class="govuk-heading-l">
         <% if @document.documentable.try(:institution_name).present? %>
           Upload your <%= @document.documentable.institution_name %> <%= I18n.t("document.document_type.qualification_transcript") %>
@@ -93,7 +91,6 @@
     <% elsif @document.unsigned_consent? %>
       <h1 class="govuk-heading-xl">Upload your unsigned consent document</h1>
     <% elsif @document.written_statement? %>
-      <span class="govuk-caption-l">Proof that you’re recognised as a teacher</span>
       <h1 class="govuk-heading-l">Upload your written statement</h1>
 
       <% if CountryCode.northern_ireland?(@application_form.region.country.code) %>

--- a/app/views/teacher_interface/work_histories/_school_form.html.erb
+++ b/app/views/teacher_interface/work_histories/_school_form.html.erb
@@ -1,6 +1,8 @@
 <%= form_with model: form, url: form.work_history.new_record? ? %i[teacher_interface application_form work_histories] : [:school, :teacher_interface, :application_form, form.work_history], method: :post do |f| %>
   <%= f.govuk_error_summary %>
 
+  <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.work_history") %></span>
+
   <h1 class="govuk-heading-l">
     <%= t("application_form.work_history.school.heading.#{form.work_history.locale_key}") %>
   </h1>

--- a/app/views/teacher_interface/work_histories/add_another.html.erb
+++ b/app/views/teacher_interface/work_histories/add_another.html.erb
@@ -4,6 +4,8 @@
 <%= form_with model: @form, url: %i[add_another teacher_interface application_form work_histories] do |f| %>
   <%= f.govuk_error_summary %>
 
+  <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.work_history") %></span>
+
   <h1 class="govuk-heading-l">
     <% if @years_count > 0 %>
       You’ve added <%= pluralize(@years_count, "year") %> and <%= pluralize(@months_count, "month") %> of work experience

--- a/app/views/teacher_interface/work_histories/edit_contact.html.erb
+++ b/app/views/teacher_interface/work_histories/edit_contact.html.erb
@@ -4,6 +4,8 @@
 <%= form_with model: @form, url: [:contact, :teacher_interface, :application_form, @work_history] do |f| %>
   <%= f.govuk_error_summary %>
 
+  <span class="govuk-caption-l"><%= I18n.t("application_form.tasks.sections.work_history") %></span>
+
   <h1 class="govuk-heading-l"><%= t("application_form.work_history.contact.heading") %></h1>
 
   <p class="govuk-body">If your application is successful, we’ll contact this person before awarding QTS to check what you’ve told us. You may want to let them know that you’ve put them forward as a reference.</p>

--- a/spec/view_objects/teacher_interface/document_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/document_view_object_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::DocumentViewObject do
+  subject(:view_object) { described_class.new(document:) }
+
+  describe "#section_caption" do
+    context "when qualification document" do
+      let(:document) { create(:document, :qualification_document) }
+
+      it "returns 'Your qualifications'" do
+        expect(view_object.section_caption).to eq("Your qualifications")
+      end
+    end
+
+    context "when qualification certificate document" do
+      let(:document) { create(:document, :qualification_certificate) }
+
+      it "returns 'Your qualifications'" do
+        expect(view_object.section_caption).to eq("Your qualifications")
+      end
+    end
+
+    context "when qualification transacript document" do
+      let(:document) { create(:document, :qualification_transcript) }
+
+      it "returns 'Your qualifications'" do
+        expect(view_object.section_caption).to eq("Your qualifications")
+      end
+    end
+
+    context "when name change document" do
+      let(:document) { create(:document, :name_change) }
+
+      it "returns 'About you'" do
+        expect(view_object.section_caption).to eq("About you")
+      end
+    end
+
+    context "when passport document" do
+      let(:document) { create(:document, :passport) }
+
+      it "returns 'About you'" do
+        expect(view_object.section_caption).to eq("About you")
+      end
+    end
+
+    context "when identification document" do
+      let(:document) { create(:document, :identification) }
+
+      it "returns 'About you'" do
+        expect(view_object.section_caption).to eq("About you")
+      end
+    end
+
+    context "when medium of instruction document" do
+      let(:document) { create(:document, :medium_of_instruction) }
+
+      it "returns 'Your English language proficiency'" do
+        expect(view_object.section_caption).to eq(
+          "Your English language proficiency",
+        )
+      end
+    end
+
+    context "when English language proficiency document" do
+      let(:document) { create(:document, :english_language_proficiency) }
+
+      it "returns 'Your English language proficiency'" do
+        expect(view_object.section_caption).to eq(
+          "Your English language proficiency",
+        )
+      end
+    end
+
+    context "when written statement document" do
+      let(:document) { create(:document, :written_statement) }
+
+      it "returns 'Proof that you’re recognised as a teacher'" do
+        expect(view_object.section_caption).to eq(
+          "Proof that you’re recognised as a teacher",
+        )
+      end
+    end
+
+    context "when signed_consent document" do
+      let(:document) { create(:document, :signed_consent) }
+
+      it "returns nil" do
+        expect(view_object.section_caption).to be_nil
+      end
+    end
+
+    context "when unsigned_consent document" do
+      let(:document) { create(:document, :unsigned_consent) }
+
+      it "returns nil" do
+        expect(view_object.section_caption).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-820

Some captions were missing, particularly across all document uploads. This PR ensures all application task pages include the relevant caption which represents the relevant task group it belongs to. 
