### PR TITLE
[AQTS-873] Timeline visual updates

### DIFF
--- a/app/components/timeline_entry/_failure_reasons.html.erb
+++ b/app/components/timeline_entry/_failure_reasons.html.erb
@@ -1,9 +1,8 @@
 <% failure_reasons.each do |failure_reason| %>
   <li>
-    <p class="govuk-body">
+    <p class="govuk-body govuk-!-margin-bottom-0">
       <%= t(failure_reason.key, scope: %i[assessor_interface assessment_sections failure_reasons as_statement]) %>
-      <br />
-      <span class="govuk-hint"><%= simple_format failure_reason.assessor_feedback %></span>
     </p>
+    <%= simple_format failure_reason.assessor_feedback, class: "govuk-hint" %>
   </li>
 <% end %>

--- a/app/components/timeline_entry/_failure_reasons.html.erb
+++ b/app/components/timeline_entry/_failure_reasons.html.erb
@@ -2,8 +2,8 @@
   <li>
     <p class="govuk-body">
       <%= t(failure_reason.key, scope: %i[assessor_interface assessment_sections failure_reasons as_statement]) %>
+      <br />
+      <span class="govuk-hint"><%= simple_format failure_reason.assessor_feedback %></span>
     </p>
-
-    <%= simple_format failure_reason.assessor_feedback %>
   </li>
 <% end %>

--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -22,26 +22,19 @@
       <% end %>
     <% elsif timeline_event.assessment_section_recorded? %>
       <p class="govuk-body">
-        <%= description_vars[:section_name] %>:
         <%= render StatusTag::Component.new(description_vars[:status]) %>
       </p>
 
-      <% if (visible_failure_reasons = description_vars[:visible_failure_reasons]).present? %>
-        <%= govuk_inset_text do %>
+      <% if (failure_reasons = description_vars[:failure_reasons]).present? %>
+        <%= govuk_details(summary_text: "View details") do %>
           <ul class="govuk-list--bullet">
-            <%= render "timeline_entry/failure_reasons", failure_reasons: visible_failure_reasons %>
-
-            <% if (hidden_failure_reasons = description_vars[:hidden_failure_reasons]).present? %>
-              <%= govuk_details(summary_text: "View additional reasons") do %>
-                <%= render "timeline_entry/failure_reasons", failure_reasons: hidden_failure_reasons %>
-              <% end %>
-            <% end %>
+            <%= render "timeline_entry/failure_reasons", failure_reasons: failure_reasons %>
           </ul>
         <% end %>
       <% end %>
     <% elsif timeline_event.requestable_reviewed? %>
       <p class="govuk-body">
-        Status has changed to: <%= render(StatusTag::Component.new(description_vars[:new_status])) %>
+        Status has changed to <%= render(StatusTag::Component.new(description_vars[:new_status])) %>
       </p>
 
       <% if (note = description_vars[:note]).present? %>
@@ -49,7 +42,7 @@
       <% end %>
     <% elsif timeline_event.requestable_verified? %>
       <p class="govuk-body">
-        Status has changed to: <%= render(StatusTag::Component.new(description_vars[:new_status])) %>
+        Status has changed to <%= render(StatusTag::Component.new(description_vars[:new_status])) %>
       </p>
 
       <% if (note = description_vars[:note]).present? %>
@@ -64,7 +57,7 @@
 
     <% elsif timeline_event.application_declined? %>
       <p class="govuk-body">
-        Status has changed to: <%= render(StatusTag::Component.new(:declined)) %>
+        Status has changed to <%= render(StatusTag::Component.new(:declined)) %>
       </p>
 
       <% TeacherInterface::ApplicationFormViewObject.new(application_form: timeline_event.application_form).declined_reasons.each do |title, reasons| %>

--- a/app/components/timeline_entry/component.html.erb
+++ b/app/components/timeline_entry/component.html.erb
@@ -38,7 +38,9 @@
       </p>
 
       <% if (note = description_vars[:note]).present? %>
-        <%= govuk_inset_text { simple_format note } %>
+        <%= govuk_details(summary_text: "View details") do %>
+          <%= simple_format note, class: "govuk-hint" %>
+        <% end %>
       <% end %>
     <% elsif timeline_event.requestable_verified? %>
       <p class="govuk-body">
@@ -46,7 +48,9 @@
       </p>
 
       <% if (note = description_vars[:note]).present? %>
-        <%= govuk_inset_text { simple_format note } %>
+        <%= govuk_details(summary_text: "View details") do %>
+          <%= simple_format note, class: "govuk-hint" %>
+        <% end %>
       <% end %>
     <% elsif timeline_event.information_changed? %>
       <p class="govuk-body">

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -19,6 +19,8 @@ module TimelineEntry
       locale_key =
         if timeline_event.requestable_event_type?
           "components.timeline_entry.title.#{timeline_event.event_type}.#{timeline_event.requestable.class.name}"
+        elsif timeline_event.assessment_section_recorded?
+          "components.timeline_entry.title.assessment_section_recorded.#{timeline_event.assessment_section.key}"
         else
           "components.timeline_entry.title.#{timeline_event.event_type}"
         end
@@ -98,18 +100,7 @@ module TimelineEntry
       {
         section_name: assessment_section.key.titleize,
         status:,
-        visible_failure_reasons:
-          if selected_failure_reasons.count <= 2
-            selected_failure_reasons
-          else
-            selected_failure_reasons.take(1)
-          end,
-        hidden_failure_reasons:
-          if selected_failure_reasons.count <= 2
-            []
-          else
-            selected_failure_reasons.drop(1)
-          end,
+        failure_reasons: selected_failure_reasons,
       }
     end
 

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -20,7 +20,17 @@ module TimelineEntry
         if timeline_event.requestable_event_type?
           "components.timeline_entry.title.#{timeline_event.event_type}.#{timeline_event.requestable.class.name}"
         elsif timeline_event.assessment_section_recorded?
-          "components.timeline_entry.title.assessment_section_recorded.#{timeline_event.assessment_section.key}"
+          preliminary_or_not =
+            (
+              if timeline_event.assessment_section.preliminary?
+                "preliminary"
+              else
+                "not_preliminary"
+              end
+            )
+
+          "components.timeline_entry.title.assessment_section_recorded" \
+            ".#{preliminary_or_not}.#{timeline_event.assessment_section.key}"
         else
           "components.timeline_entry.title.#{timeline_event.event_type}"
         end

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -56,12 +56,15 @@ en:
         age_range_subjects_verified: Age range and subjects verified
         application_declined: Application declined
         assessment_section_recorded:
-          age_range_subjects: Age range subjects assessed
-          english_language_proficiency: English language proficiency assessed
-          personal_information: Personal information assessed
-          professional_standing: Professional standing assessed
-          qualifications: Qualifications assessed
-          work_history: Work history assessed
+          not_preliminary:
+            age_range_subjects: Age range subjects assessed
+            english_language_proficiency: English language proficiency assessed
+            personal_information: Personal information assessed
+            professional_standing: Professional standing assessed
+            qualifications: Qualifications assessed
+            work_history: Work history assessed
+          preliminary:
+            qualifications: Preliminary check (qualifications) assessed
         assessor_assigned: Assessor assigned
         email_sent: Email sent
         information_changed: Information changed after submission

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -55,7 +55,13 @@ en:
         action_required_by_changed: Action required by changed
         age_range_subjects_verified: Age range and subjects verified
         application_declined: Application declined
-        assessment_section_recorded: Section assessed
+        assessment_section_recorded:
+          age_range_subjects: Age range subjects assessed
+          english_language_proficiency: English language proficiency assessed
+          personal_information: Personal information assessed
+          professional_standing: Professional standing assessed
+          qualifications: Qualifications assessed
+          work_history: Work history assessed
         assessor_assigned: Assessor assigned
         email_sent: Email sent
         information_changed: Information changed after submission

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -102,7 +102,6 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
 
     it "describes the event" do
-      expect(component.text).to include("Personal Information:")
       expect(component.text).to include("Rejected")
       expect(component.text).to include(expected_failure_reason_text)
       expect(component.text).to include(failure_reason.assessor_feedback)
@@ -422,7 +421,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
 
     it "describes the event" do
-      expect(component.text).to include("Status has changed to: Rejected")
+      expect(component.text).to include("Status has changed to Rejected")
       expect(component.text).to include("For this reason.")
     end
 
@@ -442,7 +441,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
 
     it "describes the event" do
-      expect(component.text).to include("Status has changed to: Accepted")
+      expect(component.text).to include("Status has changed to Accepted")
     end
 
     it "attributes to the creator" do
@@ -461,7 +460,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
 
     it "describes the event" do
-      expect(component.text).to include("Status has changed to: Rejected")
+      expect(component.text).to include("Status has changed to Rejected")
     end
 
     it "attributes to the creator" do
@@ -480,7 +479,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
 
     it "describes the event" do
-      expect(component.text).to include("Status has changed to: Accepted")
+      expect(component.text).to include("Status has changed to Accepted")
     end
 
     it "attributes to the creator" do
@@ -499,7 +498,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
 
     it "describes the event" do
-      expect(component.text).to include("Status has changed to: Rejected")
+      expect(component.text).to include("Status has changed to Rejected")
     end
 
     it "attributes to the creator" do
@@ -518,7 +517,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
 
     it "describes the event" do
-      expect(component.text).to include("Status has changed to: Accepted")
+      expect(component.text).to include("Status has changed to Accepted")
     end
 
     it "attributes to the creator" do
@@ -537,7 +536,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
 
     it "describes the event" do
-      expect(component.text).to include("Status has changed to: Rejected")
+      expect(component.text).to include("Status has changed to Rejected")
     end
 
     it "attributes to the creator" do

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
 
     it "describes the event" do
+      expect(component.text).to include("Personal information assessed")
       expect(component.text).to include("Rejected")
       expect(component.text).to include(expected_failure_reason_text)
       expect(component.text).to include(failure_reason.assessor_feedback)
@@ -109,6 +110,18 @@ RSpec.describe TimelineEntry::Component, type: :component do
 
     it "attributes to the creator" do
       expect(component.text).to include(creator.name)
+    end
+
+    context "when the assessment section is preliminary" do
+      let(:assessment_section) do
+        create(:assessment_section, :preliminary, :failed)
+      end
+
+      it "describes the event" do
+        expect(component.text).to include(
+          "Preliminary check (qualifications) assessed",
+        )
+      end
     end
   end
 


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-873

Updating `Section assessed` title to `section_name assessed` and removing the name of the section in the description below.
![Screenshot 2025-04-30 at 13 58 40](https://github.com/user-attachments/assets/89cfe730-c2a3-4d4a-aaa9-2d8cf7a31774)

Updating how the decline reasons appear under a section being rejected within timeline.
![Screenshot 2025-04-30 at 13 59 16](https://github.com/user-attachments/assets/4a6b0545-dd0b-43e7-82dd-fd81470d3510)

Removing the colon ':' from the "Status has changed to:"
![Screenshot 2025-04-30 at 14 00 01](https://github.com/user-attachments/assets/94aa1b18-ad7c-496f-897e-16ccb712818f)
