### PR TITLE
Revert "AQTS 787 error message location"

### DIFF
--- a/app/views/assessor_interface/assessment_sections/_english_language_exemption_content.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_english_language_exemption_content.html.erb
@@ -1,5 +1,3 @@
-<%= yield :assessment_section_top_of_form %>
-
 <% if application_form.english_language_citizenship_exempt %>
   <h2 class="govuk-heading-m">English language exemption by birth/citizenship</h2>
   <p class="govuk-body">

--- a/app/views/assessor_interface/assessment_sections/_form.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_form.html.erb
@@ -1,8 +1,6 @@
 <%= form_with model: form, url: [:assessor_interface, view_object.application_form, view_object.assessment, @view_object.assessment_section], method: :put do |f| %>
   <%= f.govuk_error_summary %>
-  
-  <%= yield :assessment_section_top_of_form %>
-  
+
   <% if view_object.show_english_language_exemption_checkbox? %>
     <% if view_object.assessment_section.personal_information? %>
       <% english_language_section_passed_label = t("#{view_object.assessment_section.key}_#{view_object.application_form.requires_passport_as_identity_proof? ? 'passport' : 'id'}", scope: %i[assessor_interface assessment_sections english_language_proficiency passed]) %>

--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -5,26 +5,25 @@
 
 <% content_for :page_title, title_with_error_prefix(t(".title.#{preliminary_key}.#{section_key}"), error: @form.errors.any?) %>
 <% content_for :back_link_url, assessor_interface_application_form_path(@application_form) %>
-<% content_for(:assessment_section_top_of_form) do %>
-  <%= render "linked_application_forms",
-            application_forms_contact_email_used_as_teacher: @view_object.work_history_application_forms_contact_email_used_as_teacher,
-            application_forms_contact_email_used_as_reference: @view_object.work_history_application_forms_contact_email_used_as_reference %>
 
-  <%= render "shared/assessor_header",
-            title: t(".title.#{preliminary_key}.#{section_key}"),
-            application_form: @view_object.application_form %>
+<%= render "linked_application_forms",
+          application_forms_contact_email_used_as_teacher: @view_object.work_history_application_forms_contact_email_used_as_teacher,
+          application_forms_contact_email_used_as_reference: @view_object.work_history_application_forms_contact_email_used_as_reference %>
 
-  <% if @view_object.show_teacher_name_and_date_of_birth? %>
-    <h2 class="govuk-heading-m"><%= @view_object.teacher_name_and_date_of_birth %></h2>
-  <% end %>
+<%= render "shared/assessor_header",
+           title: t(".title.#{preliminary_key}.#{section_key}"),
+           application_form: @view_object.application_form %>
 
-  <%= render "#{section_key}_summary",
-            region: @view_object.region,
-            application_form: @view_object.application_form,
-            assessment: @view_object.assessment,
-            assessment_section: @view_object.assessment_section,
-            highlighted_work_history_contact_emails: @view_object.highlighted_work_history_contact_emails %>
+<% if @view_object.show_teacher_name_and_date_of_birth? %>
+  <h2 class="govuk-heading-m"><%= @view_object.teacher_name_and_date_of_birth %></h2>
 <% end %>
+
+<%= render "#{section_key}_summary",
+           region: @view_object.region,
+           application_form: @view_object.application_form,
+           assessment: @view_object.assessment,
+           assessment_section: @view_object.assessment_section,
+           highlighted_work_history_contact_emails: @view_object.highlighted_work_history_contact_emails %>
 
 <% if @view_object.show_form? %>
   <%= render "form", form: @form, view_object: @view_object %>

--- a/spec/support/autoload/page_objects/assessor_interface/assessment_section.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/assessment_section.rb
@@ -19,7 +19,7 @@ module PageObjects
                  ".govuk-checkboxes__item"
         elements :failure_reason_note_textareas,
                  ".govuk-checkboxes__conditional .govuk-textarea"
-        element :continue_button, "button.govuk-button"
+        element :continue_button, "button"
       end
 
       section :preliminary_form, "form" do


### PR DESCRIPTION
Reverts DFE-Digital/apply-for-qualified-teacher-status#2761

This causes issues where on "Check professional standing" where "show_form?" in the view object returns false and as a result there is no content for "assessment_section_top_of_form" being displayed.