### PR TITLE
[AQTS-1528] Filter by region state in CMS

### DIFF
--- a/app/forms/assessor_interface/filter_form.rb
+++ b/app/forms/assessor_interface/filter_form.rb
@@ -8,6 +8,7 @@ class AssessorInterface::FilterForm
                 :date_of_birth,
                 :email,
                 :location,
+                :region_ids,
                 :name,
                 :reference,
                 :show_all,

--- a/app/lib/filters/regions.rb
+++ b/app/lib/filters/regions.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Filters::Regions < Filters::Base
+  def apply
+    return scope if country.blank? || regions.empty?
+
+    scope.where(region: regions)
+  end
+
+  private
+
+  def country
+    @country ||= Country.find_by(code: country_code)
+  end
+
+  def country_code
+    @country_code ||= CountryCode.from_location(params[:location])
+  end
+
+  def region_ids
+    params[:region_ids]
+  end
+
+  def regions
+    Region.where(id: region_ids, country:)
+  end
+end

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -162,6 +162,7 @@ class AssessorInterface::ApplicationFormsIndexViewObject
           ::Filters::Assessor,
           ::Filters::Statuses,
           ::Filters::Country,
+          ::Filters::Regions,
           ::Filters::Name,
           ::Filters::Email,
           ::Filters::DateOfBirth,

--- a/app/view_objects/assessor_interface/application_forms_index_view_object.rb
+++ b/app/view_objects/assessor_interface/application_forms_index_view_object.rb
@@ -58,6 +58,17 @@ class AssessorInterface::ApplicationFormsIndexViewObject
     )
   end
 
+  def country_filter_has_regions?
+    filtered_country.present? && filtered_country.regions.count > 1
+  end
+
+  def region_filter_options
+    filtered_country
+      .regions
+      .order(:name)
+      .map { |region| OpenStruct.new(id: region.id, name: region.name) }
+  end
+
   def stage_filter_options
     STAGE_FILTER_OPTIONS.map { |name| stage_filter_entry(name) }
   end
@@ -234,5 +245,11 @@ class AssessorInterface::ApplicationFormsIndexViewObject
 
   def suitability_matcher
     @suitability_matcher ||= SuitabilityMatcher.new
+  end
+
+  def filtered_country
+    code = CountryCode.from_location(filter_params[:location])
+
+    Country.find_by(code:)
   end
 end

--- a/app/views/assessor_interface/application_forms/index.html.erb
+++ b/app/views/assessor_interface/application_forms/index.html.erb
@@ -56,6 +56,20 @@
                         } %>
     </section>
 
+    <% if @view_object.country_filter_has_regions? %>
+      <section data-controller="checkbox-search-filter" data-checkbox-search-filter-target="container" data-checkbox-search-filter-label-value="Search state/territory trained in" id="app-applications-filters-regions" class="app-checkbox-filter app-checkbox-filter--enhanced">
+        <div class="app-checkbox-filter__container" data-checkbox-search-filter-target="checkboxContainer">
+          <div class="app-checkbox-filter__container-inner" data-checkbox-search-filter-target="checkboxInnerContainer">
+            <%= f.govuk_check_boxes_fieldset :region_ids, legend: { size: "s" }, small: true do %>
+              <% @view_object.region_filter_options.each do |option| %>
+                <%= f.govuk_check_box :region_ids, option.id, label: { text: option.name }, checked: @view_object.filter_form.region_ids&.include?(option.id.to_s), data: { checkbox_search_filter_target: "checkbox" } %>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      </section>
+    <% end %>
+
     <section id="app-applications-filters-reference">
       <%= f.govuk_text_field :reference, label: { size: "s" } %>
     </section>

--- a/config/locales/helpers.en.yml
+++ b/config/locales/helpers.en.yml
@@ -437,6 +437,7 @@ en:
         assessor_ids: Assessor name
         date_of_birth: Applicant date of birth
         flags: Flagged as
+        region_ids: State/territory trained in
         states: Status of application
         submitted_at: Created date
         submitted_at_after: Start date

--- a/spec/lib/filters/regions_spec.rb
+++ b/spec/lib/filters/regions_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Filters::Regions do
+  subject { described_class.apply(scope:, params:) }
+
+  let(:country) { create :country, code: "US" }
+
+  let(:alabama) { create :region, name: "Alabama", country: }
+  let(:hawaii) { create :region, name: "Hawaii", country: }
+  let(:texas) { create :region, name: "Texas", country: }
+
+  let!(:alabama_application) { create :application_form, region: alabama }
+
+  let!(:hawaii_application_one) { create :application_form, region: hawaii }
+  let!(:hawaii_application_two) { create :application_form, region: hawaii }
+
+  let!(:texas_application_one) { create :application_form, region: texas }
+  let!(:texas_application_two) { create :application_form, region: texas }
+  let!(:texas_application_three) { create :application_form, region: texas }
+
+  let(:scope) { ApplicationForm.all }
+
+  before do
+    create(
+      :application_form,
+      region: create(:region, :in_country, country_code: "FR"),
+    )
+    create(
+      :application_form,
+      region: create(:region, :in_country, country_code: "GH"),
+    )
+  end
+
+  context "with location param" do
+    let(:params) { { location: "country:US" } }
+
+    it "returns a filtered scope" do
+      expect(subject).to eq(scope)
+    end
+
+    context "when region_ids includes 1 US state" do
+      let(:params) { { location: "country:US", region_ids: [texas.id] } }
+      let(:filtered_results) do
+        [texas_application_one, texas_application_two, texas_application_three]
+      end
+
+      it "returns a filtered scope" do
+        expect(subject).to match_array(filtered_results)
+      end
+    end
+
+    context "when region_ids includes multiple US state" do
+      let(:params) do
+        {
+          location: "country:US",
+          region_ids: [alabama.id, hawaii.id, texas.id],
+        }
+      end
+      let(:filtered_results) do
+        [
+          alabama_application,
+          hawaii_application_one,
+          hawaii_application_two,
+          texas_application_one,
+          texas_application_two,
+          texas_application_three,
+        ]
+      end
+
+      it "returns a filtered scope" do
+        expect(subject).to match_array(filtered_results)
+      end
+    end
+
+    context "when the region_ids below to a different country" do
+      let(:params) do
+        {
+          location: "country:GH",
+          region_ids: [alabama.id, hawaii.id, texas.id],
+        }
+      end
+
+      it "returns a filtered scope" do
+        expect(subject).to eq(scope)
+      end
+    end
+
+    context "when not country location provided with the region_ids" do
+      let(:params) { { region_ids: [alabama.id, hawaii.id, texas.id] } }
+
+      it "returns a filtered scope" do
+        expect(subject).to eq(scope)
+      end
+    end
+  end
+
+  context "without location param" do
+    let(:params) { {} }
+
+    it "returns the original scope" do
+      expect(subject).to eq(scope)
+    end
+  end
+end

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
         it { is_expected.to be_empty }
       end
 
+      context "with regions filter" do
+        before do
+          allow_any_instance_of(Filters::Regions).to receive(:apply).and_return(
+            ApplicationForm.none,
+          )
+        end
+
+        it { is_expected.to be_empty }
+      end
+
       context "with a name filter" do
         before do
           allow_any_instance_of(Filters::Name).to receive(:apply).and_return(

--- a/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
+++ b/spec/view_objects/assessor_interface/application_forms_index_view_object_spec.rb
@@ -341,4 +341,76 @@ RSpec.describe AssessorInterface::ApplicationFormsIndexViewObject do
       it { expect(subject).to eq("Prioritised (1)") }
     end
   end
+
+  describe "#country_filter_has_regions?" do
+    subject(:country_filter_has_regions?) do
+      view_object.country_filter_has_regions?
+    end
+
+    context "when no country has been selected in filter" do
+      it { is_expected.to be false }
+    end
+
+    context "when country only has National region" do
+      let(:country) { create :country, :with_national_region, code: "GH" }
+
+      let(:session) do
+        { filter_params: { location: "country:#{country.code}" } }
+      end
+
+      it { is_expected.to be false }
+    end
+
+    context "when country has multiple regions" do
+      let(:country) { create :country, code: "US" }
+
+      let(:session) do
+        { filter_params: { location: "country:#{country.code}" } }
+      end
+
+      before { create_list :region, 3, country: }
+
+      it { is_expected.to be true }
+    end
+  end
+
+  describe "#region_filter_options" do
+    subject(:region_filter_options) { view_object.region_filter_options }
+
+    context "when country only has National region" do
+      let(:country) { create :country, :with_national_region, code: "GH" }
+
+      let(:session) do
+        { filter_params: { location: "country:#{country.code}" } }
+      end
+
+      it do
+        expect(subject).to eq(
+          [OpenStruct.new(id: country.regions.first.id, name: "")],
+        )
+      end
+    end
+
+    context "when country has multiple regions" do
+      let(:country) { create :country, code: "US" }
+
+      let(:session) do
+        { filter_params: { location: "country:#{country.code}" } }
+      end
+
+      let!(:alabama) { create :region, name: "Alabama", country: }
+      let!(:hawaii) { create :region, name: "Hawaii", country: }
+      let!(:texas) { create :region, name: "Texas", country: }
+
+      it do
+        expect(subject).to eq(
+          [
+            OpenStruct.new(id: alabama.id, name: "Alabama"),
+            OpenStruct.new(id: hawaii.id, name: "Hawaii"),
+            OpenStruct.new(id: texas.id, name: "Texas"),
+          ],
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1528

<img width="339" height="811" alt="Screenshot 2026-06-25 at 14 23 53" src="https://github.com/user-attachments/assets/a5749f6e-b806-41a3-9754-8189c1f703a0" />

Adds a State/territory filter to the CMS application list. When a country that has multiple regions is selected in the existing country filter, a second filter appears letting you narrow results down to a specific region within that country.

Countries with multiple regions (e.g. those where QTS eligibility or assessment differs by state/province) couldn't be filtered any further than country level. Assessors had to scan the full list to find applications for a particular region. This adds the missing level of granularity.

- Region filter is hidden by default.
- It only renders once a country with multiple regions is the active country filter.
- Selecting a different country clears any previously applied region filter.