### PR TITLE
AQTS 787 error message location

### DIFF
--- a/app/views/assessor_interface/assessment_sections/_form.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_form.html.erb
@@ -1,5 +1,5 @@
 <%= form_with model: form, url: [:assessor_interface, view_object.application_form, view_object.assessment, @view_object.assessment_section], method: :put do |f| %>
-  <%= f.govuk_error_summary %>
+  <%= content_for(:error_summary) { f.govuk_error_summary } %>
 
   <% if view_object.show_english_language_exemption_checkbox? %>
     <% if view_object.assessment_section.personal_information? %>

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -10,6 +10,8 @@
           application_forms_contact_email_used_as_teacher: @view_object.work_history_application_forms_contact_email_used_as_teacher,
           application_forms_contact_email_used_as_reference: @view_object.work_history_application_forms_contact_email_used_as_reference %>
 
+<%= yield :error_summary %>
+
 <%= render "shared/assessor_header",
            title: t(".title.#{preliminary_key}.#{section_key}"),
            application_form: @view_object.application_form %>


### PR DESCRIPTION
This pr moves the error message to the top of the Check English language proficiency page.

https://dfedigital.atlassian.net/jira/software/projects/AQTS/boards/207?selectedIssue=AQTS-787