### PR TITLE
Update decline reason text

### DIFF
--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -109,7 +109,7 @@ en:
       checks:
         age_range_subjects_matches: that the age range and subjects information the applicant has entered matches the qualifications they’ve provided
         applicant_already_dqt: applicant does not already appear in TRS
-        applicant_already_qts: applicant does not already hold QTS and induction exemption
+        applicant_already_qts: applicant does not already hold QTS
         authorisation_to_teach: confirmation that authorisation to teach has never been suspended, barred, cancelled, revoked or restricted, and there are no sanctions present
         confirm_age_range_subjects: confirmation of the age ranges and subjects the applicant is qualified to teach
         duplicate_application: up-front duplication check shows the applicant does not have another in-flight application

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -157,7 +157,7 @@ en:
           additional_degree_transcript_illegible: There is a problem with the additional degree transcript, (or translation) for example, it’s incorrect, illegible, or incomplete.
           age_range: The age range the applicant is qualified to teach does not fall within the requirements of QTS.
           applicant_already_dqt: There’s a potential existing match for this applicant. We need to ask for an additional identifier.
-          applicant_already_qts: The applicant already holds QTS and induction exemption.
+          applicant_already_qts: The applicant already holds QTS.
           application_and_qualification_names_do_not_match: The name on the application is different from one or more qualification documents, but no evidence of change of name was provided.
           authorisation_to_teach: Sanctions or restrictions were detected on professional record.
           confirm_age_range_subjects: We were not provided with sufficient evidence to confirm qualification to teach the age ranges and subjects entered on the online application form.

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -15,7 +15,7 @@ en:
             additional_degree_transcript_illegible: There is a problem with your additional degree transcript (or translation).
             age_range: The age range you are qualified to teach does not fall within the requirements of QTS.
             applicant_already_dqt: We need more information to verify your identity.
-            applicant_already_qts: You already hold QTS and induction exemption.
+            applicant_already_qts: You already hold QTS.
             application_and_qualification_names_do_not_match: Your name on the application form is different from one or more of the qualifications documents you uploaded.
             authorisation_to_teach: Sanctions or restrictions were detected on your professional record.
             confirm_age_range_subjects: We were not provided with sufficient evidence to confirm qualification to teach the age ranges and subjects entered on the application form.

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
         .items
         .first
     expect(failure_reason_item.heading.text).to eq(
-      "The applicant already holds QTS and induction exemption.",
+      "The applicant already holds QTS.",
     )
     expect(failure_reason_item.note.text).to eq("Note.")
   end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1424

**What's changed:**
Text updated from “The applicant already holds QTS and induction exemption.” to “The applicant already holds QTS.”
This change was confirmed with John and Nat following the Check, which verified that the assessor already holds QTS.
As agreed, the reference to “induction exemption” has been removed.