### PR TITLE
AQTS 978 unlinking onelogin accounts

### DIFF
--- a/app/services/find_or_create_teacher_from_gov_one.rb
+++ b/app/services/find_or_create_teacher_from_gov_one.rb
@@ -34,11 +34,7 @@ class FindOrCreateTeacherFromGovOne
       Teacher.find_by(gov_one_id:) || Teacher.find_by(email:) ||
         Teacher.create!(email:)
 
-    if teacher.gov_one_id.nil?
-      teacher.update!(gov_one_id:, gov_one_email: email)
-    else
-      teacher.update!(gov_one_email: email)
-    end
+    teacher.update!(gov_one_id:, gov_one_email: email)
   end
 
   def create_application_form!

--- a/spec/services/find_or_create_teacher_from_gov_one_spec.rb
+++ b/spec/services/find_or_create_teacher_from_gov_one_spec.rb
@@ -133,4 +133,19 @@ RSpec.describe FindOrCreateTeacherFromGovOne do
       expect(existing_teacher_matching_id.reload.gov_one_email).to eq(email)
     end
   end
+
+  context "when a teacher record exists with one gov_one_id and gets updated with a new one" do
+    let!(:existing_teacher) { create :teacher, email:, gov_one_id: "old-gov-one-id" }
+    let(:gov_one_id) { "new-gov-one-id" }
+  
+    it "does not generate a new teacher record" do
+      expect { call }.not_to change(Teacher, :count)
+    end
+
+    it "updates the gov_one_id on the existing teacher record" do
+      call
+      expect(existing_teacher.reload.gov_one_id).to eq(gov_one_id)
+    end
+  
+  end
 end

--- a/spec/services/find_or_create_teacher_from_gov_one_spec.rb
+++ b/spec/services/find_or_create_teacher_from_gov_one_spec.rb
@@ -135,9 +135,11 @@ RSpec.describe FindOrCreateTeacherFromGovOne do
   end
 
   context "when a teacher record exists with one gov_one_id and gets updated with a new one" do
-    let!(:existing_teacher) { create :teacher, email:, gov_one_id: "old-gov-one-id" }
+    let!(:existing_teacher) do
+      create :teacher, email:, gov_one_id: "old-gov-one-id"
+    end
     let(:gov_one_id) { "new-gov-one-id" }
-  
+
     it "does not generate a new teacher record" do
       expect { call }.not_to change(Teacher, :count)
     end
@@ -146,6 +148,5 @@ RSpec.describe FindOrCreateTeacherFromGovOne do
       call
       expect(existing_teacher.reload.gov_one_id).to eq(gov_one_id)
     end
-  
   end
 end


### PR DESCRIPTION
This pr makes a change to gov onelogin so that similar to `gov_one_email` the `gov_one_id` is updated every time someone logs in.

https://dfedigital.atlassian.net/jira/software/projects/AQTS/boards/207?selectedIssue=AQTS-978