### PR TITLE
[AQTS-1125] Ensure uploaded translated documents are displayed for FI responses

### DIFF
--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -32,7 +32,8 @@
         <% end %>
 
         <% if item[:applicant_upload_response] %>
-          <%= document_link_to(item.fetch(:applicant_upload_response)) %>
+          <% applicant_upload_response = item.fetch(:applicant_upload_response) %>
+          <%= document_link_to(applicant_upload_response, translated: applicant_upload_response.translated_uploads.any?) %>
         <% end %>
 
         <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Further information request</h3>


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1125

This fixes the bug where FI response where an upload has translation documents were not being surfaced to the assessor.
