### PR TITLE
AQTS 1344 Updating wording for prioritisation reference

### DIFF
--- a/app/views/assessor_interface/assessments/edit_prioritisation.html.erb
+++ b/app/views/assessor_interface/assessments/edit_prioritisation.html.erb
@@ -7,7 +7,7 @@
   <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
 
   <% if @assessment.can_prioritise? %>
-    <p class="govuk-body">You have indicated that this applicant has valid work history in England to be prioritised and have accepted at least one reference that confirms their work history in England.</p>
+    <p class="govuk-body">You have indicated that this applicant has valid work experience in England to be prioritised and have accepted at least one reference that confirms their work experience in England.</p>
 
     <%= f.govuk_collection_radio_buttons :passed,
                                        %i[true],
@@ -20,7 +20,7 @@
       <li>flag this application as prioritised</li>
     </ul>
   <% else %>
-    <p class="govuk-body">You have indicated that this applicant doesn’t have any work history in England that meets the criteria for prioritisation.</p>
+    <p class="govuk-body">You have indicated that this applicant doesn’t have any work experience in England that meets the criteria for prioritisation.</p>
 
     <%= f.govuk_collection_radio_buttons :passed,
                                        %i[false],

--- a/app/views/assessor_interface/prioritisation_reference_requests/confirmation.html.erb
+++ b/app/views/assessor_interface/prioritisation_reference_requests/confirmation.html.erb
@@ -4,7 +4,7 @@
 <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
 
 <p class="govuk-body">
-  You have submitted a work history check request to all referees.
+  You have submitted a work experience check request to all referees.
 </p>
 
 <p class="govuk-body">

--- a/app/views/assessor_interface/prioritisation_reference_requests/edit.html.erb
+++ b/app/views/assessor_interface/prioritisation_reference_requests/edit.html.erb
@@ -58,7 +58,7 @@
       <%= govuk_button_link_to "Resend reference request email", resend_email_assessor_interface_application_form_assessment_prioritisation_reference_request_path(@view_object.application_form, @assessment, @prioritisation_reference_request), secondary: true %>
     <% end %>
 
-    <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "Are you satisfied with this reference for the applicant’s work history?", size: "s" } do %>
+    <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "Are you satisfied with this reference for the applicant’s work experience?", size: "s" } do %>
       <%= f.govuk_radio_button :passed, :true, link_errors: true, disabled: @view_object.disable_form? %>
       <%= f.govuk_radio_button :passed, :false, disabled: @view_object.disable_form? do %>
         <%= f.govuk_text_area :note, label: { text: "Note to the applicant" } %>

--- a/app/views/assessor_interface/prioritisation_reference_requests/new.html.erb
+++ b/app/views/assessor_interface/prioritisation_reference_requests/new.html.erb
@@ -4,7 +4,7 @@
 <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
 
 <p class="govuk-body">
-  You must request a work history check from all referees to confirm the applicant’s work experience in England. You only need to review and accept one reference to prioritise this application.
+  You must request a work experience check from all referees to confirm the applicant’s work experience in England. You only need to review and accept one reference to prioritise this application.
 </p>
 
 <h2 class="govuk-heading-s">Institutions</h2>

--- a/app/views/assessor_interface/prioritisation_work_history_checks/edit.html.erb
+++ b/app/views/assessor_interface/prioritisation_work_history_checks/edit.html.erb
@@ -88,7 +88,7 @@
     </ul>
   <% end %>
 
-  <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "Does the applicant’s work history meet the criteria for prioritisation?" } do %>
+  <%= f.govuk_radio_buttons_fieldset :passed, legend: { text: "Does the applicant’s work experience meet the criteria for prioritisation?" } do %>
     <%= f.govuk_radio_button :passed, true, label: { text: "Yes" }, link_errors: true, disabled: @view_object.disable_form? %>
     <%= f.govuk_radio_button :passed, false, label: { text: "No" }, disabled: @view_object.disable_form? do %>
       <div id="assessor-interface-prioritisation-work-history-check-form-selected-failure-reasons-field-error"></div>

--- a/app/views/assessor_interface/prioritisation_work_history_checks/index.html.erb
+++ b/app/views/assessor_interface/prioritisation_work_history_checks/index.html.erb
@@ -4,10 +4,10 @@
 <h1 class="govuk-heading-xl"><%= t(".title")  %></h1>
 
 <p class="govuk-body">
-  You must check whether each work history in England submitted by this applicant meets the criteria for prioritisation.
+  You must check whether each work experience in England submitted by this applicant meets the criteria for prioritisation.
 </p>
 
-<h2 class="govuk-heading-m">Work history to check</h2>
+<h2 class="govuk-heading-m">Work experience to check</h2>
 
 <%= govuk_task_list do |task_list|
   @prioritisation_work_history_checks.each do |prioritisation_work_history_check|

--- a/app/views/referee_mailer/prioritisation_reference_reminder.text.erb
+++ b/app/views/referee_mailer/prioritisation_reference_reminder.text.erb
@@ -7,9 +7,9 @@ You have just 2 weeks to complete the reference request for <%= application_form
 <%= application_form_full_name(@application_form) %> has applied for qualified teacher status (QTS) in England.
 
 <% if @number_of_reminders_sent == 0 %>
-We recently asked you to confirm the information they’ve provided about their work history and experience. We have not yet received a response from you.
+We recently asked you to confirm the information they’ve provided about their work experience. We have not yet received a response from you.
 <% elsif @number_of_reminders_sent == 1 %>
-They have given us your name and email address to confirm the information they’ve provided about their work history and experience.
+They have given us your name and email address to confirm the information they’ve provided about their work experience.
 <% end %>
 
 # What you need to do

--- a/app/views/shared/_prioritisation_reference_request_summary.html.erb
+++ b/app/views/shared/_prioritisation_reference_request_summary.html.erb
@@ -3,7 +3,7 @@
 <%= render(CheckYourAnswersSummary::Component.new(
   id: "prioritisation-reference-request-#{prioritisation_reference_request.id}",
   model: prioritisation_reference_request,
-  title: "Work history check requested",
+  title: "Work experience check requested",
   fields: {
     contact_name: {
       title: t("helpers.label.teacher_interface_prioritisation_reference_request_contact_response_form.contact_name"),

--- a/app/views/teacher_interface/prioritisation_reference_requests/edit_confirm_applicant.html.erb
+++ b/app/views/teacher_interface/prioritisation_reference_requests/edit_confirm_applicant.html.erb
@@ -7,7 +7,7 @@
   <h1 class="govuk-heading-l"><%= t(".title") %></h1>
 
   <p class="body-text">
-    These are the details that <%= application_form_full_name(@application_form) %> has provided about their work history.
+    These are the details that <%= application_form_full_name(@application_form) %> has provided about their work experience.
     Take a moment to check that they’re correct.
   </p>
 

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -23,7 +23,7 @@ en:
             assessment_decision: Assessment decision
             await_professional_standing_request: Awaiting third-party professional standing
             prioritisation_work_history_checks: Check role, institution and referee details
-            prioritisation_work_history_references: Check work history with referee
+            prioritisation_work_history_references: Check work experience with referee
             prioritisation_decision: Confirm prioritisation decision
             initial_assessment_recommendation: Initial assessment recommendation
             professional_standing_request: Verify LoPS

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -91,7 +91,7 @@ en:
       edit_professional_standing:
         heading: Do you want to verify LoPS?
       edit_reference_requests:
-        heading: Request work experience references
+        heading: Request work history references
 
     assessment_sections:
       show:

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -91,7 +91,7 @@ en:
       edit_professional_standing:
         heading: Do you want to verify LoPS?
       edit_reference_requests:
-        heading: Request work history references
+        heading: Request work experience references
 
     assessment_sections:
       show:
@@ -272,11 +272,11 @@ en:
 
     prioritisation_reference_requests:
       confirmation:
-        title: Work history checks requested
+        title: Work experience checks requested
       index:
         title: Check references
       new:
-        title: Request work history confirmation from referees
+        title: Request work experience confirmation from referees
       edit:
         title: Review reference
     prioritisation_work_history_checks:
@@ -289,7 +289,7 @@ en:
         prioritisation_work_history_setting: the setting the applicant worked in is valid for prioritisation
         prioritisation_work_history_in_england: the institution is recognised in England
         prioritisation_work_history_reference_email: the referee’s email is valid
-        prioritisation_work_history_reference_job: the referee is qualified to verify this applicant’s work history (the referee must be a Headteacher, HR personnel or senior staff member)
+        prioritisation_work_history_reference_job: the referee is qualified to verify this applicant’s work experience (the referee must be a Headteacher, HR personnel or senior staff member)
       failure_reasons:
         as_statement:
           prioritisation_work_history_role: The applicant's role is not valid for prioritisation.
@@ -297,7 +297,7 @@ en:
           prioritisation_work_history_in_england: The institution the applicant has submitted is not in England.
           prioritisation_work_history_institution_not_found: We could not find the institution the applicant has submitted.
           prioritisation_work_history_reference_email: The referee’s email is invalid.
-          prioritisation_work_history_reference_job: The referee isn’t qualified to verify the applicant’s work history.
+          prioritisation_work_history_reference_job: The referee isn’t qualified to verify the applicant’s work experience.
 
     qualifications:
       edit:
@@ -594,9 +594,9 @@ en:
         assessor_interface/prioritisation_work_history_check_form:
           attributes:
             passed:
-              inclusion: Select yes if the applicant’s work history meets the criteria for prioritisation
+              inclusion: Select yes if the applicant’s work experience meets the criteria for prioritisation
             selected_failure_reasons:
-              blank: Select the reason the applicant’s work history doesn’t meet the criteria for prioritisation
+              blank: Select the reason the applicant’s work experience doesn’t meet the criteria for prioritisation
         assessor_interface/qualification_update_form:
           attributes:
             start_date:

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -507,7 +507,7 @@ en:
       teacher_interface_prioritisation_reference_request_contact_response_form:
         contact_response: Are these details correct?
       teacher_interface_prioritisation_reference_request_confirm_applicant_response_form:
-        confirm_applicant_response: Can you confirm the applicant’s work history?
+        confirm_applicant_response: Can you confirm the applicant’s work experience?
       teacher_interface_teaching_qualification_part_of_degree_form:
         teaching_qualification_part_of_degree: Is your teaching qualification part of your bachelor’s degree?
       teacher_interface_work_history_school_form:

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -414,9 +414,9 @@ en:
         teacher_interface/prioritisation_reference_request_confirm_applicant_response_form:
           attributes:
             confirm_applicant_response:
-              inclusion: Select if you can confirm the applicant’s work history
+              inclusion: Select if you can confirm the applicant’s work experience
             confirm_applicant_comment:
-              blank: Tell us why you cannot confirm the applicant's work history
+              blank: Tell us why you cannot confirm the applicant's work experience
         teacher_interface/passport_expiry_date_form:
           attributes:
             passport_expiry_date:

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -32,12 +32,12 @@ module PageObjects
         task_lists.map { |task_list| task_list.find_item(name) }.compact.first
       end
 
-      def prioritisation_work_history_check_task
+      def prioritisation_work_experience_check_task
         find_task_list_item("Check role, institution and referee details")
       end
 
       def prioritisation_reference_check_task
-        find_task_list_item("Check work history with referee")
+        find_task_list_item("Check work experience with referee")
       end
 
       def prioritisation_decision_task

--- a/spec/system/assessor_interface/prioritisation_checks_spec.rb
+++ b/spec/system/assessor_interface/prioritisation_checks_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe "Assessor prioritisation checks", type: :system do
   end
 
   def when_i_click_on_prioritisation_work_history_checks
-    assessor_application_page.prioritisation_work_history_check_task.click
+    assessor_application_page.prioritisation_work_experience_check_task.click
   end
 
   def when_i_click_on_prioritisation_reference_checks
@@ -336,7 +336,7 @@ RSpec.describe "Assessor prioritisation checks", type: :system do
   def and_i_see_prioritisation_work_history_checks_task_as_completed
     expect(
       assessor_application_page
-        .prioritisation_work_history_check_task
+        .prioritisation_work_experience_check_task
         .status_tag
         .text,
     ).to eq("Completed")
@@ -410,7 +410,7 @@ RSpec.describe "Assessor prioritisation checks", type: :system do
 
   def and_i_see_content_for_application_being_deprioritised
     expect(assessor_prioritisation_decision_page).to have_content(
-      "You have indicated that this applicant doesn’t have any work history in England " \
+      "You have indicated that this applicant doesn’t have any work experience in England " \
         "that meets the criteria for prioritisation",
     )
   end
@@ -457,8 +457,8 @@ RSpec.describe "Assessor prioritisation checks", type: :system do
 
   def and_i_see_content_for_application_being_prioritised
     expect(assessor_prioritisation_decision_page).to have_content(
-      "You have indicated that this applicant has valid work history in England " \
-        "to be prioritised and have accepted at least one reference that confirms their work history in England.",
+      "You have indicated that this applicant has valid work experience in England " \
+        "to be prioritised and have accepted at least one reference that confirms their work experience in England.",
     )
   end
 

--- a/spec/system/teacher_interface/prioritisation_reference_spec.rb
+++ b/spec/system/teacher_interface/prioritisation_reference_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe "Teacher prioritisation reference", type: :system do
     expect(summary_list.rows[3].value.text).to eq("Yes")
 
     expect(summary_list.rows[4].key.text).to eq(
-      "Can you confirm the applicant’s work history?",
+      "Can you confirm the applicant’s work experience?",
     )
     expect(summary_list.rows[4].value.text).to eq("Yes")
   end
@@ -217,7 +217,7 @@ RSpec.describe "Teacher prioritisation reference", type: :system do
     expect(summary_list.rows[4].value.text).to eq("Comments")
 
     expect(summary_list.rows[5].key.text).to eq(
-      "Can you confirm the applicant’s work history?",
+      "Can you confirm the applicant’s work experience?",
     )
     expect(summary_list.rows[5].value.text).to eq("No")
 

--- a/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_show_view_object_spec.rb
@@ -235,7 +235,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
         it do
           expect(subject).to include_task_list_item(
             "Pre-assessment tasks",
-            "Check work history with referee",
+            "Check work experience with referee",
             status: :not_started,
             link: [
               :new,
@@ -272,7 +272,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
         it do
           expect(subject).to include_task_list_item(
             "Pre-assessment tasks",
-            "Check work history with referee",
+            "Check work experience with referee",
             status: :not_started,
             link: [
               :new,
@@ -306,7 +306,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :waiting_on,
               link: [
                 :assessor_interface,
@@ -340,7 +340,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :received,
               link: [
                 :assessor_interface,
@@ -374,7 +374,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :received,
               link: [
                 :assessor_interface,
@@ -409,7 +409,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :completed,
               link: [
                 :assessor_interface,
@@ -451,7 +451,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :waiting_on,
               link: [
                 :assessor_interface,
@@ -486,7 +486,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :completed,
               link: [
                 :assessor_interface,
@@ -528,7 +528,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :received,
               link: [
                 :assessor_interface,
@@ -564,7 +564,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :completed,
               link: [
                 :assessor_interface,
@@ -607,7 +607,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :overdue,
               link: [
                 :assessor_interface,
@@ -644,7 +644,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :completed,
               link: [
                 :assessor_interface,
@@ -688,7 +688,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :overdue,
               link: [
                 :assessor_interface,
@@ -726,7 +726,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :completed,
               link: [
                 :assessor_interface,
@@ -769,7 +769,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :received,
               link: [
                 :assessor_interface,
@@ -806,7 +806,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :overdue,
               link: [
                 :assessor_interface,
@@ -842,7 +842,7 @@ RSpec.describe AssessorInterface::ApplicationFormsShowViewObject do
           it do
             expect(subject).to include_task_list_item(
               "Pre-assessment tasks",
-              "Check work history with referee",
+              "Check work experience with referee",
               status: :overdue,
               link: [
                 :assessor_interface,


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1344

**Why**

The email sent to prioritisation referees was updated to use the term “work experience”, but parts of the service and CMS still used “work history”.
This caused inconsistent wording across the journey and could be confusing for users.

**What**

Updated “work history” to “work experience” in the prioritisation reference journey:

About the applicant page
Check your answers page
Validation error message


Updated the same wording in CMS:

Pre‑assessment task names
Reference review screens
Prioritisation decision screens (accepted and rejected)