### PR TITLE
Multiple further information requests feature

### DIFF
--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -21,10 +21,13 @@ module AssessorInterface
     end
 
     def create
-      RequestFurtherInformation.call(assessment:, user: current_staff)
+      FurtherInformationRequests::CreateFromAssessmentSections.call(
+        assessment:,
+        user: current_staff,
+      )
 
       redirect_to [:status, :assessor_interface, application_form]
-    rescue RequestFurtherInformation::AlreadyExists
+    rescue FurtherInformationRequests::CreateFromAssessmentSections::AlreadyExists
       flash[:warning] = "Further information has already been requested."
       render :new, status: :unprocessable_entity
     end

--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -11,9 +11,10 @@ module AssessorInterface
     end
 
     before_action :ensure_can_decline, only: %i[edit_decline update_decline]
+    before_action :ensure_can_follow_up,
+                  only: %i[edit_follow_up update_follow_up]
     before_action :load_application_form_and_assessment, only: %i[new edit]
-    before_action :load_view_object,
-                  only: %i[edit update edit_decline update_decline]
+    before_action :load_view_object, except: %i[new create]
 
     def new
       @view_object =
@@ -56,6 +57,14 @@ module AssessorInterface
                         :assessor_interface,
                         view_object.application_form,
                         view_object.assessment,
+                      ]
+        elsif @form.follow_up_further_information_requested?
+          redirect_to [
+                        :follow_up,
+                        :assessor_interface,
+                        view_object.application_form,
+                        view_object.assessment,
+                        view_object.further_information_request,
                       ]
         else
           redirect_to [
@@ -101,11 +110,75 @@ module AssessorInterface
       end
     end
 
+    def edit_follow_up
+      @form =
+        follow_up_form_class.new(
+          user: current_staff,
+          **follow_up_form_class.initial_attributes(
+            further_information_request,
+          ),
+        )
+    end
+
+    def update_follow_up
+      @form =
+        follow_up_form_class.new(
+          further_information_request_follow_up_form_params.merge(
+            further_information_request:,
+            user: current_staff,
+          ),
+        )
+
+      if @form.save
+        redirect_to [
+                      :confirm_follow_up,
+                      :assessor_interface,
+                      view_object.application_form,
+                      view_object.assessment,
+                      view_object.further_information_request,
+                    ]
+      else
+        render :edit_follow_up, status: :unprocessable_entity
+      end
+    end
+
+    def edit_confirm_follow_up
+      @form =
+        AssessorInterface::FurtherInformationRequestConfirmFollowUpForm.new(
+          further_information_request:,
+          user: current_staff,
+        )
+    end
+
+    def update_confirm_follow_up
+      @form =
+        AssessorInterface::FurtherInformationRequestConfirmFollowUpForm.new(
+          further_information_request:,
+          user: current_staff,
+        )
+
+      if @form.save
+        redirect_to [:status, :assessor_interface, application_form]
+      else
+        render :edit_confirm_follow_up, status: :unprocessable_entity
+      end
+    rescue FurtherInformationRequests::CreateFromFurtherInformationReview::AlreadyExists
+      flash[:warning] = "Further information has already been requested."
+      render :edit_confirm_follow_up, status: :unprocessable_entity
+    end
+
     private
 
     def form_class
       @form_class ||=
         AssessorInterface::FurtherInformationRequestReviewForm.for_further_information_request(
+          further_information_request,
+        )
+    end
+
+    def follow_up_form_class
+      @follow_up_form_class ||=
+        AssessorInterface::FurtherInformationRequestFollowUpForm.for_further_information_request(
           further_information_request,
         )
     end
@@ -153,6 +226,16 @@ module AssessorInterface
       ).permit(*form_class.permittable_parameters(further_information_request))
     end
 
+    def further_information_request_follow_up_form_params
+      params.require(
+        :assessor_interface_further_information_request_follow_up_form,
+      ).permit(
+        *follow_up_form_class.permittable_parameters(
+          further_information_request,
+        ),
+      )
+    end
+
     def further_information_request_decline_form_params
       params.require(
         :assessor_interface_further_information_request_decline_form,
@@ -161,6 +244,12 @@ module AssessorInterface
 
     def ensure_can_decline
       return if view_object.can_decline?
+
+      redirect_to [:assessor_interface, view_object.application_form]
+    end
+
+    def ensure_can_follow_up
+      return if view_object.can_follow_up?
 
       redirect_to [:assessor_interface, view_object.application_form]
     end

--- a/app/forms/assessor_interface/further_information_request_confirm_follow_up_form.rb
+++ b/app/forms/assessor_interface/further_information_request_confirm_follow_up_form.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class AssessorInterface::FurtherInformationRequestConfirmFollowUpForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :further_information_request, :user
+  validates :further_information_request, :user, presence: true
+
+  def save
+    return false if invalid?
+
+    ActiveRecord::Base.transaction do
+      ReviewRequestable.call(
+        requestable: further_information_request,
+        user:,
+        passed: false,
+        note: "Further information requested",
+      )
+
+      FurtherInformationRequests::CreateFromFurtherInformationReview.call(
+        further_information_request:,
+        user:,
+      )
+    end
+
+    true
+  end
+end

--- a/app/forms/assessor_interface/further_information_request_follow_up_form.rb
+++ b/app/forms/assessor_interface/further_information_request_follow_up_form.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class AssessorInterface::FurtherInformationRequestFollowUpForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :further_information_request, :user
+  validates :further_information_request, :user, presence: true
+
+  def save
+    return false if invalid?
+
+    ActiveRecord::Base.transaction do
+      further_information_request
+        .items
+        .review_decision_further_information
+        .each do |item|
+        review_decision_note = send("#{item.id}_decision_note")
+
+        item.update!(review_decision_note:)
+      end
+    end
+
+    true
+  end
+
+  class << self
+    def for_further_information_request(further_information_request)
+      klass =
+        Class.new(self) do
+          mattr_accessor :preliminary
+
+          def self.name
+            "AssessorInterface::FurtherInformationRequestFollowUpForm"
+          end
+        end
+
+      further_information_request
+        .items
+        .review_decision_further_information
+        .each do |item|
+        klass.attribute "#{item.id}_decision_note"
+        klass.validates "#{item.id}_decision_note",
+                        presence: {
+                          message: "Enter instructions for the applicant",
+                        }
+      end
+
+      klass
+    end
+
+    def initial_attributes(further_information_request)
+      attributes = { further_information_request: }
+
+      further_information_request
+        .items
+        .review_decision_further_information
+        .each do |item|
+        attributes["#{item.id}_decision_note"] = item.review_decision_note
+      end
+
+      attributes
+    end
+
+    def permittable_parameters(further_information_request)
+      further_information_request
+        .items
+        .review_decision_further_information
+        .map { |item| "#{item.id}_decision_note" }
+    end
+  end
+end

--- a/app/forms/assessor_interface/further_information_request_review_form.rb
+++ b/app/forms/assessor_interface/further_information_request_review_form.rb
@@ -34,6 +34,12 @@ class AssessorInterface::FurtherInformationRequestReviewForm
     further_information_request.items.all?(&:review_decision_accept?)
   end
 
+  def follow_up_further_information_requested?
+    further_information_request.items.any?(
+      &:review_decision_further_information?
+    ) && further_information_request.items.none?(&:review_decision_decline?)
+  end
+
   class << self
     def for_further_information_request(further_information_request)
       klass =

--- a/app/lib/fake_data/application_form_generator.rb
+++ b/app/lib/fake_data/application_form_generator.rb
@@ -242,7 +242,7 @@ class FakeData::ApplicationFormGenerator
 
   def request_further_information
     date_generator.travel_to_next_short do
-      RequestFurtherInformation.call(
+      FurtherInformationRequests::CreateFromAssessmentSections.call(
         assessment:,
         user: application_form.assessor,
       )

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -217,6 +217,10 @@ class Assessment < ApplicationRecord
       )
   end
 
+  def latest_further_information_request
+    further_information_requests.order(:requested_at).last
+  end
+
   private
 
   def all_sections_assessed?

--- a/app/models/assessment.rb
+++ b/app/models/assessment.rb
@@ -121,7 +121,7 @@ class Assessment < ApplicationRecord
         (all_sections_assessed? && any_section_failed? && any_section_declines?)
     elsif request_further_information?
       all_further_information_requests_reviewed? &&
-        any_further_information_requests_failed?
+        latest_further_information_request_failed?
     elsif review?
       return false unless all_consent_requests_reviewed?
       return false unless all_qualification_requests_reviewed?
@@ -248,13 +248,14 @@ class Assessment < ApplicationRecord
       further_information_requests.all?(&:reviewed?)
   end
 
-  def all_further_information_requests_passed?
-    further_information_requests.present? &&
-      further_information_requests.all?(&:review_passed?)
+  def latest_further_information_requests_passed?
+    latest_further_information_request.present? &&
+      latest_further_information_request.review_passed?
   end
 
-  def any_further_information_requests_failed?
-    further_information_requests.any?(&:review_failed?)
+  def latest_further_information_request_failed?
+    latest_further_information_request.present? &&
+      latest_further_information_request.review_failed?
   end
 
   def all_reference_requests_reviewed?
@@ -394,6 +395,9 @@ class Assessment < ApplicationRecord
 
   def all_sections_or_further_information_requests_passed?
     (unknown? && all_sections_passed?) ||
-      (request_further_information? && all_further_information_requests_passed?)
+      (
+        request_further_information? &&
+          latest_further_information_requests_passed?
+      )
   end
 end

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -91,6 +91,24 @@ class FurtherInformationRequest < ApplicationRecord
     update_work_history_contact_items(user:) if verify_passed?
   end
 
+  def first_request?
+    assessment
+      .further_information_requests
+      .order(:requested_at)
+      .index(self)
+      .zero?
+  end
+
+  def second_request?
+    assessment.further_information_requests.order(:requested_at).index(self) ==
+      1
+  end
+
+  def third_request?
+    assessment.further_information_requests.order(:requested_at).index(self) ==
+      2
+  end
+
   delegate :teacher, to: :application_form
 
   private

--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -84,11 +84,11 @@ class FurtherInformationRequest < ApplicationRecord
   end
 
   def after_reviewed(user:)
-    update_work_history_contact_items(user:) if review_passed?
+    update_work_history_contact_items(user:)
   end
 
   def after_verified(user:)
-    update_work_history_contact_items(user:) if verify_passed?
+    update_work_history_contact_items(user:)
   end
 
   def first_request?
@@ -114,6 +114,8 @@ class FurtherInformationRequest < ApplicationRecord
   private
 
   def update_work_history_contact_items(user:)
-    items.each { |item| item.update_work_history_contact(user:) }
+    items.each do |item|
+      item.update_work_history_contact(user:) if item.review_decision_accept?
+    end
   end
 end

--- a/app/models/further_information_request_item.rb
+++ b/app/models/further_information_request_item.rb
@@ -42,7 +42,13 @@ class FurtherInformationRequestItem < ApplicationRecord
          work_history_contact: "work_history_contact",
        }
 
-  enum :review_decision, { accept: "accept", decline: "decline" }, prefix: true
+  enum :review_decision,
+       {
+         accept: "accept",
+         decline: "decline",
+         further_information: "further_information",
+       },
+       prefix: true
 
   def status
     if completed?

--- a/app/policies/assessor_interface/further_information_request_policy.rb
+++ b/app/policies/assessor_interface/further_information_request_policy.rb
@@ -22,4 +22,20 @@ class AssessorInterface::FurtherInformationRequestPolicy < ApplicationPolicy
   def update_decline?
     update?
   end
+
+  def edit_follow_up?
+    edit?
+  end
+
+  def update_follow_up?
+    update?
+  end
+
+  def edit_confirm_follow_up?
+    edit?
+  end
+
+  def update_confirm_follow_up?
+    update?
+  end
 end

--- a/app/services/further_information_requests/create_from_assessment_sections.rb
+++ b/app/services/further_information_requests/create_from_assessment_sections.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class RequestFurtherInformation
+class FurtherInformationRequests::CreateFromAssessmentSections
   include ServicePattern
 
   def initialize(assessment:, user:)

--- a/app/services/further_information_requests/create_from_further_information_review.rb
+++ b/app/services/further_information_requests/create_from_further_information_review.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+class FurtherInformationRequests::CreateFromFurtherInformationReview
+  include ServicePattern
+
+  def initialize(further_information_request:, user:)
+    @further_information_request = further_information_request
+    @assessment = further_information_request.assessment
+    @user = user
+  end
+
+  def call
+    if assessment.further_information_requests.not_received.exists?
+      raise AlreadyExists
+    end
+
+    send_email(create_and_request)
+  end
+
+  class AlreadyExists < StandardError
+  end
+
+  private
+
+  attr_reader :assessment, :user, :further_information_request
+
+  delegate :application_form, to: :assessment
+
+  def create_and_request
+    ActiveRecord::Base.transaction do
+      assessment.request_further_information!
+
+      requestable =
+        FurtherInformationRequest.create!(
+          assessment:,
+          items: build_follow_up_items,
+        )
+
+      RequestRequestable.call(requestable:, user:)
+
+      application_form.reload
+
+      ApplicationFormStatusUpdater.call(application_form:, user:)
+
+      requestable
+    end
+  end
+
+  def send_email(further_information_request)
+    DeliverEmail.call(
+      application_form:,
+      mailer: TeacherMailer,
+      action: :further_information_requested,
+      further_information_request:,
+    )
+  end
+
+  def build_follow_up_items
+    further_information_request
+      .items
+      .review_decision_further_information
+      .map do |follow_up_item|
+      FurtherInformationRequestItem.new(
+        information_type: follow_up_item.information_type,
+        failure_reason_key: follow_up_item.failure_reason_key,
+        failure_reason_assessor_feedback: follow_up_item.review_decision_note,
+        document:
+          (
+            if follow_up_item.document.present?
+              Document.new(document_type: follow_up_item.document.document_type)
+            end
+          ),
+        work_history: follow_up_item.work_history,
+      )
+    end
+  end
+end

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -246,8 +246,8 @@ class AssessorInterface::ApplicationFormsShowViewObject
   def further_information_request_task_list_item(further_information_request)
     {
       name:
-        I18n.t(
-          "assessor_interface.application_forms.show.assessment_tasks.items.review_requested_information",
+        further_information_request_task_list_item_name(
+          further_information_request,
         ),
       link:
         if further_information_request.received?
@@ -277,6 +277,23 @@ class AssessorInterface::ApplicationFormsShowViewObject
           :completed
         end,
     }
+  end
+
+  def further_information_request_task_list_item_name(
+    further_information_request
+  )
+    key =
+      if further_information_request.first_request?
+        "review_requested_information_first_request"
+      elsif further_information_request.second_request?
+        "review_requested_information_second_request"
+      else
+        "review_requested_information_last_request"
+      end
+
+    I18n.t(
+      "assessor_interface.application_forms.show.assessment_tasks.items.#{key}",
+    )
   end
 
   def verification_task_list_section

--- a/app/view_objects/assessor_interface/application_forms_show_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_show_view_object.rb
@@ -271,7 +271,9 @@ class AssessorInterface::ApplicationFormsShowViewObject
           else
             :in_progress
           end
-        elsif assessment.request_further_information?
+        elsif assessment.request_further_information? &&
+              assessment.latest_further_information_request ==
+                further_information_request
           :in_progress
         else
           :completed

--- a/app/view_objects/assessor_interface/further_information_request_view_object.rb
+++ b/app/view_objects/assessor_interface/further_information_request_view_object.rb
@@ -21,6 +21,19 @@ class AssessorInterface::FurtherInformationRequestViewObject
 
   delegate :application_form, :assessment, to: :further_information_request
 
+  def title
+    key =
+      if further_information_request.first_request?
+        "first_request"
+      elsif further_information_request.second_request?
+        "second_request"
+      else
+        "last_request"
+      end
+
+    I18n.t("assessor_interface.further_information_requests.edit.title.#{key}")
+  end
+
   def grouped_review_items_by_assessment_section
     items_by_assessment_section.map do |assessment_section, items|
       {

--- a/app/view_objects/teacher_interface/application_form_view_object.rb
+++ b/app/view_objects/teacher_interface/application_form_view_object.rb
@@ -30,7 +30,7 @@ class TeacherInterface::ApplicationFormViewObject
 
   def further_information_request
     @further_information_request ||=
-      assessment&.further_information_requests&.first
+      assessment&.latest_further_information_request
   end
 
   def started_at

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -1,18 +1,11 @@
-<% content_for :page_title, title_with_error_prefix(t(".title"), error: @form.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix(@view_object.title, error: @form.errors.any?) %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
 
 <%= form_with model: @form, url: [:assessor_interface, @view_object.application_form, @view_object.assessment, @view_object.further_information_request], method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
   <h1 class="govuk-heading-xl">
-    <%= t(".title") %>
-    <% if @view_object.further_information_request.first_request? %>
-      - first request
-    <% elsif @view_object.further_information_request.second_request? %>
-      - second request
-    <% else %>
-      - final request
-    <% end %>
+    <%= @view_object.title %>
   </h1>
 
   <% @view_object.grouped_review_items_by_assessment_section.each do |assessment_section_group| %>

--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -4,7 +4,17 @@
 <%= form_with model: @form, url: [:assessor_interface, @view_object.application_form, @view_object.assessment, @view_object.further_information_request], method: :put do |f| %>
   <%= f.govuk_error_summary %>
 
-  <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
+  <h1 class="govuk-heading-xl">
+    <%= t(".title") %>
+    <% if @view_object.further_information_request.first_request? %>
+      - first request
+    <% elsif @view_object.further_information_request.second_request? %>
+      - second request
+    <% else %>
+      - final request
+    <% end %>
+  </h1>
+
   <% @view_object.grouped_review_items_by_assessment_section.each do |assessment_section_group| %>
     <div class="govuk-!-margin-bottom-7 govuk-!-margin-top-9">
       <h2 class="govuk-heading-l govuk-!-margin-bottom-3"><%= assessment_section_group.fetch(:heading) %></h2>
@@ -40,6 +50,7 @@
 
         <%= f.govuk_radio_buttons_fieldset :"#{item.fetch(:id)}_decision", legend: { text: "How would you like to respond?", size: "s" } do %>
           <%= f.govuk_radio_button :"#{item.fetch(:id)}_decision", :accept, label: { text: "Yes, accept information" }, disabled: !policy([:assessor_interface, @view_object.further_information_request]).update? || !@view_object.can_update? %>
+          <%= f.govuk_radio_button :"#{item.fetch(:id)}_decision", :further_information, label: { text: "No, request further information" }, disabled: !policy([:assessor_interface, @view_object.further_information_request]).update? || !@view_object.can_update? unless @view_object.further_information_request.third_request? %>
           <%= f.govuk_radio_button :"#{item.fetch(:id)}_decision", :decline, label: { text: "No, decline application" }, disabled: !policy([:assessor_interface, @view_object.further_information_request]).update? || !@view_object.can_update? %>
         <% end %>
       <% end %>

--- a/app/views/assessor_interface/further_information_requests/edit_confirm_follow_up.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit_confirm_follow_up.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, "Check the further information you’re asking the applicant for" %>
+<% content_for :back_link_url, follow_up_assessor_interface_application_form_assessment_further_information_request_path(@application_form, @view_object.assessment, @view_object.further_information_request) %>
+
+<h1 class="govuk-heading-xl">Check the further information requests</h1>
+
+<% @view_object.grouped_follow_up_items_by_assessment_section.each do |assessment_section_group| %>
+  <section class="govuk-!-margin-bottom-9">
+    <h2 class="govuk-heading-l"><%= assessment_section_group[:heading] %></h2>
+
+    <% assessment_section_group[:review_items].each do |item| %>
+      <div class="app-further-information-request-item">
+        <h3 class="govuk-heading-s govuk-!-margin-bottom-3"><%= item[:heading] %></h3>
+
+        <%= govuk_inset_text(classes: "govuk-!-margin-top-0") do %>
+          <%= simple_format item[:review_decision_note] %>
+        <% end %>
+      </div>
+    <% end %>
+  </section>
+<% end %>
+
+<%= form_with model: [:confirm_follow_up, :assessor_interface, @view_object.application_form, @view_object.assessment, @view_object.further_information_request], method: :post do |f| %>
+  <% render "shared/assessor_interface/continue_cancel_button", f: %>
+<% end %>

--- a/app/views/assessor_interface/further_information_requests/edit_follow_up.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit_follow_up.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, title_with_error_prefix(t(".title"), error: @form.errors.any?) %>
+<% content_for :back_link_url, edit_assessor_interface_application_form_assessment_further_information_request_path(@application_form, @view_object.assessment, @view_object.further_information_request) %>
+
+<%= form_with model: @form, url: [:follow_up, :assessor_interface, @view_object.application_form, @view_object.assessment, @view_object.further_information_request], method: :post do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
+
+  <% @view_object.grouped_follow_up_items_by_assessment_section.each do |assessment_section_group| %>
+    <div>
+      <h2 class="govuk-heading-l"><%= assessment_section_group.fetch(:heading) %></h2>
+
+      <% assessment_section_group.fetch(:review_items).each do |item| %>
+        <%= f.govuk_text_area "#{item.fetch(:id)}_decision_note", label: { text: item.fetch(:heading), size: "s" } %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% if policy([:assessor_interface, @view_object.further_information_request]).update? && @view_object.can_update? %>
+    <%= render "shared/assessor_interface/continue_cancel_button", f: %>
+  <% end %>
+<% end %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -231,7 +231,7 @@ en:
 
     further_information_requests:
       edit:
-        title: Review further information from applicant
+        title: Review further information received
         check_your_answers: Further information requested
         passed: Has the applicant completed this section to your satisfaction?
         failure_assessor_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> Explain why this section is not completed to your satisfaction'
@@ -252,6 +252,8 @@ en:
       edit_decline:
         title: Add an internal note to explain why the application is being declined
         failure_assessor_note: This is an internal note. It will not be seen by the applicant.
+      edit_follow_up:
+        title: Request further information
 
   activemodel:
     errors:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -231,7 +231,10 @@ en:
 
     further_information_requests:
       edit:
-        title: Review further information received
+        title:
+          first_request: Review further information received - first request
+          second_request: Review further information received - second request
+          last_request: Review further information received - final request
         check_your_answers: Further information requested
         passed: Has the applicant completed this section to your satisfaction?
         failure_assessor_note: '<strong class="govuk-!-font-weight-bold">Internal note:</strong> Explain why this section is not completed to your satisfaction'

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -25,7 +25,9 @@ en:
             professional_standing_request: Verify LoPS
             qualification_requests: Verify qualifications
             reference_requests: Verify references
-            review_requested_information: Review further information from applicant
+            review_requested_information_first_request: Review further information received - first request
+            review_requested_information_second_request: Review further information received - second request
+            review_requested_information_last_request: Review further information received - final request
             review_verifications: Review verifications
             verification_decision: Verification decision
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -131,6 +131,15 @@ Rails.application.routes.draw do
           member do
             get "decline", to: "further_information_requests#edit_decline"
             post "decline", to: "further_information_requests#update_decline"
+
+            get "follow-up", to: "further_information_requests#edit_follow_up"
+            post "follow-up",
+                 to: "further_information_requests#update_follow_up"
+
+            get "confirm-follow-up",
+                to: "further_information_requests#edit_confirm_follow_up"
+            post "confirm-follow-up",
+                 to: "further_information_requests#update_confirm_follow_up"
           end
         end
 

--- a/spec/forms/assessor_interface/further_information_request_confirm_follow_up_form_spec.rb
+++ b/spec/forms/assessor_interface/further_information_request_confirm_follow_up_form_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::FurtherInformationRequestConfirmFollowUpForm,
+               type: :model do
+  subject(:form) { described_class.new(further_information_request:, user:) }
+
+  let(:further_information_request) do
+    create(:received_further_information_request, :with_items)
+  end
+
+  let(:user) { create(:staff) }
+
+  describe "#save" do
+    subject(:save) { form.save }
+
+    it "updates review passed field" do
+      expect { save }.to change(
+        further_information_request,
+        :review_passed,
+      ).from(nil).to(false)
+    end
+
+    it "updates review note field" do
+      expect { save }.to change(further_information_request, :review_note).from(
+        "",
+      ).to("Further information requested")
+    end
+
+    it "sets reviewed at" do
+      freeze_time do
+        expect { save }.to change(
+          further_information_request,
+          :reviewed_at,
+        ).from(nil).to(Time.zone.now)
+      end
+    end
+
+    it "generates a new further information request for assessment" do
+      expect { save }.to change(
+        further_information_request.assessment.further_information_requests,
+        :count,
+      ).from(1).to(2)
+    end
+  end
+end

--- a/spec/forms/assessor_interface/further_information_request_follow_up_form_spec.rb
+++ b/spec/forms/assessor_interface/further_information_request_follow_up_form_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::FurtherInformationRequestFollowUpForm,
+               type: :model do
+  subject(:form) do
+    described_class.for_further_information_request(
+      further_information_request,
+    ).new(further_information_request:, user:, **params)
+  end
+
+  let(:further_information_request) do
+    create(:received_further_information_request, :with_items)
+  end
+
+  let(:items) { further_information_request.items.order(:created_at) }
+
+  let(:first_item) { items.first }
+  let(:third_item) { items.third }
+
+  let(:user) { create(:staff) }
+
+  let(:params) { {} }
+
+  before do
+    first_item.review_decision_further_information!
+    third_item.review_decision_further_information!
+  end
+
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:further_information_request) }
+    it { is_expected.to validate_presence_of(:user) }
+
+    it do
+      [first_item, third_item].each do |item|
+        expect(subject).to validate_presence_of(
+          :"#{item.id}_decision_note",
+        ).with_message("Enter instructions for the applicant")
+      end
+    end
+  end
+
+  describe "#save" do
+    subject(:form_save) { form.save }
+
+    let(:params) do
+      object = {}
+
+      [first_item, third_item].each do |item|
+        object["#{item.id}_decision_note"] = "Need more information"
+      end
+
+      object
+    end
+
+    it "updates the relevant items review decision note" do
+      form_save
+
+      expect(first_item.reload.review_decision_note).to eq(
+        "Need more information",
+      )
+      expect(third_item.reload.review_decision_note).to eq(
+        "Need more information",
+      )
+    end
+  end
+
+  describe ".initial_attributes" do
+    subject(:initial_attributes) do
+      described_class.initial_attributes(further_information_request)
+    end
+
+    before do
+      first_item.update!(review_decision_note: "Testing")
+      third_item.update!(review_decision_note: "Testing")
+    end
+
+    it "sets the decision notes on all existing further information request items" do
+      expect(initial_attributes).to eq(
+        {
+          "#{first_item.id}_decision_note" => "Testing",
+          "#{third_item.id}_decision_note" => "Testing",
+          :further_information_request => further_information_request,
+        },
+      )
+    end
+  end
+
+  describe ".permittable_parameters" do
+    subject(:permittable_parameters) do
+      described_class.permittable_parameters(further_information_request)
+    end
+
+    it "returns an array of all further information request decision note attributes" do
+      expect(permittable_parameters).to contain_exactly(
+        "#{first_item.id}_decision_note",
+        "#{third_item.id}_decision_note",
+      )
+    end
+  end
+end

--- a/spec/forms/assessor_interface/further_information_request_review_form_spec.rb
+++ b/spec/forms/assessor_interface/further_information_request_review_form_spec.rb
@@ -187,6 +187,220 @@ RSpec.describe AssessorInterface::FurtherInformationRequestReviewForm,
         end
       end
     end
+
+    context "when all items request follow up" do
+      let(:params) do
+        object = {}
+
+        further_information_request.items.each do |item|
+          object["#{item.id}_decision"] = "further_information"
+        end
+
+        object
+      end
+
+      it "updates the items review_decision" do
+        form_save
+
+        expect(
+          further_information_request.items.reload.first,
+        ).to be_review_decision_further_information
+        expect(
+          further_information_request.items.reload.second,
+        ).to be_review_decision_further_information
+        expect(
+          further_information_request.items.reload.last,
+        ).to be_review_decision_further_information
+      end
+
+      it "does not update review passed field" do
+        expect { form_save }.not_to change(
+          further_information_request,
+          :review_passed,
+        )
+      end
+
+      it "does not update review note field" do
+        expect { form_save }.not_to change(
+          further_information_request,
+          :review_note,
+        )
+      end
+
+      it "does not set reviewed at" do
+        freeze_time do
+          expect { form_save }.not_to change(
+            further_information_request,
+            :reviewed_at,
+          )
+        end
+      end
+    end
+
+    context "when some items are declined and some request follow up" do
+      let(:params) do
+        object = {}
+
+        object[
+          "#{further_information_request.items.first.id}_decision"
+        ] = "decline"
+        object[
+          "#{further_information_request.items.second.id}_decision"
+        ] = "further_information"
+        object[
+          "#{further_information_request.items.last.id}_decision"
+        ] = "further_information"
+
+        object
+      end
+
+      it "updates the items review_decision" do
+        form_save
+
+        expect(
+          further_information_request.items.reload.first,
+        ).to be_review_decision_decline
+        expect(
+          further_information_request.items.reload.second,
+        ).to be_review_decision_further_information
+        expect(
+          further_information_request.items.reload.last,
+        ).to be_review_decision_further_information
+      end
+
+      it "does not update review passed field" do
+        expect { form_save }.not_to change(
+          further_information_request,
+          :review_passed,
+        )
+      end
+
+      it "does not update review note field" do
+        expect { form_save }.not_to change(
+          further_information_request,
+          :review_note,
+        )
+      end
+
+      it "does not set reviewed at" do
+        freeze_time do
+          expect { form_save }.not_to change(
+            further_information_request,
+            :reviewed_at,
+          )
+        end
+      end
+    end
+
+    context "when some items are accepted and some request follow up" do
+      let(:params) do
+        object = {}
+
+        object[
+          "#{further_information_request.items.first.id}_decision"
+        ] = "accept"
+        object[
+          "#{further_information_request.items.second.id}_decision"
+        ] = "accept"
+        object[
+          "#{further_information_request.items.last.id}_decision"
+        ] = "further_information"
+
+        object
+      end
+
+      it "updates the items review_decision" do
+        form_save
+
+        expect(
+          further_information_request.items.reload.first,
+        ).to be_review_decision_accept
+        expect(
+          further_information_request.items.reload.second,
+        ).to be_review_decision_accept
+        expect(
+          further_information_request.items.reload.last,
+        ).to be_review_decision_further_information
+      end
+
+      it "does not update review passed field" do
+        expect { form_save }.not_to change(
+          further_information_request,
+          :review_passed,
+        )
+      end
+
+      it "does not update review note field" do
+        expect { form_save }.not_to change(
+          further_information_request,
+          :review_note,
+        )
+      end
+
+      it "does not set reviewed at" do
+        freeze_time do
+          expect { form_save }.not_to change(
+            further_information_request,
+            :reviewed_at,
+          )
+        end
+      end
+    end
+
+    context "when some items are declined, some accepted and some request follow up" do
+      let(:params) do
+        object = {}
+
+        object[
+          "#{further_information_request.items.first.id}_decision"
+        ] = "decline"
+        object[
+          "#{further_information_request.items.second.id}_decision"
+        ] = "accept"
+        object[
+          "#{further_information_request.items.last.id}_decision"
+        ] = "further_information"
+
+        object
+      end
+
+      it "updates the items review_decision" do
+        form_save
+
+        expect(
+          further_information_request.items.reload.first,
+        ).to be_review_decision_decline
+        expect(
+          further_information_request.items.reload.second,
+        ).to be_review_decision_accept
+        expect(
+          further_information_request.items.reload.last,
+        ).to be_review_decision_further_information
+      end
+
+      it "does not update review passed field" do
+        expect { form_save }.not_to change(
+          further_information_request,
+          :review_passed,
+        )
+      end
+
+      it "does not update review note field" do
+        expect { form_save }.not_to change(
+          further_information_request,
+          :review_note,
+        )
+      end
+
+      it "does not set reviewed at" do
+        freeze_time do
+          expect { form_save }.not_to change(
+            further_information_request,
+            :reviewed_at,
+          )
+        end
+      end
+    end
   end
 
   describe "#all_further_information_request_items_accepted?" do
@@ -247,6 +461,232 @@ RSpec.describe AssessorInterface::FurtherInformationRequestReviewForm,
 
       it "returns false" do
         expect(all_further_information_request_items_accepted?).to be false
+      end
+    end
+
+    context "when all items request follow up" do
+      let(:params) do
+        object = {}
+
+        further_information_request.items.each do |item|
+          object["#{item.id}_decision"] = "further_information"
+        end
+
+        object
+      end
+
+      it "returns false" do
+        expect(all_further_information_request_items_accepted?).to be false
+      end
+    end
+
+    context "when some items are declined and some request follow up" do
+      let(:params) do
+        object = {}
+
+        object[
+          "#{further_information_request.items.first.id}_decision"
+        ] = "decline"
+        object[
+          "#{further_information_request.items.second.id}_decision"
+        ] = "further_information"
+        object[
+          "#{further_information_request.items.last.id}_decision"
+        ] = "further_information"
+
+        object
+      end
+
+      it "returns false" do
+        expect(all_further_information_request_items_accepted?).to be false
+      end
+    end
+
+    context "when some items are accepted and some request follow up" do
+      let(:params) do
+        object = {}
+
+        object[
+          "#{further_information_request.items.first.id}_decision"
+        ] = "accept"
+        object[
+          "#{further_information_request.items.second.id}_decision"
+        ] = "accept"
+        object[
+          "#{further_information_request.items.last.id}_decision"
+        ] = "further_information"
+
+        object
+      end
+
+      it "returns false" do
+        expect(all_further_information_request_items_accepted?).to be false
+      end
+    end
+
+    context "when some items are declined, some accepted and some request follow up" do
+      let(:params) do
+        object = {}
+
+        object[
+          "#{further_information_request.items.first.id}_decision"
+        ] = "decline"
+        object[
+          "#{further_information_request.items.second.id}_decision"
+        ] = "accept"
+        object[
+          "#{further_information_request.items.last.id}_decision"
+        ] = "further_information"
+
+        object
+      end
+
+      it "returns false" do
+        expect(all_further_information_request_items_accepted?).to be false
+      end
+    end
+  end
+
+  describe "#follow_up_further_information_requested?" do
+    subject(:follow_up_further_information_requested?) do
+      form.follow_up_further_information_requested?
+    end
+
+    before { form.save }
+
+    context "when all items are accepted" do
+      let(:params) do
+        object = {}
+
+        further_information_request.items.each do |item|
+          object["#{item.id}_decision"] = "accept"
+        end
+
+        object
+      end
+
+      it "returns false" do
+        expect(follow_up_further_information_requested?).to be false
+      end
+    end
+
+    context "when some items are declined and some accepted" do
+      let(:params) do
+        object = {}
+
+        object[
+          "#{further_information_request.items.first.id}_decision"
+        ] = "decline"
+        object[
+          "#{further_information_request.items.second.id}_decision"
+        ] = "accept"
+        object[
+          "#{further_information_request.items.last.id}_decision"
+        ] = "accept"
+
+        object
+      end
+
+      it "returns false" do
+        expect(follow_up_further_information_requested?).to be false
+      end
+    end
+
+    context "when all items are declined" do
+      let(:params) do
+        object = {}
+
+        further_information_request.items.each do |item|
+          object["#{item.id}_decision"] = "decline"
+        end
+
+        object
+      end
+
+      it "returns false" do
+        expect(follow_up_further_information_requested?).to be false
+      end
+    end
+
+    context "when all items request follow up" do
+      let(:params) do
+        object = {}
+
+        further_information_request.items.each do |item|
+          object["#{item.id}_decision"] = "further_information"
+        end
+
+        object
+      end
+
+      it "returns true" do
+        expect(follow_up_further_information_requested?).to be true
+      end
+    end
+
+    context "when some items are declined and some request follow up" do
+      let(:params) do
+        object = {}
+
+        object[
+          "#{further_information_request.items.first.id}_decision"
+        ] = "decline"
+        object[
+          "#{further_information_request.items.second.id}_decision"
+        ] = "further_information"
+        object[
+          "#{further_information_request.items.last.id}_decision"
+        ] = "further_information"
+
+        object
+      end
+
+      it "returns false" do
+        expect(follow_up_further_information_requested?).to be false
+      end
+    end
+
+    context "when some items are accepted and some request follow up" do
+      let(:params) do
+        object = {}
+
+        object[
+          "#{further_information_request.items.first.id}_decision"
+        ] = "accept"
+        object[
+          "#{further_information_request.items.second.id}_decision"
+        ] = "accept"
+        object[
+          "#{further_information_request.items.last.id}_decision"
+        ] = "further_information"
+
+        object
+      end
+
+      it "returns true" do
+        expect(follow_up_further_information_requested?).to be true
+      end
+    end
+
+    context "when some items are declined, some accepted and some request follow up" do
+      let(:params) do
+        object = {}
+
+        object[
+          "#{further_information_request.items.first.id}_decision"
+        ] = "decline"
+        object[
+          "#{further_information_request.items.second.id}_decision"
+        ] = "accept"
+        object[
+          "#{further_information_request.items.last.id}_decision"
+        ] = "further_information"
+
+        object
+      end
+
+      it "returns false" do
+        expect(follow_up_further_information_requested?).to be false
       end
     end
   end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -489,4 +489,44 @@ RSpec.describe Assessment, type: :model do
       it { is_expected.to include("request_further_information") }
     end
   end
+
+  describe "#latest_further_information_request" do
+    context "when assessment has no further information requests" do
+      it "returns nil" do
+        expect(assessment.latest_further_information_request).to be_nil
+      end
+    end
+
+    context "when assessment has one further information requests" do
+      let!(:further_information_request) do
+        create :further_information_request, assessment:
+      end
+
+      it "returns the further information request" do
+        expect(assessment.reload.latest_further_information_request).to eq(
+          further_information_request,
+        )
+      end
+    end
+
+    context "when assessment has multiple further information requests" do
+      let!(:latest_further_information_request) do
+        create :further_information_request,
+               assessment:,
+               requested_at: 1.day.ago
+      end
+
+      before do
+        create :further_information_request,
+               assessment:,
+               requested_at: 2.days.ago
+      end
+
+      it "returns the latest further information request" do
+        expect(assessment.reload.latest_further_information_request).to eq(
+          latest_further_information_request,
+        )
+      end
+    end
+  end
 end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -125,6 +125,46 @@ RSpec.describe Assessment, type: :model do
 
             it { is_expected.to be false }
           end
+
+          context "with multiple further information requests" do
+            context "with a passed latest further information request" do
+              before do
+                create(
+                  :further_information_request,
+                  :review_failed,
+                  assessment:,
+                  requested_at: 2.days.ago,
+                )
+                create(
+                  :further_information_request,
+                  :review_passed,
+                  assessment:,
+                  requested_at: 1.day.ago,
+                )
+              end
+
+              it { is_expected.to be true }
+            end
+
+            context "with a failed latest further information request" do
+              before do
+                create(
+                  :further_information_request,
+                  :review_failed,
+                  assessment:,
+                  requested_at: 2.days.ago,
+                )
+                create(
+                  :further_information_request,
+                  :review_failed,
+                  assessment:,
+                  requested_at: 1.day.ago,
+                )
+              end
+
+              it { is_expected.to be false }
+            end
+          end
         end
       end
 
@@ -300,6 +340,46 @@ RSpec.describe Assessment, type: :model do
 
         it { is_expected.to be true }
       end
+
+      context "with multiple further information requests" do
+        context "with a passed latest further information request" do
+          before do
+            create(
+              :further_information_request,
+              :review_failed,
+              assessment:,
+              requested_at: 2.days.ago,
+            )
+            create(
+              :further_information_request,
+              :review_passed,
+              assessment:,
+              requested_at: 1.day.ago,
+            )
+          end
+
+          it { is_expected.to be false }
+        end
+
+        context "with a failed latest further information request" do
+          before do
+            create(
+              :further_information_request,
+              :review_failed,
+              assessment:,
+              requested_at: 2.days.ago,
+            )
+            create(
+              :further_information_request,
+              :review_failed,
+              assessment:,
+              requested_at: 1.day.ago,
+            )
+          end
+
+          it { is_expected.to be true }
+        end
+      end
     end
 
     context "when awarded pending verification" do
@@ -432,6 +512,46 @@ RSpec.describe Assessment, type: :model do
             end
 
             it { is_expected.to be false }
+          end
+
+          context "with multiple further information requests" do
+            context "with a passed latest further information request" do
+              before do
+                create(
+                  :further_information_request,
+                  :review_failed,
+                  assessment:,
+                  requested_at: 2.days.ago,
+                )
+                create(
+                  :further_information_request,
+                  :review_passed,
+                  assessment:,
+                  requested_at: 1.day.ago,
+                )
+              end
+
+              it { is_expected.to be true }
+            end
+
+            context "with a failed latest further information request" do
+              before do
+                create(
+                  :further_information_request,
+                  :review_failed,
+                  assessment:,
+                  requested_at: 2.days.ago,
+                )
+                create(
+                  :further_information_request,
+                  :review_failed,
+                  assessment:,
+                  requested_at: 1.day.ago,
+                )
+              end
+
+              it { is_expected.to be false }
+            end
           end
         end
       end

--- a/spec/models/further_information_request_spec.rb
+++ b/spec/models/further_information_request_spec.rb
@@ -25,7 +25,9 @@
 require "rails_helper"
 
 RSpec.describe FurtherInformationRequest do
-  subject(:further_information_request) { create(:further_information_request) }
+  subject(:model) { further_information_request }
+
+  let(:further_information_request) { create(:further_information_request) }
 
   it_behaves_like "a remindable" do
     subject { create(:requested_further_information_request) }
@@ -61,6 +63,228 @@ RSpec.describe FurtherInformationRequest do
       end
 
       it { is_expected.to eq([expected]) }
+    end
+  end
+
+  describe "#first_request?" do
+    subject(:first_request?) { further_information_request.first_request? }
+
+    let(:further_information_request) do
+      create(:requested_further_information_request)
+    end
+
+    context "when the only further information request within assessment" do
+      it { is_expected.to be true }
+    end
+
+    context "when one other further information request exists within assesment requested previously" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at - 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when one other further information request exists within assesment requested after" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at + 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when two other further information request exists within assesment requested previously" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at - 2.days,
+               assessment: further_information_request.assessment
+
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at - 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when two other further information request exists within assesment requested after" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at + 2.days,
+               assessment: further_information_request.assessment
+
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at + 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when two other further information request exists within assesment requested before and after" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at - 2.days,
+               assessment: further_information_request.assessment
+
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at + 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be false }
+    end
+  end
+
+  describe "#second_request?" do
+    subject(:second_request?) { further_information_request.second_request? }
+
+    let(:further_information_request) do
+      create(:requested_further_information_request)
+    end
+
+    context "when the only further information request within assessment" do
+      it { is_expected.to be false }
+    end
+
+    context "when one other further information request exists within assesment requested previously" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at - 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when one other further information request exists within assesment requested after" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at + 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when two other further information request exists within assesment requested previously" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at - 2.days,
+               assessment: further_information_request.assessment
+
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at - 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when two other further information request exists within assesment requested after" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at + 2.days,
+               assessment: further_information_request.assessment
+
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at + 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when two other further information request exists within assesment requested before and after" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at - 2.days,
+               assessment: further_information_request.assessment
+
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at + 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "#third_request?" do
+    subject(:third_request?) { further_information_request.third_request? }
+
+    let(:further_information_request) do
+      create(:requested_further_information_request)
+    end
+
+    context "when the only further information request within assessment" do
+      it { is_expected.to be false }
+    end
+
+    context "when one other further information request exists within assesment requested previously" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at - 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when one other further information request exists within assesment requested after" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at + 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when two other further information request exists within assesment requested previously" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at - 2.days,
+               assessment: further_information_request.assessment
+
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at - 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be true }
+    end
+
+    context "when two other further information request exists within assesment requested after" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at + 2.days,
+               assessment: further_information_request.assessment
+
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at + 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when two other further information request exists within assesment requested before and after" do
+      before do
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at - 2.days,
+               assessment: further_information_request.assessment
+
+        create :requested_further_information_request,
+               requested_at: further_information_request.requested_at + 1.day,
+               assessment: further_information_request.assessment
+      end
+
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/policies/assessor_interface/further_information_request_policy_spec.rb
+++ b/spec/policies/assessor_interface/further_information_request_policy_spec.rb
@@ -58,6 +58,30 @@ RSpec.describe AssessorInterface::FurtherInformationRequestPolicy do
     it_behaves_like "a policy method requiring the assess permission"
   end
 
+  describe "#edit_follow_up?" do
+    subject(:edit_follow_up?) { policy.edit_follow_up? }
+
+    it_behaves_like "a policy method with permission"
+  end
+
+  describe "#update_follow_up?" do
+    subject(:update_follow_up?) { policy.update_follow_up? }
+
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+
+  describe "#edit_confirm_follow_up?" do
+    subject(:edit_confirm_follow_up?) { policy.edit_confirm_follow_up? }
+
+    it_behaves_like "a policy method with permission"
+  end
+
+  describe "#update_confirm_follow_up?" do
+    subject(:update_confirm_follow_up?) { policy.update_confirm_follow_up? }
+
+    it_behaves_like "a policy method requiring the assess permission"
+  end
+
   describe "#destroy?" do
     subject(:destroy?) { policy.destroy? }
 

--- a/spec/services/further_information_requests/create_from_assessment_sections_spec.rb
+++ b/spec/services/further_information_requests/create_from_assessment_sections_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe RequestFurtherInformation do
+RSpec.describe FurtherInformationRequests::CreateFromAssessmentSections do
   subject(:call) { described_class.call(assessment:, user:) }
 
   let(:application_form) { create(:application_form, :submitted) }
@@ -56,7 +56,9 @@ RSpec.describe RequestFurtherInformation do
     before { create(:further_information_request, assessment:) }
 
     it "raises an error" do
-      expect { call }.to raise_error(RequestFurtherInformation::AlreadyExists)
+      expect { call }.to raise_error(
+        FurtherInformationRequests::CreateFromAssessmentSections::AlreadyExists,
+      )
     end
   end
 end

--- a/spec/services/further_information_requests/create_from_further_information_review_spec.rb
+++ b/spec/services/further_information_requests/create_from_further_information_review_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FurtherInformationRequests::CreateFromFurtherInformationReview do
+  subject(:call) { described_class.call(further_information_request:, user:) }
+
+  let(:new_further_information_request) do
+    assessment.reload.latest_further_information_request
+  end
+
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:assessment) { create(:assessment, application_form:) }
+  let(:further_information_request) do
+    create :received_further_information_request,
+           :with_items,
+           assessment:,
+           reviewed_at: Time.current,
+           review_passed: false
+  end
+  let(:user) { create(:staff) }
+
+  let(:items) { further_information_request.items.order(:created_at) }
+
+  let(:first_item) { items.first }
+  let(:third_item) { items.third }
+
+  before do
+    first_item.review_decision_further_information!
+    first_item.update!(review_decision_note: "Provide more information.")
+
+    third_item.review_decision_further_information!
+    third_item.update!(review_decision_note: "Provide more information.")
+  end
+
+  it "generates a new further information request" do
+    expect { call }.to change(
+      assessment.further_information_requests,
+      :count,
+    ).from(1).to(2)
+  end
+
+  it "marks the new further information request to requested" do
+    call
+
+    expect(new_further_information_request.requested?).to be true
+  end
+
+  it "creates items for reviewed items that require further information" do
+    call
+
+    expect(new_further_information_request.items.count).to eq 2
+    expect(
+      new_further_information_request.items.find_by(
+        information_type: first_item.information_type,
+      ),
+    ).to have_attributes(
+      information_type: first_item.information_type,
+      failure_reason_key: first_item.failure_reason_key,
+      failure_reason_assessor_feedback: "Provide more information.",
+      work_history: first_item.work_history,
+    )
+    expect(
+      new_further_information_request.items.find_by(
+        information_type: third_item.information_type,
+      ),
+    ).to have_attributes(
+      information_type: third_item.information_type,
+      failure_reason_key: third_item.failure_reason_key,
+      failure_reason_assessor_feedback: "Provide more information.",
+      work_history: third_item.work_history,
+    )
+  end
+
+  it "changes the application form statuses" do
+    expect { call }.to change(application_form, :statuses).to(
+      %w[waiting_on_further_information],
+    )
+  end
+
+  describe "sending application received email" do
+    it "queues an email job" do
+      expect { call }.to have_enqueued_mail(
+        TeacherMailer,
+        :further_information_requested,
+      )
+    end
+  end
+
+  it "sets the assessment recommendation" do
+    expect { call }.to change(assessment, :request_further_information?).from(
+      false,
+    ).to(true)
+  end
+
+  it "records a requestable requested timeline event" do
+    expect { call }.to have_recorded_timeline_event(:requestable_requested)
+  end
+
+  context "with an existing request not yet received" do
+    before { create(:further_information_request, assessment:) }
+
+    it "raises an error" do
+      expect { call }.to raise_error(
+        FurtherInformationRequests::CreateFromFurtherInformationReview::AlreadyExists,
+      )
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -64,8 +64,10 @@ module PageObjects
         find_task_list_item("Check professional standing")
       end
 
-      def review_requested_information_task
-        find_task_list_item("Review further information from applicant")
+      def review_first_requested_information_task
+        find_task_list_item(
+          "Review further information received - first request",
+        )
       end
 
       def verify_professional_standing_task

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -70,6 +70,12 @@ module PageObjects
         )
       end
 
+      def review_second_requested_information_task
+        find_task_list_item(
+          "Review further information received - second request",
+        )
+      end
+
       def verify_professional_standing_task
         find_task_list_item("Verify LoPS")
       end

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -76,6 +76,12 @@ module PageObjects
         )
       end
 
+      def review_final_requested_information_task
+        find_task_list_item(
+          "Review further information received - final request",
+        )
+      end
+
       def verify_professional_standing_task
         find_task_list_item("Verify LoPS")
       end

--- a/spec/support/autoload/page_objects/assessor_interface/confirm_follow_up_further_information_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/confirm_follow_up_further_information_request.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class ConfirmFollowUpFurtherInformationRequest < SitePrism::Page
+      set_url "/assessor/applications/{reference}/assessments/{assessment_id}" \
+                "/further-information-requests/{id}/confirm-follow-up"
+
+      element :heading, ".govuk-heading-xl"
+
+      section :form, "form" do
+        element :submit_button, ".govuk-button"
+      end
+    end
+  end
+end

--- a/spec/support/autoload/page_objects/assessor_interface/follow_up_further_information_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/follow_up_further_information_request.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module AssessorInterface
+    class FollowUpFurtherInformationRequest < SitePrism::Page
+      set_url "/assessor/applications/{reference}/assessments/{assessment_id}" \
+                "/further-information-requests/{id}/follow-up"
+
+      element :heading, ".govuk-heading-xl"
+
+      section :form, "form" do
+        elements :review_decision_note_textareas, ".govuk-textarea"
+        element :submit_button, ".govuk-button"
+      end
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -233,6 +233,16 @@ module PageHelpers
       PageObjects::AssessorInterface::DeclineFurtherInformationRequest.new
   end
 
+  def assessor_follow_up_further_information_request_page
+    @assessor_follow_up_further_information_request_page ||=
+      PageObjects::AssessorInterface::FollowUpFurtherInformationRequest.new
+  end
+
+  def assessor_confirm_follow_up_further_information_request_page
+    @assessor_confirm_follow_up_further_information_request_page ||=
+      PageObjects::AssessorInterface::ConfirmFollowUpFurtherInformationRequest.new
+  end
+
   def assessor_review_professional_standing_request_page
     @assessor_review_professional_standing_request_page ||=
       PageObjects::AssessorInterface::ReviewProfessionalStandingRequest.new

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     and_i_see_a_decline_qts_option
   end
 
-  it "further information request passed and assessment finished" do
+  it "review all accept and assessment finished" do
     further_information_request.update!(review_passed: true)
     further_information_request.assessment.award!
 
@@ -95,6 +95,39 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     )
     and_i_see_the_fi_responses
     and_i_do_not_see_the_review_further_information_form
+  end
+
+  it "review request further information" do
+    when_i_visit_the(:assessor_application_page, reference:)
+    and_i_click_review_requested_information
+    then_i_see_the(
+      :assessor_review_further_information_request_page,
+      reference:,
+      assessment_id:,
+      id: further_information_request.id,
+    )
+    and_i_see_the_fi_responses
+
+    when_i_mark_the_information_received_as_requiring_further_information
+    then_i_see_the(
+      :assessor_follow_up_further_information_request_page,
+      reference:,
+    )
+    when_i_add_a_review_decision_notes_and_submit
+
+    then_i_see_the(
+      :assessor_confirm_follow_up_further_information_request_page,
+      reference:,
+    )
+
+    when_i_review_the_follow_up_notes_and_submit
+
+    then_i_see_the(:assessor_application_status_page, reference:)
+    and_i_receive_a_further_information_requested_email
+
+    when_i_click_to_go_to_application_overview
+    then_i_see_the(:assessor_application_page, reference:)
+    and_i_see_a_new_further_information_request_created
   end
 
   private
@@ -171,20 +204,97 @@ RSpec.describe "Assessor reviewing further information", type: :system do
     assessor_review_further_information_request_page.form.submit_button.click
   end
 
+  def when_i_mark_the_information_received_as_requiring_further_information
+    assessor_review_further_information_request_page.find(
+      "#assessor-interface-further-information-request-review-form-#{
+        further_information_request.items.first.id
+      }-decision-accept-field",
+      visible: false,
+    ).choose
+
+    assessor_review_further_information_request_page.find(
+      "#assessor-interface-further-information-request-review-form-#{
+        further_information_request.items.second.id
+      }-decision-further-information-field",
+      visible: false,
+    ).choose
+
+    assessor_review_further_information_request_page.find(
+      "#assessor-interface-further-information-request-review-form-#{
+        further_information_request.items.last.id
+      }-decision-further-information-field",
+      visible: false,
+    ).choose
+
+    assessor_review_further_information_request_page.form.submit_button.click
+  end
+
   def when_i_add_a_decline_note_and_submit
     assessor_decline_further_information_request_page.form.note_textarea.fill_in with:
       "Decline note."
     assessor_decline_further_information_request_page.form.submit_button.click
   end
 
+  def when_i_add_a_review_decision_notes_and_submit
+    assessor_follow_up_further_information_request_page
+      .form
+      .review_decision_note_textareas
+      .first.fill_in with: "We require more information."
+    assessor_follow_up_further_information_request_page
+      .form
+      .review_decision_note_textareas
+      .last.fill_in with: "We require even more information."
+    assessor_follow_up_further_information_request_page.form.submit_button.click
+  end
+
+  def when_i_review_the_follow_up_notes_and_submit
+    expect(
+      assessor_confirm_follow_up_further_information_request_page,
+    ).to have_content("We require more information.").and have_content(
+            "We require even more information.",
+          )
+
+    assessor_confirm_follow_up_further_information_request_page
+      .form
+      .submit_button
+      .click
+  end
+
   def and_i_see_a_decline_qts_option
     expect(assessor_complete_assessment_page.decline_qts).not_to be_nil
+  end
+
+  def and_i_see_a_new_further_information_request_created
+    expect(assessor_application_page).to have_content(
+      "Review further information received - second request",
+    )
+
+    expect(
+      assessor_application_page.review_first_requested_information_task,
+    ).to have_content("Completed")
+    expect(
+      assessor_application_page.review_second_requested_information_task,
+    ).to have_content("Cannot start")
   end
 
   def and_i_do_not_see_the_review_further_information_form
     expect(
       assessor_review_further_information_request_page.form,
     ).not_to have_submit_button
+  end
+
+  def and_i_receive_a_further_information_requested_email
+    message = ActionMailer::Base.deliveries.last
+    expect(message).not_to be_nil
+
+    expect(message.subject).to eq(
+      "Your QTS application: More information needed",
+    )
+    expect(message.to).to include(application_form.teacher.email)
+  end
+
+  def when_i_click_to_go_to_application_overview
+    assessor_application_status_page.button_group.overview_button.click
   end
 
   def application_form

--- a/spec/system/assessor_interface/reviewing_further_information_spec.rb
+++ b/spec/system/assessor_interface/reviewing_further_information_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe "Assessor reviewing further information", type: :system do
   end
 
   def and_i_click_review_requested_information
-    assessor_application_page.review_requested_information_task.click
+    assessor_application_page.review_first_requested_information_task.click
   end
 
   def and_i_see_the_fi_responses

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -426,6 +426,121 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       end
     end
 
+    context "with multiple further information requests where one has failed and another one is requested" do
+      before do
+        assessment.request_further_information!
+        create(
+          :received_further_information_request,
+          :with_items,
+          :review_failed,
+          assessment:,
+          requested_at: 2.days.ago,
+        )
+        create(
+          :received_further_information_request,
+          :with_items,
+          assessment:,
+          requested_at: 1.day.ago,
+        )
+      end
+
+      it do
+        expect(subject).to include_task_list_item(
+          "Assessment",
+          "Review further information received - first request",
+          status: :completed,
+        )
+      end
+
+      it do
+        expect(subject).to include_task_list_item(
+          "Assessment",
+          "Review further information received - second request",
+          status: :not_started,
+        )
+      end
+
+      context "with the new one being partially filled out" do
+        before do
+          assessment.reload.latest_further_information_request.items.update_all(
+            review_decision: "accept",
+          )
+        end
+
+        it do
+          expect(subject).to include_task_list_item(
+            "Assessment",
+            "Review further information received - second request",
+            status: :in_progress,
+          )
+        end
+      end
+    end
+
+    context "with multiple further information requests where both have failed" do
+      before do
+        assessment.decline!
+        create(
+          :received_further_information_request,
+          :review_failed,
+          assessment:,
+        )
+        create(
+          :received_further_information_request,
+          :review_failed,
+          assessment:,
+        )
+      end
+
+      it do
+        expect(subject).to include_task_list_item(
+          "Assessment",
+          "Review further information received - first request",
+          status: :completed,
+        )
+      end
+
+      it do
+        expect(subject).to include_task_list_item(
+          "Assessment",
+          "Review further information received - second request",
+          status: :completed,
+        )
+      end
+    end
+
+    context "with multiple further information requests where one failed and other accepted" do
+      before do
+        assessment.award!
+        create(
+          :received_further_information_request,
+          :review_passed,
+          assessment:,
+        )
+        create(
+          :received_further_information_request,
+          :review_passed,
+          assessment:,
+        )
+      end
+
+      it do
+        expect(subject).to include_task_list_item(
+          "Assessment",
+          "Review further information received - first request",
+          status: :completed,
+        )
+      end
+
+      it do
+        expect(subject).to include_task_list_item(
+          "Assessment",
+          "Review further information received - second request",
+          status: :completed,
+        )
+      end
+    end
+
     context "with a professional standing request" do
       before do
         assessment.verify!

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       it do
         expect(subject).to include_task_list_item(
           "Assessment",
-          "Review further information from applicant",
+          "Review further information received - first request",
           status: :cannot_start,
         )
       end
@@ -323,7 +323,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       it do
         expect(subject).to include_task_list_item(
           "Assessment",
-          "Review further information from applicant",
+          "Review further information received - first request",
           status: :not_started,
         )
       end
@@ -342,7 +342,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       it do
         expect(subject).to include_task_list_item(
           "Assessment",
-          "Review further information from applicant",
+          "Review further information received - first request",
           status: :in_progress,
         )
       end
@@ -361,7 +361,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       it do
         expect(subject).to include_task_list_item(
           "Assessment",
-          "Review further information from applicant",
+          "Review further information received - first request",
           status: :in_progress,
         )
       end
@@ -382,7 +382,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       it do
         expect(subject).to include_task_list_item(
           "Assessment",
-          "Review further information from applicant",
+          "Review further information received - first request",
           status: :in_progress,
         )
       end
@@ -401,7 +401,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       it do
         expect(subject).to include_task_list_item(
           "Assessment",
-          "Review further information from applicant",
+          "Review further information received - first request",
           status: :completed,
         )
       end
@@ -420,7 +420,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
       it do
         expect(subject).to include_task_list_item(
           "Assessment",
-          "Review further information from applicant",
+          "Review further information received - first request",
           status: :completed,
         )
       end

--- a/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
@@ -114,6 +114,45 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
     end
   end
 
+  describe "#title" do
+    subject(:title) { view_object.title }
+
+    it "returns as review of first request" do
+      expect(title).to eq("Review further information received - first request")
+    end
+
+    context "when it is the second request" do
+      before do
+        create :further_information_request,
+               assessment:,
+               requested_at: further_information_request.requested_at - 1.day
+      end
+
+      it "returns as review of second request" do
+        expect(title).to eq(
+          "Review further information received - second request",
+        )
+      end
+    end
+
+    context "when it is the third request" do
+      before do
+        create :further_information_request,
+               assessment:,
+               requested_at: further_information_request.requested_at - 1.day
+        create :further_information_request,
+               assessment:,
+               requested_at: further_information_request.requested_at - 2.days
+      end
+
+      it "returns as review of final request" do
+        expect(title).to eq(
+          "Review further information received - final request",
+        )
+      end
+    end
+  end
+
   describe "#grouped_follow_up_items_by_assessment_section" do
     subject(:grouped_follow_up_items_by_assessment_section) do
       view_object.grouped_follow_up_items_by_assessment_section

--- a/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/further_information_request_view_object_spec.rb
@@ -114,6 +114,104 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
     end
   end
 
+  describe "#grouped_follow_up_items_by_assessment_section" do
+    subject(:grouped_follow_up_items_by_assessment_section) do
+      view_object.grouped_follow_up_items_by_assessment_section
+    end
+
+    let(:personal_information_assessment_section) do
+      create :assessment_section, :personal_information, assessment:
+    end
+
+    let!(:passport_document_illegible) do
+      create(
+        :further_information_request_item,
+        :with_document_response,
+        :completed,
+        further_information_request:,
+        failure_reason_key: "passport_document_illegible",
+        review_decision: "accept",
+      )
+    end
+
+    let!(:passport_document_mismatch) do
+      create(
+        :further_information_request_item,
+        :with_document_response,
+        :completed,
+        further_information_request:,
+        failure_reason_key: "passport_document_mismatch",
+        review_decision: "further_information",
+        review_decision_note: "Further information requested.",
+      )
+    end
+
+    let!(:qualifications_dont_match_other_details) do
+      create(
+        :further_information_request_item,
+        :with_text_response,
+        :completed,
+        further_information_request:,
+        failure_reason_key: "qualifications_dont_match_other_details",
+        review_decision: "further_information",
+        review_decision_note: "Further information requested.",
+      )
+    end
+
+    let!(:qualifications_or_modules_required_not_provided) do
+      create(
+        :further_information_request_item,
+        :with_document_response,
+        :completed,
+        further_information_request:,
+        failure_reason_key: "qualifications_or_modules_required_not_provided",
+        review_decision: "accept",
+      )
+    end
+
+    let(:qualifications_assessment_section) do
+      create :assessment_section, :qualifications, assessment:
+    end
+
+    before do
+      create :selected_failure_reason,
+             assessment_section: personal_information_assessment_section,
+             key: passport_document_illegible.failure_reason_key
+      create :selected_failure_reason,
+             assessment_section: personal_information_assessment_section,
+             key: passport_document_mismatch.failure_reason_key
+
+      create :selected_failure_reason,
+             assessment_section: qualifications_assessment_section,
+             key: qualifications_dont_match_other_details.failure_reason_key
+      create :selected_failure_reason,
+             assessment_section: qualifications_assessment_section,
+             key:
+               qualifications_or_modules_required_not_provided.failure_reason_key
+    end
+
+    it "returns the grouped items by assessment section for items that require further information only" do
+      expect(subject).to eq(
+        [
+          {
+            section_id: personal_information_assessment_section.id,
+            heading: "Personal information",
+            review_items:
+              view_object.review_items([passport_document_mismatch]),
+          },
+          {
+            section_id: qualifications_assessment_section.id,
+            heading: "Qualifications",
+            review_items:
+              view_object.review_items(
+                [qualifications_dont_match_other_details],
+              ),
+          },
+        ],
+      )
+    end
+  end
+
   describe "#review_items" do
     subject(:review_items) do
       view_object.review_items(
@@ -194,6 +292,63 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
         ],
       )
     end
+
+    context "when the review items have a decision note" do
+      before do
+        [text_item, document_item, work_history_contact_item].each do |item|
+          item.update!(review_decision_note: "Further information required.")
+        end
+      end
+
+      it do
+        expect(subject).to eq(
+          [
+            {
+              id: document_item.id,
+              recieved_date:
+                further_information_request.received_at.to_date.to_fs,
+              requested_date:
+                further_information_request.requested_at.to_date.to_fs,
+              heading:
+                "The ID document is illegible or in a format that we cannot accept.",
+              assessor_request: document_item.failure_reason_assessor_feedback,
+              applicant_upload_response: document_item.document,
+              review_decision_note: "Further information required.",
+            },
+            {
+              id: text_item.id,
+              recieved_date:
+                further_information_request.received_at.to_date.to_fs,
+              requested_date:
+                further_information_request.requested_at.to_date.to_fs,
+              heading:
+                "Subjects entered are acceptable for QTS, but the uploaded qualifications do not match them.",
+              assessor_request: text_item.failure_reason_assessor_feedback,
+              applicant_text_response: text_item.response,
+              review_decision_note: "Further information required.",
+            },
+            {
+              id: work_history_contact_item.id,
+              recieved_date:
+                further_information_request.received_at.to_date.to_fs,
+              requested_date:
+                further_information_request.requested_at.to_date.to_fs,
+              heading:
+                "We could not verify 1 or more references entered by the applicant" \
+                  " for #{work_history_contact_item.work_history.school_name}.",
+              assessor_request:
+                work_history_contact_item.failure_reason_assessor_feedback,
+              applicant_contact_response: [
+                "Contact’s name: John Scott",
+                "Contact’s job: Principal",
+                "Contact’s email: john@school.com",
+              ],
+              review_decision_note: "Further information required.",
+            },
+          ],
+        )
+      end
+    end
   end
 
   describe "#can_update?" do
@@ -206,6 +361,16 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
       end
 
       it { is_expected.to be true }
+
+      context "with the further information request not being the latest request" do
+        before do
+          create :further_information_request,
+                 assessment: further_information_request.assessment,
+                 requested_at: further_information_request.requested_at + 1.hour
+        end
+
+        it { is_expected.to be false }
+      end
     end
 
     context "when passed and not recommended" do
@@ -237,7 +402,7 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
   end
 
   describe "#can_decline?" do
-    subject(:can_update?) { view_object.can_decline? }
+    subject(:can_decline?) { view_object.can_decline? }
 
     let(:further_information_request) do
       create(:received_further_information_request, :with_items, assessment:)
@@ -299,4 +464,123 @@ RSpec.describe AssessorInterface::FurtherInformationRequestViewObject do
       it { is_expected.to be false }
     end
   end
+
+  describe "#can_follow_up?" do
+    subject(:can_follow_up?) { view_object.can_follow_up? }
+
+    let(:further_information_request) do
+      create(:received_further_information_request, :with_items, assessment:)
+    end
+
+    context "when further information can be updated" do
+      before do
+        further_information_request.update!(review_passed: false)
+        assessment.request_further_information!
+      end
+
+      context "with no decisions yet made on any of the further information request items" do
+        it { is_expected.to be false }
+      end
+
+      context "with the further information request items being all accepted" do
+        before do
+          further_information_request.items.update_all(
+            review_decision: "accept",
+          )
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context "with the further information request items being all declined" do
+        before do
+          further_information_request.items.update_all(
+            review_decision: "decline",
+          )
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context "with the further information request items being mix of accept and decline" do
+        before do
+          further_information_request.items.first.update!(
+            review_decision: "accept",
+          )
+          further_information_request.items.second.update!(
+            review_decision: "accept",
+          )
+          further_information_request.items.third.update!(
+            review_decision: "decline",
+          )
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context "with the further information request items being mix of accept, decline and follow up" do
+        before do
+          further_information_request.items.first.update!(
+            review_decision: "accept",
+          )
+          further_information_request.items.second.update!(
+            review_decision: "further_information",
+          )
+          further_information_request.items.third.update!(
+            review_decision: "decline",
+          )
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context "with the further information request items being mix of decline and follow up" do
+        before do
+          further_information_request.items.first.update!(
+            review_decision: "decline",
+          )
+          further_information_request.items.second.update!(
+            review_decision: "further_information",
+          )
+          further_information_request.items.third.update!(
+            review_decision: "further_information",
+          )
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context "with the further information request items being mix of accept and follow up" do
+        before do
+          further_information_request.items.first.update!(
+            review_decision: "accept",
+          )
+          further_information_request.items.second.update!(
+            review_decision: "further_information",
+          )
+          further_information_request.items.third.update!(
+            review_decision: "further_information",
+          )
+        end
+
+        it { is_expected.to be true }
+      end
+    end
+
+    context "when further information cannot be updated" do
+      before do
+        further_information_request.update!(review_passed: true)
+        assessment.award!
+      end
+
+      it { is_expected.to be false }
+    end
+  end
 end
+
+# def can_follow_up?
+#   can_update? &&
+#     further_information_request.items.any?(
+#       &:review_decision_further_information?
+#     ) && further_information_request.items.none?(&:review_decision_decline?)
+# end

--- a/spec/view_objects/teacher_interface/application_form_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/application_form_view_object_spec.rb
@@ -28,13 +28,35 @@ RSpec.describe TeacherInterface::ApplicationFormViewObject do
 
     it { is_expected.to be_nil }
 
-    context "with an application form" do
+    context "with a further information request" do
       before do
         assessment = create(:assessment, application_form:)
         create(:further_information_request, assessment:)
       end
 
       it { is_expected.not_to be_nil }
+    end
+
+    context "with multiple further information requests" do
+      let(:assessment) { create(:assessment, application_form:) }
+
+      let!(:new_further_information_request) do
+        create(
+          :further_information_request,
+          assessment:,
+          requested_at: 1.day.ago,
+        )
+      end
+
+      before do
+        create(
+          :further_information_request,
+          assessment:,
+          requested_at: 2.days.ago,
+        )
+      end
+
+      it { is_expected.to eq(new_further_information_request) }
     end
   end
 


### PR DESCRIPTION
Tickets:
https://dfedigital.atlassian.net/browse/AQTS-875
https://dfedigital.atlassian.net/browse/AQTS-877
https://dfedigital.atlassian.net/browse/AQTS-879
https://dfedigital.atlassian.net/browse/AQTS-878
https://dfedigital.atlassian.net/browse/AQTS-912

This PR implements the new multiple further information (FI) requests  feature. Currently, FI requests can only be sent once and the response from applicants can be either accepted or declined (which leads to applications being declined). However, assessors sometimes need clarification based on the applicants response, and currently that happens outside the system, but we want assessors to be able to use the system to request any follow up questions to previous FI requests.

In this PR, I have introduced a new option within reviewing a further information for "No, request further information" alongside the accept and decline.
![Screenshot 2025-04-24 at 15 23 25](https://github.com/user-attachments/assets/94d0006d-07a6-45b9-bb73-107352bd2675) 

If any of the FI items have "No, request further information" and no declines have been selected on the review, then the flow moves into entering the `review_decision_note` for each of the FI items. In this specific page, all FI items selected for a follow up have been grouped by their original assessment section which is implemented by `grouped_follow_up_items_by_assessment_section` within the `AssessorInterface::FurtherInformationRequestViewObject` view object. 

Additionally, the `AssessorInterface::FurtherInformationRequestFollowUpForm` object uses a similar pattern to `AssessorInterface::AssessmentSectionForm` to dynamically build attributes and validations for the form based on the selection made from the previous section. 

For this pattern, we have 3 class methods:
1. `for_further_information_request(further_information_request)` - This is used to define the class from a specific further_information_request so that the relevant attributes and validations depending on which items have been selected for further information can be dynamically part of the characteristics of the class.
2. `initial_attributes(further_information_request)` - The purpose of this is to dynamically identify the attribute values and set them on the form object when it has already been filled out before. This helps display existing values on the page.
3. `permittable_parameters(further_information_request)` - The purpose of this is to ensure when wanted to define the permitted parameters used within the controller dynamically based on the FI item selections.

![Screenshot 2025-04-25 at 00 00 48](https://github.com/user-attachments/assets/148c0878-6901-41d0-b13c-bde8884e9542)

The flow then moves into a page utilised by `grouped_follow_up_items_by_assessment_section` method to display a review section of the new FI request being sent.

![Screenshot 2025-04-25 at 00 03 48](https://github.com/user-attachments/assets/847b469f-1824-4969-9fc2-9b7aab61f1d8)

For the benefit of once an assessor has submitted I have renamed original `RequestFurtherInformation` class which is a service used to generate an FI request from initial assessment to `FurtherInformationRequests::CreateFromAssessmentSections` this then has allowed me to also create a new service class `FurtherInformationRequests::CreateFromFurtherInformationReview` which generates an FI request from an existing FI requests review. 

**Important:** An edge-case is also that for FI request items that change referee details, if any are accepted, the work history reference/contact details will be automatically updated, even if the request goes for any follow ups. This change can be seen within `after_reviewed` method inside the `FurtherInformationRequest` model which is triggered automatically after every `Requestable` object is reviewed. 

This process can then be repeated up to 2 times (3 FI requests total) before the assessor no longer is able to see the "No, request further information" option on the final/third request.

![Screenshot 2025-04-25 at 00 16 53](https://github.com/user-attachments/assets/d54f760d-a84e-4235-bbd6-13b1bb8b9f3c)

Additionally, this PR ensures that 2nd and 3rd requests expire within 3 weeks (instead of 6 for the initial request) and that we only send 2 reminders at 1 week before expiry and 2 days (instead of 2 weeks, 1 week and 2 days before). This change can be seen within `expires_after` (part of the `Requestable` concern) and `should_send_reminder_email?` (part of the `Remindable` concern) methods within the `FurtherInformationRequest`.
