### PR TITLE
[AQTS-874] Adding new FI filter on CMS (assessor interface)

### DIFF
--- a/app/forms/assessor_interface/filter_form.rb
+++ b/app/forms/assessor_interface/filter_form.rb
@@ -13,5 +13,6 @@ class AssessorInterface::FilterForm
                 :show_all,
                 :stage,
                 :submitted_at_after,
-                :submitted_at_before
+                :submitted_at_before,
+                :fi_request_statuses
 end

--- a/app/lib/filters/statuses.rb
+++ b/app/lib/filters/statuses.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Filters::Statuses < Filters::Base
+  def apply
+    return scope if statuses.empty?
+
+    scope.where("statuses && array[?]::varchar[]", statuses)
+  end
+
+  private
+
+  def statuses
+    Array(params[:fi_request_statuses]).compact_blank
+  end
+end

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -69,6 +69,15 @@
         <%= f.govuk_check_box :show_all, :true, multiple: false, label: { text: "Show applications completed over 90 days ago" }, checked: @view_object.filter_form.show_all == "true" %>
       <% end %>
     </section>
+
+
+    <section id="app-applications-filters-fi-requests">
+      <%= f.govuk_check_boxes_fieldset :fi_request_statuses, legend: { size: "s" }, small: true do %>
+        <% @view_object.fi_request_statuses_filter_options.each do |option| %>
+          <%= f.govuk_check_box :fi_request_statuses, option.id, label: { text: option.label }, checked: @view_object.filter_form.fi_request_statuses&.include?(option.id) %>
+        <% end %>
+      <% end %>
+    </section>
   <% end %>
 </div>
 

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -334,6 +334,7 @@ en:
         submitted_at: Created date
         submitted_at_after: Start date
         submitted_at_before: End date
+        fi_request_statuses: FI requests
       assessor_interface_select_work_histories_form:
         work_history_ids: Schools
       assessor_interface_suitability_record_form:

--- a/spec/lib/filters/statuses_spec.rb
+++ b/spec/lib/filters/statuses_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Filters::Statuses do
+  subject(:filtered_scope) { described_class.apply(scope:, params:) }
+
+  context "the params includes fi_request_statuses" do
+    let(:params) { { fi_request_statuses: "waiting_on_further_information" } }
+    let(:scope) { ApplicationForm.all }
+
+    let!(:included) do
+      create(
+        :application_form,
+        :submitted,
+        statuses: ["waiting_on_further_information"],
+      )
+    end
+
+    before do
+      create(
+        :application_form,
+        :submitted,
+        statuses: ["received_further_information"],
+      )
+    end
+
+    it { is_expected.to contain_exactly(included) }
+
+    context "with application form having multiple statuses" do
+      let!(:included) do
+        create(
+          :application_form,
+          :submitted,
+          statuses: %w[preliminary_check waiting_on_further_information],
+        )
+      end
+
+      it { is_expected.to contain_exactly(included) }
+    end
+  end
+
+  context "the params include multiple fi_request_statuses" do
+    let(:params) do
+      {
+        fi_request_statuses: %w[
+          waiting_on_further_information
+          received_further_information
+        ],
+      }
+    end
+    let(:scope) { ApplicationForm.all }
+
+    let!(:included) do
+      [
+        create(
+          :application_form,
+          :submitted,
+          statuses: ["waiting_on_further_information"],
+        ),
+        create(
+          :application_form,
+          :submitted,
+          statuses: ["received_further_information"],
+        ),
+      ]
+    end
+
+    before { create(:application_form, :submitted) }
+
+    it { is_expected.to match_array(included) }
+
+    context "with application form having multiple statuses" do
+      let!(:included) do
+        [
+          create(
+            :application_form,
+            :submitted,
+            statuses: %w[preliminary_check waiting_on_further_information],
+          ),
+          create(
+            :application_form,
+            :submitted,
+            statuses: ["received_further_information"],
+          ),
+        ]
+      end
+
+      it { is_expected.to match_array(included) }
+    end
+  end
+
+  context "the params don't include fi_request_statuses" do
+    let(:params) { {} }
+    let(:scope) { double }
+
+    it { is_expected.to eq(scope) }
+  end
+end

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -95,6 +95,16 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
         it { is_expected.to be_empty }
       end
 
+      context "with a fi_request_statuses filter" do
+        before do
+          allow_any_instance_of(Filters::Statuses).to receive(
+            :apply,
+          ).and_return(ApplicationForm.none)
+        end
+
+        it { is_expected.to be_empty }
+      end
+
       context "with show all filter" do
         before do
           allow_any_instance_of(Filters::Stage).to receive(:apply).and_return(
@@ -232,6 +242,61 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
             OpenStruct.new(id: "verification", label: "Verification (4)"),
             OpenStruct.new(id: "review", label: "Review (5)"),
             OpenStruct.new(id: "completed", label: "Completed (6)"),
+          ],
+        )
+      end
+    end
+  end
+
+  describe "#fi_request_statuses_filter_options" do
+    subject(:fi_request_statuses_filter_options) do
+      view_object.fi_request_statuses_filter_options
+    end
+
+    it do
+      expect(subject).to eq(
+        [
+          OpenStruct.new(
+            id: "waiting_on_further_information",
+            label: "Waiting on further information (0)",
+          ),
+          OpenStruct.new(
+            id: "received_further_information",
+            label: "Received further information (0)",
+          ),
+        ],
+      )
+    end
+
+    context "with application forms" do
+      before do
+        create_list(
+          :application_form,
+          2,
+          :submitted,
+          :assessment_stage,
+          statuses: [:waiting_on_further_information],
+        )
+        create_list(
+          :application_form,
+          3,
+          :submitted,
+          :assessment_stage,
+          statuses: [:received_further_information],
+        )
+      end
+
+      it do
+        expect(subject).to eq(
+          [
+            OpenStruct.new(
+              id: "waiting_on_further_information",
+              label: "Waiting on further information (2)",
+            ),
+            OpenStruct.new(
+              id: "received_further_information",
+              label: "Received further information (3)",
+            ),
           ],
         )
       end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-874

Adding new filter on CMS (assessor interface) to filter for waiting on and received further information requests for applications. 

![Screenshot 2025-03-24 at 11 35 53](https://github.com/user-attachments/assets/a6abecb8-435c-4d2e-a886-1154a1ebb94e)
