### PR TITLE
[AQTS-1191] New SLA status page within CMS to manage prioritisation SLA's

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ inherit_mode:
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
 
+Layout/LineLength:
+  Max: 130
+
 RSpec/AnyInstance:
   Enabled: false
 

--- a/app/controllers/assessor_interface/service_level_agreements_controller.rb
+++ b/app/controllers/assessor_interface/service_level_agreements_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AssessorInterface::ServiceLevelAgreementsController < AssessorInterface::BaseController
+  def index
+    authorize %i[assessor_interface service_level_agreement]
+
+    @view_object =
+      AssessorInterface::ServiceLevelAgreementIndexViewObject.new(params:)
+
+    render layout: "full_from_desktop"
+  end
+end

--- a/app/policies/assessor_interface/service_level_agreement_policy.rb
+++ b/app/policies/assessor_interface/service_level_agreement_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AssessorInterface::ServiceLevelAgreementPolicy < ApplicationPolicy
+  def index?
+    user.manage_staff_permission? && !user.archived?
+  end
+end

--- a/app/view_objects/assessor_interface/service_level_agreement_index_view_object.rb
+++ b/app/view_objects/assessor_interface/service_level_agreement_index_view_object.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+class AssessorInterface::ServiceLevelAgreementIndexViewObject
+  include ActionView::Helpers::FormOptionsHelper
+  include Pagy::Backend
+
+  def initialize(params:)
+    @params = params
+  end
+
+  def application_forms_pagy
+    application_forms_with_pagy.first
+  end
+
+  def application_forms_records
+    application_forms_with_pagy.last
+  end
+
+  def breached_sla_for_starting_prioritisation_checks_count
+    application_forms_with_prioritisation_checks_not_started.where(
+      "working_days_between_submitted_and_today > ?",
+      WORKING_DAYS_TO_START_PRIORITISATION_CHECKS,
+    ).count
+  end
+
+  def nearing_sla_for_starting_prioritisation_checks_count
+    application_forms_with_prioritisation_checks_not_started.where(
+      working_days_between_submitted_and_today:
+        WORKING_DAYS_NEARING_START_PRIORITISATION_CHECKS_DEADLINE..WORKING_DAYS_TO_START_PRIORITISATION_CHECKS,
+    ).count
+  end
+
+  def breached_sla_for_completing_prioritised_applications_count
+    application_forms_prioritised_but_assessment_not_completed.where(
+      "working_days_between_submitted_and_today > ?",
+      WORKING_DAYS_TO_FINISH_ASSESSMENT_FOR_PRIORITISED,
+    ).count
+  end
+
+  def nearing_sla_for_completing_prioritised_applications_count
+    application_forms_prioritised_but_assessment_not_completed.where(
+      working_days_between_submitted_and_today:
+        WORKING_DAYS_NEARING_FINISH_ASSESSMENT_FOR_PRIORITISED_DEADLINE..WORKING_DAYS_TO_FINISH_ASSESSMENT_FOR_PRIORITISED,
+    ).count
+  end
+
+  def sla_start_prioritisation_checks_tag_colour(application_form)
+    return if application_form.assessment.nil?
+
+    if application_form.assessment.started_at.present? ||
+         application_form.assessment.prioritisation_work_history_checks.empty?
+      return
+    end
+
+    if application_form.working_days_between_submitted_and_today.to_i >
+         WORKING_DAYS_TO_START_PRIORITISATION_CHECKS
+      "red"
+    elsif application_form.working_days_between_submitted_and_today.to_i >=
+          WORKING_DAYS_NEARING_START_PRIORITISATION_CHECKS_DEADLINE
+      "yellow"
+    else
+      "green"
+    end
+  end
+
+  def sla_completed_prioritised_tag_colour(application_form)
+    return if application_form.assessment.nil?
+
+    if !application_form.assessment.prioritised? ||
+         application_form.assessment.verification_started_at.present?
+      return
+    end
+
+    if application_form.working_days_between_submitted_and_today.to_i >
+         WORKING_DAYS_TO_FINISH_ASSESSMENT_FOR_PRIORITISED
+      "red"
+    elsif application_form.working_days_between_submitted_and_today.to_i >=
+          WORKING_DAYS_NEARING_FINISH_ASSESSMENT_FOR_PRIORITISED_DEADLINE
+      "yellow"
+    else
+      "green"
+    end
+  end
+
+  private
+
+  WORKING_DAYS_TO_START_PRIORITISATION_CHECKS = 10
+  WORKING_DAYS_NEARING_START_PRIORITISATION_CHECKS_DEADLINE = 8
+
+  WORKING_DAYS_TO_FINISH_ASSESSMENT_FOR_PRIORITISED = 40
+  WORKING_DAYS_NEARING_FINISH_ASSESSMENT_FOR_PRIORITISED_DEADLINE = 35
+
+  def application_forms_with_pagy
+    @application_forms_with_pagy ||=
+      pagy(
+        application_forms_with_filter.order(
+          working_days_between_submitted_and_today: :desc,
+        ),
+      )
+  end
+
+  def application_forms_with_filter
+    @application_forms_with_filter ||=
+      if params[:tab] == "40"
+        application_forms_prioritised_but_assessment_not_completed
+      else
+        application_forms_with_prioritisation_checks_not_started
+      end
+  end
+
+  def application_forms_with_prioritisation_checks_not_started
+    ApplicationForm
+      .joins(assessment: :prioritisation_work_history_checks)
+      .where(assessment: { started_at: nil })
+      .where.not(assessment: { prioritisation_work_history_checks: nil })
+      .distinct
+  end
+
+  def application_forms_prioritised_but_assessment_not_completed
+    ApplicationForm
+      .joins(:assessment)
+      .where(assessment: { verification_started_at: nil, prioritised: true })
+      .distinct
+  end
+
+  attr_reader :params
+end

--- a/app/views/assessor_interface/service_level_agreements/index.html.erb
+++ b/app/views/assessor_interface/service_level_agreements/index.html.erb
@@ -1,0 +1,83 @@
+<% content_for :page_title, "SLA Status" %>
+
+<h1 class="govuk-heading-xl">SLA Status (Prioritisation)</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <h3 class="govuk-heading-m">Breached 10 day SLA</h3>
+    <%= govuk_inset_text { @view_object.breached_sla_for_starting_prioritisation_checks_count.to_s } %>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <h3 class="govuk-heading-m">Breached 40 day SLA</h3>
+    <%= govuk_inset_text { @view_object.breached_sla_for_completing_prioritised_applications_count.to_s } %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <h3 class="govuk-heading-m">Nearing 10 day SLA</h3>
+    <%= govuk_inset_text { @view_object.nearing_sla_for_starting_prioritisation_checks_count.to_s } %>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <h3 class="govuk-heading-m">Nearing 40 day SLA</h3>
+    <%= govuk_inset_text { @view_object.nearing_sla_for_completing_prioritised_applications_count.to_s } %>
+  </div>
+</div>
+
+<%= govuk_details(summary_text: "SLA definitions") do %>
+  <p class="govuk-body">10 day SLA relates to application forms that are going through prioritisation checks and expect checks to begin within 10 days of being submitted. For these applications, we consider them as nearing SLA once they are within 2 days of breaching the SLA.</p>
+  <p class="govuk-body">40 day SLA relates to application forms are prioritised and expect initial assessment to be completed and moved to verification within 40 days of being submitted. For these applications, we consider them as nearing SLA once they are within 5 days of breaching the SLA.</p>
+<% end %>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+<h2 class="govuk-heading-l">Application forms</h2>
+
+<div class="govuk-tabs" data-module="govuk-tabs">
+  <h2 class="govuk-tabs__title">
+    Contents
+  </h2>
+  <ul class="govuk-tabs__list">
+    <li class="govuk-tabs__list-item <%= 'govuk-tabs__list-item--selected' if params[:tab] != "40" %>">
+      <%= link_to "10 day SLA", assessor_interface_service_level_agreements_path %>
+    </li>
+    <li class="govuk-tabs__list-item <%= 'govuk-tabs__list-item--selected' if params[:tab] == "40" %>">
+      <%= link_to "40 day SLA", assessor_interface_service_level_agreements_path(tab: "40") %>
+    </li>
+  </ul>
+  <div class="govuk-tabs__panel">
+    <% if (records = @view_object.application_forms_records).present? %>
+      <%=
+        govuk_table(classes: "application-forms-sla") do |table|
+          table.with_head do |head|
+            head.with_row do |row|
+              row.with_cell(header: true, text: "Reference")
+              row.with_cell(header: true, text: "Country/Region")
+              row.with_cell(header: true, text: "Working days since submission")
+            end
+          end
+
+          table.with_body do |body|
+            records.each do |application_form|
+              body.with_row do |row|
+                row.with_cell { govuk_link_to application_form.reference, [:assessor_interface, application_form] }
+                row.with_cell { CountryName.from_region(application_form.region) }
+                row.with_cell do
+                  if params[:tab] == "40"
+                    govuk_tag(text: application_form.working_days_between_submitted_and_today, colour: @view_object.sla_completed_prioritised_tag_colour(application_form) )
+                  else
+                    govuk_tag(text: application_form.working_days_between_submitted_and_today, colour: @view_object.sla_start_prioritisation_checks_tag_colour(application_form) )
+                  end
+                end
+              end
+            end
+          end
+        end
+      %>
+      <%= govuk_pagination(pagy: @view_object.application_forms_pagy) %>
+    <% else %>
+      <h2 class="govuk-heading-m"><%= t(".results.empty") %></h2>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -31,6 +31,11 @@
           href: main_app.assessor_interface_staff_index_path,
           active: current_page?(main_app.assessor_interface_staff_index_path)
         ) %>
+        <% service_navigation.with_navigation_item(
+          text: "SLA Status",
+          href: main_app.assessor_interface_service_level_agreements_path,
+          active: current_page?(main_app.assessor_interface_service_level_agreements_path)
+        ) %>
       <% end %>
       <% service_navigation.with_navigation_item(text: "Sign out", href: main_app.destroy_staff_session_path) %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
   namespace :assessor_interface, path: "/assessor" do
     root to: redirect("/assessor/applications")
 
+    resources :service_level_agreements, only: %i[index]
+
     resources :staff, only: %i[index edit update] do
       member do
         get "archive", to: "staff#edit_archive"

--- a/spec/policies/assessor_interface/service_level_agreement_policy_spec.rb
+++ b/spec/policies/assessor_interface/service_level_agreement_policy_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::ServiceLevelAgreementPolicy do
+  it_behaves_like "a policy"
+
+  describe "#index?" do
+    subject(:index?) { described_class.new(user, nil).index? }
+
+    it_behaves_like "a policy method requiring the manage staff permission"
+  end
+end

--- a/spec/view_objects/assessor_interface/service_level_agreement_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/service_level_agreement_index_view_object_spec.rb
@@ -1,0 +1,319 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::ServiceLevelAgreementIndexViewObject do
+  subject(:view_object) { described_class.new(params:) }
+
+  let(:params) { {} }
+
+  let!(:application_form_draft) { create :application_form }
+
+  let!(:application_form_submitted) do
+    create :application_form,
+           :with_assessment,
+           :submitted,
+           working_days_between_submitted_and_today: 45
+  end
+
+  let!(:application_form_with_prioritisation_checks_not_started_within_sla) do
+    create(
+      :application_form,
+      :submitted,
+      :with_assessment,
+      working_days_between_submitted_and_today: 5,
+    ) do |application_form|
+      create :prioritisation_work_history_check,
+             assessment: application_form.assessment
+    end
+  end
+
+  let!(:application_form_with_prioritisation_checks_started_within_sla) do
+    create(
+      :application_form,
+      :submitted,
+      :with_assessment,
+      working_days_between_submitted_and_today: 5,
+    ) do |application_form|
+      application_form.assessment.update!(started_at: Time.current)
+      create :prioritisation_work_history_check,
+             assessment: application_form.assessment
+    end
+  end
+
+  let!(:application_form_with_prioritisation_checks_nearing_sla) do
+    create(
+      :application_form,
+      :submitted,
+      :with_assessment,
+      working_days_between_submitted_and_today: 9,
+    ) do |application_form|
+      create :prioritisation_work_history_check,
+             assessment: application_form.assessment
+    end
+  end
+
+  let!(:application_form_with_prioritisation_checks_breached_sla) do
+    create(
+      :application_form,
+      :submitted,
+      :with_assessment,
+      working_days_between_submitted_and_today: 12,
+    ) do |application_form|
+      create :prioritisation_work_history_check,
+             assessment: application_form.assessment
+    end
+  end
+
+  let!(:application_form_prioritised_incomplete_within_sla) do
+    create :application_form,
+           :submitted,
+           :with_assessment,
+           working_days_between_submitted_and_today: 15 do |application_form|
+      application_form.assessment.update!(prioritised: true)
+    end
+  end
+
+  let!(:application_form_prioritised_complete_within_sla) do
+    create(
+      :application_form,
+      :submitted,
+      :with_assessment,
+      working_days_between_submitted_and_today: 30,
+    ) do |application_form|
+      application_form.assessment.update!(
+        prioritised: true,
+        verification_started_at: Time.current,
+      )
+    end
+  end
+
+  let!(:application_form_prioritised_breached_sla) do
+    create(
+      :application_form,
+      :submitted,
+      :with_assessment,
+      working_days_between_submitted_and_today: 42,
+    ) do |application_form|
+      application_form.assessment.update!(prioritised: true)
+    end
+  end
+
+  let!(:application_form_prioritised_nearing_sla) do
+    create(
+      :application_form,
+      :submitted,
+      :with_assessment,
+      working_days_between_submitted_and_today: 38,
+    ) do |application_form|
+      application_form.assessment.update!(prioritised: true)
+    end
+  end
+
+  let!(:application_form_prioritised_completed_and_after_sla) do
+    create(
+      :application_form,
+      :submitted,
+      :with_assessment,
+      working_days_between_submitted_and_today: 50,
+    ) do |application_form|
+      application_form.assessment.update!(
+        prioritised: true,
+        verification_started_at: Time.current,
+      )
+    end
+  end
+
+  describe "#application_forms_pagy" do
+    subject(:application_forms_pagy) { view_object.application_forms_pagy }
+
+    it { is_expected.not_to be_nil }
+
+    it "is configured correctly" do
+      expect(application_forms_pagy.limit).to eq(20)
+      expect(application_forms_pagy.page).to eq(1)
+    end
+  end
+
+  describe "#application_forms_records" do
+    subject(:application_forms_records) do
+      view_object.application_forms_records
+    end
+
+    it "returns all application forms related to the prioritisation checks 10 day SLA" do
+      expect(subject).to contain_exactly(
+        application_form_with_prioritisation_checks_not_started_within_sla,
+        application_form_with_prioritisation_checks_nearing_sla,
+        application_form_with_prioritisation_checks_breached_sla,
+      )
+    end
+
+    context "when the params includes tab for 40 day SLA" do
+      let(:params) { { tab: "40" } }
+
+      it "returns all prioritised application forms related to the 40 day SLA" do
+        expect(subject).to contain_exactly(
+          application_form_prioritised_incomplete_within_sla,
+          application_form_prioritised_breached_sla,
+          application_form_prioritised_nearing_sla,
+        )
+      end
+    end
+  end
+
+  describe "#breached_sla_for_starting_prioritisation_checks_count" do
+    subject(:breached_sla_for_starting_prioritisation_checks_count) do
+      view_object.breached_sla_for_starting_prioritisation_checks_count
+    end
+
+    it { is_expected.to eq(1) }
+  end
+
+  describe "#nearing_sla_for_starting_prioritisation_checks_count" do
+    subject(:nearing_sla_for_starting_prioritisation_checks_count) do
+      view_object.nearing_sla_for_starting_prioritisation_checks_count
+    end
+
+    it { is_expected.to eq(1) }
+  end
+
+  describe "#breached_sla_for_completing_prioritised_applications_count" do
+    subject(:breached_sla_for_completing_prioritised_applications_count) do
+      view_object.breached_sla_for_completing_prioritised_applications_count
+    end
+
+    it { is_expected.to eq(1) }
+  end
+
+  describe "#nearing_sla_for_completing_prioritised_applications_count" do
+    subject(:nearing_sla_for_completing_prioritised_applications_count) do
+      view_object.nearing_sla_for_completing_prioritised_applications_count
+    end
+
+    it { is_expected.to eq(1) }
+  end
+
+  describe "#sla_start_prioritisation_checks_tag_colour" do
+    subject(:sla_start_prioritisation_checks_tag_colour) do
+      view_object.sla_start_prioritisation_checks_tag_colour(application_form)
+    end
+
+    context "when draft application form" do
+      let(:application_form) { application_form_draft }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when submitted non-prioritised application form" do
+      let(:application_form) { application_form_submitted }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when submitted application form going through prioritisation checks not started and within SLA" do
+      let(:application_form) do
+        application_form_with_prioritisation_checks_not_started_within_sla
+      end
+
+      it { is_expected.to eq("green") }
+    end
+
+    context "when submitted application form going through prioritisation checks started and within SLA" do
+      let(:application_form) do
+        application_form_with_prioritisation_checks_started_within_sla
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when submitted application form going through prioritisation checks not started and nearing SLA" do
+      let(:application_form) do
+        application_form_with_prioritisation_checks_nearing_sla
+      end
+
+      it { is_expected.to eq("yellow") }
+    end
+
+    context "when submitted application form going through prioritisation checks not started and breached SLA" do
+      let(:application_form) do
+        application_form_with_prioritisation_checks_breached_sla
+      end
+
+      it { is_expected.to eq("red") }
+    end
+
+    context "when submitted application form going over SLA but has already been prioritised" do
+      let(:application_form) do
+        application_form_prioritised_incomplete_within_sla
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe "#sla_completed_prioritised_tag_colour" do
+    subject(:sla_completed_prioritised_tag_colour) do
+      view_object.sla_completed_prioritised_tag_colour(application_form)
+    end
+
+    context "when draft application form" do
+      let(:application_form) { application_form_draft }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when submitted non-prioritised application form" do
+      let(:application_form) { application_form_submitted }
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when submitted application form going through prioritisation checks not started and breached SLA" do
+      let(:application_form) do
+        application_form_with_prioritisation_checks_breached_sla
+      end
+
+      before do
+        application_form.update!(working_days_between_submitted_and_today: 50)
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when submitted prioritised application form incomplete within SLA" do
+      let(:application_form) do
+        application_form_prioritised_incomplete_within_sla
+      end
+
+      it { is_expected.to eq("green") }
+    end
+
+    context "when submitted prioritised application form complete within SLA" do
+      let(:application_form) do
+        application_form_prioritised_complete_within_sla
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context "when submitted prioritised application form breached SLA" do
+      let(:application_form) { application_form_prioritised_breached_sla }
+
+      it { is_expected.to eq("red") }
+    end
+
+    context "when submitted prioritised application form complete nearing SLA" do
+      let(:application_form) { application_form_prioritised_nearing_sla }
+
+      it { is_expected.to eq("yellow") }
+    end
+
+    context "when submitted prioritised application form complete and after SLA" do
+      let(:application_form) do
+        application_form_prioritised_completed_and_after_sla
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1191

This PR introduces a simple page available within CMS for staff members who have staff management access to show the number of applications relevant to our service level agreements (SLA's) when it comes to prioritisation.

This new page gives an overview of the number of applications nearing and breaching the SLA's (10 and 40 day SLA's) as well as a list of all application forms relevant:

<img width="942" height="431" alt="Screenshot 2025-09-19 at 11 01 29" src="https://github.com/user-attachments/assets/672fa6e7-73c0-4d47-9efe-1a0699089daf" />
<img width="924" height="741" alt="Screenshot 2025-09-19 at 11 01 24" src="https://github.com/user-attachments/assets/e6cdb2de-cb8c-4095-a923-ec724dd24269" />

10 day SLA relates to application forms that are going through prioritisation checks and expect checks to begin within 10 days of being submitted. For these applications, we consider them as nearing SLA once they are within 2 days of breaching the SLA.

40 day SLA relates to application forms are prioritised and expect initial assessment to be completed and moved to verification within 40 days of being submitted. For these applications, we consider them as nearing SLA once they are within 5 days of breaching the SLA.
