### PR TITLE
Moving application_forms_suitability_records to blocklist

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -64,9 +64,6 @@
     - written_statement_confirmation
     - written_statement_optional
     - written_statement_status
-  :application_forms_suitability_records:
-    - application_form_id
-    - suitability_record_id
   :assessment_sections:
     - assessed_at
     - assessment_id

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -20,6 +20,9 @@
     - name
     - record_id
     - record_type
+  :application_forms_suitability_records:
+    - application_form_id
+    - suitability_record_id
   :assessments:
     - age_range_note
     - qualifications_assessor_note


### PR DESCRIPTION
We are moving `application_forms_suitability_records` as this table doesn't seem to be accurate and used at all in analytics.