### PR TITLE
[AQTS-853] Work history FI updates

### DIFF
--- a/app/forms/assessor_interface/assessment_section_form.rb
+++ b/app/forms/assessor_interface/assessment_section_form.rb
@@ -78,6 +78,11 @@ class AssessorInterface::AssessmentSectionForm
       klass.preliminary = assessment_section.preliminary?
 
       assessment_section.failure_reasons.each do |failure_reason|
+        selected_failure_reason =
+          assessment_section.selected_failure_reasons.find_by(
+            key: failure_reason,
+          )
+
         klass.attribute "#{failure_reason}_checked", :boolean
 
         if assessment_section.preliminary?
@@ -90,6 +95,9 @@ class AssessorInterface::AssessmentSectionForm
           klass.validates "#{failure_reason}_work_history_checked",
                           presence: true,
                           if: :"#{failure_reason}_checked"
+        elsif selected_failure_reason.present? &&
+              selected_failure_reason.work_histories.present?
+          klass.attribute "#{failure_reason}_work_history_checked"
         end
 
         klass.attribute "#{failure_reason}_notes", :string
@@ -122,7 +130,8 @@ class AssessorInterface::AssessmentSectionForm
       selected_failure_reasons_hash.each do |key, notes|
         attributes["#{key}_checked"] = true
         attributes["#{key}_notes"] = notes[:assessor_feedback]
-        if FailureReasons.chooses_work_history?(key)
+        if FailureReasons.chooses_work_history?(key) ||
+             notes[:work_history_ids].present?
           attributes["#{key}_work_history_checked"] = notes[:work_history_ids]
         end
       end

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -77,7 +77,7 @@ class FailureReasons
     WRITTEN_STATEMENT_RECENT = "written_statement_recent",
   ].freeze
 
-  WORK_HISTORY_FAILURE_REASONS = [SCHOOL_DETAILS_CANNOT_BE_VERIFIED].freeze
+  WORK_HISTORY_REFERENCE_FAILURE_REASONS = [UNRECOGNISED_REFERENCES].freeze
 
   ALL = (DECLINABLE + FURTHER_INFORMATIONABLE).freeze
 
@@ -138,6 +138,6 @@ class FailureReasons
   end
 
   def self.chooses_work_history?(failure_reason)
-    WORK_HISTORY_FAILURE_REASONS.include?(failure_reason.to_s)
+    WORK_HISTORY_REFERENCE_FAILURE_REASONS.include?(failure_reason.to_s)
   end
 end

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -28,7 +28,11 @@ module AssessorInterface
     delegate :registration_number,
              :requires_preliminary_check,
              to: :application_form
-    delegate :checks, :failure_reasons, :preliminary?, to: :assessment_section
+    delegate :checks,
+             :failure_reasons,
+             :preliminary?,
+             :selected_failure_reasons,
+             to: :assessment_section
     delegate :region, :country, to: :application_form
 
     def notes_label_key_for(failure_reason:)

--- a/app/view_objects/assessor_interface/assessment_section_view_object.rb
+++ b/app/view_objects/assessor_interface/assessment_section_view_object.rb
@@ -47,6 +47,10 @@ module AssessorInterface
       build_key(failure_reason, "placeholder")
     end
 
+    def selected_work_histories_for(failure_reason:)
+      selected_failure_reasons.find_by(key: failure_reason)&.work_histories
+    end
+
     def show_form?
       return true if preliminary?
 

--- a/app/views/assessor_interface/assessment_sections/_form.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_form.html.erb
@@ -82,7 +82,7 @@
                                     hint: { text: t(view_object.notes_hint_key_for(failure_reason:)) },
                                     placeholder: t(view_object.notes_placeholder_key_for(failure_reason:)),
                                     disabled: view_object.disable_form? %>
-              <% if FailureReasons.chooses_work_history?(failure_reason) || view_object.selected_failure_reasons.find_by(key: failure_reason)&.work_histories.present? %>
+              <% if FailureReasons.chooses_work_history?(failure_reason) || view_object.selected_work_histories_for(failure_reason:).present? %>
                 <%= f.govuk_check_boxes_fieldset :"#{failure_reason}_work_history_checked", legend: { size: "s" } do %>
                   <% view_object.work_histories.each do |work_history| %>
                     <%= f.govuk_check_box :"#{failure_reason}_work_history_checked", work_history.id, label: { text: work_history.school_name }, disabled: view_object.disable_form? %>

--- a/app/views/assessor_interface/assessment_sections/_form.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_form.html.erb
@@ -82,7 +82,7 @@
                                     hint: { text: t(view_object.notes_hint_key_for(failure_reason:)) },
                                     placeholder: t(view_object.notes_placeholder_key_for(failure_reason:)),
                                     disabled: view_object.disable_form? %>
-              <% if FailureReasons::chooses_work_history?(failure_reason) %>
+              <% if FailureReasons.chooses_work_history?(failure_reason) || view_object.selected_failure_reasons.find_by(key: failure_reason)&.work_histories.present? %>
                 <%= f.govuk_check_boxes_fieldset :"#{failure_reason}_work_history_checked", legend: { size: "s" } do %>
                   <% view_object.work_histories.each do |work_history| %>
                     <%= f.govuk_check_box :"#{failure_reason}_work_history_checked", work_history.id, label: { text: work_history.school_name }, disabled: view_object.disable_form? %>

--- a/app/views/assessor_interface/further_information_requests/new.html.erb
+++ b/app/views/assessor_interface/further_information_requests/new.html.erb
@@ -4,7 +4,7 @@
 <h1 class="govuk-heading-xl">Check the information you’re asking the applicant for</h1>
 
 <% @further_information_request.items.group_by(&:failure_reason_key).each do |failure_reason_key, items| %>
-  <% if failure_reason_key == FailureReasons::UNRECOGNISED_REFERENCES %>
+  <% if FailureReasons.chooses_work_history?(failure_reason_key) %>
     <section class="app-further-information-request-item">
       <h2 class="govuk-heading-m">Reason for request</h2>
       <% if items.size == 1 %>

--- a/app/views/assessor_interface/further_information_requests/new.html.erb
+++ b/app/views/assessor_interface/further_information_requests/new.html.erb
@@ -4,7 +4,7 @@
 <h1 class="govuk-heading-xl">Check the information you’re asking the applicant for</h1>
 
 <% @further_information_request.items.group_by(&:failure_reason_key).each do |failure_reason_key, items| %>
-  <% if failure_reason_key == "school_details_cannot_be_verified" %>
+  <% if failure_reason_key == FailureReasons::UNRECOGNISED_REFERENCES %>
     <section class="app-further-information-request-item">
       <h2 class="govuk-heading-m">Reason for request</h2>
       <% if items.size == 1 %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -193,7 +193,7 @@ en:
           teaching_qualifications_from_ineligible_country: The teaching qualifications were completed in a different country to where they are recognised as a teacher.​
           teaching_qualifications_not_at_required_level: The teaching qualifications do not meet the required academic level (level 6).
           teaching_transcript_illegible: There is a problem with the teaching qualification transcript (or translation), for example, it’s incorrect, illegible, or incomplete.
-          unrecognised_references: Application contained 1 or more references that cannot be considered.
+          unrecognised_references: We could not verify 1 or more references entered by the applicant.
           work_history_break: There is an unexplained break in the applicant’s work history.
           work_history_duration: The applicant’s work experience does not meet the minimum duration requirements.
           written_statement_illegible: There is a problem with the letter, for example, it’s missing, incorrect or illegible.

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -326,6 +326,7 @@ en:
         selected_failure_reasons: What are the reasons for your recommendation?
         scotland_full_registration: Does the applicant have or are they eligible for full registration?
         school_details_cannot_be_verified_work_history_checked: Select the school that we were unable to verify (there may be more than one)
+        unrecognised_references_work_history_checked: Select the school that we were unable to verify the reference for (there may be more than one)
       assessor_interface_filter_form:
         action_required_by: Action required by
         assessor_ids: Assessor name

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -57,7 +57,7 @@ en:
             teaching_qualifications_from_ineligible_country: Your teaching qualifications were completed in a different country to where you are recognised as a teacher.​
             teaching_qualifications_not_at_required_level: Your teaching qualifications do not meet the required academic level (level 6).
             teaching_transcript_illegible: There is a problem with your teaching qualification transcript (or translation).
-            unrecognised_references: Your application contained one or more references we cannot consider.
+            unrecognised_references: We could not verify 1 or more references you provided.
             work_history_break: There is an unexplained break in your work history.
             work_history_duration: Your work experience does not meet the minimum duration requirements.
             written_statement_illegible: There is a problem with the written confirmation that proves you’re recognised as a teacher.

--- a/spec/forms/assessor_interface/assessment_section_form_spec.rb
+++ b/spec/forms/assessor_interface/assessment_section_form_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe AssessorInterface::AssessmentSectionForm, type: :model do
   let(:further_information_failure_reason) do
     (
       FailureReasons::FURTHER_INFORMATIONABLE -
-        FailureReasons::WORK_HISTORY_FAILURE_REASONS
+        FailureReasons::WORK_HISTORY_REFERENCE_FAILURE_REASONS
     ).sample.to_sym
   end
   let(:work_history_failure_reason) do
-    FailureReasons::WORK_HISTORY_FAILURE_REASONS.sample.to_sym
+    FailureReasons::WORK_HISTORY_REFERENCE_FAILURE_REASONS.sample.to_sym
   end
   let(:decline_failure_reason) { FailureReasons::AGE_RANGE.to_sym }
   let(:user) { create(:staff) }

--- a/spec/system/assessor_interface/checking_submitted_details_spec.rb
+++ b/spec/system/assessor_interface/checking_submitted_details_spec.rb
@@ -551,7 +551,7 @@ RSpec.describe "Assessor check submitted details", type: :system do
           :work_history,
           assessment: application_form.assessment,
           failure_reasons: %w[
-            school_details_cannot_be_verified
+            unrecognised_references
             identification_document_expired
           ],
         )

--- a/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/assessment_section_view_object_spec.rb
@@ -199,6 +199,50 @@ RSpec.describe AssessorInterface::AssessmentSectionViewObject do
     end
   end
 
+  describe "#selected_work_histories_for" do
+    subject(:selected_work_histories_for) do
+      view_object.selected_work_histories_for(failure_reason:)
+    end
+
+    let(:application_form) do
+      create(:application_form, :with_work_history, region:)
+    end
+    let(:failure_reason) { FailureReasons::UNRECOGNISED_REFERENCES }
+    let(:work_histories) { application_form.work_histories }
+    let(:selected_failure_reason) do
+      create :selected_failure_reason,
+             key: failure_reason,
+             assessment_section:,
+             work_histories:
+    end
+
+    before { selected_failure_reason }
+
+    it "returns the work histories attached to the selected failure reason" do
+      expect(selected_work_histories_for).to eq(application_form.work_histories)
+    end
+
+    context "when there is no work history attached" do
+      let(:work_histories) { [] }
+
+      it "returns the empty" do
+        expect(selected_work_histories_for).to be_empty
+      end
+    end
+
+    context "when the selected failure reason is not on assessment section" do
+      let(:selected_failure_reason) do
+        create :selected_failure_reason,
+               key: FailureReasons::SCHOOL_DETAILS_CANNOT_BE_VERIFIED,
+               assessment_section:
+      end
+
+      it "returns nil" do
+        expect(selected_work_histories_for).to be_nil
+      end
+    end
+  end
+
   describe "#show_form?" do
     subject(:show_form?) { view_object.show_form? }
 


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-853

This PR:
1. Updates the content for unrecognised references failure reason on the work history task.
2. "Unrecognised references" FI to now capture new referee details instead of "school details cannot be verified"
As part of this, we ensure that existing assessment that have already sent these reasons, still display the work histories selected under "school details cannot be verified" for future reference + the existing FI's sent out won't be impacted by this change and the applicant will still return the originally expected response type.

![Screenshot 2025-03-04 at 10 52 37](https://github.com/user-attachments/assets/78ac563c-e1dd-45e1-8edc-b3c24090d315)
