### PR TITLE
AQTS 1426 add new country

### DIFF
--- a/app/controllers/support_interface/countries_controller.rb
+++ b/app/controllers/support_interface/countries_controller.rb
@@ -35,6 +35,13 @@ module SupportInterface
       @form.assign_country_attributes
     end
 
+    def new
+      authorize [:support_interface, Country]
+    end
+
+    def create
+    end
+
     private
 
     def country

--- a/app/controllers/support_interface/countries_controller.rb
+++ b/app/controllers/support_interface/countries_controller.rb
@@ -43,11 +43,10 @@ module SupportInterface
     def create
       authorize [:support_interface, Country]
       @form = SupportInterface::NewCountryForm.new(new_country_params)
-      if @form.invalid?
-        render :new, status: :unprocessable_entity
-      else
-        @form.save!
+      if @form.save
         redirect_to %i[support_interface countries]
+      else
+        render :new, status: :unprocessable_entity
       end
     end
 

--- a/app/controllers/support_interface/countries_controller.rb
+++ b/app/controllers/support_interface/countries_controller.rb
@@ -37,9 +37,18 @@ module SupportInterface
 
     def new
       authorize [:support_interface, Country]
+      @form = SupportInterface::NewCountryForm.new
     end
 
     def create
+      authorize [:support_interface, Country]
+      @form = SupportInterface::NewCountryForm.new(new_country_params)
+      if @form.invalid?
+        render :new, status: :unprocessable_entity
+      else
+        @form.save!
+        redirect_to %i[support_interface countries]
+      end
     end
 
     private
@@ -50,6 +59,15 @@ module SupportInterface
                     :support_interface,
                     Country.includes(:regions).find(params[:id]),
                   ]
+    end
+
+    def new_country_params
+      params.require(:support_interface_new_country_form).permit(
+        :location,
+        :eligibility_route,
+        :has_regions,
+        :region_names,
+      )
     end
 
     def country_params

--- a/app/forms/support_interface/new_country_form.rb
+++ b/app/forms/support_interface/new_country_form.rb
@@ -16,8 +16,8 @@ class SupportInterface::NewCountryForm
   validates :has_regions, inclusion: { in: [true, false] }
   validates :region_names, presence: true, if: :has_regions
 
-  def save!
-    raise ActiveRecord::RecordInvalid, self if invalid?
+  def save
+    return false if invalid?
 
     country =
       Country.new(

--- a/app/forms/support_interface/new_country_form.rb
+++ b/app/forms/support_interface/new_country_form.rb
@@ -9,10 +9,7 @@ class SupportInterface::NewCountryForm
   attribute :has_regions, :boolean
   attribute :region_names, :string
 
-  validates :location,
-            presence: {
-              message: "Select the country of recognition",
-            }
+  validates :location, presence: true
   validate :location_must_be_valid_country, if: -> { location.present? }
   validate :country_must_not_already_exist, if: -> { location.present? }
   validates :eligibility_route, inclusion: { in: %w[expanded reduced standard] }
@@ -54,17 +51,12 @@ class SupportInterface::NewCountryForm
   private
 
   def location_must_be_valid_country
-    unless Country::CODES.include?(country_code)
-      errors.add(:location, "Select the country of recognition")
-    end
+    errors.add(:location, :invalid) unless Country::CODES.include?(country_code)
   end
 
   def country_must_not_already_exist
     if Country.exists?(code: country_code)
-      errors.add(
-        :location,
-        "You must select a country that does not already exist",
-      )
+      errors.add(:location, :already_exists)
     end
   end
 end

--- a/app/forms/support_interface/new_country_form.rb
+++ b/app/forms/support_interface/new_country_form.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+class SupportInterface::NewCountryForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :location, :string
+  attribute :eligibility_route, :string
+  attribute :has_regions, :boolean
+  attribute :region_names, :string
+
+  validates :location,
+            presence: {
+              message: "Select the country of recognition",
+            }
+  validate :location_must_be_valid_country, if: -> { location.present? }
+  validate :country_must_not_already_exist, if: -> { location.present? }
+  validates :eligibility_route, inclusion: { in: %w[expanded reduced standard] }
+  validates :has_regions, inclusion: { in: [true, false] }
+  validates :region_names, presence: true, if: :has_regions
+
+  def save!
+    raise ActiveRecord::RecordInvalid, self if invalid?
+
+    country =
+      Country.new(
+        code: country_code,
+        eligibility_enabled: false,
+        eligibility_skip_questions: eligibility_route == "reduced",
+        subject_limited: eligibility_route == "expanded",
+      )
+
+    ActiveRecord::Base.transaction do
+      country.save!
+
+      if has_regions
+        region_names
+          .split("\n")
+          .map(&:chomp)
+          .reject(&:empty?)
+          .each { |name| country.regions.create!(name:) }
+      else
+        country.regions.create!(name: "")
+      end
+    end
+
+    country
+  end
+
+  def country_code
+    CountryCode.from_location(location)
+  end
+
+  private
+
+  def location_must_be_valid_country
+    unless Country::CODES.include?(country_code)
+      errors.add(:location, "Select the country of recognition")
+    end
+  end
+
+  def country_must_not_already_exist
+    if Country.exists?(code: country_code)
+      errors.add(
+        :location,
+        "You must select a country that does not already exist",
+      )
+    end
+  end
+end

--- a/app/policies/support_interface/country_policy.rb
+++ b/app/policies/support_interface/country_policy.rb
@@ -12,4 +12,12 @@ class SupportInterface::CountryPolicy < ApplicationPolicy
   def preview?
     user.support_console_permission? && !user.archived?
   end
+
+  def new?
+    user.support_console_permission? && !user.archived?
+  end
+
+  def create?
+    user.support_console_permission? && !user.archived?
+  end
 end

--- a/app/views/support_interface/countries/edit.html.erb
+++ b/app/views/support_interface/countries/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for :back_link_url, support_interface_countries_path %>
 <% content_for :page_title, title_with_error_prefix(CountryName.from_country(@country), error: @form.errors.any?) %>
 
 <%= form_with model: @form, url: [:support_interface, @country], method: :put do |f| %>

--- a/app/views/support_interface/countries/index.html.erb
+++ b/app/views/support_interface/countries/index.html.erb
@@ -2,6 +2,8 @@
 
 <h1 class="govuk-heading-l">Countries</h1>
 
+<%= govuk_button_link_to "Add a new country" %>
+
 <% @countries.each do |country| %>
   <%= govuk_table do |table| %>
     <%= table.with_head do |head| %>

--- a/app/views/support_interface/countries/index.html.erb
+++ b/app/views/support_interface/countries/index.html.erb
@@ -2,7 +2,7 @@
 
 <h1 class="govuk-heading-l">Countries</h1>
 
-<%= govuk_button_link_to "Add a new country" %>
+<%= govuk_button_link_to "Add a new country", new_support_interface_country_path %>
 
 <% @countries.each do |country| %>
   <%= govuk_table do |table| %>

--- a/app/views/support_interface/countries/new.html.erb
+++ b/app/views/support_interface/countries/new.html.erb
@@ -1,0 +1,1 @@
+Create a new country

--- a/app/views/support_interface/countries/new.html.erb
+++ b/app/views/support_interface/countries/new.html.erb
@@ -1,1 +1,38 @@
-Create a new country
+<% content_for :page_title, title_with_error_prefix("Create a new country", error: @form.errors.any?) %>
+
+<%= form_with model: @form, url: support_interface_countries_path do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <h1 class="govuk-heading-l">Create a new country</h1>
+
+  <%= f.govuk_select :location,
+                     options_for_select(locations, @form.location),
+                     label: { text: "Country of recognition" },
+                     options: { include_blank: true },
+                     data: {
+                       controller: "location-picker-autocomplete",
+                       location_picker_autocomplete_url_value: autocomplete_locations_path,
+                       location_picker_autocomplete_name_value: "location_autocomplete"
+                     } %>
+
+  <%= f.govuk_collection_radio_buttons :eligibility_route,
+                                       [
+                                         OpenStruct.new(value: :standard, label: "Standard – Asks 5 standard questions that most countries would need to be asked."),
+                                         OpenStruct.new(value: :reduced, label: "Reduced – Only asks if the applicant's teaching qualification was completed in their country of recognition."),
+                                         OpenStruct.new(value: :expanded, label: "Expanded – Asks 5 standard questions but the subjects are restricted and age range taught changes to 11-16 years.")
+                                       ],
+                                       :value,
+                                       :label,
+                                       legend: { text: "Which route will applicants take through the eligibility checker?" } %>
+
+  <%= f.govuk_radio_buttons_fieldset :has_regions, legend: { text: "Does this country have regions within it that have a different teaching authority or service journey?" } do %>
+    <%= f.govuk_radio_button :has_regions, :true, label: { text: "Yes" }, link_errors: true do %>
+      <%= f.govuk_text_area :region_names, label: { text: "Add regions below, one region per line." }, hint: { text: "This will allow you to customise the service for each region." }, rows: 10 %>
+    <% end %>
+    <%= f.govuk_radio_button :has_regions, :false, label: { text: "No" } %>
+  <% end %>
+
+  <%= f.govuk_submit "Create" do %>
+    <%= govuk_link_to "Cancel", support_interface_countries_path, class: "govuk-link--no-visited-state" %>
+  <% end %>
+<% end %>

--- a/app/views/support_interface/countries/new.html.erb
+++ b/app/views/support_interface/countries/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for :back_link_url, support_interface_countries_path %>
 <% content_for :page_title, title_with_error_prefix("Create a new country", error: @form.errors.any?) %>
 
 <%= form_with model: @form, url: support_interface_countries_path do |f| %>

--- a/config/locales/support_interface.en.yml
+++ b/config/locales/support_interface.en.yml
@@ -2,6 +2,12 @@ en:
   activemodel:
     errors:
       models:
+        support_interface/new_country_form:
+          attributes:
+            location:
+              blank: Select the country of recognition
+              invalid: Select the country of recognition
+              already_exists: You must select a country that does not already exist
         support_interface/country_form:
           attributes:
             eligibility_enabled:

--- a/config/locales/support_interface.en.yml
+++ b/config/locales/support_interface.en.yml
@@ -8,6 +8,12 @@ en:
               blank: Select the country of recognition
               invalid: Select the country of recognition
               already_exists: You must select a country that does not already exist
+            eligibility_route:
+              inclusion: You must select a valid eligibility route
+            has_regions:
+              inclusion: You must specify whether this country has regions
+            region_names:
+              blank: You must provide region names if the country has regions
         support_interface/country_form:
           attributes:
             eligibility_enabled:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -348,7 +348,7 @@ Rails.application.routes.draw do
 
     mount FeatureFlags::Engine, at: "features"
 
-    resources :countries, only: %i[index edit update] do
+    resources :countries, only: %i[index edit update new create] do
       get "preview", on: :member
     end
 

--- a/spec/forms/support_interface/new_country_form_spec.rb
+++ b/spec/forms/support_interface/new_country_form_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe SupportInterface::NewCountryForm, type: :model do
     end
   end
 
-  describe "#save!" do
-    subject(:save!) { form.save! }
+  describe "#save" do
+    subject(:save) { form.save }
 
     let(:form) do
       described_class.new(
@@ -145,12 +145,12 @@ RSpec.describe SupportInterface::NewCountryForm, type: :model do
     context "when form is invalid" do
       let(:location) { "" }
 
-      it "raises ActiveRecord::RecordInvalid" do
-        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      it "returns false" do
+        expect(subject).to be_falsey
       end
 
       it "does not create a country" do
-        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+        expect { subject }.not_to change(Country, :count)
         expect(Country.where(code: "AF")).not_to exist
       end
     end

--- a/spec/forms/support_interface/new_country_form_spec.rb
+++ b/spec/forms/support_interface/new_country_form_spec.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SupportInterface::NewCountryForm, type: :model do
+  describe "#valid?" do
+    subject(:form) do
+      described_class.new(
+        location:,
+        eligibility_route: "standard",
+        has_regions: false,
+        region_names: "",
+      )
+    end
+
+    let(:location) { "country:AF" }
+
+    it { is_expected.to be_valid }
+
+    context "when location is blank" do
+      let(:location) { "" }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when location is not a recognised country code" do
+      let(:location) { "country:INVALID" }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when the country already exists" do
+      let(:existing_country) { create(:country, code: "AF") }
+      let(:location) { "country:AF" }
+
+      before { existing_country }
+
+      it { is_expected.not_to be_valid }
+    end
+
+    it do
+      expect(subject).to validate_inclusion_of(:eligibility_route).in_array(
+        %w[expanded reduced standard],
+      )
+    end
+
+    it do
+      expect(subject).to validate_inclusion_of(:has_regions).in_array(
+        [true, false],
+      )
+    end
+
+    context "when has_regions is true" do
+      subject(:form) do
+        described_class.new(
+          location: "country:AF",
+          eligibility_route: "standard",
+          has_regions: true,
+          region_names:,
+        )
+      end
+
+      context "and region_names is blank" do
+        let(:region_names) { "" }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context "and region_names is present" do
+        let(:region_names) { "Kabul" }
+
+        it { is_expected.to be_valid }
+      end
+    end
+  end
+
+  describe "#save!" do
+    subject(:save!) { form.save! }
+
+    let(:form) do
+      described_class.new(
+        location:,
+        eligibility_route:,
+        has_regions:,
+        region_names:,
+      )
+    end
+
+    let(:location) { "country:AF" }
+    let(:eligibility_route) { "standard" }
+    let(:has_regions) { false }
+    let(:region_names) { "" }
+
+    it "creates a country with eligibility_enabled set to false" do
+      country = subject
+      expect(country).to have_attributes(
+        code: "AF",
+        eligibility_enabled: false,
+        eligibility_skip_questions: false,
+        subject_limited: false,
+      )
+    end
+
+    it "creates a national region with a blank name" do
+      country = subject
+      expect(country.regions.count).to eq(1)
+      expect(country.regions.first).to have_attributes(name: "")
+    end
+
+    context "when eligibility_route is reduced" do
+      let(:eligibility_route) { "reduced" }
+
+      it "sets eligibility_skip_questions to true" do
+        country = subject
+        expect(country).to have_attributes(
+          eligibility_skip_questions: true,
+          subject_limited: false,
+        )
+      end
+    end
+
+    context "when eligibility_route is expanded" do
+      let(:eligibility_route) { "expanded" }
+
+      it "sets subject_limited to true" do
+        country = subject
+        expect(country).to have_attributes(
+          eligibility_skip_questions: false,
+          subject_limited: true,
+        )
+      end
+    end
+
+    context "when has_regions is true" do
+      let(:has_regions) { true }
+      let(:region_names) { "Kabul\nHerat" }
+
+      it "creates named regions" do
+        country = subject
+        expect(country.regions.count).to eq(2)
+        expect(country.regions.map(&:name)).to contain_exactly("Kabul", "Herat")
+      end
+    end
+
+    context "when form is invalid" do
+      let(:location) { "" }
+
+      it "raises ActiveRecord::RecordInvalid" do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+
+      it "does not create a country" do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(Country.where(code: "AF")).not_to exist
+      end
+    end
+  end
+end

--- a/spec/policies/support_interface/country_policy_spec.rb
+++ b/spec/policies/support_interface/country_policy_spec.rb
@@ -28,4 +28,16 @@ RSpec.describe SupportInterface::CountryPolicy do
 
     it_behaves_like "a policy method requiring the support console permission"
   end
+
+  describe "#new?" do
+    subject(:new?) { described_class.new(user, nil).new? }
+
+    it_behaves_like "a policy method requiring the support console permission"
+  end
+
+  describe "#create?" do
+    subject(:create?) { described_class.new(user, nil).create? }
+
+    it_behaves_like "a policy method requiring the support console permission"
+  end
 end

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -62,12 +62,14 @@ RSpec.describe "Countries support", type: :system do
     and_i_see_the_updated_countries
   end
 
-  it "makes Add a new country button visible" do
+  it "allows visiting new country page" do
     given_countries_exist
     given_i_am_authorized_as_a_support_user
     when_i_visit_the_countries_page
 
     expect(page).to have_link("Add a new country")
+    and_i_click_new_country
+    then_i_see_the_new_country_page
   end
 
   private
@@ -240,5 +242,13 @@ RSpec.describe "Countries support", type: :system do
 
   def and_i_click_preview
     click_button "Preview", visible: false
+  end
+
+  def and_i_click_new_country
+    click_link "Add a new country"
+  end
+
+  def then_i_see_the_new_country_page
+    expect(page).to have_content("Create a new country")
   end
 end

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -62,6 +62,14 @@ RSpec.describe "Countries support", type: :system do
     and_i_see_the_updated_countries
   end
 
+  it "makes Add a new country button visible" do
+    given_countries_exist
+    given_i_am_authorized_as_a_support_user
+    when_i_visit_the_countries_page
+
+    expect(page).to have_link("Add a new country")
+  end
+
   private
 
   def given_countries_exist

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -165,8 +165,8 @@ RSpec.describe "Countries support", type: :system do
   end
 
   def then_i_complete_the_new_country_form_without_regions
-    select "Afghanistan",
-           from: "support-interface-new-country-form-location-field"
+    fill_in "support-interface-new-country-form-location-field",
+            with: "Afghanistan"
     choose "support-interface-new-country-form-eligibility-route-standard-field",
            visible: :all
     choose "support-interface-new-country-form-has-regions-false-field",
@@ -175,8 +175,8 @@ RSpec.describe "Countries support", type: :system do
   end
 
   def then_i_complete_the_new_country_form_with_regions
-    select "Afghanistan",
-           from: "support-interface-new-country-form-location-field"
+    fill_in "support-interface-new-country-form-location-field",
+            with: "Afghanistan"
     choose "support-interface-new-country-form-eligibility-route-standard-field",
            visible: :all
     choose "support-interface-new-country-form-has-regions-true-field",

--- a/spec/system/support_interface/countries_spec.rb
+++ b/spec/system/support_interface/countries_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Countries support", type: :system do
     and_i_see_the_updated_countries
   end
 
-  it "allows visiting new country page" do
+  it "allows creating a new country without regions" do
     given_countries_exist
     given_i_am_authorized_as_a_support_user
     when_i_visit_the_countries_page
@@ -70,6 +70,26 @@ RSpec.describe "Countries support", type: :system do
     expect(page).to have_link("Add a new country")
     and_i_click_new_country
     then_i_see_the_new_country_page
+
+    then_i_complete_the_new_country_form_without_regions
+    then_i_see_the_countries_page
+    and_i_see "Afghanistan"
+  end
+
+  it "allows creating a new country with regions" do
+    given_countries_exist
+    given_i_am_authorized_as_a_support_user
+    when_i_visit_the_countries_page
+
+    expect(page).to have_link("Add a new country")
+    and_i_click_new_country
+    then_i_see_the_new_country_page
+
+    then_i_complete_the_new_country_form_with_regions
+    then_i_see_the_countries_page
+    and_i_see "Afghanistan"
+    and_i_see "Kabul"
+    and_i_see "Herat"
   end
 
   private
@@ -142,6 +162,28 @@ RSpec.describe "Countries support", type: :system do
     expect(page).to have_content("Certified translations")
     click_on "Proof of qualifications"
     expect(page).to have_content("Qualifications information")
+  end
+
+  def then_i_complete_the_new_country_form_without_regions
+    select "Afghanistan",
+           from: "support-interface-new-country-form-location-field"
+    choose "support-interface-new-country-form-eligibility-route-standard-field",
+           visible: :all
+    choose "support-interface-new-country-form-has-regions-false-field",
+           visible: :all
+    click_button "Create"
+  end
+
+  def then_i_complete_the_new_country_form_with_regions
+    select "Afghanistan",
+           from: "support-interface-new-country-form-location-field"
+    choose "support-interface-new-country-form-eligibility-route-standard-field",
+           visible: :all
+    choose "support-interface-new-country-form-has-regions-true-field",
+           visible: :all
+    fill_in "support-interface-new-country-form-region-names-field",
+            with: "Kabul\nHerat"
+    click_button "Create"
   end
 
   def when_i_fill_regions
@@ -250,5 +292,9 @@ RSpec.describe "Countries support", type: :system do
 
   def then_i_see_the_new_country_page
     expect(page).to have_content("Create a new country")
+  end
+
+  def and_i_see(text)
+    expect(page).to have_content(text)
   end
 end


### PR DESCRIPTION
**Jira:** https://dfedigital.atlassian.net/browse/AQTS-1426

### What is changing
This change introduces a new “Create a new country” flow in the Support Console, allowing a new country can be created via a dedicated form, capturing the country of recognition and key eligibility configuration, and will be created as ineligible (inactive) by default.

### Why are we making this change?
Adding a new country currently requires developer involvement. This slows delivery when policy or service needs change and creates unnecessary dependency on engineering for routine configuration.
This change enables staff users with support console access to add a new country themselves.