### PR TITLE
AQTS 911 show applicant FI reason

### DIFF
--- a/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class="govuk-heading-l">Further information required</h1>
 
-<h2 class="govuk-heading-s"><%=I18n.t("teacher_interface.application_forms.show.declined.failure_reasons.#{@further_information_request_item.failure_reason_key}")%></h2>
+<h2 class="govuk-heading-s"><%= I18n.t("teacher_interface.application_forms.show.declined.failure_reasons.#{@further_information_request_item.failure_reason_key}") %></h2>
 
 <%= govuk_inset_text do %>
   <%= simple_format @further_information_request_item.failure_reason_assessor_feedback %>

--- a/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class="govuk-heading-l">Further information required</h1>
 
-<h2 class="govuk-heading-s">Notes from the assessor</h2>
+<h2 class="govuk-heading-s"><%=I18n.t("assessor_interface.assessment_sections.failure_reasons.as_statement.#{@further_information_request_item.failure_reason_key}")%></h2>
 
 <%= govuk_inset_text do %>
   <%= simple_format @further_information_request_item.failure_reason_assessor_feedback %>

--- a/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
@@ -4,7 +4,7 @@
 
 <h1 class="govuk-heading-l">Further information required</h1>
 
-<h2 class="govuk-heading-s"><%=I18n.t("assessor_interface.assessment_sections.failure_reasons.as_statement.#{@further_information_request_item.failure_reason_key}")%></h2>
+<h2 class="govuk-heading-s"><%=I18n.t("teacher_interface.application_forms.show.declined.failure_reasons.#{@further_information_request_item.failure_reason_key}")%></h2>
 
 <%= govuk_inset_text do %>
   <%= simple_format @further_information_request_item.failure_reason_assessor_feedback %>

--- a/spec/support/autoload/page_objects/teacher_interface/further_information_required.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/further_information_required.rb
@@ -7,6 +7,7 @@ module PageObjects
 
       element :back_link, ".govuk-back-link"
       element :heading, ".govuk-heading-l"
+      element :failure_reason_heading, "h2.govuk-heading-s"
       element :feedback, ".govuk-inset-text"
 
       section :form, "form" do

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -103,23 +103,25 @@ RSpec.describe "Teacher further information", type: :system do
 
   def when_i_click_the_text_task_list_item
     text_task_list_item.click
-    expect(teacher_further_information_required_page.failure_reason_heading.text).to eq(
+    expect(
+      teacher_further_information_required_page.failure_reason_heading.text,
+    ).to eq(
       "The subjects you entered are acceptable for QTS, but the uploaded qualifications do not match them.",
     )
   end
 
   def when_i_click_the_work_history_contact_task_list_item
     work_history_task_list_item.click
-    expect(teacher_further_information_required_page.failure_reason_heading.text).to eq(
-      "We could not verify 1 or more references you provided.",
-    )
+    expect(
+      teacher_further_information_required_page.failure_reason_heading.text,
+    ).to eq("We could not verify 1 or more references you provided.")
   end
 
   def when_i_click_the_document_task_list_item
     document_task_list_item.click
-    expect(teacher_further_information_required_page.failure_reason_heading.text).to eq(
-      "Your ID document is illegible or in a format we cannot accept.",
-    )
+    expect(
+      teacher_further_information_required_page.failure_reason_heading.text,
+    ).to eq("Your ID document is illegible or in a format we cannot accept.")
   end
 
   def when_i_fill_in_the_response

--- a/spec/system/teacher_interface/further_information_spec.rb
+++ b/spec/system/teacher_interface/further_information_spec.rb
@@ -103,14 +103,23 @@ RSpec.describe "Teacher further information", type: :system do
 
   def when_i_click_the_text_task_list_item
     text_task_list_item.click
+    expect(teacher_further_information_required_page.failure_reason_heading.text).to eq(
+      "The subjects you entered are acceptable for QTS, but the uploaded qualifications do not match them.",
+    )
   end
 
   def when_i_click_the_work_history_contact_task_list_item
     work_history_task_list_item.click
+    expect(teacher_further_information_required_page.failure_reason_heading.text).to eq(
+      "We could not verify 1 or more references you provided.",
+    )
   end
 
   def when_i_click_the_document_task_list_item
     document_task_list_item.click
+    expect(teacher_further_information_required_page.failure_reason_heading.text).to eq(
+      "Your ID document is illegible or in a format we cannot accept.",
+    )
   end
 
   def when_i_fill_in_the_response


### PR DESCRIPTION
This pr changes the title the applicant sees when providing FI to the FI reason

https://dfedigital.atlassian.net/browse/AQTS-911
<img width="683" alt="Screenshot 2025-04-11 at 12 01 50" src="https://github.com/user-attachments/assets/ca2641b3-f52f-4b5f-9a1c-02b387d59ffc" />
<img width="665" alt="Screenshot 2025-04-11 at 12 01 35" src="https://github.com/user-attachments/assets/bc3ae001-c58a-46f1-ba56-1f9f35daa94b" />
<img width="668" alt="Screenshot 2025-04-11 at 12 01 16" src="https://github.com/user-attachments/assets/182eef86-edd2-4e1c-a3d2-2ff693de3bb7" />

