### PR TITLE
[AQTS-796] Remove teaching confirmation being set to true on edit by default

### DIFF
--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -165,7 +165,6 @@ module TeacherInterface
           start_date: qualification.start_date,
           complete_date: qualification.complete_date,
           certificate_date: qualification.certificate_date,
-          teaching_confirmation: true,
         )
     end
 

--- a/spec/system/teacher_interface/back_links_spec.rb
+++ b/spec/system/teacher_interface/back_links_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Teacher back links", type: :system do
     #  <- teacher_edit_qualification_page
 
     when_i_click_qualifications
+    and_i_check_teaching_qualification_confirmation
     and_i_click_continue
     then_i_see_the(:teacher_upload_document_page)
 
@@ -58,6 +59,7 @@ RSpec.describe "Teacher back links", type: :system do
     #  -> teacher_part_of_degree_page
     #  <- document_form_page <- document_form_page <- teacher_edit_qualification_page
 
+    and_i_check_teaching_qualification_confirmation
     when_i_click_continue
     then_i_see_the(:teacher_check_document_page)
 
@@ -86,6 +88,7 @@ RSpec.describe "Teacher back links", type: :system do
     #  -> teacher_part_of_degree_page -> teacher_check_qualification_page
     #  <- teacher_application_page
 
+    and_i_check_teaching_qualification_confirmation
     when_i_click_continue
     then_i_see_the(:teacher_check_document_page)
 
@@ -124,6 +127,7 @@ RSpec.describe "Teacher back links", type: :system do
       qualification_id: qualification.id,
     )
 
+    and_i_check_teaching_qualification_confirmation
     when_i_click_continue
     then_i_see_the(:teacher_check_qualifications_page)
 
@@ -286,6 +290,11 @@ RSpec.describe "Teacher back links", type: :system do
       .actions
       .link
       .click
+  end
+
+  def and_i_check_teaching_qualification_confirmation
+    check "I confirm this is the first qualification I have that qualifies me to teach.",
+          visible: false
   end
 
   def when_i_add_another_qualification

--- a/spec/system/teacher_interface/check_answers_spec.rb
+++ b/spec/system/teacher_interface/check_answers_spec.rb
@@ -26,6 +26,9 @@ RSpec.describe "Teacher application check answers", type: :system do
     when_i_click_change_links(:who_you_can_teach, :qualification) do
       if teacher_check_document_page.displayed?(0)
         and_i_dont_need_to_upload_another_file
+      elsif teacher_edit_qualification_page.displayed?
+        and_i_check_teaching_qualification_confirmation
+        and_i_click_continue
       else
         and_i_click_continue
       end
@@ -162,6 +165,11 @@ RSpec.describe "Teacher application check answers", type: :system do
   def and_i_dont_need_to_upload_another_file
     teacher_check_document_page.form.false_radio_item.input.click
     teacher_check_document_page.form.continue_button.click
+  end
+
+  def and_i_check_teaching_qualification_confirmation
+    check "I confirm this is the first qualification I have that qualifies me to teach.",
+          visible: false
   end
 
   def when_i_click_change_link_for_english_language_proficiency


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-796

This PR ensures that the applicant must check the confirmation box whenever they go to edit the teaching qualification. Previously, if the user saved their progress and came back later, the checkbox would be checked by default which is the incorrect behaviour. 