### PR TITLE
[AQTS-1496] Fix issue with prioritisation reference reminder to applicant

### DIFF
--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -332,6 +332,8 @@ class ApplicationForm < ApplicationRecord
         )
       end
     when "prioritisation_references"
+      return false if assessment.prioritisation_decision_at.present?
+
       prioritisation_reference_requests_not_yet_received_or_rejected.any? do |prioritisation_reference_request|
         prioritisation_reference_request.should_send_reminder_email?(
           "expiration",

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -332,6 +332,7 @@ class ApplicationForm < ApplicationRecord
         )
       end
     when "prioritisation_references"
+      return false if assessment.nil?
       return false if assessment.prioritisation_decision_at.present?
 
       prioritisation_reference_requests_not_yet_received_or_rejected.any? do |prioritisation_reference_request|

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -451,6 +451,132 @@ RSpec.describe ApplicationForm, type: :model do
           it { is_expected.to be false }
         end
       end
+
+      context "with prioritisation reference reminders" do
+        let(:name) { "prioritisation_references" }
+
+        context "with no references outstanding" do
+          let(:number_of_reminders_sent) { 0 }
+
+          before do
+            create(
+              :received_prioritisation_reference_request,
+              assessment:,
+              requested_at: 3.weeks.ago,
+            )
+
+            create(
+              :received_prioritisation_reference_request,
+              assessment:,
+              requested_at: 3.weeks.ago,
+            )
+          end
+
+          it { is_expected.to be false }
+        end
+
+        context "with references outstanding and no reminders sent" do
+          let(:number_of_reminders_sent) { 0 }
+
+          before do
+            create(
+              :received_prioritisation_reference_request,
+              assessment:,
+              requested_at: 3.weeks.ago,
+            )
+
+            create(
+              :prioritisation_reference_request,
+              assessment:,
+              requested_at: 3.weeks.ago,
+            )
+          end
+
+          it { is_expected.to be true }
+
+          context "when the prioritisation decision has been made" do
+            before do
+              assessment.update!(
+                prioritisation_decision_at: Time.current,
+                prioritised: true,
+              )
+            end
+
+            it { is_expected.to be false }
+          end
+        end
+
+        context "with references outstanding and first reminder sent with second reminder not due" do
+          let(:number_of_reminders_sent) { 1 }
+
+          before do
+            create(
+              :received_prioritisation_reference_request,
+              assessment:,
+              requested_at: 3.weeks.ago,
+            )
+
+            create(
+              :prioritisation_reference_request,
+              assessment:,
+              requested_at: 3.weeks.ago,
+            )
+          end
+
+          it { is_expected.to be false }
+        end
+
+        context "with reference outstanding and first reminder sent with second reminder due" do
+          let(:number_of_reminders_sent) { 1 }
+
+          before do
+            create(
+              :received_prioritisation_reference_request,
+              assessment:,
+              requested_at: 4.weeks.ago,
+            )
+
+            create(
+              :prioritisation_reference_request,
+              assessment:,
+              requested_at: 4.weeks.ago,
+            )
+          end
+
+          it { is_expected.to be true }
+
+          context "when the prioritisation decision has been made" do
+            before do
+              assessment.update!(
+                prioritisation_decision_at: Time.current,
+                prioritised: true,
+              )
+            end
+
+            it { is_expected.to be false }
+          end
+        end
+
+        context "with reference outstanding and first and second reminders sent" do
+          let(:number_of_reminders_sent) { 2 }
+
+          before do
+            create(
+              :received_prioritisation_reference_request,
+              assessment:,
+              requested_at: 4.weeks.ago,
+            )
+
+            create(
+              :prioritisation_reference_request,
+              assessment:,
+              requested_at: 4.weeks.ago,
+            )
+          end
+
+          it { is_expected.to be false }
+        end
+      end
     end
 
     describe "#from_ineligible_country" do


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1496

## Problem
Our service sends reminders for prioritisation requests to applicants and their referees if they're still outstanding. For the rare scenario of multiple prioritisation reference requests on a single application, our assessors can make a decision on the prioritisation status even if only 1 has been received. Once the assessor makes the prioritisation decision, the other outstanding requests can no longer be filled out and the referees no longer receive reminders. However, the applicant still seems to be receiving these reminders which they shouldn't be. 


## Change
Updating `#should_send_reminder_email?` method on `ApplicationForm` so that once a prioritisation decision has been made, no prioritisation reference reminders will be sent to applicants. This method is responsible for handling reminders directly to the applicant while the `should_send_reminder_email?` on `PrioritisationReferenceRequest` is responsible determining on whether to send the reminders to the referee themselves.