### PR TITLE
AQTS 1001 remove ecctis portal link

### DIFF
--- a/app/views/assessor_interface/qualification_requests/index_consent_methods.html.erb
+++ b/app/views/assessor_interface/qualification_requests/index_consent_methods.html.erb
@@ -6,7 +6,7 @@
 <p class="govuk-body">You need to:</p>
 
 <ul class="govuk-list govuk-list--bullet govuk-!-padding-bottom-4">
-  <li>go to the <%= govuk_link_to "Ecctis portal", "https://www.ecctis.com/login.aspx" %> to check the method of consent for each qualification</li>
+  <li>go to the Ecctis portal to check the method of consent for each qualification</li>
   <li>download any documents you may need</li>
   <li>return to this page to continue</li>
 </ul>


### PR DESCRIPTION
This pr removes the link around ecctis portal as it no longer takes you to a valid page

https://dfedigital.atlassian.net/browse/AQTS-1001