### PR TITLE
AQTS-1217: Update suitability tag text

### DIFF
--- a/app/components/application_form_search_result/component.html.erb
+++ b/app/components/application_form_search_result/component.html.erb
@@ -4,7 +4,7 @@
     <% if unsuitable || prioritised || on_hold  %>
       <br />
 
-      <%= govuk_tag(text: "Flagged for suitability", colour: "red") if unsuitable %>
+      <%= govuk_tag(text: "Suitability", colour: "red") if unsuitable %>
       <%= render StatusTag::Component.new("prioritised") if prioritised %>
       <%= render StatusTag::Component.new("on_hold") if on_hold %>
     <% end %>

--- a/spec/components/application_form_search_result_component_spec.rb
+++ b/spec/components/application_form_search_result_component_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ApplicationFormSearchResult::Component, type: :component do
     context "when unsuitable true" do
       let(:unsuitable) { true }
 
-      it { expect(subject).to eq("Flagged for suitability") }
+      it { expect(subject).to eq("Suitability") }
     end
 
     context "when prioritised true" do


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1217

### Updated tag naming

The tag “Flagged for suitability” has been renamed to “Suitability”.

The tags will continue to be shown in the following order:

Suitability
Prioritised
On hold