### PR TITLE
[AQTS-1093] Prioritisation: invalidating the prioritisation referee link - rejected post overdue status

### DIFF
--- a/app/models/prioritisation_reference_request.rb
+++ b/app/models/prioritisation_reference_request.rb
@@ -46,7 +46,7 @@ class PrioritisationReferenceRequest < ApplicationRecord
 
   scope :respondable,
         -> do
-          joins(:assessment).requested.not_received.where(
+          joins(:assessment).requested.not_received.not_reviewed.where(
             assessment: {
               prioritisation_decision_at: nil,
             },

--- a/spec/system/teacher_interface/prioritisation_reference_spec.rb
+++ b/spec/system/teacher_interface/prioritisation_reference_spec.rb
@@ -89,7 +89,23 @@ RSpec.describe "Teacher prioritisation reference", type: :system do
     end
   end
 
-  context "when the prioritisation has already been made" do
+  context "when the reference was overdue and already reviewed" do
+    before do
+      prioritisation_reference_request.update!(
+        expired_at: 1.day.ago,
+        reviewed_at: Time.current,
+        review_passed: false,
+        review_note: "Failed",
+      )
+    end
+
+    it "lets the referee know that the reference is no longer required" do
+      when_i_visit_the(:teacher_prioritisation_reference_requested_page, slug:)
+      then_i_see_not_found_page
+    end
+  end
+
+  context "when the prioritisation decision has already been made" do
     before do
       prioritisation_reference_request.assessment.update!(
         prioritisation_decision_at: Time.current,


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1093

Ensure if an overdue prioritisation reference request has already been reviewed, then the referee can no longer respond to the reference request