### PR TITLE
[AQTS-880] Further information request check your answers page

### DIFF
--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -16,13 +16,8 @@ module AssessorInterface
                   only: %i[edit update edit_decline update_decline]
 
     def new
-      @further_information_request =
-        assessment.further_information_requests.build(
-          items:
-            FurtherInformationRequestItemsFactory.call(
-              assessment_sections: assessment.sections,
-            ),
-        )
+      @view_object =
+        AssessorInterface::FurtherInformationRequestNewViewObject.new(params:)
     end
 
     def create

--- a/app/lib/further_information_request_items_by_assessment_section.rb
+++ b/app/lib/further_information_request_items_by_assessment_section.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class FurtherInformationRequestItemsByAssessmentSection
+  include ServicePattern
+
+  def initialize(further_information_request:)
+    @further_information_request = further_information_request
+  end
+
+  def call
+    items_grouped_by_assessment_section.sort_by do |assessment_section, _items|
+      AssessmentSection.keys.keys.index(assessment_section.key)
+    end
+  end
+
+  private
+
+  attr_reader :further_information_request
+
+  def items_grouped_by_assessment_section
+    @items_grouped_by_assessment_section ||=
+      further_information_request.items.group_by do |item|
+        item
+          .further_information_request
+          .assessment
+          .sections
+          .includes(:selected_failure_reasons)
+          .find_by(selected_failure_reasons: { key: item.failure_reason_key })
+      end
+  end
+end

--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -80,11 +80,4 @@ class FurtherInformationRequestItem < ApplicationRecord
       email: contact_email,
     )
   end
-
-  def assessment_section
-    assessment
-      .sections
-      .includes(:selected_failure_reasons)
-      .find_by(selected_failure_reasons: { key: failure_reason_key })
-  end
 end

--- a/app/view_objects/assessor_interface/further_information_request_new_view_object.rb
+++ b/app/view_objects/assessor_interface/further_information_request_new_view_object.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+class AssessorInterface::FurtherInformationRequestNewViewObject
+  def initialize(params:)
+    @params = params
+  end
+
+  def further_information_request
+    @further_information_request ||=
+      assessment.further_information_requests.build(
+        items:
+          FurtherInformationRequestItemsFactory.call(
+            assessment_sections: assessment.sections,
+          ),
+      )
+  end
+
+  def grouped_review_items_by_assessment_section
+    items_by_assessment_section.map do |assessment_section, items|
+      {
+        heading:
+          I18n.t(
+            assessment_section.key,
+            scope: %i[
+              assessor_interface
+              further_information_requests
+              edit
+              assessment_section
+            ],
+          ),
+        items: review_items(items),
+      }
+    end
+  end
+
+  private
+
+  attr_reader :params
+
+  def assessment
+    @assessment ||= Assessment.find(params[:assessment_id])
+  end
+
+  def items_by_assessment_section
+    @items_by_assessment_section ||=
+      FurtherInformationRequestItemsByAssessmentSection.call(
+        further_information_request:,
+      )
+  end
+
+  def item_heading(item)
+    content =
+      I18n.t(
+        item.failure_reason_key,
+        scope: %i[
+          assessor_interface
+          assessment_sections
+          failure_reasons
+          as_statement
+        ],
+      )
+
+    if item.work_history_contact?
+      content.gsub(".", " for #{item.work_history.school_name}.")
+    else
+      content
+    end
+  end
+
+  def review_items(items)
+    items
+      .sort_by(&:failure_reason_key)
+      .map do |item|
+        {
+          heading: item_heading(item),
+          feedback: item.failure_reason_assessor_feedback,
+        }.compact
+      end
+  end
+end

--- a/app/views/assessor_interface/further_information_requests/new.html.erb
+++ b/app/views/assessor_interface/further_information_requests/new.html.erb
@@ -1,43 +1,22 @@
 <% content_for :page_title, "Check the further information you’re asking the applicant for" %>
 <% content_for :back_link_url, edit_assessor_interface_application_form_assessment_path(@application_form, @assessment) %>
 
-<h1 class="govuk-heading-xl">Check the information you’re asking the applicant for</h1>
+<h1 class="govuk-heading-xl">Check the further information requests</h1>
 
-<% @further_information_request.items.group_by(&:failure_reason_key).each do |failure_reason_key, items| %>
-  <% if FailureReasons.chooses_work_history?(failure_reason_key) %>
-    <section class="app-further-information-request-item">
-      <h2 class="govuk-heading-m">Reason for request</h2>
-      <% if items.size == 1 %>
-        <p class="govuk-body">We were unable to verify the details for <%= items.first.work_history.school_name %>.</p>
-      <% else %>
-        <p class="govuk-body">We were unable to verify the details for:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <% items.each do |item| %>
-            <li><%= item.work_history.school_name %></li>
-          <% end %>
-        </ul>
+<% @view_object.grouped_review_items_by_assessment_section.each do |assessment_section_group| %>
+  <div class="govuk-!-margin-bottom-9">
+    <h2 class="govuk-heading-l"><%= assessment_section_group[:heading] %></h2>
+
+    <% assessment_section_group[:items].each do |item| %>
+      <h3 class="govuk-heading-s govuk-!-margin-bottom-3"><%= item[:heading] %></h3>
+
+      <%= govuk_inset_text(classes: "govuk-!-margin-top-0") do %>
+        <%= simple_format item[:feedback] %>
       <% end %>
-      <h2 class="govuk-heading-m">Note to applicant</h2>
-
-      <%= govuk_inset_text do %>
-        <%= simple_format items.first.failure_reason_assessor_feedback %>
-      <% end %>
-    </section>
-  <% else %>
-    <% items.each do |item| %>
-      <section class="app-further-information-request-item">
-        <p class="govuk-body"><%= t(item.failure_reason_key, scope: %i[assessor_interface assessment_sections failure_reasons as_statement]) %></p>
-
-        <h2 class="govuk-heading-m">Note to applicant</h2>
-
-        <%= govuk_inset_text do %>
-          <%= simple_format item.failure_reason_assessor_feedback %>
-        <% end %>
-      </section>
     <% end %>
-  <% end %>
+  </div>
 <% end %>
 
-<%= form_with model: [:assessor_interface, @application_form, @assessment, @further_information_request] do |f| %>
+<%= form_with model: [:assessor_interface, @application_form, @assessment, @view_object.further_information_request] do |f| %>
   <% render "shared/assessor_interface/continue_cancel_button", f: %>
 <% end %>

--- a/app/views/assessor_interface/further_information_requests/new.html.erb
+++ b/app/views/assessor_interface/further_information_requests/new.html.erb
@@ -4,17 +4,19 @@
 <h1 class="govuk-heading-xl">Check the further information requests</h1>
 
 <% @view_object.grouped_review_items_by_assessment_section.each do |assessment_section_group| %>
-  <div class="govuk-!-margin-bottom-9">
+  <section class="govuk-!-margin-bottom-9">
     <h2 class="govuk-heading-l"><%= assessment_section_group[:heading] %></h2>
 
     <% assessment_section_group[:items].each do |item| %>
-      <h3 class="govuk-heading-s govuk-!-margin-bottom-3"><%= item[:heading] %></h3>
+      <div class="app-further-information-request-item">
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-3"><%= item[:heading] %></h3>
 
-      <%= govuk_inset_text(classes: "govuk-!-margin-top-0") do %>
-        <%= simple_format item[:feedback] %>
-      <% end %>
+        <%= govuk_inset_text(classes: "govuk-!-margin-top-0") do %>
+          <%= simple_format item[:feedback] %>
+        <% end %>
+      </div>
     <% end %>
-  </div>
+  </section>
 <% end %>
 
 <%= form_with model: [:assessor_interface, @application_form, @assessment, @view_object.further_information_request] do |f| %>

--- a/spec/lib/further_information_request_items_by_assessment_section_spec.rb
+++ b/spec/lib/further_information_request_items_by_assessment_section_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FurtherInformationRequestItemsByAssessmentSection do
+  describe "#call" do
+    subject(:call) { described_class.call(further_information_request:) }
+
+    let(:assessment) { create(:assessment) }
+
+    let(:further_information_request) do
+      create(:received_further_information_request, assessment:)
+    end
+
+    let!(:personal_information_assessment_section) do
+      create :assessment_section, :personal_information, assessment:
+    end
+
+    let!(:qualifications_assessment_section) do
+      create :assessment_section, :qualifications, assessment:
+    end
+
+    let!(:work_history_assessment_section) do
+      create :assessment_section, :work_history, assessment:
+    end
+
+    let!(:professional_standing_assessment_section) do
+      create :assessment_section, :professional_standing, assessment:
+    end
+
+    let!(:passport_document_illegible) do
+      create(
+        :further_information_request_item,
+        :with_document_response,
+        :completed,
+        further_information_request:,
+        failure_reason_key: "passport_document_illegible",
+      )
+    end
+
+    let!(:passport_document_mismatch) do
+      create(
+        :further_information_request_item,
+        :with_document_response,
+        :completed,
+        further_information_request:,
+        failure_reason_key: "passport_document_mismatch",
+      )
+    end
+
+    let!(:satisfactory_evidence_work_history) do
+      create(
+        :further_information_request_item,
+        :with_text_response,
+        :completed,
+        further_information_request:,
+        failure_reason_key: "satisfactory_evidence_work_history",
+      )
+    end
+
+    let!(:qualifications_dont_match_other_details) do
+      create(
+        :further_information_request_item,
+        :with_text_response,
+        :completed,
+        further_information_request:,
+        failure_reason_key: "qualifications_dont_match_other_details",
+      )
+    end
+
+    let!(:qualifications_or_modules_required_not_provided) do
+      create(
+        :further_information_request_item,
+        :with_document_response,
+        :completed,
+        further_information_request:,
+        failure_reason_key: "qualifications_or_modules_required_not_provided",
+      )
+    end
+
+    let!(:written_statement_illegible) do
+      create(
+        :further_information_request_item,
+        :with_document_response,
+        :completed,
+        further_information_request:,
+        failure_reason_key: "written_statement_illegible",
+      )
+    end
+
+    let!(:written_statement_recent) do
+      create(
+        :further_information_request_item,
+        :with_document_response,
+        :completed,
+        further_information_request:,
+        failure_reason_key: "written_statement_recent",
+      )
+    end
+
+    before do
+      create :selected_failure_reason,
+             assessment_section: personal_information_assessment_section,
+             key: "passport_document_illegible"
+      create :selected_failure_reason,
+             assessment_section: personal_information_assessment_section,
+             key: "passport_document_mismatch"
+
+      create :selected_failure_reason,
+             assessment_section: qualifications_assessment_section,
+             key: "qualifications_dont_match_other_details"
+      create :selected_failure_reason,
+             assessment_section: qualifications_assessment_section,
+             key: "qualifications_or_modules_required_not_provided"
+
+      create :selected_failure_reason,
+             assessment_section: work_history_assessment_section,
+             key: "satisfactory_evidence_work_history"
+
+      create :selected_failure_reason,
+             assessment_section: professional_standing_assessment_section,
+             key: "written_statement_illegible"
+      create :selected_failure_reason,
+             assessment_section: professional_standing_assessment_section,
+             key: "written_statement_recent"
+    end
+
+    it do
+      expect(call).to eq(
+        [
+          [
+            personal_information_assessment_section,
+            [passport_document_illegible, passport_document_mismatch],
+          ],
+          [
+            qualifications_assessment_section,
+            [
+              qualifications_dont_match_other_details,
+              qualifications_or_modules_required_not_provided,
+            ],
+          ],
+          [
+            work_history_assessment_section,
+            [satisfactory_evidence_work_history],
+          ],
+          [
+            professional_standing_assessment_section,
+            [written_statement_illegible, written_statement_recent],
+          ],
+        ],
+      )
+    end
+  end
+end

--- a/spec/models/further_information_request_item_spec.rb
+++ b/spec/models/further_information_request_item_spec.rb
@@ -163,34 +163,4 @@ RSpec.describe FurtherInformationRequestItem do
       it { is_expected.to be false }
     end
   end
-
-  describe "#assessment_section" do
-    subject(:further_information_request_item) do
-      create(
-        :further_information_request_item,
-        :with_work_history_contact_response,
-      )
-    end
-
-    let!(:assessment_section) do
-      create :assessment_section,
-             assessment: further_information_request_item.assessment
-    end
-
-    it "returns nil when no assessment section with selected failure reason exists" do
-      expect(subject.assessment_section).to be_nil
-    end
-
-    context "when assessment section with selected failure reason exists" do
-      before do
-        create :selected_failure_reason,
-               assessment_section:,
-               key: further_information_request_item.failure_reason_key
-      end
-
-      it "returns assessment section" do
-        expect(subject.assessment_section).to eq(assessment_section)
-      end
-    end
-  end
 end

--- a/spec/view_objects/assessor_interface/further_information_request_new_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/further_information_request_new_view_object_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::FurtherInformationRequestNewViewObject do
+  subject(:view_object) do
+    described_class.new(params: ActionController::Parameters.new(params))
+  end
+
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:assessment) { create(:assessment, application_form:) }
+  let(:params) do
+    {
+      assessment_id: assessment.id,
+      application_form_reference: application_form.reference,
+    }
+  end
+
+  describe "#grouped_review_items_by_assessment_section" do
+    subject(:grouped_review_items_by_assessment_section) do
+      view_object.grouped_review_items_by_assessment_section
+    end
+
+    let(:personal_information_assessment_section) do
+      create :assessment_section, :personal_information, assessment:
+    end
+
+    let(:qualifications_assessment_section) do
+      create :assessment_section, :qualifications, assessment:
+    end
+
+    before do
+      create :selected_failure_reason,
+             assessment_section: personal_information_assessment_section,
+             key: "passport_document_illegible"
+      create :selected_failure_reason,
+             assessment_section: personal_information_assessment_section,
+             key: "passport_document_mismatch"
+
+      create :selected_failure_reason,
+             assessment_section: qualifications_assessment_section,
+             key: "qualifications_dont_match_other_details"
+      create :selected_failure_reason,
+             assessment_section: qualifications_assessment_section,
+             key: "qualifications_or_modules_required_not_provided"
+    end
+
+    it do
+      expect(subject).to eq(
+        [
+          {
+            heading: "Personal information",
+            items: [
+              {
+                heading:
+                  "There is a problem with the passport. For example, " \
+                    "it’s incorrect, illegible, or incomplete.",
+                feedback: "We need more information.",
+              },
+              {
+                heading:
+                  "The name on the application form is different from the passport, " \
+                    "but no evidence of change of name was provided.",
+                feedback: "We need more information.",
+              },
+            ],
+          },
+          {
+            heading: "Qualifications",
+            items: [
+              {
+                heading:
+                  "Uploaded qualifications do not match other information entered, " \
+                    "for example, the subject, name of qualification, name of institution or dates.",
+                feedback: "We need more information.",
+              },
+              {
+                heading:
+                  "The applicant has not provided the required qualifications or modules.",
+                feedback: "We need more information.",
+              },
+            ],
+          },
+        ],
+      )
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-880

This PR implements the following:
1. Refactoring to improve the `FurtherInformationRequestViewObject`. Here I have decided to move the logic for grouping further information request items by assessment sections into its own responsible class.
2. Implementing the new UI for the new "check your further information request" page. As part of this, I have decided to introduce a new view object specific for this page.

![Screenshot 2025-04-08 at 17 32 10](https://github.com/user-attachments/assets/51187f5e-c8cf-4cff-869e-afc865ef1091)
