### PR TITLE
Ensure test data for review app to have passport route by default

### DIFF
--- a/app/lib/fake_data/application_form_generator.rb
+++ b/app/lib/fake_data/application_form_generator.rb
@@ -98,7 +98,7 @@ class FakeData::ApplicationFormGenerator
     traits = %i[
       with_personal_information
       with_degree_qualification
-      with_identification_document
+      with_passport_document
       with_age_range
       with_subjects
     ]

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -259,6 +259,7 @@ FactoryBot.define do
     end
 
     trait :with_passport_document do
+      requires_passport_as_identity_proof { true }
       passport_document_status { "completed" }
 
       passport_country_of_issue_code { "FRA" }

--- a/spec/system/teacher_interface/submitting_spec.rb
+++ b/spec/system/teacher_interface/submitting_spec.rb
@@ -124,7 +124,6 @@ RSpec.describe "Teacher submitting", type: :system do
         :with_written_statement,
         :with_registration_number,
         teacher:,
-        requires_passport_as_identity_proof: true,
       )
     end
 
@@ -156,7 +155,6 @@ RSpec.describe "Teacher submitting", type: :system do
           :with_written_statement,
           :with_registration_number,
           teacher:,
-          requires_passport_as_identity_proof: true,
           passport_expiry_date: 2.days.ago.to_date,
         )
       end

--- a/spec/system/teacher_interface/view_answers_spec.rb
+++ b/spec/system/teacher_interface/view_answers_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe "Teacher application view answers", type: :system do
         :with_teaching_qualification,
         :submitted,
         teacher:,
-        requires_passport_as_identity_proof: true,
       )
     end
 


### PR DESCRIPTION
This PR makes all the fake data generated have passport as a way to verify identity for review apps. 