### PR TITLE
[AQTS-1444] Ensure "Upload of consent" task is clickable in a 'cannot start' status for Consent flow

### DIFF
--- a/app/view_objects/teacher_interface/consent_requests_view_object.rb
+++ b/app/view_objects/teacher_interface/consent_requests_view_object.rb
@@ -62,11 +62,14 @@ module TeacherInterface
           status: download_unsigned_consent_document_status(consent_request),
         },
         {
-          link: [
-            :teacher_interface,
-            :application_form,
-            consent_request.signed_consent_document,
-          ],
+          link:
+            if consent_request.unsigned_document_downloaded?
+              [
+                :teacher_interface,
+                :application_form,
+                consent_request.signed_consent_document,
+              ]
+            end,
           name: "Upload #{institution_name} consent document",
           status: upload_signed_consent_document_status(consent_request),
         },

--- a/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
@@ -48,11 +48,7 @@ RSpec.describe TeacherInterface::ConsentRequestsViewObject do
                 },
                 {
                   name: "Upload University of Maths consent document",
-                  link: [
-                    :teacher_interface,
-                    :application_form,
-                    consent_request.signed_consent_document,
-                  ],
+                  link: nil,
                   status: :cannot_start,
                 },
               ],


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1444

This change fixes a small bug/inconsistency around consent request task items.

"Upload of consent" task for applicants is currently hyperlinked and does not reflect the "Cannot start" status shown. This code change ensures the task status reflects whether the link/task is available or not.

"Upload of consent" is now no longer hyperlinked when the task is "Cannot start". Once the "Consent document" template is downloaded and the Upload is then "Not started", it then allows the user to access the link to upload their signed document.