### PR TITLE
[AQTS-728] Verification spoke showing on applications which were declined during assessment

### DIFF
--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -354,6 +354,12 @@ class AssessorInterface::ApplicationFormsShowViewObject
   end
 
   def verification_decision_task_list_item
+    if assessment.decline? && qualification_requests_task_list_item.nil? &&
+         reference_requests_task_list_item.nil? &&
+         professional_standing_request_task_list_item.nil?
+      return
+    end
+
     {
       name:
         I18n.t(

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -444,6 +444,74 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       end
     end
 
+    context "without any verification steps but application awarded" do
+      before do
+        assessment.award!
+      end
+
+      it do
+        expect(subject).not_to include_task_list_item(
+          "Verification",
+          "Verify qualifications",
+        )
+      end
+
+      it do
+        expect(subject).not_to include_task_list_item(
+          "Verification",
+          "Verify references",
+        )
+      end
+
+      it do
+        expect(subject).not_to include_task_list_item(
+          "Verification",
+          "Verify LoPS",
+        )
+      end
+
+      it do
+        expect(subject).to include_task_list_item(
+          "Verification",
+          "Verification decision",
+        )
+      end
+    end
+
+    context "without any verification steps but application declined" do
+      before do
+        assessment.decline!
+      end
+
+      it do
+        expect(subject).not_to include_task_list_item(
+          "Verification",
+          "Verify qualifications",
+        )
+      end
+
+      it do
+        expect(subject).not_to include_task_list_item(
+          "Verification",
+          "Verify references",
+        )
+      end
+
+      it do
+        expect(subject).not_to include_task_list_item(
+          "Verification",
+          "Verify LoPS",
+        )
+      end
+
+      it do
+        expect(subject).not_to include_task_list_item(
+          "Verification",
+          "Verification decision"
+        )
+      end
+    end
+
     context "with a reference request" do
       before do
         assessment.verify!

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -445,9 +445,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
     end
 
     context "without any verification steps but application awarded" do
-      before do
-        assessment.award!
-      end
+      before { assessment.award! }
 
       it do
         expect(subject).not_to include_task_list_item(
@@ -479,9 +477,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
     end
 
     context "without any verification steps but application declined" do
-      before do
-        assessment.decline!
-      end
+      before { assessment.decline! }
 
       it do
         expect(subject).not_to include_task_list_item(
@@ -507,7 +503,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       it do
         expect(subject).not_to include_task_list_item(
           "Verification",
-          "Verification decision"
+          "Verification decision",
         )
       end
     end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-728

This PR fixes the issue for when declined applications that were declined during initial assessment still show the verification decision task in the assessor UI.
