### PR TITLE
[AQTS-1455] Rails configuration for forcing ssl and browser Cache-Control

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
   layout "two_thirds"
 
+  before_action :set_no_cache_headers
   before_action :authenticate_support!, unless: :service_open?
 
   def current_user
@@ -24,6 +25,10 @@ class ApplicationController < ActionController::Base
       username == ENV.fetch("SUPPORT_USERNAME") &&
         password == ENV.fetch("SUPPORT_PASSWORD")
     end
+  end
+
+  def set_no_cache_headers
+    response.set_header("Cache-Control", "no-store")
   end
 
   def service_open?

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,6 +51,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  config.assume_ssl = true
+
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
   config.log_level = Sidekiq.server? ? :warn : :info


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1455

Uncommenting config.force_ssl = true in `config/environments/production.rb` to explicitly enforce HTTPS, HSTS, and secure cookie flags. This ensures all traffic is served over HTTPS and enables HSTS, instructing browsers to only connect via secure channels.

Adding a before_action in ApplicationController to set `Cache-Control: no-store` on all responses, preventing browsers from caching pages. this prevents sensitive personal data from being stored in browser cache, reducing risk on shared or public devices. 