### PR TITLE
[AQTS-1177] Fix issue with most recent role being miscalculated and considering other England work history

### DIFF
--- a/app/forms/assessor_interface/select_work_histories_form.rb
+++ b/app/forms/assessor_interface/select_work_histories_form.rb
@@ -15,6 +15,7 @@ class AssessorInterface::SelectWorkHistoriesForm
                 form
                   .application_form
                   &.work_histories
+                  &.teaching_role
                   &.pluck(:id)
                   &.map(&:to_s) || []
               end,
@@ -46,7 +47,7 @@ class AssessorInterface::SelectWorkHistoriesForm
     return if application_form.region.checks_available?
 
     most_recent_work_history_id =
-      application_form.work_histories.order_by_role.first.id.to_s
+      application_form.work_histories.teaching_role.order_by_role.first.id.to_s
 
     unless work_history_ids.include?(most_recent_work_history_id)
       errors.add(:work_history_ids, :most_recent_not_selected)

--- a/spec/forms/assessor_interface/select_work_histories_form_spec.rb
+++ b/spec/forms/assessor_interface/select_work_histories_form_spec.rb
@@ -52,6 +52,48 @@ RSpec.describe AssessorInterface::SelectWorkHistoriesForm, type: :model do
 
       it { is_expected.not_to be_valid }
     end
+
+    context "when there is a most recent other England work history" do
+      let!(:work_history_3) do
+        create(
+          :work_history,
+          :completed,
+          :other_england_role,
+          application_form:,
+          start_date: Date.new(2024, 1, 1),
+        )
+      end
+
+      it do
+        expect(subject).to validate_inclusion_of(:work_history_ids).in_array(
+          [work_history_1.id.to_s, work_history_2.id.to_s],
+        )
+      end
+
+      context "with other England work history being submitted" do
+        let(:work_history_ids) do
+          [
+            work_history_1.id.to_s,
+            work_history_2.id.to_s,
+            work_history_3.id.to_s,
+          ]
+        end
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "with latest teaching work history" do
+        let(:work_history_ids) { [work_history_1.id.to_s] }
+
+        it { is_expected.to be_valid }
+      end
+
+      context "without latest teaching work history" do
+        let(:work_history_ids) { [work_history_2.id.to_s] }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
   end
 
   describe "#save" do


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1177

This PR addresses the issue when moving an application form into verification by verifying references, however because of the new prioritisation feature and the introduction of "Other England" work histories causing a miscalculation when identifying of the "most current" teaching role.