### PR TITLE
[AQTS-1478] Show email delivery failures on CMS

### DIFF
--- a/app/assets/stylesheets/application.sass.scss
+++ b/app/assets/stylesheets/application.sass.scss
@@ -94,6 +94,10 @@ ul.autocomplete__menu {
   vertical-align: middle;
 }
 
+.app-table__layout_fixed {
+  table-layout: fixed;
+}
+
 .app-background-inset-text {
   background-color: #f3f2f1;
 }

--- a/app/controllers/assessor_interface/email_delivery_failures_controller.rb
+++ b/app/controllers/assessor_interface/email_delivery_failures_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AssessorInterface::EmailDeliveryFailuresController < AssessorInterface::BaseController
+  def index
+    authorize %i[assessor_interface email_delivery]
+
+    @view_object =
+      AssessorInterface::EmailDeliveryFailuresIndexViewObject.new(params:)
+
+    render layout: "full_from_desktop"
+  end
+end

--- a/app/policies/assessor_interface/email_delivery_policy.rb
+++ b/app/policies/assessor_interface/email_delivery_policy.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AssessorInterface::EmailDeliveryPolicy < ApplicationPolicy
+  def index?
+    return false if user.archived?
+
+    true
+  end
+end

--- a/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
+++ b/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
@@ -70,6 +70,7 @@ class AssessorInterface::EmailDeliveryFailuresIndexViewObject
           notify_completed_at: :desc,
         ),
         count: active_tab_failures_count,
+        limit: 100,
       )
   end
 

--- a/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
+++ b/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
@@ -17,15 +17,15 @@ class AssessorInterface::EmailDeliveryFailuresIndexViewObject
   end
 
   def this_week_tab_name
-    "This week #{this_week_start_readable_date} to #{this_week_end_readable_date} (#{email_failures_for_this_week.count})"
+    "This week #{this_week_start_readable_date} to #{this_week_end_readable_date} (#{this_week_failures_count})"
   end
 
   def last_week_tab_name
-    "Last week #{last_week_start_readable_date} to #{last_week_end_readable_date} (#{email_failures_for_last_week.count})"
+    "Last week #{last_week_start_readable_date} to #{last_week_end_readable_date} (#{last_week_failures_count})"
   end
 
   def last_week_delivery_stats_statement
-    "#{email_failures_for_last_week_count} out of #{email_deliveries_for_last_week_count} emails " \
+    "#{last_week_failures_count} out of #{last_week_total_count} emails " \
       "failed to send between #{last_week_start_readable_date} and #{last_week_end_readable_date}."
   end
 
@@ -69,6 +69,7 @@ class AssessorInterface::EmailDeliveryFailuresIndexViewObject
         email_deliveries_with_filter.preload(application_form: :assessor).order(
           notify_completed_at: :desc,
         ),
+        count: active_tab_failures_count,
       )
   end
 
@@ -88,10 +89,6 @@ class AssessorInterface::EmailDeliveryFailuresIndexViewObject
       )
   end
 
-  def email_failures_for_last_week_count
-    email_failures_for_last_week.count
-  end
-
   def email_failures_for_this_week
     @email_failures_for_this_week ||=
       EmailDelivery.failed.where(
@@ -99,10 +96,27 @@ class AssessorInterface::EmailDeliveryFailuresIndexViewObject
       )
   end
 
-  def email_deliveries_for_last_week_count
-    EmailDelivery.where(
-      notify_completed_at: last_week_start_at..last_week_end_at,
-    ).count
+  def this_week_failures_count
+    @this_week_failures_count ||= email_failures_for_this_week.count
+  end
+
+  def last_week_failures_count
+    @last_week_failures_count ||= email_failures_for_last_week.count
+  end
+
+  def last_week_total_count
+    @last_week_total_count ||=
+      EmailDelivery.where(
+        notify_completed_at: last_week_start_at..last_week_end_at,
+      ).count
+  end
+
+  def active_tab_failures_count
+    if params[:tab] == "last_week"
+      last_week_failures_count
+    else
+      this_week_failures_count
+    end
   end
 
   attr_reader :params

--- a/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
+++ b/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
@@ -16,7 +16,47 @@ class AssessorInterface::EmailDeliveryFailuresIndexViewObject
     email_deliveries_with_pagy.last
   end
 
+  def this_week_tab_name
+    "This week #{this_week_start_readable_date} to #{this_week_end_readable_date} (#{email_failures_for_this_week.count})"
+  end
+
+  def last_week_tab_name
+    "Last week #{last_week_start_readable_date} to #{last_week_end_readable_date} (#{email_failures_for_last_week.count})"
+  end
+
   private
+
+  def this_week_start_at
+    Time.current.beginning_of_week
+  end
+
+  def this_week_start_readable_date
+    this_week_start_at.to_date.to_fs(:short)
+  end
+
+  def this_week_end_at
+    Time.current.end_of_week
+  end
+
+  def this_week_end_readable_date
+    this_week_end_at.to_date.to_fs(:short)
+  end
+
+  def last_week_start_at
+    1.week.ago.beginning_of_week
+  end
+
+  def last_week_start_readable_date
+    last_week_start_at.to_date.to_fs(:short)
+  end
+
+  def last_week_end_at
+    1.week.ago.end_of_week
+  end
+
+  def last_week_end_readable_date
+    last_week_end_at.to_date.to_fs(:short)
+  end
 
   def email_deliveries_with_pagy
     @email_deliveries_with_pagy ||=
@@ -26,23 +66,24 @@ class AssessorInterface::EmailDeliveryFailuresIndexViewObject
   def email_deliveries_with_filter
     @email_deliveries_with_filter ||=
       if params[:tab] == "last_week"
-        email_delivery_failures_for_last_week
+        email_failures_for_last_week
       else
-        email_delivery_failures_for_this_week
+        email_failures_for_this_week
       end
   end
 
-  def email_delivery_failures_for_last_week
-    EmailDelivery.failed.where(
-      notify_completed_at: 1.week.ago.beginning_of_week..1.week.ago.end_of_week,
-    )
+  def email_failures_for_last_week
+    @email_failures_for_last_week ||=
+      EmailDelivery.failed.where(
+        notify_completed_at: last_week_start_at..last_week_end_at,
+      )
   end
 
-  def email_delivery_failures_for_this_week
-    EmailDelivery.failed.where(
-      notify_completed_at:
-        Time.current.beginning_of_week..Time.current.end_of_week,
-    )
+  def email_failures_for_this_week
+    @email_failures_for_this_week ||=
+      EmailDelivery.failed.where(
+        notify_completed_at: this_week_start_at..this_week_end_at,
+      )
   end
 
   attr_reader :params

--- a/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
+++ b/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class AssessorInterface::EmailDeliveryFailuresIndexViewObject
-  include ActionView::Helpers::FormOptionsHelper
   include Pagy::Backend
 
   def initialize(params:)

--- a/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
+++ b/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class AssessorInterface::EmailDeliveryFailuresIndexViewObject
+  include ActionView::Helpers::FormOptionsHelper
+  include Pagy::Backend
+
+  def initialize(params:)
+    @params = params
+  end
+
+  def email_deliveries_pagy
+    email_deliveries_with_pagy.first
+  end
+
+  def email_deliveries_records
+    email_deliveries_with_pagy.last
+  end
+
+  private
+
+  def email_deliveries_with_pagy
+    @email_deliveries_with_pagy ||=
+      pagy(email_deliveries_with_filter.order(notify_completed_at: :desc))
+  end
+
+  def email_deliveries_with_filter
+    @email_deliveries_with_filter ||=
+      if params[:tab] == "last_week"
+        email_delivery_failures_for_last_week
+      else
+        email_delivery_failures_for_this_week
+      end
+  end
+
+  def email_delivery_failures_for_last_week
+    EmailDelivery.failed.where(
+      notify_completed_at: 1.week.ago.beginning_of_week..1.week.ago.end_of_week,
+    )
+  end
+
+  def email_delivery_failures_for_this_week
+    EmailDelivery.failed.where(
+      notify_completed_at:
+        Time.current.beginning_of_week..Time.current.end_of_week,
+    )
+  end
+
+  attr_reader :params
+end

--- a/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
+++ b/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
@@ -65,7 +65,11 @@ class AssessorInterface::EmailDeliveryFailuresIndexViewObject
 
   def email_deliveries_with_pagy
     @email_deliveries_with_pagy ||=
-      pagy(email_deliveries_with_filter.order(notify_completed_at: :desc))
+      pagy(
+        email_deliveries_with_filter.preload(application_form: :assessor).order(
+          notify_completed_at: :desc,
+        ),
+      )
   end
 
   def email_deliveries_with_filter

--- a/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
+++ b/app/view_objects/assessor_interface/email_delivery_failures_index_view_object.rb
@@ -24,6 +24,11 @@ class AssessorInterface::EmailDeliveryFailuresIndexViewObject
     "Last week #{last_week_start_readable_date} to #{last_week_end_readable_date} (#{email_failures_for_last_week.count})"
   end
 
+  def last_week_delivery_stats_statement
+    "#{email_failures_for_last_week_count} out of #{email_deliveries_for_last_week_count} emails " \
+      "failed to send between #{last_week_start_readable_date} and #{last_week_end_readable_date}."
+  end
+
   private
 
   def this_week_start_at
@@ -79,11 +84,21 @@ class AssessorInterface::EmailDeliveryFailuresIndexViewObject
       )
   end
 
+  def email_failures_for_last_week_count
+    email_failures_for_last_week.count
+  end
+
   def email_failures_for_this_week
     @email_failures_for_this_week ||=
       EmailDelivery.failed.where(
         notify_completed_at: this_week_start_at..this_week_end_at,
       )
+  end
+
+  def email_deliveries_for_last_week_count
+    EmailDelivery.where(
+      notify_completed_at: last_week_start_at..last_week_end_at,
+    ).count
   end
 
   attr_reader :params

--- a/app/views/assessor_interface/email_delivery_failures/index.html.erb
+++ b/app/views/assessor_interface/email_delivery_failures/index.html.erb
@@ -47,7 +47,7 @@
                 end
                 row.with_cell { email_delivery.to }
                 row.with_cell { t(".mailer_class_names.#{email_delivery.mailer_class_name}") }
-                row.with_cell { email_delivery.notify_completed_at.to_fs(:short) }
+                row.with_cell { email_delivery.notify_completed_at.localtime.to_fs(:short) }
                 row.with_cell { t(".mailer_action_names.#{email_delivery.mailer_action_name}") }
                 row.with_cell { email_delivery.application_form.assessor&.name }
               end

--- a/app/views/assessor_interface/email_delivery_failures/index.html.erb
+++ b/app/views/assessor_interface/email_delivery_failures/index.html.erb
@@ -8,10 +8,10 @@
   </h2>
   <ul class="govuk-tabs__list">
     <li class="govuk-tabs__list-item <%= 'govuk-tabs__list-item--selected' if params[:tab] != "last_week" %>">
-      <%= link_to "This week", assessor_interface_email_delivery_failures_path %>
+      <%= link_to @view_object.this_week_tab_name, assessor_interface_email_delivery_failures_path %>
     </li>
     <li class="govuk-tabs__list-item <%= 'govuk-tabs__list-item--selected' if params[:tab] == "last_week" %>">
-      <%= link_to "Last week", assessor_interface_email_delivery_failures_path(tab: "last_week") %>
+      <%= link_to @view_object.last_week_tab_name, assessor_interface_email_delivery_failures_path(tab: "last_week") %>
     </li>
   </ul>
   <div class="govuk-tabs__panel">

--- a/app/views/assessor_interface/email_delivery_failures/index.html.erb
+++ b/app/views/assessor_interface/email_delivery_failures/index.html.erb
@@ -2,6 +2,10 @@
 
 <h1 class="govuk-heading-xl">Email failures</h1>
 
+<%= govuk_inset_text do %>
+  <%= @view_object.last_week_delivery_stats_statement %>
+<% end %>
+
 <div class="govuk-tabs" data-module="govuk-tabs">
   <h2 class="govuk-tabs__title">
     Contents
@@ -50,17 +54,18 @@
             end
           end
         %>
-        <%= govuk_pagination(pagy: @view_object.email_deliveries_pagy) %>
       <% else %>
         <%=
           table.with_body do |body|
             body.with_row do |row|
-              row.with_cell(classes: "govuk-body-l", colspan: 6) { t(".results.empty") }
+              row.with_cell(classes: "govuk-body-l govuk-!-font-weight-bold", colspan: 6) { t(".results.empty") }
             end
           end
         %>
       <% end %>
     <% end %>
+
+    <%= govuk_pagination(pagy: @view_object.email_deliveries_pagy) %>
   </div>
 </div>
 

--- a/app/views/assessor_interface/email_delivery_failures/index.html.erb
+++ b/app/views/assessor_interface/email_delivery_failures/index.html.erb
@@ -1,0 +1,66 @@
+<% content_for :page_title, "Email failures" %>
+
+<h1 class="govuk-heading-xl">Email failures</h1>
+
+<div class="govuk-tabs" data-module="govuk-tabs">
+  <h2 class="govuk-tabs__title">
+    Contents
+  </h2>
+  <ul class="govuk-tabs__list">
+    <li class="govuk-tabs__list-item <%= 'govuk-tabs__list-item--selected' if params[:tab] != "last_week" %>">
+      <%= link_to "This week", assessor_interface_email_delivery_failures_path %>
+    </li>
+    <li class="govuk-tabs__list-item <%= 'govuk-tabs__list-item--selected' if params[:tab] == "last_week" %>">
+      <%= link_to "Last week", assessor_interface_email_delivery_failures_path(tab: "last_week") %>
+    </li>
+  </ul>
+  <div class="govuk-tabs__panel">
+    <%= govuk_table(classes: "app-table__layout_fixed govuk-!-text-break-word") do |table| %>
+      <%=
+        table.with_head do |head|
+          head.with_row do |row|
+            row.with_cell(header: true, text: "Application")
+            row.with_cell(header: true, text: "Email address", width: "one-quarter")
+            row.with_cell(header: true, text: "User")
+            row.with_cell(header: true, text: "Failed at")
+            row.with_cell(header: true, text: "Email type")
+            row.with_cell(header: true, text: "Assigned to")
+          end
+        end
+      %>
+
+      <% if (records = @view_object.email_deliveries_records).present? %>
+        <%=
+          table.with_body do |body|
+            records.each do |email_delivery|
+              body.with_row do |row|
+                row.with_cell do
+                  if email_delivery.application_form.submitted?
+                    govuk_link_to email_delivery.application_form.reference, [:assessor_interface, email_delivery.application_form]
+                  else
+                    "Draft"
+                  end
+                end
+                row.with_cell { email_delivery.to }
+                row.with_cell { t(".mailer_class_names.#{email_delivery.mailer_class_name}") }
+                row.with_cell { email_delivery.notify_completed_at.to_fs(:short) }
+                row.with_cell { t(".mailer_action_names.#{email_delivery.mailer_action_name}") }
+                row.with_cell { email_delivery.application_form.assessor&.name }
+              end
+            end
+          end
+        %>
+        <%= govuk_pagination(pagy: @view_object.email_deliveries_pagy) %>
+      <% else %>
+        <%=
+          table.with_body do |body|
+            body.with_row do |row|
+              row.with_cell(classes: "govuk-body-l", colspan: 6) { t(".results.empty") }
+            end
+          end
+        %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/assessor_interface/email_delivery_failures/index.html.erb
+++ b/app/views/assessor_interface/email_delivery_failures/index.html.erb
@@ -47,7 +47,7 @@
                 end
                 row.with_cell { email_delivery.to }
                 row.with_cell { t(".mailer_class_names.#{email_delivery.mailer_class_name}") }
-                row.with_cell { email_delivery.notify_completed_at.localtime.to_fs(:short) }
+                row.with_cell { email_delivery.notify_completed_at.localtime.strftime("%-d %b %l:%M%P") }
                 row.with_cell { t(".mailer_action_names.#{email_delivery.mailer_action_name}") }
                 row.with_cell { email_delivery.application_form.assessor&.name }
               end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -25,6 +25,10 @@
         <% service_navigation.with_navigation_item(text: "Email domain records", href: main_app.assessor_interface_eligibility_domains_path) %>
       <% end %>
 
+      <% if AssessorInterface::EligibilityDomainPolicy.new(current_staff, EmailDelivery).index? %>
+        <% service_navigation.with_navigation_item(text: "Email failures", href: main_app.assessor_interface_email_delivery_failures_path) %>
+      <% end %>
+
       <% if SupportInterface::CountryPolicy.new(current_staff, Country).index? %>
         <% service_navigation.with_navigation_item(text: "Support console", href: main_app.support_interface_root_path) %>
       <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -25,7 +25,7 @@
         <% service_navigation.with_navigation_item(text: "Email domain records", href: main_app.assessor_interface_eligibility_domains_path) %>
       <% end %>
 
-      <% if AssessorInterface::EligibilityDomainPolicy.new(current_staff, EmailDelivery).index? %>
+      <% if AssessorInterface::EmailDeliveryPolicy.new(current_staff, EmailDelivery).index? %>
         <% service_navigation.with_navigation_item(text: "Email failures", href: main_app.assessor_interface_email_delivery_failures_path) %>
       <% end %>
 

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -241,6 +241,44 @@ en:
     decision_review_requests:
       edit:
         title: Review request for decision review
+
+    email_delivery_failures:
+      index:
+        mailer_action_names:
+          application_awarded: Awarded
+          application_declined: Declined
+          application_from_ineligible_country: Country no longer accepted
+          application_not_submitted: Draft reminder
+          application_prioritised: Prioritised
+          application_not_prioritised: Not prioritised
+          application_received: Application received
+          application_submitted: Application submitted
+          consent_reminder: Consent reminder
+          consent_requested: Consent requested
+          consent_submitted: Consent submitted
+          decision_review_received: Decision review received
+          decision_review_reviewed: Decision review reviewed
+          further_information_received: Further information received
+          further_information_requested: Further information requested
+          further_information_reminder: Further information reminder
+          initial_checks_required: Initial checks required
+          professional_standing_received: Professional standing received
+          professional_standing_requested: Professional standing requested
+          prioritisation_checks_required: Prioritisation checks required
+          prioritisation_reference_reminder: Prioritisation reference reminder
+          prioritisation_reference_requested: Prioritisation reference requested
+          prioritisation_references_requested: Prioritisation references requested
+          prioritisation_references_reminder: Prioritisation references reminder
+          reference_reminder: Reference reminder
+          reference_requested: Reference requested
+          references_requested: References requested
+          references_reminder: References reminder
+        mailer_class_names:
+          teacher_mailer: Applicant
+          referee_mailer: Referee
+          teaching_authority_mailer: Teaching authority
+        results:
+          empty: No failures recorded for this week
     further_information_requests:
       edit:
         title:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -315,6 +315,10 @@ Rails.application.routes.draw do
       end
     end
 
+    resources :email_delivery_failures,
+              path: "/email-delivery-failures",
+              only: :index
+
     resources :suitability_records, path: "/suitability-records" do
       get "archive", on: :member
     end

--- a/spec/models/email_delivery_spec.rb
+++ b/spec/models/email_delivery_spec.rb
@@ -33,30 +33,43 @@
 #  fk_rails_...  (prioritisation_reference_request_id => prioritisation_reference_requests.id)
 #  fk_rails_...  (reference_request_id => reference_requests.id)
 #
-class EmailDelivery < ApplicationRecord
-  belongs_to :application_form
-  belongs_to :reference_request, optional: true
-  belongs_to :prioritisation_reference_request, optional: true
-  belongs_to :further_information_request, optional: true
 
-  scope :failed,
-        -> do
-          where(
-            notify_status: %i[
-              permanent_failure
-              temporary_failure
-              technical_failure
-            ],
-          )
-        end
+require "rails_helper"
 
-  enum :notify_status,
-       {
-         created: "created",
-         delivered: "delivered",
-         permanent_failure: "permanent-failure",
-         temporary_failure: "temporary-failure",
-         technical_failure: "technical-failure",
-       },
-       prefix: true
+RSpec.describe EmailDelivery, type: :model do
+  describe ".failed" do
+    subject(:failed) { described_class.failed }
+
+    before do
+      create(:email_delivery, to: "created@test.com", notify_status: :created)
+      create(
+        :email_delivery,
+        to: "delivered@test.com",
+        notify_status: :delivered,
+      )
+      create(
+        :email_delivery,
+        to: "permanent_failure@test.com",
+        notify_status: :permanent_failure,
+      )
+      create(
+        :email_delivery,
+        to: "temporary_failure@test.com",
+        notify_status: :temporary_failure,
+      )
+      create(
+        :email_delivery,
+        to: "technical_failure@test.com",
+        notify_status: :technical_failure,
+      )
+    end
+
+    it "returns all email deliveries with failure statuses" do
+      expect(subject.pluck(:to)).to contain_exactly(
+        "permanent_failure@test.com",
+        "temporary_failure@test.com",
+        "technical_failure@test.com",
+      )
+    end
+  end
 end

--- a/spec/policies/assessor_interface/email_delivery_policy_spec.rb
+++ b/spec/policies/assessor_interface/email_delivery_policy_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::EmailDeliveryPolicy do
+  subject(:policy) { described_class.new(user, record) }
+
+  let(:record) { nil }
+  let(:user) { nil }
+
+  it_behaves_like "a policy"
+
+  describe "#index?" do
+    subject(:index?) { policy.index? }
+
+    it_behaves_like "a policy method with permission"
+  end
+end

--- a/spec/view_objects/assessor_interface/email_delivery_failures_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/email_delivery_failures_index_view_object_spec.rb
@@ -114,4 +114,60 @@ RSpec.describe AssessorInterface::EmailDeliveryFailuresIndexViewObject do
       end
     end
   end
+
+  describe "#last_week_delivery_stats_statement" do
+    subject(:last_week_delivery_stats_statement) do
+      view_object.last_week_delivery_stats_statement
+    end
+
+    around do |example|
+      travel_to Date.new(2026, 6, 1) do
+        example.run
+      end
+    end
+
+    it "returns statement for delivery failures rate for last week" do
+      expect(subject).to eq(
+        "0 out of 0 emails failed to send between 25 May and 31 May.",
+      )
+    end
+
+    context "when there are email deliveries without any failures" do
+      before do
+        create_list :email_delivery,
+                    20,
+                    notify_completed_at: Time.current,
+                    notify_status: :delivered
+        create_list :email_delivery,
+                    30,
+                    notify_completed_at: 1.week.ago,
+                    notify_status: :delivered
+      end
+
+      it "returns statement for delivery failures rate for last week" do
+        expect(subject).to eq(
+          "0 out of 30 emails failed to send between 25 May and 31 May.",
+        )
+      end
+
+      context "with failures for this and last week" do
+        before do
+          create_list :email_delivery,
+                      2,
+                      notify_completed_at: Time.current,
+                      notify_status: :permanent_failure
+          create_list :email_delivery,
+                      3,
+                      notify_completed_at: 1.week.ago,
+                      notify_status: :permanent_failure
+        end
+
+        it "returns statement for delivery failures rate for last week with correct failure rate" do
+          expect(subject).to eq(
+            "3 out of 33 emails failed to send between 25 May and 31 May.",
+          )
+        end
+      end
+    end
+  end
 end

--- a/spec/view_objects/assessor_interface/email_delivery_failures_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/email_delivery_failures_index_view_object_spec.rb
@@ -7,35 +7,6 @@ RSpec.describe AssessorInterface::EmailDeliveryFailuresIndexViewObject do
 
   let(:params) { {} }
 
-  let!(:email_delivery_failure_this_week) do
-    create :email_delivery,
-           notify_status: :permanent_failure,
-           notify_completed_at: Time.current
-  end
-
-  let!(:email_delivery_failure_last_week) do
-    create :email_delivery,
-           notify_status: :permanent_failure,
-           notify_completed_at: 1.week.ago
-  end
-
-  before do
-    # Email delivery delivered from this week
-    create :email_delivery,
-           notify_status: :delivered,
-           notify_completed_at: Time.current
-
-    # Email delivery delivered from last week
-    create :email_delivery,
-           notify_status: :delivered,
-           notify_completed_at: 1.week.ago
-
-    # Email delivery failures from 2 weeks ago
-    create :email_delivery,
-           notify_status: :permanent_failure,
-           notify_completed_at: 2.weeks.ago
-  end
-
   describe "#email_deliveries_pagy" do
     subject(:email_deliveries_pagy) { view_object.email_deliveries_pagy }
 
@@ -50,6 +21,35 @@ RSpec.describe AssessorInterface::EmailDeliveryFailuresIndexViewObject do
   describe "#email_deliveries_records" do
     subject(:email_deliveries_records) { view_object.email_deliveries_records }
 
+    let!(:email_delivery_failure_this_week) do
+      create :email_delivery,
+             notify_status: :permanent_failure,
+             notify_completed_at: Time.current
+    end
+
+    let!(:email_delivery_failure_last_week) do
+      create :email_delivery,
+             notify_status: :permanent_failure,
+             notify_completed_at: 1.week.ago
+    end
+
+    before do
+      # Email delivery delivered from this week
+      create :email_delivery,
+             notify_status: :delivered,
+             notify_completed_at: Time.current
+
+      # Email delivery delivered from last week
+      create :email_delivery,
+             notify_status: :delivered,
+             notify_completed_at: 1.week.ago
+
+      # Email delivery failures from 2 weeks ago
+      create :email_delivery,
+             notify_status: :permanent_failure,
+             notify_completed_at: 2.weeks.ago
+    end
+
     it "returns only email delivery failures from this week" do
       expect(subject).to contain_exactly(email_delivery_failure_this_week)
     end
@@ -59,6 +59,58 @@ RSpec.describe AssessorInterface::EmailDeliveryFailuresIndexViewObject do
 
       it "returns only email delivery failures from last week" do
         expect(subject).to contain_exactly(email_delivery_failure_last_week)
+      end
+    end
+  end
+
+  describe "#this_week_tab_name" do
+    subject(:this_week_tab_name) { view_object.this_week_tab_name }
+
+    around do |example|
+      travel_to Date.new(2026, 6, 1) do
+        example.run
+      end
+    end
+
+    it "returns tab name for this week ranging from beginning and end of week" do
+      expect(subject).to eq("This week 01 Jun to 07 Jun (0)")
+    end
+
+    context "when there is an email delivery failure for this week" do
+      before do
+        create :email_delivery,
+               notify_status: :permanent_failure,
+               notify_completed_at: Time.current
+      end
+
+      it "returns tab name for this week ranging from beginning and end of week with counter" do
+        expect(subject).to eq("This week 01 Jun to 07 Jun (1)")
+      end
+    end
+  end
+
+  describe "#last_week_tab_name" do
+    subject(:last_week_tab_name) { view_object.last_week_tab_name }
+
+    around do |example|
+      travel_to Date.new(2026, 6, 1) do
+        example.run
+      end
+    end
+
+    it "returns tab name for last week ranging from beginning and end of week" do
+      expect(subject).to eq("Last week 25 May to 31 May (0)")
+    end
+
+    context "when there is an email delivery failure for last week" do
+      before do
+        create :email_delivery,
+               notify_status: :permanent_failure,
+               notify_completed_at: 1.week.ago
+      end
+
+      it "returns tab name for last week ranging from beginning and end of week with counter" do
+        expect(subject).to eq("Last week 25 May to 31 May (1)")
       end
     end
   end

--- a/spec/view_objects/assessor_interface/email_delivery_failures_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/email_delivery_failures_index_view_object_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssessorInterface::EmailDeliveryFailuresIndexViewObject do
+  subject(:view_object) { described_class.new(params:) }
+
+  let(:params) { {} }
+
+  let!(:email_delivery_failure_this_week) do
+    create :email_delivery,
+           notify_status: :permanent_failure,
+           notify_completed_at: Time.current
+  end
+
+  let!(:email_delivery_failure_last_week) do
+    create :email_delivery,
+           notify_status: :permanent_failure,
+           notify_completed_at: 1.week.ago
+  end
+
+  before do
+    # Email delivery delivered from this week
+    create :email_delivery,
+           notify_status: :delivered,
+           notify_completed_at: Time.current
+
+    # Email delivery delivered from last week
+    create :email_delivery,
+           notify_status: :delivered,
+           notify_completed_at: 1.week.ago
+
+    # Email delivery failures from 2 weeks ago
+    create :email_delivery,
+           notify_status: :permanent_failure,
+           notify_completed_at: 2.weeks.ago
+  end
+
+  describe "#email_deliveries_pagy" do
+    subject(:email_deliveries_pagy) { view_object.email_deliveries_pagy }
+
+    it { is_expected.not_to be_nil }
+
+    it "is configured correctly" do
+      expect(subject.limit).to eq(20)
+      expect(subject.page).to eq(1)
+    end
+  end
+
+  describe "#email_deliveries_records" do
+    subject(:email_deliveries_records) { view_object.email_deliveries_records }
+
+    it "returns only email delivery failures from this week" do
+      expect(subject).to contain_exactly(email_delivery_failure_this_week)
+    end
+
+    context "when the params includes tab for last week" do
+      let(:params) { { tab: "last_week" } }
+
+      it "returns only email delivery failures from last week" do
+        expect(subject).to contain_exactly(email_delivery_failure_last_week)
+      end
+    end
+  end
+end

--- a/spec/view_objects/assessor_interface/email_delivery_failures_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/email_delivery_failures_index_view_object_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AssessorInterface::EmailDeliveryFailuresIndexViewObject do
     it { is_expected.not_to be_nil }
 
     it "is configured correctly" do
-      expect(subject.limit).to eq(20)
+      expect(subject.limit).to eq(100)
       expect(subject.page).to eq(1)
     end
   end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1478

## What

This add an "Email failures" page to the assessor CMS so staff can see which Notify emails failed to deliver. The page shows failed deliveries for the current and previous week (Mon-Sun) across two tabs, each labelled with its date range and failure count, plus a banner summarising last week's delivery rate ("X out of Y emails failed to send between … and …"). We currently provide this to managers via a manual report every week and this work eliminates the manual workaround.

The `EmailDeliveryFailuresIndexViewObject` is where most of the logic lives as it builds the tab data, counts, and paginated records. Performance has been considered to ensure the page stays efficient and preventing N+1 queries.

--- 

Other notes:

I considered a partial index (`notify_completed_at` scoped to the failure statuses) but deliberately chose not include it here. At current volumes in production, the query completes in well under a millisecond and the planner would prefer a seq scan at this size anyway. The index is cheap to add when justified, so the call is to defer it until the table is materially larger and the page is confirmed as a bottleneck, rather than index on a guess.

