### PR TITLE
[AQTS-900] Tracking of validation error triggering

### DIFF
--- a/app/controllers/teacher_interface/application_forms_controller.rb
+++ b/app/controllers/teacher_interface/application_forms_controller.rb
@@ -2,6 +2,7 @@
 
 module TeacherInterface
   class ApplicationFormsController < BaseController
+    include HandleApplicationFormSection
     include HistoryTrackable
 
     before_action :redirect_if_application_form_active, only: %i[new create]
@@ -39,6 +40,8 @@ module TeacherInterface
       elsif @country_region_form.save(validate: true)
         redirect_to teacher_interface_application_form_path
       else
+        send_errors_to_big_query(@country_region_form)
+
         render :new, status: :unprocessable_entity
       end
     end
@@ -78,6 +81,8 @@ module TeacherInterface
         SubmitApplicationForm.call(application_form:, user: current_teacher)
         redirect_to %i[teacher_interface application_form]
       else
+        send_errors_to_big_query(@sanction_confirmation_form)
+
         render :edit, status: :unprocessable_entity
       end
     end

--- a/app/controllers/teacher_interface/qualifications_controller.rb
+++ b/app/controllers/teacher_interface/qualifications_controller.rb
@@ -149,6 +149,8 @@ module TeacherInterface
           end
         end
       else
+        send_errors_to_big_query(@form)
+
         render :add_another, status: :unprocessable_entity
       end
     end
@@ -209,6 +211,8 @@ module TeacherInterface
       if @form.save(validate: true)
         redirect_to %i[check teacher_interface application_form qualifications]
       else
+        send_errors_to_big_query(@form)
+
         render :delete, status: :unprocessable_entity
       end
     end

--- a/app/controllers/teacher_interface/uploads_controller.rb
+++ b/app/controllers/teacher_interface/uploads_controller.rb
@@ -66,6 +66,8 @@ module TeacherInterface
       if @form.save(validate: true)
         redirect_to [:teacher_interface, :application_form, document]
       else
+        send_errors_to_big_query(@form)
+
         render :delete, status: :unprocessable_entity
       end
     end

--- a/app/controllers/teacher_interface/work_histories_controller.rb
+++ b/app/controllers/teacher_interface/work_histories_controller.rb
@@ -121,6 +121,8 @@ module TeacherInterface
           end
         end
       else
+        send_errors_to_big_query(@form)
+
         render :add_another, status: :unprocessable_entity
       end
     end
@@ -226,6 +228,8 @@ module TeacherInterface
       if @form.save(validate: true)
         redirect_to %i[check teacher_interface application_form work_histories]
       else
+        send_errors_to_big_query(@form)
+
         render :delete, status: :unprocessable_entity
       end
     end

--- a/config/analytics_custom_events.yml
+++ b/config/analytics_custom_events.yml
@@ -1,0 +1,2 @@
+shared:
+  - form_validation_failure

--- a/spec/controllers/concerns/handle_application_form_section_spec.rb
+++ b/spec/controllers/concerns/handle_application_form_section_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe HandleApplicationFormSection, type: :controller do
       )
     end
 
-    let(:form) { double }
+    let(:form) { instance_double(TeacherInterface::BaseForm, errors: []) }
     let(:if_success_then_redirect) { :redirect }
     let(:if_failure_then_render) { :render }
 

--- a/spec/controllers/concerns/handle_application_form_section_spec.rb
+++ b/spec/controllers/concerns/handle_application_form_section_spec.rb
@@ -11,8 +11,19 @@ RSpec.describe HandleApplicationFormSection, type: :controller do
     end
   end
   let(:session) { {} }
+  let(:current_teacher) { create(:teacher) }
+  let(:request) do
+    ActionController::TestRequest.new({}, {}, TeacherInterface::BaseController)
+  end
 
-  before { allow(controller).to receive_messages(params:, session:) }
+  before do
+    allow(controller).to receive_messages(
+      params:,
+      session:,
+      current_teacher:,
+      request:,
+    )
+  end
 
   describe "#handle_application_form_section" do
     subject(:handle_application_form_section) do
@@ -40,11 +51,30 @@ RSpec.describe HandleApplicationFormSection, type: :controller do
       end
 
       context "when form is invalid" do
+        let(:error) do
+          ActiveModel::Error.new(
+            TeacherInterface::NameAndDateOfBirthForm.new,
+            :given_names,
+          )
+        end
+
+        let(:form) do
+          instance_double(
+            TeacherInterface::NameAndDateOfBirthForm,
+            errors: [error],
+          )
+        end
+
         before { allow(form).to receive(:save).and_return(false) }
 
-        it "renders the failure" do
+        it "renders the failure and sends a custom form_validation_failure event to BigQuery" do
           expect(controller).to receive(:render)
+
           handle_application_form_section
+
+          expect(
+            :form_validation_failure,
+          ).to have_been_enqueued_as_analytics_events
         end
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,7 @@ require "rspec/rails"
 
 require "capybara/cuprite"
 require "dfe/analytics/testing"
+require "dfe/analytics/rspec/matchers"
 require "support/page_helpers"
 require "site_prism"
 require "site_prism/all_there"

--- a/terraform/application/config/review/variables.yml
+++ b/terraform/application/config/review/variables.yml
@@ -1,2 +1,3 @@
 ---
 TRS_API_URL: https://dev.teacher-qualifications-api.education.gov.uk
+BIGQUERY_DISABLE: true

--- a/terraform/application/config/review/variables.yml
+++ b/terraform/application/config/review/variables.yml
@@ -1,3 +1,2 @@
 ---
 TRS_API_URL: https://dev.teacher-qualifications-api.education.gov.uk
-BIGQUERY_DISABLE: true


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-900

In this PR, we are adding the capability for any validation error messages that are triggered within the teacher interface are sent as a `form_validation_failure` custom event via dfe_analytics to BigQuery. This data will include information about the request, current user/teacher and additional data around the form class, the column it relates to and the error message that was shown.

I've made a decision to integrate this into the existing `HandleApplicationFormSection` concern used across teacher interface controllers.

Below is an example of how these appear in BigQuery following a quick test using the review environment:

![Screenshot 2025-03-20 at 12 37 16](https://github.com/user-attachments/assets/1ac71bf6-c2c3-418d-931f-f0b5e7fd77bf)
