### PR TITLE
[AQTS-867] Ensure LoPS is not generated due to session value being passed

### DIFF
--- a/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_verify_controller.rb
@@ -37,7 +37,8 @@ module AssessorInterface
     end
 
     def update
-      professional_standing = session[:professional_standing]
+      professional_standing =
+        skip_professional_standing? ? nil : session[:professional_standing]
       qualifications =
         application_form.qualifications.where(id: session[:qualification_ids])
       qualifications_assessor_note =

--- a/spec/services/verify_assessment_spec.rb
+++ b/spec/services/verify_assessment_spec.rb
@@ -65,6 +65,26 @@ RSpec.describe VerifyAssessment do
         expect { call }.not_to change(ProfessionalStandingRequest, :count)
       end
     end
+
+    context "when reduced evidence is accepted for application" do
+      let(:application_form) do
+        create(:application_form, :submitted, reduced_evidence_accepted: true)
+      end
+
+      it "doesn't create a professional standing request" do
+        expect { call }.not_to change(ProfessionalStandingRequest, :count)
+      end
+    end
+
+    context "when work history is not required for application" do
+      let(:application_form) do
+        create(:application_form, :submitted, needs_work_history: false)
+      end
+
+      it "doesn't create a professional standing request" do
+        expect { call }.not_to change(ProfessionalStandingRequest, :count)
+      end
+    end
   end
 
   describe "creating reference request" do
@@ -82,6 +102,26 @@ RSpec.describe VerifyAssessment do
       it "sets the attributes correctly" do
         expect(reference_request.requested?).to be true
       end
+    end
+
+    context "when reduced evidence is accepted for application" do
+      let(:application_form) do
+        create(:application_form, :submitted, reduced_evidence_accepted: true)
+      end
+
+      before { call }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when work history is not required for application" do
+      let(:application_form) do
+        create(:application_form, :submitted, needs_work_history: false)
+      end
+
+      before { call }
+
+      it { is_expected.to be_nil }
     end
   end
 


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-867

The verification recommendation form submission relies on session values stored during the process of filling out the recommendation by the assessor for each application. However, at times there may be LoPS requested for a different assessment being passed over for application that do not require them and as a result, it ends up with the application with incorrect verification steps. 

This PR for now ensures that LoPS and references are only generated if the application does not skip them. 

In the future we may want to move away from relying on storing the progress within the session as it could bring up more issues. 