### PR TITLE
[AQTS-798] Ensure FI request pages/forms cannot be accessed if application form already declined

### DIFF
--- a/app/controllers/teacher_interface/further_information_requests_controller.rb
+++ b/app/controllers/teacher_interface/further_information_requests_controller.rb
@@ -5,6 +5,7 @@ module TeacherInterface
     include HistoryTrackable
 
     before_action :load_view_object
+    before_action :ensure_application_form_not_declined
 
     define_history_origin :show
     define_history_check :edit
@@ -29,6 +30,12 @@ module TeacherInterface
     def load_view_object
       @view_object =
         FurtherInformationRequestViewObject.new(current_teacher:, params:)
+    end
+
+    def ensure_application_form_not_declined
+      if @view_object.application_form.declined?
+        redirect_to %i[teacher_interface application_form]
+      end
     end
   end
 end

--- a/app/view_objects/teacher_interface/further_information_request_view_object.rb
+++ b/app/view_objects/teacher_interface/further_information_request_view_object.rb
@@ -59,6 +59,10 @@ module TeacherInterface
         end
     end
 
+    def application_form
+      @application_form ||= current_teacher.application_form
+    end
+
     private
 
     attr_reader :current_teacher, :params
@@ -73,9 +77,6 @@ module TeacherInterface
          Contact job: #{item.contact_job}<br/>
          Contact email: #{item.contact_email}".html_safe
       end
-    end
-    def application_form
-      @application_form ||= current_teacher.application_form
     end
 
     def item_name(item)


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-798

This bug fix addresses the issue where an application form previously requiring further information (FI) and has been declined due to the information not being submitted by the applicant in time, still having the ability to have the FI submitted if the applicant still has access to the link.

The fix includes a before_action which ensures that FI controller actions can only be accessed if the application form is not already declined.