### PR TITLE
[AQTS-862] Remove review previous referee details on FI after it has been accepted

### DIFF
--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -7,7 +7,7 @@
   <h2 class="govuk-heading-m"><%= item.fetch(:heading) %></h2>
   <%= govuk_inset_text(text: item.fetch(:description)) %>
   <%= render(CheckYourAnswersSummary::Component.new(**item.fetch(:check_your_answers))) %>
-  <% if (item[:work_history_summary_list_rows]).present? %>
+  <% if (item[:work_history_summary_list_rows]).present? && !@view_object.further_information_request.review_passed? %>
     <%= govuk_details(summary_text: "Review previous referee details?") do %>
       <%= govuk_summary_list(rows: item[:work_history_summary_list_rows]) %>
     <% end %>

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
       assessment_id:,
       id: further_information_request.id,
     )
-    and_i_see_the_check_your_answers_items
+    and_i_see_the_check_your_answers_items_without_the_previous_referee_details
     and_i_do_not_see_the_review_further_information_form
   end
 
@@ -94,6 +94,25 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     expect(rows.first.key.text).to eq(
       "Tell us more about the subjects you can teach",
     )
+
+    expect(page).to have_content("Review previous referee details?")
+
+    expect(rows.last.key.text).to eq("Upload your identity document")
+  end
+
+  def and_i_see_the_check_your_answers_items_without_the_previous_referee_details
+    rows =
+      assessor_review_further_information_request_page.summary_lists.flat_map(
+        &:rows
+      )
+
+    expect(rows.count).to eq(5)
+
+    expect(rows.first.key.text).to eq(
+      "Tell us more about the subjects you can teach",
+    )
+
+    expect(page).not_to have_content("Review previous referee details?")
 
     expect(rows.last.key.text).to eq("Upload your identity document")
   end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-862

Minor change to remove showing previous referee details once the FI has already been reviewed. Since once it's accepted, the values will be the same because of the update and this may cause confusion.