### PR TITLE
[AQTS-950] Adding new GOV.UK Notify API key and template IDs for our new account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN yarn build && yarn build:css
 # Precompile assets
 RUN RAILS_ENV=production \
     SECRET_KEY_BASE=required-to-run-but-not-used \
-    GOVUK_NOTIFY_API_KEY=required-to-run-but-not-used \
+    GOVUK_NOTIFY_V2_API_KEY=required-to-run-but-not-used \
     REDIS_URL=redis://required-to-run-but-not-used \
     bundle exec rails assets:precompile
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -6,7 +6,7 @@ class ApplicationMailer < Mail::Notify::Mailer
   GOVUK_NOTIFY_TEMPLATE_ID =
     ENV.fetch(
       "GOVUK_NOTIFY_TEMPLATE_ID_APPLICATION",
-      "95adafaf-0920-4623-bddc-340853c047af",
+      "7f036b52-9e08-40c9-8b52-0bb527d70f4a",
     )
 
   rescue_from Notifications::Client::RequestError do

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -6,7 +6,7 @@ class DeviseMailer < Devise::Passwordless::Mailer
   GOVUK_NOTIFY_TEMPLATE_ID =
     ENV.fetch(
       "GOVUK_NOTIFY_TEMPLATE_ID_DEVISE",
-      "8331da6b-6e8a-4782-ab56-2a74200d51d2",
+      "4981b601-eaab-46a3-9f6a-7a42cdd0d4cf",
     )
 
   def devise_mail(record, action, opts = {}, &_block)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -97,6 +97,6 @@ Rails.application.configure do
   }
   config.action_mailer.delivery_method = :notify
   config.action_mailer.notify_settings = {
-    api_key: ENV.fetch("GOVUK_NOTIFY_API_KEY"),
+    api_key: ENV.fetch("GOVUK_NOTIFY_V2_API_KEY"),
   }
 end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-950

This work introduces references to our new GOV.UK Notify account. I have decided to introduce a new API key name so that we have no downtime between updating the environment variable and the code deploying. Once deployed, we can remove the old key.