### PR TITLE
[AQTS-955] Adding new failure reason for ESOL expired

### DIFF
--- a/app/lib/assessment_factories/english_language_proficiency_section.rb
+++ b/app/lib/assessment_factories/english_language_proficiency_section.rb
@@ -31,6 +31,7 @@ module AssessmentFactories
           [
             FailureReasons::EL_REQUIRE_ALTERNATIVE,
             FailureReasons::EL_ESOL_DOCUMENT_ILLEGIBLE,
+            FailureReasons::EL_ESOL_EXPIRED,
             FailureReasons::EL_ESOL_EXPIRED_DURING_ASSESSMENT,
             FailureReasons::EL_QUALIFICATION_INVALID,
             FailureReasons::EL_ESOL_BELOW_REQUIRED_LEVEL,

--- a/app/lib/assessment_factories/english_language_proficiency_section.rb
+++ b/app/lib/assessment_factories/english_language_proficiency_section.rb
@@ -47,7 +47,6 @@ module AssessmentFactories
             ),
             FailureReasons::EL_GRADE_BELOW_B2,
             FailureReasons::EL_SELT_EXPIRED,
-            FailureReasons::EL_SELT_EXPIRED_DURING_ASSESSMENT,
             FailureReasons::EL_REQUIRE_ALTERNATIVE,
           ]
         end

--- a/app/lib/assessment_factories/english_language_proficiency_section.rb
+++ b/app/lib/assessment_factories/english_language_proficiency_section.rb
@@ -32,7 +32,6 @@ module AssessmentFactories
             FailureReasons::EL_REQUIRE_ALTERNATIVE,
             FailureReasons::EL_ESOL_DOCUMENT_ILLEGIBLE,
             FailureReasons::EL_ESOL_EXPIRED,
-            FailureReasons::EL_ESOL_EXPIRED_DURING_ASSESSMENT,
             FailureReasons::EL_QUALIFICATION_INVALID,
             FailureReasons::EL_ESOL_BELOW_REQUIRED_LEVEL,
           ]

--- a/app/lib/failure_reasons.rb
+++ b/app/lib/failure_reasons.rb
@@ -18,6 +18,7 @@ class FailureReasons
     EL_GRADE_BELOW_B2 = "english_language_not_achieved_b2",
     EL_MOI_NOT_TAUGHT_IN_ENGLISH = "english_language_moi_not_taught_in_english",
     EL_QUALIFICATION_INVALID = "english_language_qualification_invalid",
+    EL_ESOL_EXPIRED = "english_language_esol_expired",
     EL_SELT_EXPIRED = "english_language_selt_expired",
     FRAUD = "fraud",
     FULL_PROFESSIONAL_STATUS = "full_professional_status",

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -172,7 +172,7 @@ en:
           english_language_qualification_invalid: The applicant’s English language qualification is not from one of the approved providers.
           english_language_esol_expired: The applicant provided evidence of an ESOL but the test was not completed within the last 2 years.
           english_language_selt_expired: The applicant provided evidence of a SELT but the test was not completed within the last 2 years.
-          english_language_selt_expired_during_assessment: The SELT evidence expired whilst the applicant waited for initial assessment.
+          english_language_selt_expired_during_assessment: "[DO NOT USE] The SELT evidence expired whilst the applicant waited for initial assessment."
           english_language_unverifiable_reference_number: There’s a problem with the reference number, for example, it’s incorrect and can’t be verified.
           fraud: Applicant has provided information that cannot be verified and is potentially fraudulent.
           full_professional_status: Recognition level as a teacher does not match the required level, or has outstanding additional conditions.

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -170,6 +170,7 @@ en:
           english_language_proficiency_document_illegible: There’s a problem with the English language proficiency test document, for example, it’s incorrect, illegible, or incomplete.
           english_language_proficiency_require_alternative: The applicant needs to provide an MOI to verify their English language proficiency.
           english_language_qualification_invalid: The applicant’s English language qualification is not from one of the approved providers.
+          english_language_esol_expired: The applicant provided evidence of an ESOL but the test was not completed within the last 2 years.
           english_language_selt_expired: The applicant provided evidence of a SELT but the test was not completed within the last 2 years.
           english_language_selt_expired_during_assessment: The SELT evidence expired whilst the applicant waited for initial assessment.
           english_language_unverifiable_reference_number: There’s a problem with the reference number, for example, it’s incorrect and can’t be verified.

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -170,7 +170,7 @@ en:
           english_language_proficiency_document_illegible: There’s a problem with the English language proficiency test document, for example, it’s incorrect, illegible, or incomplete.
           english_language_proficiency_require_alternative: The applicant needs to provide an MOI to verify their English language proficiency.
           english_language_qualification_invalid: The applicant’s English language qualification is not from one of the approved providers.
-          english_language_esol_expired: The applicant provided evidence of an ESOL but the test was not completed within the last 2 years.
+          english_language_esol_expired: The applicant provided evidence of an ESOL but it was not completed within the last 2 years.
           english_language_selt_expired: The applicant provided evidence of a SELT but the test was not completed within the last 2 years.
           english_language_selt_expired_during_assessment: "[DO NOT USE] The SELT evidence expired whilst the applicant waited for initial assessment."
           english_language_unverifiable_reference_number: There’s a problem with the reference number, for example, it’s incorrect and can’t be verified.

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -28,7 +28,7 @@ en:
             english_language_proficiency_document_illegible: There’s a problem with your English language proficiency test document.
             english_language_proficiency_require_alternative: You need to provide another way to verify your English language proficiency.
             english_language_qualification_invalid: Your English language qualification is not from one of the approved providers.
-            english_language_esol_expired: You have provided evidence of your English for Speakers of Other Languages (ESOL) certificate but the test was not completed within the last 2 years.
+            english_language_esol_expired: You have provided evidence of an English for Speakers of Other Languages (ESOL) certificate but it was not completed within the last 2 years.
             english_language_selt_expired: You have provided evidence of a secure English language test (SELT) but the test was not completed within the last 2 years.
             english_language_selt_expired_during_assessment: You have provided evidence of a secure English language test (SELT) but the test was completed more than 2 years ago.
             english_language_unverifiable_reference_number: We were unable to verify the reference number you have provided.

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -28,6 +28,7 @@ en:
             english_language_proficiency_document_illegible: There’s a problem with your English language proficiency test document.
             english_language_proficiency_require_alternative: You need to provide another way to verify your English language proficiency.
             english_language_qualification_invalid: Your English language qualification is not from one of the approved providers.
+            english_language_esol_expired: You have provided evidence of your English for Speakers of Other Languages (ESOL) certificate but the test was not completed within the last 2 years.
             english_language_selt_expired: You have provided evidence of a secure English language test (SELT) but the test was not completed within the last 2 years.
             english_language_selt_expired_during_assessment: You have provided evidence of a secure English language test (SELT) but the test was completed more than 2 years ago.
             english_language_unverifiable_reference_number: We were unable to verify the reference number you have provided.

--- a/spec/jobs/sync_assessment_checks_and_failure_reasons_job_spec.rb
+++ b/spec/jobs/sync_assessment_checks_and_failure_reasons_job_spec.rb
@@ -160,7 +160,6 @@ RSpec.describe SyncAssessmentChecksAndFailureReasonsJob do
           english_language_unverifiable_reference_number
           english_language_not_achieved_b2
           english_language_selt_expired
-          english_language_selt_expired_during_assessment
           english_language_proficiency_require_alternative
         ],
       )

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -444,6 +444,7 @@ RSpec.describe AssessmentFactory do
               %w[
                 english_language_proficiency_require_alternative
                 english_language_esol_document_illegible
+                english_language_esol_expired
                 english_language_esol_expired_during_assessment
                 english_language_qualification_invalid
                 english_language_esol_below_required_level

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -400,7 +400,6 @@ RSpec.describe AssessmentFactory do
                 english_language_unverifiable_reference_number
                 english_language_not_achieved_b2
                 english_language_selt_expired
-                english_language_selt_expired_during_assessment
                 english_language_proficiency_require_alternative
                 suitability
                 suitability_previously_declined
@@ -421,7 +420,6 @@ RSpec.describe AssessmentFactory do
                   english_language_proficiency_document_illegible
                   english_language_not_achieved_b2
                   english_language_selt_expired
-                  english_language_selt_expired_during_assessment
                   english_language_proficiency_require_alternative
                   suitability
                   suitability_previously_declined

--- a/spec/lib/assessment_factory_spec.rb
+++ b/spec/lib/assessment_factory_spec.rb
@@ -445,7 +445,6 @@ RSpec.describe AssessmentFactory do
                 english_language_proficiency_require_alternative
                 english_language_esol_document_illegible
                 english_language_esol_expired
-                english_language_esol_expired_during_assessment
                 english_language_qualification_invalid
                 english_language_esol_below_required_level
                 suitability


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-955

1. Adding new ESOL expired decline reason to applications that have ESOL as an option to prove English language proficiency (ELP).
2. Remove the existing ESOL expired during assessment FI reason - This will be applied to new and existing applications.
3. Remove the existing SELT expired during assessment FI reason - This will be applies to new applications while existing applications will have a "[DO NOT USE]" at the beginning of this FI reasons for the assessor.

### Post release action

Given that there are a few applications from the relevant country and with ESOL selected, we need to add this new reason to those existing submissions after we release the feature.

This can be done by running: `SyncAssessmentChecksAndFailureReasonsJob.perform_later(assessment)` for each of those application assessments.

It's important to note that we're only doing this to applications that have not yet started their assessment (which happens to be the case for all the applications with ESOL since it's a newly released feature)