### PR TITLE
AQTS 1484 Update sign in email content

### DIFF
--- a/app/views/teachers/mailer/magic_link.text.erb
+++ b/app/views/teachers/mailer/magic_link.text.erb
@@ -1,13 +1,11 @@
 Hello, <%= @resource.email %>,
 
-<% if @resource.sign_in_count == 0 %>
-Thank you for your interest in applying for qualified teacher status (QTS) in England. Use the link below to confirm your email address and start your application.
-<% else %>
-Welcome back to apply for qualified teacher status (QTS) in England. Use the link below to confirm your email address and sign in to your application.
-<% end %>
+You have received this email because you're signing in to the apply for qualified teacher status (QTS) service.
 
-[Confirm your email address](<%= teacher_magic_link_url(token: @token) %>)
+To sign in, select the link below:
 
-Please note, this link will expire in <%= Devise.passwordless_login_within.inspect %>. After that time, you will need to [return to the service](<%= create_or_new_teacher_session_url %>) and request another confirmation link.
+^ [Confirm your email address](<%= teacher_magic_link_url(token: @token) %>)
+
+This link is only valid for <%= Devise.passwordless_login_within.inspect %>. If the link expires, [return to the service](<%= create_or_new_teacher_session_url %>) and sign in again.
 
 <%= render "shared/teacher_mailer/footer" %>

--- a/app/views/teachers/mailer/magic_link.text.erb
+++ b/app/views/teachers/mailer/magic_link.text.erb
@@ -1,6 +1,6 @@
 Hello, <%= @resource.email %>,
 
-You have received this email because you're signing in to the apply for qualified teacher status (QTS) service.
+You have received this email because you’re signing in to the apply for qualified teacher status (QTS) service.
 
 To sign in, select the link below:
 

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -177,22 +177,10 @@ RSpec.describe "Teacher authentication", type: :system do
     expect(message.to).to include("test@example.com")
 
     email_body = message.body.raw_source
-    teacher = Teacher.find_by(email: "test@example.com")
-    if teacher.sign_in_count == 0
-      expect(email_body).to include(
-        "Thank you for your interest in applying for qualified teacher status (QTS) in England.",
-      )
-      expect(email_body).not_to include(
-        "Welcome back to apply for qualified teacher status (QTS) in England.",
-      )
-    else
-      expect(email_body).to include(
-        "Welcome back to apply for qualified teacher status (QTS) in England.",
-      )
-      expect(email_body).not_to include(
-        "Thank you for your interest in applying for qualified teacher status (QTS) in England.",
-      )
-    end
+
+    expect(email_body).to include(
+      "You have received this email because you're signing in to the apply for qualified teacher status (QTS) service.",
+    )
   end
 
   def when_i_sign_in_using_magic_link

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -179,7 +179,7 @@ RSpec.describe "Teacher authentication", type: :system do
     email_body = message.body.raw_source
 
     expect(email_body).to include(
-      "You have received this email because you're signing in to the apply for qualified teacher status (QTS) service.",
+      "You have received this email because you’re signing in to the apply for qualified teacher status (QTS) service.",
     )
   end
 

--- a/spec/system/teacher_interface/authentication_spec.rb
+++ b/spec/system/teacher_interface/authentication_spec.rb
@@ -185,8 +185,12 @@ RSpec.describe "Teacher authentication", type: :system do
 
   def when_i_sign_in_using_magic_link
     message = ActionMailer::Base.deliveries.last
-    link_line = message.body.raw_source.lines.fifth.chomp
-    url = link_line.match(/\((http[^)]+)\)/)[1]
+    url =
+      message.body.raw_source.match(
+        /\[Confirm your email address\]\((http[^)]+)\)/,
+      )[
+        1
+      ]
     uri = URI.parse(url)
     expect(uri.path).to eq("/teacher/magic_link")
     expect(uri.query).to include("token")


### PR DESCRIPTION
https://dfedigital.atlassian.net/browse/AQTS-1484

This pr change removes two versions of the sign in email for first time sign in and following sign ins to have just one email version and alters the text to reduce the number of zendesk replies to this email.

By adding inset text to the sign in link it should be clearer to the user how to sign in