### PR TITLE
[AQTS-1438] Ability to rollback application that is auto declined due to further information request expiry

### DIFF
--- a/app/models/further_information_request.rb
+++ b/app/models/further_information_request.rb
@@ -73,6 +73,15 @@ class FurtherInformationRequest < ApplicationRecord
     end
   end
 
+  def after_requested(*)
+    DeliverEmail.call(
+      application_form:,
+      mailer: TeacherMailer,
+      action: :further_information_requested,
+      further_information_request: self,
+    )
+  end
+
   def after_received(*)
     DeliverEmail.call(
       application_form:,

--- a/app/services/further_information_requests/create_from_assessment_sections.rb
+++ b/app/services/further_information_requests/create_from_assessment_sections.rb
@@ -11,7 +11,7 @@ class FurtherInformationRequests::CreateFromAssessmentSections
   def call
     raise AlreadyExists if assessment.further_information_requests.exists?
 
-    send_email(create_and_request)
+    create_and_request
   end
 
   class AlreadyExists < StandardError
@@ -44,14 +44,5 @@ class FurtherInformationRequests::CreateFromAssessmentSections
 
       requestable
     end
-  end
-
-  def send_email(further_information_request)
-    DeliverEmail.call(
-      application_form:,
-      mailer: TeacherMailer,
-      action: :further_information_requested,
-      further_information_request:,
-    )
   end
 end

--- a/app/services/further_information_requests/create_from_further_information_review.rb
+++ b/app/services/further_information_requests/create_from_further_information_review.rb
@@ -14,7 +14,7 @@ class FurtherInformationRequests::CreateFromFurtherInformationReview
       raise AlreadyExists
     end
 
-    send_email(create_and_request)
+    create_and_request
   end
 
   class AlreadyExists < StandardError
@@ -44,15 +44,6 @@ class FurtherInformationRequests::CreateFromFurtherInformationReview
 
       requestable
     end
-  end
-
-  def send_email(further_information_request)
-    DeliverEmail.call(
-      application_form:,
-      mailer: TeacherMailer,
-      action: :further_information_requested,
-      further_information_request:,
-    )
   end
 
   def build_follow_up_items

--- a/app/services/rollback_assessment.rb
+++ b/app/services/rollback_assessment.rb
@@ -12,15 +12,16 @@ class RollbackAssessment
     ActiveRecord::Base.transaction do
       validate_state
       update_assessment
-
-      if previously_further_information_requested? &&
-           latest_further_information_request.expired?
-        re_request_latest_further_information_request
-      end
-
       update_application_form
       delete_draft_application_forms
     end
+
+    if previously_further_information_requested? &&
+         latest_further_information_request.expired?
+      re_request_latest_further_information_request
+    end
+
+    ApplicationFormStatusUpdater.call(application_form:, user:)
   end
 
   private
@@ -80,8 +81,6 @@ class RollbackAssessment
     if application_form.declined_at.present?
       application_form.update!(declined_at: nil)
     end
-
-    ApplicationFormStatusUpdater.call(application_form:, user:)
   end
 
   def delete_draft_application_forms

--- a/app/services/rollback_assessment.rb
+++ b/app/services/rollback_assessment.rb
@@ -12,6 +12,12 @@ class RollbackAssessment
     ActiveRecord::Base.transaction do
       validate_state
       update_assessment
+
+      if previously_further_information_requested? &&
+           latest_further_information_request.expired?
+        re_request_latest_further_information_request
+      end
+
       update_application_form
       delete_draft_application_forms
     end
@@ -38,7 +44,11 @@ class RollbackAssessment
 
   def valid_assessment_state?
     assessment.award? || assessment.decline? ||
-      (assessment.unknown? && application_form.declined_at.present?)
+      (assessment.unknown? && application_form.declined_at.present?) ||
+      (
+        assessment.request_further_information? &&
+          application_form.declined_at.present?
+      )
   end
 
   def update_assessment
@@ -80,6 +90,19 @@ class RollbackAssessment
       .find_each do |application_form|
         DestroyApplicationForm.call(application_form:)
       end
+  end
+
+  def re_request_latest_further_information_request
+    RequestRequestable.call(
+      requestable: latest_further_information_request,
+      user:,
+      allow_already_requested: true,
+    )
+  end
+
+  def latest_further_information_request
+    @latest_further_information_request ||=
+      assessment.latest_further_information_request
   end
 
   class InvalidState < StandardError

--- a/spec/factories/assessments.rb
+++ b/spec/factories/assessments.rb
@@ -66,6 +66,11 @@ FactoryBot.define do
       recommended_at { Time.zone.now }
     end
 
+    trait :request_further_information do
+      recommendation { "request_further_information" }
+      recommended_at { Time.zone.now }
+    end
+
     trait :review do
       recommendation { "review" }
       recommended_at { Time.zone.now }

--- a/spec/services/rollback_assessment_spec.rb
+++ b/spec/services/rollback_assessment_spec.rb
@@ -92,10 +92,12 @@ RSpec.describe RollbackAssessment do
       end
     end
 
-    context "having requested further information" do
-      before { create(:requested_further_information_request, assessment:) }
+    context "having requested further information and expired" do
+      let!(:further_information_request) do
+        create(:requested_further_information_request, :expired, assessment:)
+      end
 
-      it "sets the assessment to unknown" do
+      it "sets the assessment to request_further_information" do
         expect { call }.to change(assessment, :request_further_information?).to(
           true,
         )
@@ -103,6 +105,91 @@ RSpec.describe RollbackAssessment do
 
       it "reverts application form status" do
         expect { call }.to change(application_form, :stage).to("assessment")
+      end
+
+      it "re-requests the further information request" do
+        expect {
+          call
+
+          further_information_request.reload
+        }.to change(further_information_request, :expired?).to(
+          false,
+        ).and change(
+                further_information_request,
+                :requested_at,
+              ).and have_enqueued_mail(
+                      TeacherMailer,
+                      :further_information_requested,
+                    ).with(
+                      params: {
+                        further_information_request:,
+                        application_form:,
+                      },
+                      args: [],
+                    )
+      end
+
+      it "records a timeline event" do
+        expect { call }.to have_recorded_timeline_event(
+          :stage_changed,
+          creator: user,
+        )
+      end
+
+      context "with multiple further information requests" do
+        before do
+          create(
+            :received_further_information_request,
+            assessment:,
+            review_passed: false,
+            requested_at: further_information_request.requested_at - 10.days,
+          )
+        end
+
+        it "re-requests the lastest expired further information request" do
+          expect {
+            call
+
+            further_information_request.reload
+          }.to change(further_information_request, :expired?).to(
+            false,
+          ).and change(
+                  further_information_request,
+                  :requested_at,
+                ).and have_enqueued_mail(
+                        TeacherMailer,
+                        :further_information_requested,
+                      ).with(
+                        params: {
+                          further_information_request:,
+                          application_form:,
+                        },
+                        args: [],
+                      )
+        end
+      end
+    end
+
+    context "having received further information" do
+      let!(:further_information_request) do
+        create(:received_further_information_request, assessment:)
+      end
+
+      it "sets the assessment to request_further_information" do
+        expect { call }.to change(assessment, :request_further_information?).to(
+          true,
+        )
+      end
+
+      it "reverts application form status" do
+        expect { call }.to change(application_form, :stage).to("assessment")
+      end
+
+      it "does not re-request the further information request" do
+        expect { call }.not_to change(
+          further_information_request,
+          :requested_at,
+        )
       end
 
       it "records a timeline event" do
@@ -163,7 +250,7 @@ RSpec.describe RollbackAssessment do
       expect { call }.not_to change(assessment, :unknown?)
     end
 
-    it "reverts application form status" do
+    it "reverts application form stage" do
       expect { call }.to change(application_form, :stage).to("not_started")
     end
 


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1438

This change allows rollback/reverse of declined applications due to further information request expiring. 

The change introduces a new private method call within `RollbackAssessment` service of `re_request_latest_further_information_request` for applications declined due to `further_information_request` expiry. This method ensures the latest further information that was expired is re-requested with a brand new requested at date, new expiry deadline and email to the applicant.