### PR TITLE
[AQTS-1435] Draft user stuck with other work experience in england

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,10 @@ RSpec/SpecFilePathFormat:
     - spec/components/*
     - spec/lib/business_calendar_spec.rb
 
+Rails/SaveBang:
+  Exclude:
+    - spec/**/*
+
 RSpec/SubjectStub:
   Enabled: false
 

--- a/app/controllers/teacher_interface/other_england_work_histories_controller.rb
+++ b/app/controllers/teacher_interface/other_england_work_histories_controller.rb
@@ -39,17 +39,17 @@ module TeacherInterface
                       application_form
                       other_england_work_histories
                     ]
-      elsif (
-            work_history =
-              application_form
-                .work_histories
-                .other_england_educational_role
-                .order_by_user
-                .find(&:incomplete?)
-          )
-        redirect_to school_teacher_interface_application_form_other_england_work_history_path(
-                      work_history,
-                    )
+      elsif application_form
+            .work_histories
+            .other_england_educational_role
+            .order_by_user
+            .find(&:incomplete?)
+        redirect_to %i[
+                      meets_criteria
+                      teacher_interface
+                      application_form
+                      other_england_work_histories
+                    ]
       elsif (
             work_history =
               application_form
@@ -183,12 +183,25 @@ module TeacherInterface
 
       if @form.save(validate: params[:button] != "save_and_return")
         if @form.has_other_england_work_history
-          redirect_to %i[
-                        new
-                        teacher_interface
-                        application_form
-                        other_england_work_history
-                      ]
+          if (
+               work_history =
+                 application_form
+                   .work_histories
+                   .other_england_educational_role
+                   .order_by_user
+                   .find(&:incomplete?)
+             )
+            redirect_to school_teacher_interface_application_form_other_england_work_history_path(
+                          work_history,
+                        )
+          else
+            redirect_to %i[
+                          new
+                          teacher_interface
+                          application_form
+                          other_england_work_history
+                        ]
+          end
         else
           redirect_to %i[teacher_interface application_form]
         end

--- a/app/controllers/teacher_interface/other_england_work_histories_controller.rb
+++ b/app/controllers/teacher_interface/other_england_work_histories_controller.rb
@@ -29,21 +29,14 @@ module TeacherInterface
                       application_form
                       other_england_work_histories
                     ]
-      elsif application_form
-            .work_histories
-            .other_england_educational_role
-            .empty?
+      elsif other_england_work_histories.empty?
         redirect_to %i[
                       meets_criteria
                       teacher_interface
                       application_form
                       other_england_work_histories
                     ]
-      elsif application_form
-            .work_histories
-            .other_england_educational_role
-            .order_by_user
-            .find(&:incomplete?)
+      elsif other_england_work_histories.find(&:incomplete?)
         redirect_to %i[
                       meets_criteria
                       teacher_interface
@@ -52,11 +45,9 @@ module TeacherInterface
                     ]
       elsif (
             work_history =
-              application_form
-                .work_histories
-                .other_england_educational_role
-                .order_by_user
-                .find(&:invalid_email_domain_for_contact?)
+              other_england_work_histories.find(
+                &:invalid_email_domain_for_contact?
+              )
           )
         redirect_to contact_teacher_interface_application_form_other_england_work_history_path(
                       work_history,
@@ -72,11 +63,7 @@ module TeacherInterface
     end
 
     def check_collection
-      @work_histories =
-        application_form
-          .work_histories
-          .other_england_educational_role
-          .order_by_user
+      @work_histories = other_england_work_histories
       @came_from_add_another =
         history_stack.last_entry&.fetch(:path) ==
           add_another_teacher_interface_application_form_other_england_work_histories_path
@@ -150,10 +137,7 @@ module TeacherInterface
               check_teacher_interface_application_form_other_england_work_histories_path
 
           if came_from_check_collection ||
-               application_form
-                 .work_histories
-                 .other_england_educational_role
-                 .count == 1
+               other_england_work_histories.count == 1
             redirect_to %i[teacher_interface application_form]
           else
             redirect_to check_teacher_interface_application_form_other_england_work_histories_path
@@ -183,14 +167,7 @@ module TeacherInterface
 
       if @form.save(validate: params[:button] != "save_and_return")
         if @form.has_other_england_work_history
-          if (
-               work_history =
-                 application_form
-                   .work_histories
-                   .other_england_educational_role
-                   .order_by_user
-                   .find(&:incomplete?)
-             )
+          if (work_history = other_england_work_histories.find(&:incomplete?))
             redirect_to school_teacher_interface_application_form_other_england_work_history_path(
                           work_history,
                         )
@@ -287,12 +264,7 @@ module TeacherInterface
     def check_member
       @work_history = work_history
 
-      work_histories =
-        application_form
-          .work_histories
-          .other_england_educational_role
-          .order_by_user
-          .to_a
+      work_histories = other_england_work_histories.to_a
       @next_work_history =
         work_histories[work_histories.index(work_history) + 1]
     end
@@ -311,7 +283,7 @@ module TeacherInterface
         )
 
       if @form.save(validate: true)
-        if application_form.work_histories.other_england_educational_role.empty?
+        if other_england_work_histories.empty?
           history_stack.replace_self(
             path: teacher_interface_application_form_path,
             origin: false,
@@ -342,10 +314,15 @@ module TeacherInterface
     private
 
     def work_history
-      @work_history ||=
-        application_form.work_histories.other_england_educational_role.find(
-          params[:id],
-        )
+      @work_history ||= other_england_work_histories.find(params[:id])
+    end
+
+    def other_england_work_histories
+      @other_england_work_histories ||=
+        application_form
+          .work_histories
+          .other_england_educational_role
+          .order_by_user
     end
 
     def meets_criteria_form_params

--- a/app/forms/teacher_interface/other_england_work_history_meets_criteria_form.rb
+++ b/app/forms/teacher_interface/other_england_work_history_meets_criteria_form.rb
@@ -10,6 +10,13 @@ module TeacherInterface
 
     def update_model
       application_form.update!(has_other_england_work_history:)
+
+      unless has_other_england_work_history
+        application_form
+          .work_histories
+          .other_england_educational_role
+          .destroy_all
+      end
     end
   end
 end

--- a/spec/forms/assessor_interface/assessment_section_form_spec.rb
+++ b/spec/forms/assessor_interface/assessment_section_form_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe AssessorInterface::AssessmentSectionForm, type: :model do
           },
         )
 
-        save # rubocop:disable Rails/SaveBang
+        save
       end
     end
 
@@ -250,7 +250,7 @@ RSpec.describe AssessorInterface::AssessmentSectionForm, type: :model do
           },
         )
 
-        save # rubocop:disable Rails/SaveBang
+        save
       end
     end
   end

--- a/spec/forms/assessor_interface/personal_information_form_spec.rb
+++ b/spec/forms/assessor_interface/personal_information_form_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe AssessorInterface::PersonalInformationForm, type: :model do
       it { is_expected.to be true }
 
       it "sets the attributes" do
-        save # rubocop:disable Rails/SaveBang
+        save
 
         expect(assessment_section.reload.passed).to be true
       end
@@ -61,7 +61,7 @@ RSpec.describe AssessorInterface::PersonalInformationForm, type: :model do
       it "sets the passed attribute on the english language proficiency section" do
         application_form.update!(english_language_citizenship_exempt: true)
 
-        save # rubocop:disable Rails/SaveBang
+        save
 
         expect(english_language_section.reload.passed).to be true
       end
@@ -69,7 +69,7 @@ RSpec.describe AssessorInterface::PersonalInformationForm, type: :model do
       it "ignores the passed attribute for the ELP section if exemption is by qualifications" do
         application_form.update!(english_language_qualification_exempt: true)
 
-        save # rubocop:disable Rails/SaveBang
+        save
 
         expect(english_language_section.reload.passed).to be_nil
       end

--- a/spec/forms/assessor_interface/qualifications_form_spec.rb
+++ b/spec/forms/assessor_interface/qualifications_form_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe AssessorInterface::QualificationsForm, type: :model do
       it { is_expected.to be true }
 
       it "sets the attributes" do
-        save # rubocop:disable Rails/SaveBang
+        save
 
         expect(assessment_section.reload.passed).to be true
       end
@@ -49,7 +49,7 @@ RSpec.describe AssessorInterface::QualificationsForm, type: :model do
       it "sets the passed attribute on the english language proficiency section" do
         application_form.update!(english_language_qualification_exempt: true)
 
-        save # rubocop:disable Rails/SaveBang
+        save
 
         expect(english_language_section.reload.passed).to be true
       end
@@ -57,7 +57,7 @@ RSpec.describe AssessorInterface::QualificationsForm, type: :model do
       it "ignores the passed attribute for the ELP section if exemption is by citizenship" do
         application_form.update!(english_language_citizenship_exempt: true)
 
-        save # rubocop:disable Rails/SaveBang
+        save
 
         expect(english_language_section.reload.passed).to be_nil
       end

--- a/spec/forms/assessor_interface/requestable_review_form_spec.rb
+++ b/spec/forms/assessor_interface/requestable_review_form_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe AssessorInterface::RequestableReviewForm, type: :model do
 
       it "updates induction required" do
         expect(UpdateAssessmentInductionRequired).to receive(:call)
-        save # rubocop:disable Rails/SaveBang
+        save
       end
     end
 
@@ -72,7 +72,7 @@ RSpec.describe AssessorInterface::RequestableReviewForm, type: :model do
 
       it "updates induction required" do
         expect(UpdateAssessmentInductionRequired).to receive(:call)
-        save # rubocop:disable Rails/SaveBang
+        save
       end
     end
   end

--- a/spec/forms/assessor_interface/requestable_verify_failed_form_spec.rb
+++ b/spec/forms/assessor_interface/requestable_verify_failed_form_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe AssessorInterface::RequestableVerifyFailedForm, type: :model do
 
       it "updates induction required" do
         expect(UpdateAssessmentInductionRequired).to receive(:call)
-        save # rubocop:disable Rails/SaveBang
+        save
       end
     end
   end

--- a/spec/forms/assessor_interface/requestable_verify_passed_form_spec.rb
+++ b/spec/forms/assessor_interface/requestable_verify_passed_form_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe AssessorInterface::RequestableVerifyPassedForm, type: :model do
 
       it "updates induction required" do
         expect(UpdateAssessmentInductionRequired).to receive(:call)
-        save # rubocop:disable Rails/SaveBang
+        save
       end
     end
 
@@ -85,7 +85,7 @@ RSpec.describe AssessorInterface::RequestableVerifyPassedForm, type: :model do
 
       it "doesn't update induction required" do
         expect(UpdateAssessmentInductionRequired).not_to receive(:call)
-        save # rubocop:disable Rails/SaveBang
+        save
       end
     end
   end

--- a/spec/forms/teacher_interface/base_form_spec.rb
+++ b/spec/forms/teacher_interface/base_form_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe TeacherInterface::BaseForm, type: :model do
 
       it "updates the model" do
         expect(application_form.given_names).to eq("Old name")
-        save # rubocop:disable Rails/SaveBang
+        save
         expect(application_form.given_names).to eq(given_names)
       end
 
@@ -37,7 +37,7 @@ RSpec.describe TeacherInterface::BaseForm, type: :model do
         expect(ApplicationFormSectionStatusUpdater).to receive(:call).with(
           application_form:,
         )
-        save # rubocop:disable Rails/SaveBang
+        save
       end
     end
 
@@ -46,7 +46,7 @@ RSpec.describe TeacherInterface::BaseForm, type: :model do
 
       it "doesn't update the model" do
         expect(application_form.given_names).to eq("Old name")
-        save # rubocop:disable Rails/SaveBang
+        save
         expect(application_form.given_names).to eq("Old name")
       end
     end

--- a/spec/forms/teacher_interface/other_england_work_history_meets_criteria_form_spec.rb
+++ b/spec/forms/teacher_interface/other_england_work_history_meets_criteria_form_spec.rb
@@ -23,12 +23,52 @@ RSpec.describe TeacherInterface::OtherEnglandWorkHistoryMeetsCriteriaForm,
   end
 
   describe "#save" do
-    let(:has_other_england_work_history) { "true" }
+    context "when has_other_england_work_history is true" do
+      let(:has_other_england_work_history) { "true" }
 
-    before { form.save(validate: true) }
+      it "saves the application form" do
+        form.save(validate: true)
 
-    it "saves the application form" do
-      expect(application_form.has_other_england_work_history).to be(true)
+        expect(application_form.has_other_england_work_history).to be(true)
+      end
+
+      context "with existing other England work experiences" do
+        before do
+          create(:work_history, application_form:)
+          create(:work_history, :other_england_role, application_form:)
+        end
+
+        it "does not destroy any existing other educational roles in England" do
+          expect { form.save(validate: true) }.not_to change(
+            application_form.work_histories,
+            :count,
+          )
+        end
+      end
+    end
+
+    context "when has_other_england_work_history is false" do
+      let(:has_other_england_work_history) { "false" }
+
+      it "saves the application form" do
+        form.save(validate: true)
+
+        expect(application_form.has_other_england_work_history).to be(false)
+      end
+
+      context "with existing other England work experiences" do
+        before do
+          create(:work_history, application_form:)
+          create(:work_history, :other_england_role, application_form:)
+        end
+
+        it "destroys any existing other educational roles in England" do
+          expect { form.save(validate: true) }.to change(
+            application_form.work_histories,
+            :count,
+          ).by(-1)
+        end
+      end
     end
   end
 end

--- a/spec/support/autoload/page_objects/teacher_interface/edit_other_england_work_history.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/edit_other_england_work_history.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module TeacherInterface
+    class EditOtherEnglandWorkHistory < SitePrism::Page
+      set_url "/teacher/application/other_england_work_histories/{work_history_id}/school"
+
+      section :form, "form" do
+        element :school_name_input,
+                "#teacher-interface-other-england-work-history-school-form-school-name-field"
+        element :address_line1_input,
+                "#teacher-interface-other-england-work-history-school-form-address-line1-field"
+        element :address_line2_input,
+                "#teacher-interface-other-england-work-history-school-form-address-line2-field"
+        element :city_input,
+                "#teacher-interface-other-england-work-history-school-form-city-field"
+        element :country_input,
+                "#teacher-interface-other-england-work-history-school-form-country-location-field"
+        element :postcode_input,
+                "#teacher-interface-other-england-work-history-school-form-postcode-field"
+        element :school_website_input,
+                "#teacher-interface-other-england-work-history-school-form-school-website-field"
+
+        element :job_input,
+                "#teacher-interface-other-england-work-history-school-form-job-field"
+
+        element :start_date_month_input,
+                "#teacher_interface_other_england_work_history_school_form_start_date_2i"
+        element :start_date_year_input,
+                "#teacher_interface_other_england_work_history_school_form_start_date_1i"
+
+        sections :still_employed_radio_items,
+                 GovukRadioItem,
+                 ".govuk-radios__item"
+
+        element :end_date_month_input,
+                "#teacher_interface_other_england_work_history_school_form_end_date_2i"
+        element :end_date_year_input,
+                "#teacher_interface_other_england_work_history_school_form_end_date_1i"
+
+        element :continue_button, ".govuk-button:not(.govuk-button--secondary)"
+        element :save_and_come_back_later_button,
+                ".govuk-button.govuk-button--secondary"
+      end
+    end
+  end
+end

--- a/spec/support/page_helpers.rb
+++ b/spec/support/page_helpers.rb
@@ -816,6 +816,11 @@ module PageHelpers
       PageObjects::TeacherInterface::NewOtherEnglandWorkHistory.new
   end
 
+  def teacher_edit_other_england_work_history_page
+    @teacher_edit_other_england_work_history_page ||=
+      PageObjects::TeacherInterface::EditOtherEnglandWorkHistory.new
+  end
+
   def teacher_edit_other_england_work_history_contact_page
     @teacher_edit_other_england_work_history_contact_page ||=
       PageObjects::TeacherInterface::EditOtherEnglandWorkHistoryContact.new

--- a/spec/support/shared_examples/age_range_subjects_form.rb
+++ b/spec/support/shared_examples/age_range_subjects_form.rb
@@ -140,7 +140,7 @@ RSpec.shared_examples_for "an age range subjects form" do
       it { is_expected.to be true }
 
       it "sets the attributes" do
-        save # rubocop:disable Rails/SaveBang
+        save
 
         expect(assessment.age_range_min).to eq(5)
         expect(assessment.age_range_max).to eq(16)
@@ -173,7 +173,7 @@ RSpec.shared_examples_for "an age range subjects form" do
       it { is_expected.to be true }
 
       it "sets the attributes" do
-        save # rubocop:disable Rails/SaveBang
+        save
 
         expect(assessment.age_range_note).to eq("A note.")
         expect(assessment.subjects_note).to eq("Another note.")

--- a/spec/system/teacher_interface/other_england_work_history_spec.rb
+++ b/spec/system/teacher_interface/other_england_work_history_spec.rb
@@ -102,6 +102,34 @@ RSpec.describe "Teacher work history in England", type: :system do
     then_i_see_the(:teacher_meets_criteria_other_england_work_history_page)
   end
 
+  it "allows to update and complete when the other work history in England is in progress" do
+    given_incomplete_other_england_work_history_exists
+
+    when_i_visit_the(:teacher_application_page)
+    then_i_see_the(:teacher_application_page)
+    and_i_see_the_other_england_work_history_task
+
+    when_i_click_the_other_england_work_history_task
+    then_i_see_the(:teacher_meets_criteria_other_england_work_history_page)
+
+    when_i_choose_yes_to_having_other_work_experience_in_england
+    then_i_see_the(:teacher_edit_other_england_work_history_page)
+
+    when_i_fill_in_the_school_information(name: "Other School 1")
+    then_i_see_the(:teacher_edit_other_england_work_history_contact_page)
+
+    when_i_fill_in_the_contact_information
+    then_i_see_the(:teacher_check_other_england_work_history_page)
+    and_i_see_the_other_england_work_history_information(name: "Other School 1")
+
+    when_i_click_continue
+    then_i_see_the(:teacher_add_another_other_england_work_history_page)
+
+    when_i_dont_add_another_other_england_work_history
+    then_i_see_the(:teacher_application_page)
+    and_i_see_other_work_experience_in_england_task_as_completed
+  end
+
   context "when the work history has update needed as status with email domain feature enabled" do
     before do
       FeatureFlags::FeatureFlag.activate(:email_domains_for_referees)
@@ -140,6 +168,17 @@ RSpec.describe "Teacher work history in England", type: :system do
 
   def given_some_work_history_exists
     create_list(:work_history, 3, :completed, application_form:)
+    ApplicationFormSectionStatusUpdater.call(application_form:)
+  end
+
+  def given_incomplete_other_england_work_history_exists
+    create(
+      :work_history,
+      :other_england_role,
+      application_form:,
+      country_code: "GB-ENG",
+    )
+    application_form.update!(has_other_england_work_history: true)
     ApplicationFormSectionStatusUpdater.call(application_form:)
   end
 


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1435

We had a report come in that one of our users was stuck filling out their "Other work experience in England". This specific spoke is a multi-step form where the first questions asks them whether they have "Other work experience in England". If they select "Yes", they're progressed to creating the details of this work experience, starting with the school details. 
<img width="714" height="904" alt="Screenshot 2026-04-10 at 14 53 57" src="https://github.com/user-attachments/assets/aa2156a4-4201-49d8-80b3-969550fb8717" />

However, this specific user decided they did not meet the requirements to fill this out, so they clicked "Save and come back later" which persisted the "work history" record and took them back to their main application page. At this stage, the "Add other work experience in England" was then "In progress". Whenever they went back into it to update their answer from "Yes" to "No", then they would end up back on updating the school details without any way for them to go and change their answer.
<img width="719" height="212" alt="Screenshot 2026-04-10 at 14 53 39" src="https://github.com/user-attachments/assets/9757d885-4714-4eee-b7cd-8794c13f3f97" />
<img width="839" height="1045" alt="Screenshot 2026-04-10 at 14 54 11" src="https://github.com/user-attachments/assets/26fa4a98-9df0-4f26-a0f0-6f32c8325fd4" />

The workaround would have been for them to just complete the form with dummy data and delete the record to get the question pop-up again, however that is not an acceptable user experience.

In this PR, we ensure that whenever the "Add other work experience in England" is "In Progress", we take the user back to the original question of "Do you have other educational work experience in England that meets our criteria?" before continuing to update the incomplete record. Additionally, we ensure that if they select "No", any existing "Other work experience in England" roles are destroyed so we don't end up with weird abandoned work history records. 

