### PR TITLE
[DO NOT MERGE][AQTS-495] Move from azure-storage-blob to azure-blob

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "rails", "~> 8.0"
 
 gem "activerecord-session_store"
 gem "amazing_print"
-gem "azure-storage-blob"
+gem "azure-blob"
 gem "bootsnap", require: false
 gem "business"
 gem "combine_pdf"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,14 +123,8 @@ GEM
     annotaterb (4.14.0)
     ast (2.4.2)
     attr_required (1.0.2)
-    azure-storage-blob (2.0.3)
-      azure-storage-common (~> 2.0)
-      nokogiri (~> 1, >= 1.10.8)
-    azure-storage-common (2.0.4)
-      faraday (~> 1.0)
-      faraday_middleware (~> 1.0, >= 1.0.0.rc1)
-      net-http-persistent (~> 4.0)
-      nokogiri (~> 1, >= 1.10.8)
+    azure-blob (0.5.7)
+      rexml
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
@@ -231,8 +225,6 @@ GEM
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
     faraday-retry (1.0.3)
-    faraday_middleware (1.2.0)
-      faraday (~> 1.0)
     ferrum (0.15)
       addressable (~> 2.5)
       concurrent-ruby (~> 1.1)
@@ -353,8 +345,6 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
-    net-http-persistent (4.0.2)
-      connection_pool (~> 2.2)
     net-imap (0.5.6)
       date
       net-protocol
@@ -704,7 +694,7 @@ DEPENDENCIES
   activerecord-session_store
   amazing_print
   annotaterb
-  azure-storage-blob
+  azure-blob
   bootsnap
   business
   capybara

--- a/app/services/fetch_malware_scan_result.rb
+++ b/app/services/fetch_malware_scan_result.rb
@@ -17,7 +17,7 @@ class FetchMalwareScanResult
 
     begin
       response = fetch_scan_result
-    rescue Azure::Core::Http::HTTPError
+    rescue AzureBlob::Http::Error
       upload.malware_scan_error!
       return
     end
@@ -32,35 +32,26 @@ class FetchMalwareScanResult
   def blob_service
     @blob_service ||=
       AzureBlob::Client.new(
-        storage_account_name: ENV["AZURE_STORAGE_ACCOUNT_NAME"],
-        storage_access_key: ENV["AZURE_STORAGE_ACCESS_KEY"],
+        account_name: ENV["AZURE_STORAGE_ACCOUNT_NAME"],
+        access_key: ENV["AZURE_STORAGE_ACCESS_KEY"],
+        container: ENV["AZURE_STORAGE_CONTAINER"],
       )
   end
 
   def fetch_scan_result
-    blob_service.call(:get, get_tags_for_blob_url)
-  end
-
-  def get_tags_for_blob_url
-    @get_tags_for_blob_url ||=
-      blob_service.generate_uri(
-        File.join("uploads", upload.attachment.key),
-        { comp: "tags" },
-      )
+    blob_service.get_blob(
+      "#{File.join("uploads", upload.attachment.key)}?comp=tags",
+    )
   end
 
   def update_scan_result(response)
-    if response.success?
-      if response.body =~ SCAN_RESULT_TAG_KEY
-        if response.body =~ SCAN_RESULT_TAG_VALUE_CLEAN
-          upload.malware_scan_clean!
-        else
-          upload.malware_scan_suspect!
-          upload.attachment.purge_later
-        end
+    if response =~ SCAN_RESULT_TAG_KEY
+      if response =~ SCAN_RESULT_TAG_VALUE_CLEAN
+        upload.malware_scan_clean!
+      else
+        upload.malware_scan_suspect!
+        upload.attachment.purge_later
       end
-    else
-      upload.malware_scan_error!
     end
   end
 end

--- a/app/services/fetch_malware_scan_result.rb
+++ b/app/services/fetch_malware_scan_result.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
+require "azure_blob"
+
 class FetchMalwareScanResult
   include ServicePattern
-
-  # Only later versions of the Azure Storage REST API support tags operations.
-  Kernel.silence_warnings do
-    Azure::Storage::Blob::Default::STG_VERSION = "2022-11-02"
-  end
 
   SCAN_RESULT_TAG_KEY = /Malware Scanning scan result/
   SCAN_RESULT_TAG_VALUE_CLEAN = /No threats found/
@@ -34,7 +31,7 @@ class FetchMalwareScanResult
 
   def blob_service
     @blob_service ||=
-      Azure::Storage::Blob::BlobService.new(
+      AzureBlob::Client.new(
         storage_account_name: ENV["AZURE_STORAGE_ACCOUNT_NAME"],
         storage_access_key: ENV["AZURE_STORAGE_ACCESS_KEY"],
       )

--- a/app/services/fetch_malware_scan_result.rb
+++ b/app/services/fetch_malware_scan_result.rb
@@ -39,9 +39,7 @@ class FetchMalwareScanResult
   end
 
   def fetch_scan_result
-    blob_service.get_blob(
-      "#{File.join("uploads", upload.attachment.key)}?comp=tags",
-    )
+    blob_service.get_blob("#{upload.attachment.key}?comp=tags")
   end
 
   def update_scan_result(response)

--- a/app/services/resend_stored_blob_data.rb
+++ b/app/services/resend_stored_blob_data.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
 
+require "azure_blob"
+
 class ResendStoredBlobData
   include ServicePattern
-
-  # Only later versions of the Azure Storage REST API support tags operations.
-  Kernel.silence_warnings do
-    Azure::Storage::Blob::Default::STG_VERSION = "2022-11-02"
-  end
 
   BLOB_CONTAINER_NAME = ENV["AZURE_STORAGE_CONTAINER"] || "uploads"
 
@@ -34,7 +31,7 @@ class ResendStoredBlobData
 
   def blob_service
     @blob_service ||=
-      Azure::Storage::Blob::BlobService.new(
+      AzureBlob::Client.new(
         storage_account_name: ENV["AZURE_STORAGE_ACCOUNT_NAME"],
         storage_access_key: ENV["AZURE_STORAGE_ACCESS_KEY"],
       )

--- a/app/services/resend_stored_blob_data.rb
+++ b/app/services/resend_stored_blob_data.rb
@@ -17,10 +17,7 @@ class ResendStoredBlobData
     end
 
     success =
-      blob_service.create_block_blob(
-        File.join(BLOB_CONTAINER_NAME, upload.attachment.key),
-        attachment_data,
-      )
+      blob_service.create_block_blob(upload.attachment.key, attachment_data)
 
     if success
       UpdateMalwareScanResultJob.set(wait: 2.seconds).perform_later(upload)
@@ -44,11 +41,5 @@ class ResendStoredBlobData
 
   def attachment_data
     @attachment_data ||= upload.attachment.download
-  end
-
-  def put_blob_url
-    blob_service.generate_uri(
-      File.join(BLOB_CONTAINER_NAME, upload.attachment.key),
-    )
   end
 end

--- a/app/services/resend_stored_blob_data.rb
+++ b/app/services/resend_stored_blob_data.rb
@@ -5,8 +5,6 @@ require "azure_blob"
 class ResendStoredBlobData
   include ServicePattern
 
-  BLOB_CONTAINER_NAME = ENV["AZURE_STORAGE_CONTAINER"] || "uploads"
-
   def initialize(upload:)
     @upload = upload
   end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,7 +7,7 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 microsoft:
-  service: AzureStorage
+  service: AzureBlob
   storage_account_name: <%= ENV["AZURE_STORAGE_ACCOUNT_NAME"] %>
   storage_access_key: <%= ENV["AZURE_STORAGE_ACCESS_KEY"] %>
   container: <%= ENV["AZURE_STORAGE_CONTAINER"] %>

--- a/spec/services/fetch_malware_scan_result_spec.rb
+++ b/spec/services/fetch_malware_scan_result_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FetchMalwareScanResult do
     subject(:call) { described_class.call(upload:) }
 
     let(:upload) { create(:upload) }
-    let(:tags_key) { "uploads/#{upload.attachment.key}?comp=tags" }
+    let(:tags_key) { "#{upload.attachment.key}?comp=tags" }
     let(:scan_result) { "No threats found" }
     let(:response_body) { <<-XML.squish }
       <Tags>

--- a/spec/services/fetch_malware_scan_result_spec.rb
+++ b/spec/services/fetch_malware_scan_result_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe FetchMalwareScanResult do
     subject(:call) { described_class.call(upload:) }
 
     let(:upload) { create(:upload) }
-    let(:tags_url) { "https://example.com/uploads/xyz123?comp=tags" }
-    let(:response_success) { true }
+    let(:tags_key) { "uploads/#{upload.attachment.key}?comp=tags" }
     let(:scan_result) { "No threats found" }
     let(:response_body) { <<-XML.squish }
       <Tags>
@@ -18,25 +17,18 @@ RSpec.describe FetchMalwareScanResult do
         </Tag>
       </Tags>
       XML
-    let(:stubbed_blob_service) do
-      instance_double(AzureBlob::Client, generate_uri: tags_url)
-    end
-    let(:stubbed_response) do
-      instance_double(
-        Azure::Core::Http::HttpResponse,
-        success?: response_success,
-        body: response_body,
-      )
-    end
+    let(:stubbed_blob_service) { instance_double(AzureBlob::Client) }
 
     before do
       allow(AzureBlob::Client).to receive(:new).and_return(stubbed_blob_service)
-      allow(stubbed_blob_service).to receive(:call).and_return(stubbed_response)
+      allow(stubbed_blob_service).to receive(:get_blob).and_return(
+        response_body,
+      )
     end
 
     it "calls the Azure Storage REST API for the scan result" do
-      expect(stubbed_blob_service).to receive(:call).with(:get, tags_url)
       call
+      expect(stubbed_blob_service).to have_received(:get_blob).with(tags_key)
     end
 
     context "with a successful scan result" do
@@ -63,6 +55,12 @@ RSpec.describe FetchMalwareScanResult do
 
     context "with an unsuccessful response" do
       let(:response_success) { false }
+
+      before do
+        allow(AzureBlob::Client).to receive(:new).and_raise(
+          AzureBlob::Http::Error,
+        )
+      end
 
       it "saves the result" do
         expect { call }.to change(upload, :malware_scan_error?).from(false).to(

--- a/spec/services/fetch_malware_scan_result_spec.rb
+++ b/spec/services/fetch_malware_scan_result_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe FetchMalwareScanResult do
       </Tags>
       XML
     let(:stubbed_blob_service) do
-      instance_double(Azure::Storage::Blob::BlobService, generate_uri: tags_url)
+      instance_double(AzureBlob::Client, generate_uri: tags_url)
     end
     let(:stubbed_response) do
       instance_double(
@@ -30,9 +30,7 @@ RSpec.describe FetchMalwareScanResult do
     end
 
     before do
-      allow(Azure::Storage::Blob::BlobService).to receive(:new).and_return(
-        stubbed_blob_service,
-      )
+      allow(AzureBlob::Client).to receive(:new).and_return(stubbed_blob_service)
       allow(stubbed_blob_service).to receive(:call).and_return(stubbed_response)
     end
 

--- a/spec/services/resend_stored_blob_data_spec.rb
+++ b/spec/services/resend_stored_blob_data_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ResendStoredBlobData do
       resend_stored_blob_data
 
       expect(stubbed_blob_service).to have_received(:create_block_blob).with(
-        "uploads/#{upload.attachment.key}",
+        upload.attachment.key,
         upload.attachment.download,
       )
     end

--- a/spec/services/resend_stored_blob_data_spec.rb
+++ b/spec/services/resend_stored_blob_data_spec.rb
@@ -12,26 +12,21 @@ RSpec.describe ResendStoredBlobData do
     let(:stubbed_blob_service) do
       instance_double(AzureBlob::Client, generate_uri: put_blob_url)
     end
-    let(:stubbed_response) do
-      instance_double(
-        Azure::Core::Http::HttpResponse,
-        success?: response_success,
-      )
-    end
 
     before do
       allow(AzureBlob::Client).to receive(:new).and_return(stubbed_blob_service)
-      allow(stubbed_blob_service).to receive(:call).and_return(stubbed_response)
+      allow(stubbed_blob_service).to receive(:create_block_blob).and_return(
+        response_success,
+      )
     end
 
     it "calls the Azure Storage REST API to PUT blob data from the upload attachment" do
-      expect(stubbed_blob_service).to receive(:call).with(
-        :put,
-        put_blob_url,
-        upload.attachment.download,
-        anything,
-      )
       resend_stored_blob_data
+
+      expect(stubbed_blob_service).to have_received(:create_block_blob).with(
+        "uploads/#{upload.attachment.key}",
+        upload.attachment.download,
+      )
     end
 
     it "enqueues a FetchMalwareScanResultJob" do

--- a/spec/services/resend_stored_blob_data_spec.rb
+++ b/spec/services/resend_stored_blob_data_spec.rb
@@ -10,10 +10,7 @@ RSpec.describe ResendStoredBlobData do
     let(:response_success) { true }
     let(:put_blob_url) { "http://example.com/uploads/#{upload.attachment.key}" }
     let(:stubbed_blob_service) do
-      instance_double(
-        Azure::Storage::Blob::BlobService,
-        generate_uri: put_blob_url,
-      )
+      instance_double(AzureBlob::Client, generate_uri: put_blob_url)
     end
     let(:stubbed_response) do
       instance_double(
@@ -23,9 +20,7 @@ RSpec.describe ResendStoredBlobData do
     end
 
     before do
-      allow(Azure::Storage::Blob::BlobService).to receive(:new).and_return(
-        stubbed_blob_service,
-      )
+      allow(AzureBlob::Client).to receive(:new).and_return(stubbed_blob_service)
       allow(stubbed_blob_service).to receive(:call).and_return(stubbed_response)
     end
 

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -125,17 +125,14 @@ module SystemHelpers
         </Tag>
       </Tags>
     XML
-    stubbed_service =
-      instance_double(Azure::Storage::Blob::BlobService, generate_uri: tags_url)
+    stubbed_service = instance_double(AzureBlob::Client, generate_uri: tags_url)
     stubbed_response =
       instance_double(
         Azure::Core::Http::HttpResponse,
         success?: true,
         body: response_body,
       )
-    allow(Azure::Storage::Blob::BlobService).to receive(:new).and_return(
-      stubbed_service,
-    )
+    allow(AzureBlob::Client).to receive(:new).and_return(stubbed_service)
     allow(stubbed_service).to receive(:call).and_return(stubbed_response)
   end
 

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -116,7 +116,6 @@ module SystemHelpers
 
   def given_malware_scanning_is_enabled(scan_result: "No threats found")
     FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result)
-    tags_url = "https://example.com/uploads/abc987xyz123?comp=tags"
     response_body = <<-XML.squish
       <Tags>
         <Tag>

--- a/spec/support/system_helpers.rb
+++ b/spec/support/system_helpers.rb
@@ -125,15 +125,9 @@ module SystemHelpers
         </Tag>
       </Tags>
     XML
-    stubbed_service = instance_double(AzureBlob::Client, generate_uri: tags_url)
-    stubbed_response =
-      instance_double(
-        Azure::Core::Http::HttpResponse,
-        success?: true,
-        body: response_body,
-      )
+    stubbed_service = instance_double(AzureBlob::Client)
     allow(AzureBlob::Client).to receive(:new).and_return(stubbed_service)
-    allow(stubbed_service).to receive(:call).and_return(stubbed_response)
+    allow(stubbed_service).to receive(:get_blob).and_return(response_body)
   end
 
   def given_malware_scanning_is_disabled


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-495

The [Azure Storage library](https://github.com/Azure/azure-storage-ruby) that we were using for file uploads has been deprecated and will no longer be supported after the 13th September.

That doesn’t mean file uploads will stop working after that date, but there is the potential for bugs or security issues to be discovered in the library that will then be up to us to fix.

[azure-blob](https://github.com/testdouble/azure-blob) is a library that replaces the abandoned azure-storage-blob. This library is being used by a few other services in DfE as well and is maintained.