### PR TITLE
Upgrade rack version to 2.2.18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,7 +453,7 @@ GEM
       activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.17)
+    rack (2.2.18)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-oauth2 (1.21.3)


### PR DESCRIPTION
Due to the [this security risk](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/security/dependabot/69) this upgrade is necessary.