### PR TITLE
[AQTS-1309] Improvement on RequestRequestable related to request race conditions

### DIFF
--- a/app/services/request_requestable.rb
+++ b/app/services/request_requestable.rb
@@ -25,7 +25,9 @@ class RequestRequestable
       )
     end
 
-    requestable.after_requested(user:)
+    ActiveRecord.after_all_transactions_commit do
+      requestable.after_requested(user:)
+    end
   end
 
   class AlreadyRequested < StandardError

--- a/app/services/rollback_assessment.rb
+++ b/app/services/rollback_assessment.rb
@@ -12,16 +12,15 @@ class RollbackAssessment
     ActiveRecord::Base.transaction do
       validate_state
       update_assessment
+
+      if previously_further_information_requested? &&
+           latest_further_information_request.expired?
+        re_request_latest_further_information_request
+      end
+
       update_application_form
       delete_draft_application_forms
     end
-
-    if previously_further_information_requested? &&
-         latest_further_information_request.expired?
-      re_request_latest_further_information_request
-    end
-
-    ApplicationFormStatusUpdater.call(application_form:, user:)
   end
 
   private
@@ -81,6 +80,8 @@ class RollbackAssessment
     if application_form.declined_at.present?
       application_form.update!(declined_at: nil)
     end
+
+    ApplicationFormStatusUpdater.call(application_form:, user:)
   end
 
   def delete_draft_application_forms

--- a/spec/services/rollback_assessment_spec.rb
+++ b/spec/services/rollback_assessment_spec.rb
@@ -104,7 +104,11 @@ RSpec.describe RollbackAssessment do
       end
 
       it "reverts application form status" do
-        expect { call }.to change(application_form, :stage).to("assessment")
+        expect { call }.to change(application_form, :stage).to(
+          "assessment",
+        ).and change(application_form, :statuses).to(
+                ["waiting_on_further_information"],
+              )
       end
 
       it "re-requests the further information request" do


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1309

This PR fixes race condition in RequestRequestable when called within an outer transaction.

### Problem

When `RequestRequestable` is called inside an outer `ActiveRecord::Base.transaction` block, the `after_requested` callback (which enqueues a background job) fires before the outer transaction has committed. This means the background worker can pick up the job and attempt to read data that isn't yet visible, leading to race conditions, stale reads, missing records, or failed jobs.

### Solution

[ActiveRecord.after_all_transactions_commit](https://guides.rubyonrails.org/active_record_callbacks.html#activerecord-after-all-transactions-commit) to defer `after_requested` when there is an open outer transaction. When no outer transaction exists, behaviour is unchanged and `after_requested` fires immediately as before.

### Testing

To ensure all existing callers of `RequestRequestable` still work or benefit from this change, we should test the following scenarios:

- [x] Submitting application form for HK or Alberta which requests LoPS - Ensure still works fine with email triggering and that there are no more errors occurring on the first job run due to `assessment` not being generated yet.
- [x] Call after application from Nigeria prelim checks pass. - Ensure still works fine with email triggering.
- [x] Call after application from Nigeria is prioritised. - Ensure still works fine with email triggering.
- [x] When application requests prioritisation reference request.  - Ensure still works fine with email triggering.
- [x] When requesting FI (1st, 2nd and 3rd).  - Ensure still works fine with email triggering.
- [x] Requesting reference request. -  Ensure still works fine with email triggering.
- [x] Updating referee contact details. -  Ensure still works fine with email triggering.
- [x] Rolling back assessment due to further information auto-declined. - Ensure still works fine with email triggering and the expiry date is correct. Previously a race condition would cause the date to be incorrect and based on the previous `requested_at` date.