### PR TITLE
[AQTS-799] Ensure logs exclude all parameters from forms on top of PI data

### DIFF
--- a/config/initializers/filter_logging.rb
+++ b/config/initializers/filter_logging.rb
@@ -26,6 +26,12 @@ Rails.application.config.filter_parameters += %i[
   unconfirmed_email
   current_sign_in_ip
   last_sign_in_ip
+  _form
+  _feedback
+  _note
+  _text
+  _response
+  _comment
 ]
 
 Rails.application.config.filter_redirect << %r{/teacher/check_email}


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-799

Adding new parameters to filter logs by all contents sent via form parameters to ensure no personal data goes through our logs if in the future new columns are introduced that may contain PI data.