### PR TITLE
Upgrading cgi gem to 0.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,7 +152,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    cgi (0.4.1)
+    cgi (0.4.2)
     choice (0.2.0)
     climate_control (1.2.0)
     coderay (1.1.3)


### PR DESCRIPTION
Upgrading the gem due to 2 security alerts by dependabot:

https://github.com/DFE-Digital/apply-for-qualified-teacher-status/security/dependabot/54
https://github.com/DFE-Digital/apply-for-qualified-teacher-status/security/dependabot/55
