### PR TITLE
Add ingress rate limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ bin/konduit.sh
 .terraform
 terraform/*token*
 terraform/*/vendor
+terraform/domains/*/vendor/

--- a/terraform/domains/environment_domains/config/production.tfvars.json
+++ b/terraform/domains/environment_domains/config/production.tfvars.json
@@ -2,5 +2,16 @@
   "domains": ["www", "apex"],
   "environment_short": "pd",
   "environment_tag": "Prod",
-  "origin_hostname": "apply-for-qts-production-web.teacherservices.cloud"
+  "origin_hostname": "apply-for-qts-production-web.teacherservices.cloud",
+  "rate_limit": [
+    {
+      "agent": "all",
+      "priority": 100,
+      "duration": 5,
+      "limit": 300,
+      "selector": "Host",
+      "operator": "GreaterThanOrEqual",
+      "match_values": "0"
+    }
+  ]
 }

--- a/terraform/domains/environment_domains/main.tf
+++ b/terraform/domains/environment_domains/main.tf
@@ -6,6 +6,7 @@ module "domains" {
   domains             = var.domains
   environment         = var.environment_short
   host_name           = var.origin_hostname
+  rate_limit          = try(var.rate_limit, null)
 }
 
 data "azurerm_cdn_frontdoor_profile" "main" {

--- a/terraform/domains/environment_domains/variables.tf
+++ b/terraform/domains/environment_domains/variables.tf
@@ -35,6 +35,19 @@ variable "origin_hostname" {
   description = "Origin endpoint url"
 }
 
+variable "rate_limit" {
+  type = list(object({
+    agent        = optional(string)
+    priority     = optional(number)
+    duration     = optional(number)
+    limit        = optional(number)
+    selector     = optional(string)
+    operator     = optional(string)
+    match_values = optional(string)
+  }))
+  default = null
+}
+
 locals {
   hostname = "${var.domains[0]}.${var.zone}"
 }


### PR DESCRIPTION
### Context

Configure rate limiting for production

### Changes proposed in this pull request

Add global rate limit per IP for 5 minute intervals
Value for global rate set from checking ingress logs for the last 2 weeks and is higher than any 10 minute period in that time.

### Guidance to review

make production deploy-plan

### Link to Trello card

https://trello.com/c/rmljcE5W/2345-add-rate-limiting-for-services
