### PR TITLE
[AQTS-1191] Ensure declined and withdrawn applications are excluded from the 40 day SLA for prioritisation

### DIFF
--- a/app/view_objects/assessor_interface/service_level_agreement_index_view_object.rb
+++ b/app/view_objects/assessor_interface/service_level_agreement_index_view_object.rb
@@ -118,7 +118,15 @@ class AssessorInterface::ServiceLevelAgreementIndexViewObject
   def application_forms_prioritised_but_assessment_not_completed
     ApplicationForm
       .joins(:assessment)
-      .where(assessment: { verification_started_at: nil, prioritised: true })
+      .where(
+        awarded_at: nil,
+        declined_at: nil,
+        withdrawn_at: nil,
+        assessment: {
+          verification_started_at: nil,
+          prioritised: true,
+        },
+      )
       .distinct
   end
 

--- a/spec/view_objects/assessor_interface/service_level_agreement_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/service_level_agreement_index_view_object_spec.rb
@@ -124,6 +124,26 @@ RSpec.describe AssessorInterface::ServiceLevelAgreementIndexViewObject do
     end
   end
 
+  before do
+    # Including some already completed application forms to ensure they never show
+    create(:application_form, :with_assessment, :awarded) do |application_form|
+      application_form.assessment.update!(
+        prioritised: true,
+        verification_started_at: Time.current,
+      )
+    end
+    create(:application_form, :with_assessment, :declined) do |application_form|
+      application_form.assessment.update!(prioritised: true)
+    end
+    create(
+      :application_form,
+      :with_assessment,
+      :withdrawn,
+    ) do |application_form|
+      application_form.assessment.update!(prioritised: true)
+    end
+  end
+
   describe "#application_forms_pagy" do
     subject(:application_forms_pagy) { view_object.application_forms_pagy }
 


### PR DESCRIPTION
This ensures that declined/withdrawn applications are not visible SLA list and reporting 