### PR TITLE
AQTS-1037-error-message-bug-fix

### DIFF
--- a/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
+++ b/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
@@ -35,7 +35,7 @@ module AssessorInterface::AgeRangeSubjectsForm
     attribute :subject_3_raw, :string
     attribute :subjects_note, :string
 
-    validates :subject_1, presence: true
+    validate :subject_1_is_present
   end
 
   def save
@@ -73,5 +73,11 @@ module AssessorInterface::AgeRangeSubjectsForm
 
     application_form.age_range_min != age_range_min ||
       application_form.age_range_max != age_range_max
+  end
+
+  def subject_1_is_present
+    return if subject_1.present? && subject_1_raw.present?
+
+    errors.add(:subject_1, :blank)
   end
 end

--- a/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
+++ b/app/forms/concerns/assessor_interface/age_range_subjects_form.rb
@@ -36,7 +36,6 @@ module AssessorInterface::AgeRangeSubjectsForm
     attribute :subjects_note, :string
 
     validates :subject_1, presence: true
-    validates :subject_1_raw, presence: true
   end
 
   def save

--- a/app/views/shared/_age_range_subjects_form_fields.html.erb
+++ b/app/views/shared/_age_range_subjects_form_fields.html.erb
@@ -15,18 +15,40 @@
 <p class="govuk-hint">You can enter up to three</p>
 <p class="govuk-body">Based on the evidence the applicant has provided, you can either copy the subjects they entered if you agree, or edit them.</p>
 
-<% (1..3).map { |i| "subject_#{i}" }.each do |field| %>
-  <%= render DfE::Autocomplete::View.new(
-    f,
-    attribute_name: field,
-    form_field: f.govuk_select(
-      field,
-      options_for_select(
-        dfe_autocomplete_options(Subject.all),
-        f.object.send(field),
-      )
+<%= render DfE::Autocomplete::View.new(
+  f,
+  attribute_name: :subject_1,
+  form_field: f.govuk_select(
+    :subject_1,
+    options_for_select(
+      dfe_autocomplete_options(Subject.all),
+      f.object.send(:subject_1),
     )
-  ) %>
-<% end %>
+  )
+) %>
+
+<%= render DfE::Autocomplete::View.new(
+  f,
+  attribute_name: :subject_2,
+  form_field: f.govuk_select(
+    :subject_2,
+    options_for_select(
+      dfe_autocomplete_options(Subject.all),
+      f.object.send(:subject_2),
+    )
+  )
+) %>
+
+<%= render DfE::Autocomplete::View.new(
+  f,
+  attribute_name: :subject_3,
+  form_field: f.govuk_select(
+    :subject_3,
+    options_for_select(
+      dfe_autocomplete_options(Subject.all),
+      f.object.send(:subject_3),
+    )
+  )
+) %>
 
 <%= f.govuk_text_area :subjects_note, label: { text: t("helpers.label.assessor_interface_assessment_section_form.subjects_note").html_safe } %>

--- a/spec/support/shared_examples/age_range_subjects_form.rb
+++ b/spec/support/shared_examples/age_range_subjects_form.rb
@@ -79,11 +79,7 @@ RSpec.shared_examples_for "an age range subjects form" do
 
       it "adds an error to subject_1" do
         form.valid?
-        expect(form.errors[:subject_1]).to include(
-          I18n.t(
-            "activemodel.errors.models.assessor_interface/assessment_section_form.attributes.subject_1.blank",
-          ),
-        )
+        expect(form.errors[:subject_1]).to include(I18n.t("Enter the subject"))
       end
     end
 
@@ -97,11 +93,7 @@ RSpec.shared_examples_for "an age range subjects form" do
 
       it "adds an error to subject_1" do
         form.valid?
-        expect(form.errors[:subject_1]).to include(
-          I18n.t(
-            "activemodel.errors.models.assessor_interface/assessment_section_form.attributes.subject_1.blank",
-          ),
-        )
+        expect(form.errors[:subject_1]).to include(I18n.t("Enter the subject"))
       end
     end
 
@@ -115,11 +107,7 @@ RSpec.shared_examples_for "an age range subjects form" do
 
       it "adds an error to subject_1" do
         form.valid?
-        expect(form.errors[:subject_1]).to include(
-          I18n.t(
-            "activemodel.errors.models.assessor_interface/assessment_section_form.attributes.subject_1.blank",
-          ),
-        )
+        expect(form.errors[:subject_1]).to include(I18n.t("Enter the subject"))
       end
     end
 

--- a/spec/support/shared_examples/age_range_subjects_form.rb
+++ b/spec/support/shared_examples/age_range_subjects_form.rb
@@ -69,8 +69,60 @@ RSpec.shared_examples_for "an age range subjects form" do
 
     it { is_expected.not_to validate_presence_of(:age_range_note) }
 
-    it { is_expected.to validate_presence_of(:subject_1) }
-    it { is_expected.not_to validate_presence_of(:subject_1_raw) }
+    context "when subject_1 is present but subject_1_raw is missing" do
+      before do
+        age_range_subjects_attributes[:subject_1] = "Math"
+        age_range_subjects_attributes[:subject_1_raw] = ""
+      end
+
+      it { is_expected.to be_invalid }
+
+      it "adds an error to subject_1" do
+        form.valid?
+        expect(form.errors[:subject_1]).to include(
+          I18n.t(
+            "activemodel.errors.models.assessor_interface/assessment_section_form.attributes.subject_1.blank",
+          ),
+        )
+      end
+    end
+
+    context "when subject_1 is missing but subject_1_raw is present" do
+      before do
+        age_range_subjects_attributes[:subject_1] = ""
+        age_range_subjects_attributes[:subject_1_raw] = "Mathematics"
+      end
+
+      it { is_expected.to be_invalid }
+
+      it "adds an error to subject_1" do
+        form.valid?
+        expect(form.errors[:subject_1]).to include(
+          I18n.t(
+            "activemodel.errors.models.assessor_interface/assessment_section_form.attributes.subject_1.blank",
+          ),
+        )
+      end
+    end
+
+    context "when both subject_1 and subject_1_raw are missing" do
+      before do
+        age_range_subjects_attributes[:subject_1] = ""
+        age_range_subjects_attributes[:subject_1_raw] = ""
+      end
+
+      it { is_expected.to be_invalid }
+
+      it "adds an error to subject_1" do
+        form.valid?
+        expect(form.errors[:subject_1]).to include(
+          I18n.t(
+            "activemodel.errors.models.assessor_interface/assessment_section_form.attributes.subject_1.blank",
+          ),
+        )
+      end
+    end
+
     it { is_expected.not_to validate_presence_of(:subject_2) }
     it { is_expected.not_to validate_presence_of(:subject_3) }
     it { is_expected.not_to validate_presence_of(:subjects_note) }

--- a/spec/support/shared_examples/age_range_subjects_form.rb
+++ b/spec/support/shared_examples/age_range_subjects_form.rb
@@ -79,7 +79,7 @@ RSpec.shared_examples_for "an age range subjects form" do
 
       it "adds an error to subject_1" do
         form.valid?
-        expect(form.errors[:subject_1]).to include(I18n.t("Enter the subject"))
+        expect(form.errors[:subject_1]).to include("Enter the subject")
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.shared_examples_for "an age range subjects form" do
 
       it "adds an error to subject_1" do
         form.valid?
-        expect(form.errors[:subject_1]).to include(I18n.t("Enter the subject"))
+        expect(form.errors[:subject_1]).to include("Enter the subject")
       end
     end
 
@@ -107,7 +107,7 @@ RSpec.shared_examples_for "an age range subjects form" do
 
       it "adds an error to subject_1" do
         form.valid?
-        expect(form.errors[:subject_1]).to include(I18n.t("Enter the subject"))
+        expect(form.errors[:subject_1]).to include("Enter the subject")
       end
     end
 

--- a/spec/support/shared_examples/age_range_subjects_form.rb
+++ b/spec/support/shared_examples/age_range_subjects_form.rb
@@ -70,7 +70,7 @@ RSpec.shared_examples_for "an age range subjects form" do
     it { is_expected.not_to validate_presence_of(:age_range_note) }
 
     it { is_expected.to validate_presence_of(:subject_1) }
-    it { is_expected.to validate_presence_of(:subject_1_raw) }
+    it { is_expected.not_to validate_presence_of(:subject_1_raw) }
     it { is_expected.not_to validate_presence_of(:subject_2) }
     it { is_expected.not_to validate_presence_of(:subject_3) }
     it { is_expected.not_to validate_presence_of(:subjects_note) }


### PR DESCRIPTION
https://dfedigital.atlassian.net/jira/software/projects/AQTS/boards/207?selectedIssue=AQTS-1037

This pr is to fix the validation for the subject 1 field on the Verify age range and subjects page in the assessor view. 

![image](https://github.com/user-attachments/assets/b85f14e8-e7a3-41c2-b556-6805f4ce470e)
