### PR TITLE
[AQTS-1173] Public email domain blocking FI scenario

### DIFF
--- a/app/forms/teacher_interface/further_information_request_item_work_history_contact_form.rb
+++ b/app/forms/teacher_interface/further_information_request_item_work_history_contact_form.rb
@@ -11,12 +11,30 @@ module TeacherInterface
     validates :contact_name, :contact_job, presence: true
     validates :contact_email, presence: true, valid_for_notify: true
 
+    validate :contact_email_has_private_email_domain
+
     def update_model
       further_information_request_item.update(
         contact_name:,
         contact_job:,
         contact_email:,
       )
+    end
+
+    delegate :application_form, to: :further_information_request_item
+
+    private
+
+    def parsed_contact_email
+      EmailAddress.new(contact_email)
+    end
+
+    def contact_email_has_private_email_domain
+      return unless application_form.requires_private_email_for_referee?
+
+      if EmailDomain.public?(parsed_contact_email.host_name)
+        errors.add(:contact_email, :invalid_email_domain)
+      end
     end
   end
 end

--- a/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
@@ -54,7 +54,7 @@
       <p>We’ll ask them to confirm that you worked at the school for the period you’ve told us about.</p>
 
       <% if @further_information_request_item.application_form.requires_private_email_for_referee? %>
-        <p>Your references need to have an email address that uses the schools domain, which is the part of an email address that shows who provides it. It comes after the @ symbol. For example, in name@school.edu the domain is school.edu.</p>
+        <p>Your references need to have an email address that uses the school’s domain, which is the part of an email address that shows who provides it. It comes after the @ symbol. For example, in name@school.edu the domain is school.edu.</p>
       <% end %>
     <% end %>
 <% end %>

--- a/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
@@ -35,11 +35,15 @@
   <% work_history = @further_information_request_item.work_history %>
     <p class="govuk-body">Enter the contact details of a suitable referee who can verify your time spent working at <%= work_history.school_name %> from <%= work_history.start_date.to_fs(:month_and_year) %><% if work_history.end_date.present? %> to <%= work_history.end_date.to_fs(:month_and_year) %><% end %>.</p>
 
-    <%= f.govuk_text_field :contact_name, label: {text: "Contact’s name"} %>
+    <%= f.govuk_text_field :contact_name, label: { text: "Contact’s name" } %>
 
-    <%= f.govuk_text_field :contact_job, label: {text: "Contact’s job title"} %>
+    <%= f.govuk_text_field :contact_job, label: { text: "Contact’s job title" } %>
 
-    <%= f.govuk_email_field :contact_email, label: {text: "Contact’s email address"} %>
+    <% if @further_information_request_item.application_form.requires_private_email_for_referee? %>
+      <%= f.govuk_email_field :contact_email, label: { text: "Contact’s email address" }, hint: { text: "The email address must use the school’s domain, for example, name@school.edu" } %>
+    <% else %>
+      <%= f.govuk_email_field :contact_email, label: { text: "Contact’s email address" } %>
+    <% end %>
 
     <%= govuk_details(summary_text: "Choosing someone to verify this role") do %>
 
@@ -48,6 +52,10 @@
       <p>Make sure you have an up-to-date email address for the person you choose, because the reference they provide will be important to your application.</p>
 
       <p>We’ll ask them to confirm that you worked at the school for the period you’ve told us about.</p>
+
+      <% if @further_information_request_item.application_form.requires_private_email_for_referee? %>
+        <p>Your references need to have an email address that uses the schools domain, which is the part of an email address that shows who provides it. It comes after the @ symbol. For example, in name@school.edu the domain is school.edu.</p>
+      <% end %>
     <% end %>
 <% end %>
 

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -350,6 +350,7 @@ en:
               blank: Enter this person’s job title
             contact_email:
               blank: Enter this person’s email address
+              invalid_email_domain: Enter an official email address that uses the school’s domain
         teacher_interface/name_and_date_of_birth_form:
           attributes:
             date_of_birth:

--- a/spec/forms/teacher_interface/further_information_request_item_work_history_contact_form_spec.rb
+++ b/spec/forms/teacher_interface/further_information_request_item_work_history_contact_form_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TeacherInterface::FurtherInformationRequestItemWorkHistoryContactForm,
+               type: :model do
+  subject(:form) do
+    described_class.new(
+      further_information_request_item:,
+      contact_name:,
+      contact_job:,
+      contact_email:,
+    )
+  end
+
+  let(:further_information_request_item) do
+    create(
+      :further_information_request_item,
+      :with_work_history_contact_response,
+    )
+  end
+
+  describe "validations" do
+    let(:contact_name) { "" }
+    let(:contact_job) { "" }
+    let(:contact_email) { "" }
+
+    it { is_expected.to validate_presence_of(:contact_name) }
+    it { is_expected.to validate_presence_of(:contact_job) }
+    it { is_expected.to validate_presence_of(:contact_email) }
+
+    context "when contact email has public email domain" do
+      let(:contact_name) { "John Doe" }
+      let(:contact_job) { "Head Teacher" }
+      let(:contact_email) { "test@gmail.com" }
+
+      it { is_expected.to be_valid }
+    end
+
+    context "when the application form requires private email for referee is enabled" do
+      before do
+        further_information_request_item.application_form.update!(
+          requires_private_email_for_referee: true,
+        )
+      end
+
+      context "when contact email has public email domain" do
+        let(:contact_name) { "John Doe" }
+        let(:contact_job) { "Head Teacher" }
+        let(:contact_email) { "test@gmail.com" }
+
+        it { is_expected.not_to be_valid }
+      end
+    end
+  end
+
+  describe "#save" do
+    subject(:save) { form.save(validate: true) }
+
+    let(:contact_name) { "First Last" }
+    let(:contact_job) { "Job" }
+    let(:contact_email) { "school@example.com" }
+
+    before { expect(save).to be true }
+
+    it "saves the work history contact information" do
+      expect(further_information_request_item.contact_name).to eq("First Last")
+      expect(further_information_request_item.contact_job).to eq("Job")
+      expect(further_information_request_item.contact_email).to eq(
+        "school@example.com",
+      )
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1173

This PR ensures that a validation is added to restrict referee email with a public email domain to be submitted for a reference update via further information request.

This will only apply for application forms that were submitted post release of the feature.