### PR TITLE
AQTS 1421 check your answers task

### DIFF
--- a/app/forms/teacher_interface/download_unsigned_consent_document_form.rb
+++ b/app/forms/teacher_interface/download_unsigned_consent_document_form.rb
@@ -9,7 +9,7 @@ module TeacherInterface
     validates :downloaded, presence: true
 
     def update_model
-      consent_request.update!(unsigned_document_downloaded: true) if downloaded
+      consent_request.update!(unsigned_document_downloaded: !!downloaded)
     end
   end
 end

--- a/app/forms/teacher_interface/download_unsigned_consent_document_form.rb
+++ b/app/forms/teacher_interface/download_unsigned_consent_document_form.rb
@@ -9,7 +9,7 @@ module TeacherInterface
     validates :downloaded, presence: true
 
     def update_model
-      consent_request.update!(unsigned_document_downloaded: !!downloaded)
+      consent_request.update!(unsigned_document_downloaded: !downloaded.nil?)
     end
   end
 end

--- a/app/forms/teacher_interface/download_unsigned_consent_document_form.rb
+++ b/app/forms/teacher_interface/download_unsigned_consent_document_form.rb
@@ -9,7 +9,11 @@ module TeacherInterface
     validates :downloaded, presence: true
 
     def update_model
-      consent_request.update!(unsigned_document_downloaded: !downloaded.nil?)
+      if downloaded
+        consent_request.update!(unsigned_document_downloaded: true)
+      else
+        consent_request.update!(unsigned_document_downloaded: false)
+      end
     end
   end
 end

--- a/app/view_objects/teacher_interface/consent_requests_view_object.rb
+++ b/app/view_objects/teacher_interface/consent_requests_view_object.rb
@@ -38,6 +38,34 @@ module TeacherInterface
       end
     end
 
+    def check_your_answers_task_group
+      {
+        heading:
+          I18n.t(
+            :check_your_answers,
+            scope: %i[
+              teacher_interface
+              further_information_request
+              show
+              section
+            ],
+          ),
+        items: [
+          {
+            title:
+              I18n.t(
+                "teacher_interface.further_information_request.show.check",
+              ),
+            href:
+              if can_submit?
+                %i[check teacher_interface application_form consent_requests]
+              end,
+            status: can_submit? ? "not_started" : "cannot_start",
+          },
+        ],
+      }
+    end
+
     private
 
     attr_reader :application_form

--- a/app/view_objects/teacher_interface/consent_requests_view_object.rb
+++ b/app/view_objects/teacher_interface/consent_requests_view_object.rb
@@ -24,8 +24,6 @@ module TeacherInterface
       end
     end
 
-    alias_method :can_check_answers?, :can_submit?
-
     def check_your_answers_fields
       consent_requests.each_with_object({}) do |consent_request, memo|
         memo[consent_request.id] = {
@@ -51,10 +49,10 @@ module TeacherInterface
           {
             title: I18n.t("teacher_interface.consent_requests.index.check"),
             href:
-              if can_check_answers?
+              if can_submit?
                 %i[check teacher_interface application_form consent_requests]
               end,
-            status: can_check_answers? ? "not_started" : "cannot_start",
+            status: can_submit? ? "not_started" : "cannot_start",
           },
         ],
       }

--- a/app/view_objects/teacher_interface/consent_requests_view_object.rb
+++ b/app/view_objects/teacher_interface/consent_requests_view_object.rb
@@ -24,6 +24,8 @@ module TeacherInterface
       end
     end
 
+    alias_method :can_check_answers?, :can_submit?
+
     def check_your_answers_fields
       consent_requests.each_with_object({}) do |consent_request, memo|
         memo[consent_request.id] = {
@@ -49,10 +51,10 @@ module TeacherInterface
           {
             title: I18n.t("teacher_interface.consent_requests.index.check"),
             href:
-              if can_submit?
+              if can_check_answers?
                 %i[check teacher_interface application_form consent_requests]
               end,
-            status: can_submit? ? "not_started" : "cannot_start",
+            status: can_check_answers? ? "not_started" : "cannot_start",
           },
         ],
       }

--- a/app/view_objects/teacher_interface/consent_requests_view_object.rb
+++ b/app/view_objects/teacher_interface/consent_requests_view_object.rb
@@ -45,8 +45,8 @@ module TeacherInterface
             :check_your_answers,
             scope: %i[
               teacher_interface
-              further_information_request
-              show
+              consent_requests
+              index
               section
             ],
           ),
@@ -54,7 +54,7 @@ module TeacherInterface
           {
             title:
               I18n.t(
-                "teacher_interface.further_information_request.show.check",
+                "teacher_interface.consent_requests.index.check",
               ),
             href:
               if can_submit?

--- a/app/view_objects/teacher_interface/consent_requests_view_object.rb
+++ b/app/view_objects/teacher_interface/consent_requests_view_object.rb
@@ -43,19 +43,11 @@ module TeacherInterface
         heading:
           I18n.t(
             :check_your_answers,
-            scope: %i[
-              teacher_interface
-              consent_requests
-              index
-              section
-            ],
+            scope: %i[teacher_interface consent_requests index section],
           ),
         items: [
           {
-            title:
-              I18n.t(
-                "teacher_interface.consent_requests.index.check",
-              ),
+            title: I18n.t("teacher_interface.consent_requests.index.check"),
             href:
               if can_submit?
                 %i[check teacher_interface application_form consent_requests]

--- a/app/views/teacher_interface/consent_requests/check.html.erb
+++ b/app/views/teacher_interface/consent_requests/check.html.erb
@@ -1,6 +1,7 @@
 <% content_for :page_title, "Check your uploaded consent documents" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_consent_requests_path) %>
 
+<span class="govuk-caption-xl">Your application</span>
 <h1 class="govuk-heading-xl">Check your uploaded consent documents</h1>
 
 <%= render(CheckYourAnswersSummary::Component.new(

--- a/app/views/teacher_interface/consent_requests/index.html.erb
+++ b/app/views/teacher_interface/consent_requests/index.html.erb
@@ -13,6 +13,16 @@
   end %>
 <% end %>
 
+<h2 class="govuk-heading-m"><%= @view_object.check_your_answers_task_group[:heading] %></h2>
+<%= govuk_task_list do |task_list|
+  @view_object.check_your_answers_task_group[:items].each do |item|
+    task_list.with_item do |row|
+      row.with_title(text: item[:title], hint: item[:description], href: item[:href])
+      row.with_status(text: render(StatusTag::Component.new(item[:status])), classes: "app-white-space-nowrap")
+    end
+  end
+end %>
+
 <div class="govuk-button-group">
   <% if @view_object.can_submit? %>
     <%= govuk_button_link_to "Continue", check_teacher_interface_application_form_consent_requests_path %>

--- a/app/views/teacher_interface/consent_requests/index.html.erb
+++ b/app/views/teacher_interface/consent_requests/index.html.erb
@@ -4,7 +4,7 @@
 <h1 class="govuk-heading-xl">Consent documents overview</h1>
 
 <% @view_object.task_list_sections.each do |section| %>
-  <h3 class="govuk-heading-m"><%= section[:title] %></h3>
+  <h2 class="govuk-heading-m"><%= section[:title] %></h2>
 
   <%= govuk_task_list(id_prefix: section[:title].parameterize) do |task_list|
     section[:items].each do |item|
@@ -24,10 +24,6 @@
 end %>
 
 <div class="govuk-button-group">
-  <% if @view_object.can_submit? %>
-    <%= govuk_button_link_to "Continue", check_teacher_interface_application_form_consent_requests_path %>
-  <% end %>
-
   <% if FeatureFlags::FeatureFlag.active?(:gov_one_applicant_login) %>
     <%= govuk_button_link_to t("teacher_interface.application_forms.show.draft.save"), logout_uri, secondary: true %>
   <% else %>

--- a/app/views/teacher_interface/consent_requests/index.html.erb
+++ b/app/views/teacher_interface/consent_requests/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "Consent documents overview" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
-<h1 class="govuk-heading-xl">Consent documents overview</h1>
+<h1 class="govuk-heading-l">Consent documents overview</h1>
 
 <% @view_object.task_list_sections.each do |section| %>
   <h2 class="govuk-heading-m"><%= section[:title] %></h2>

--- a/app/views/teacher_interface/consent_requests/index.html.erb
+++ b/app/views/teacher_interface/consent_requests/index.html.erb
@@ -1,6 +1,7 @@
 <% content_for :page_title, "Consent documents overview" %>
 <% content_for :back_link_url, back_history_path(default: teacher_interface_application_form_path) %>
 
+<span class="govuk-caption-l">Your application</span>
 <h1 class="govuk-heading-l">Consent documents overview</h1>
 
 <% @view_object.task_list_sections.each do |section| %>

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -111,6 +111,11 @@ en:
         description: We need to know which of the approved providers you used for your English language proficiency test.
       edit_provider_reference:
         heading: English language proficiency
+    consent_requests:
+      index:
+        check: Check your answers before submitting
+        section:
+          check_your_answers: Check your answers
     further_information_request:
       show:
         check: Check your answers before submitting

--- a/spec/factories/consent_requests.rb
+++ b/spec/factories/consent_requests.rb
@@ -50,7 +50,11 @@ FactoryBot.define do
 
     trait :with_signed_upload do
       after(:create) do |consent_request, _evaluator|
-        create(:upload, document: consent_request.signed_consent_document)
+        create(
+          :upload,
+          :clean,
+          document: consent_request.signed_consent_document,
+        )
       end
     end
 

--- a/spec/forms/teacher_interface/download_unsigned_consent_document_form_spec.rb
+++ b/spec/forms/teacher_interface/download_unsigned_consent_document_form_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe TeacherInterface::DownloadUnsignedConsentDocumentForm,
     subject(:save) { form.save(validate: false) }
 
     context "with a positive response" do
-      let(:downloaded) { "true" }
+      let(:downloaded) { true }
 
       it "sets unsigned_document_downloaded" do
         expect { save }.to change(
@@ -30,13 +30,63 @@ RSpec.describe TeacherInterface::DownloadUnsignedConsentDocumentForm,
     end
 
     context "with a negative response" do
-      let(:downloaded) { "false" }
+      let(:downloaded) { false }
 
       it "doesn't set unsigned_document_downloaded" do
         expect { save }.not_to change(
           consent_request,
           :unsigned_document_downloaded,
         )
+      end
+    end
+
+    context "with nil response" do
+      let(:downloaded) { nil }
+
+      it "doesn't set unsigned_document_downloaded" do
+        expect { save }.not_to change(
+          consent_request,
+          :unsigned_document_downloaded,
+        )
+      end
+    end
+
+    context "when unsigned consent already downloaded" do
+      let(:consent_request) do
+        create(:consent_request, unsigned_document_downloaded: true)
+      end
+
+      context "with a positive response" do
+        let(:downloaded) { true }
+
+        it "sets does not change unsigned_document_downloaded" do
+          expect { save }.not_to change(
+            consent_request,
+            :unsigned_document_downloaded,
+          )
+        end
+      end
+
+      context "with a negative response" do
+        let(:downloaded) { false }
+
+        it "changes unsigned_document_downloaded to false" do
+          expect { save }.to change(
+            consent_request,
+            :unsigned_document_downloaded,
+          ).to(false)
+        end
+      end
+
+      context "with nil response" do
+        let(:downloaded) { nil }
+
+        it "changes unsigned_document_downloaded to false" do
+          expect { save }.to change(
+            consent_request,
+            :unsigned_document_downloaded,
+          ).to(false)
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,10 +20,6 @@ require "rspec/retry"
 require "rspec/core/formatters/base_text_formatter"
 
 RSpec.configure do |config|
-  if ENV["COVERAGE"]
-    require "simplecov"
-    SimpleCov.start "rails"
-  end
   # RSpec-retry configuration, retry and log any indeterminate tests.
   if ENV["CI"]
     reporter = RSpec::Core::Reporter.new(config)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,10 @@ require "rspec/retry"
 require "rspec/core/formatters/base_text_formatter"
 
 RSpec.configure do |config|
+  if ENV["COVERAGE"]
+    require "simplecov"
+    SimpleCov.start "rails"
+  end
   # RSpec-retry configuration, retry and log any indeterminate tests.
   if ENV["CI"]
     reporter = RSpec::Core::Reporter.new(config)

--- a/spec/support/autoload/page_objects/teacher_interface/consent_requests.rb
+++ b/spec/support/autoload/page_objects/teacher_interface/consent_requests.rb
@@ -7,8 +7,6 @@ module PageObjects
 
       sections :task_lists, GovukTaskList, ".govuk-task-list"
 
-      element :check_your_answers_button,
-              ".govuk-button:not(.govuk-button--secondary)"
       element :save_and_sign_out_button, ".govuk-button.govuk-button--secondary"
     end
   end

--- a/spec/system/teacher_interface/consent_spec.rb
+++ b/spec/system/teacher_interface/consent_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "Teacher consent", type: :system do
 
   def and_i_see_the_download_and_upload_tasks
     task_lists = teacher_consent_requests_page.task_lists
-    expect(task_lists.count).to eq(1)
+    expect(task_lists.count).to eq(2)
 
     task_list = task_lists.first
     expect(task_list.items.count).to eq(2)

--- a/spec/system/teacher_interface/consent_spec.rb
+++ b/spec/system/teacher_interface/consent_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "Teacher consent", type: :system do
   end
 
   def when_i_click_check_your_answers
-    teacher_consent_requests_page.check_your_answers_button.click
+    teacher_consent_requests_page.task_lists.second.items.first.click
   end
 
   def and_i_see_the_documents

--- a/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
@@ -211,5 +211,65 @@ RSpec.describe TeacherInterface::ConsentRequestsViewObject do
         expect(check_your_answers_task_group[:items].first[:href]).to be_present
       end
     end
+
+    context "when there are two consent requests" do
+      context "when one is incomplete and the other is complete" do
+        before do
+          create(
+            :consent_request,
+            :requested,
+            assessment: application_form.assessment,
+          )
+          create(
+            :consent_request,
+            :requested,
+            :with_signed_upload,
+            assessment: application_form.assessment,
+            unsigned_document_downloaded: true,
+          )
+        end
+
+        it "enables check your answers in task list group" do
+          expect(check_your_answers_task_group[:heading]).to eq(
+            "Check your answers",
+          )
+          expect(check_your_answers_task_group[:items].first[:status]).to eq(
+            "cannot_start",
+          )
+          expect(check_your_answers_task_group[:items].first[:href]).to be_nil
+        end
+      end
+
+      context "when both are complete" do
+        before do
+          create(
+            :consent_request,
+            :requested,
+            :with_signed_upload,
+            assessment: application_form.assessment,
+            unsigned_document_downloaded: true,
+          )
+          create(
+            :consent_request,
+            :requested,
+            :with_signed_upload,
+            assessment: application_form.assessment,
+            unsigned_document_downloaded: true,
+          )
+        end
+
+        it "enables check your answers in task list group" do
+          expect(check_your_answers_task_group[:heading]).to eq(
+            "Check your answers",
+          )
+          expect(check_your_answers_task_group[:items].first[:status]).to eq(
+            "not_started",
+          )
+          expect(
+            check_your_answers_task_group[:items].first[:href],
+          ).to be_present
+        end
+      end
+    end
   end
 end

--- a/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
@@ -135,6 +135,43 @@ RSpec.describe TeacherInterface::ConsentRequestsViewObject do
     end
   end
 
+  describe "#can_submit?" do
+    subject(:can_submit?) { view_object.can_submit? }
+
+    context "with incomplete consent requests" do
+      before do
+        create(
+          :consent_request,
+          :requested,
+          assessment: application_form.assessment,
+        )
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "with complete consent requests" do
+      let(:consent_request) do
+        create(
+          :consent_request,
+          :requested,
+          assessment: application_form.assessment,
+          unsigned_document_downloaded: true,
+        )
+      end
+
+      before do
+        create(
+          :upload,
+          :clean,
+          document: consent_request.signed_consent_document,
+        )
+      end
+
+      it { is_expected.to be true }
+    end
+  end
+
   describe "#check_your_answers_task_group" do
     subject(:check_your_answers_task_group) do
       view_object.check_your_answers_task_group

--- a/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
@@ -151,20 +151,13 @@ RSpec.describe TeacherInterface::ConsentRequestsViewObject do
     end
 
     context "with complete consent requests" do
-      let(:consent_request) do
+      before do
         create(
           :consent_request,
           :requested,
+          :with_signed_upload,
           assessment: application_form.assessment,
           unsigned_document_downloaded: true,
-        )
-      end
-
-      before do
-        create(
-          :upload,
-          :clean,
-          document: consent_request.signed_consent_document,
         )
       end
 

--- a/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe TeacherInterface::ConsentRequestsViewObject do
           )
         end
 
-        it "enables check your answers in task list group" do
+        it "disables check your answers in task list group" do
           expect(check_your_answers_task_group[:heading]).to eq(
             "Check your answers",
           )

--- a/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
@@ -170,15 +170,15 @@ RSpec.describe TeacherInterface::ConsentRequestsViewObject do
       view_object.check_your_answers_task_group
     end
 
-    let!(:consent_request) do
-      create(
-        :consent_request,
-        :requested,
-        assessment: application_form.assessment,
-      )
-    end
-
     context "when items are incomplete" do
+      before do
+        create(
+          :consent_request,
+          :requested,
+          assessment: application_form.assessment,
+        )
+      end
+
       it "disables check your answers in task list group" do
         expect(check_your_answers_task_group[:heading]).to eq(
           "Check your answers",
@@ -192,11 +192,12 @@ RSpec.describe TeacherInterface::ConsentRequestsViewObject do
 
     context "when items are complete" do
       before do
-        consent_request.update!(unsigned_document_downloaded: true)
         create(
-          :upload,
-          :clean,
-          document: consent_request.signed_consent_document,
+          :consent_request,
+          :requested,
+          :with_signed_upload,
+          assessment: application_form.assessment,
+          unsigned_document_downloaded: true,
         )
       end
 

--- a/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
@@ -150,6 +150,19 @@ RSpec.describe TeacherInterface::ConsentRequestsViewObject do
       it { is_expected.to be false }
     end
 
+    context "when unsigned document downloaded but without a signed upload" do
+      before do
+        create(
+          :consent_request,
+          :requested,
+          assessment: application_form.assessment,
+          unsigned_document_downloaded: true,
+        )
+      end
+
+      it { is_expected.to be false }
+    end
+
     context "with complete consent requests" do
       before do
         create(
@@ -162,6 +175,48 @@ RSpec.describe TeacherInterface::ConsentRequestsViewObject do
       end
 
       it { is_expected.to be true }
+    end
+
+    context "when there are two consent requests" do
+      context "when one is incomplete and the other is complete" do
+        before do
+          create(
+            :consent_request,
+            :requested,
+            assessment: application_form.assessment,
+          )
+          create(
+            :consent_request,
+            :requested,
+            :with_signed_upload,
+            assessment: application_form.assessment,
+            unsigned_document_downloaded: true,
+          )
+        end
+
+        it { is_expected.to be false }
+      end
+
+      context "when both are complete" do
+        before do
+          create(
+            :consent_request,
+            :requested,
+            :with_signed_upload,
+            assessment: application_form.assessment,
+            unsigned_document_downloaded: true,
+          )
+          create(
+            :consent_request,
+            :requested,
+            :with_signed_upload,
+            assessment: application_form.assessment,
+            unsigned_document_downloaded: true,
+          )
+        end
+
+        it { is_expected.to be true }
+      end
     end
   end
 
@@ -176,6 +231,27 @@ RSpec.describe TeacherInterface::ConsentRequestsViewObject do
           :consent_request,
           :requested,
           assessment: application_form.assessment,
+        )
+      end
+
+      it "disables check your answers in task list group" do
+        expect(check_your_answers_task_group[:heading]).to eq(
+          "Check your answers",
+        )
+        expect(check_your_answers_task_group[:items].first[:status]).to eq(
+          "cannot_start",
+        )
+        expect(check_your_answers_task_group[:items].first[:href]).to be_nil
+      end
+    end
+
+    context "when unsigned document downloaded but without a signed upload" do
+      before do
+        create(
+          :consent_request,
+          :requested,
+          assessment: application_form.assessment,
+          unsigned_document_downloaded: true,
         )
       end
 

--- a/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
+++ b/spec/view_objects/teacher_interface/consent_requests_view_object_spec.rb
@@ -134,4 +134,51 @@ RSpec.describe TeacherInterface::ConsentRequestsViewObject do
       end
     end
   end
+
+  describe "#check_your_answers_task_group" do
+    subject(:check_your_answers_task_group) do
+      view_object.check_your_answers_task_group
+    end
+
+    let!(:consent_request) do
+      create(
+        :consent_request,
+        :requested,
+        assessment: application_form.assessment,
+      )
+    end
+
+    context "when items are incomplete" do
+      it "disables check your answers in task list group" do
+        expect(check_your_answers_task_group[:heading]).to eq(
+          "Check your answers",
+        )
+        expect(check_your_answers_task_group[:items].first[:status]).to eq(
+          "cannot_start",
+        )
+        expect(check_your_answers_task_group[:items].first[:href]).to be_nil
+      end
+    end
+
+    context "when items are complete" do
+      before do
+        consent_request.update!(unsigned_document_downloaded: true)
+        create(
+          :upload,
+          :clean,
+          document: consent_request.signed_consent_document,
+        )
+      end
+
+      it "enables check your answers in task list group" do
+        expect(check_your_answers_task_group[:heading]).to eq(
+          "Check your answers",
+        )
+        expect(check_your_answers_task_group[:items].first[:status]).to eq(
+          "not_started",
+        )
+        expect(check_your_answers_task_group[:items].first[:href]).to be_present
+      end
+    end
+  end
 end


### PR DESCRIPTION
**Jira:** [https://dfedigital.atlassian.net/browse/AQTS-1421](https://dfedigital.atlassian.net/jira/software/projects/AQTS/boards/207?selectedIssue=AQTS-1421)

### What is changing
This PR introduces a task-based "Check your answers" section to the consent request flow. 

### Why are we making this change?
Currently, the layout of the consent request flow causes confusion for applicants. Many mistakenly believe they have completed the process after uploading their documents, missing the final step to review and submit their answers.

By adopting the task-list pattern previously successfully implemented for Further Information (FI) requests, we are making the final review step an explicit task. This standardizes the user experience across the service, prevents premature drop-offs, and ensures applicants explicitly review and submit their consent documents.