### PR TITLE
[AQTS-896] Do not show an error message when confirming an award assessor

### DIFF
--- a/app/views/assessor_interface/assessment_recommendation_award/age_range_subjects.html.erb
+++ b/app/views/assessor_interface/assessment_recommendation_award/age_range_subjects.html.erb
@@ -38,6 +38,7 @@
   end
 end %>
 
-<%= form_with url: [:confirm, :assessor_interface, @application_form, @assessment, :assessment_recommendation_award] do |f| %>
-  <% render "shared/assessor_interface/continue_cancel_button", f: %>
-<% end %>
+<div class="govuk-button-group">
+  <%= govuk_button_link_to "Continue", [:confirm, :assessor_interface, @application_form, @assessment, :assessment_recommendation_award] %>
+  <%= render "shared/assessor_interface/cancel_link" %>
+</div>


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-896

Previously, when moving to the final section to award QTS to application, an error would should by default for the confirmation question. We are now removing this as part of this PR. 

The error was happening due to the fact that the previous page, the continue button was part of the next pages form and as a result of the value of the confirmation not being passed through, the error message was being rendered. 