### PR TITLE
Ensure whitespacing prepended and appended on family name is not sent to duplicate checks

### DIFF
--- a/app/lib/trs/find_teachers_params.rb
+++ b/app/lib/trs/find_teachers_params.rb
@@ -20,7 +20,7 @@ module TRS
             if reverse_name
               application_form.given_names.split(" ").first
             else
-              application_form.family_name
+              application_form.family_name.strip
             end
           ),
       }

--- a/spec/lib/trs/find_teachers_params_spec.rb
+++ b/spec/lib/trs/find_teachers_params_spec.rb
@@ -26,6 +26,27 @@ RSpec.describe TRS::FindTeachersParams do
       )
     end
 
+    context "when family name includes whitespace around the sides" do
+      let(:application_form) do
+        create(
+          :application_form,
+          date_of_birth: Date.new(1960, 1, 1),
+          given_names: "Rowdy Roddy",
+          family_name: " Piper Unknown  ",
+        )
+      end
+
+      it "returns camel case params with lastName trimmed" do
+        expect(call).to eq(
+          {
+            dateOfBirth: "1960-01-01",
+            findBy: "LastNameAndDateOfBirth",
+            lastName: "Piper Unknown",
+          },
+        )
+      end
+    end
+
     context "when reverse_name is true" do
       let(:reverse_name) { true }
 


### PR DESCRIPTION
We have recently had duplicate check against DQT/TRS not returning records because of whitespace appended on the family name. This PR ensures that whitespaces are trimmed on family name when doing checks on TRS