### PR TITLE
Fix bug for assessment section that does not yield the top of form section

### DIFF
--- a/app/views/assessor_interface/assessment_sections/show.html.erb
+++ b/app/views/assessor_interface/assessment_sections/show.html.erb
@@ -28,8 +28,8 @@
 
 <% if @view_object.show_form? %>
   <%= render "form", form: @form, view_object: @view_object %>
-<% end %>
-
-<% if @view_object.show_english_language_exemption_content? %>
+<% elsif @view_object.show_english_language_exemption_content? %>
   <%= render "english_language_exemption_content", application_form: @view_object.application_form %>
+<% else %>
+  <%= yield :assessment_section_top_of_form %>
 <% end %>


### PR DESCRIPTION
The issue came up as as we got a report from one of the assessors that the "Check professional standing" request is showing an empty page.

THis was due to the fact that both `@view_object.show_form?` and `@view_object.show_english_language_exemption_content?` were returning false and the content for `assessment_section_top_of_form` was not being yielded. 

This change ensures that we always show the top of form info even if no form or ELP content can be displayed.