### PR TITLE
Column on "further_information_request_items" table from blocklist to PII on DfE analytics dataform

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -171,6 +171,7 @@
     - contact_job
     - contact_name
     - created_at
+    - failure_reason_assessor_feedback
     - failure_reason_key
     - further_information_request_id
     - id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -41,7 +41,6 @@
   :further_information_requests:
     - review_note
   :further_information_request_items:
-    - failure_reason_assessor_feedback
     - response
   :notes:
     - text

--- a/config/analytics_hidden_pii.yml
+++ b/config/analytics_hidden_pii.yml
@@ -12,6 +12,7 @@
   :assessments:
     - recommendation_assessor_note
   :further_information_request_items:
+    - failure_reason_assessor_feedback
     - contact_email
     - contact_name
     - review_decision_note


### PR DESCRIPTION
This PR moves the "failure_reason_assessor_feedback" column on "further_information_request_items" table from blocklist to PII on DfE analytics dataform.

Corresponding dataform PR: https://github.com/DFE-Digital/apply-for-qualified-teacher-status-dataform/pull/195

Once deployed, we need to run `bundle exec rails dfe:analytics:import_entity['further_information_request_items']`