### PR TITLE
Block anonymous access for uploads storage account

### DIFF
--- a/terraform/application/storage.tf
+++ b/terraform/application/storage.tf
@@ -12,6 +12,7 @@ resource "azurerm_storage_account" "uploads" {
   account_kind                      = "StorageV2"
   min_tls_version                   = "TLS1_2"
   infrastructure_encryption_enabled = true
+  allow_nested_items_to_be_public   = false
 
   blob_properties {
     last_access_time_enabled = true


### PR DESCRIPTION
### Context

Our default practice is to disable anonymous access for storage accounts.
While the containers are set to private already, we should disallow at the account level too.

### Changes proposed in this pull request

Set to disallow for uploads 

### Review

see review app sa s189t01afqtsrv3228sa settings
make env terraform-plan (should show sa will be updated in place)