### PR TITLE
Remove access to default device session pages that are not used

### DIFF
--- a/app/controllers/concerns/enforce_entra_id_sign_in.rb
+++ b/app/controllers/concerns/enforce_entra_id_sign_in.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module EnforceEntraIdSignIn
+  extend ActiveSupport::Concern
+
+  private
+
+  def enforce_entra_id_sign_in
+    if FeatureFlags::FeatureFlag.active?(:sign_in_with_active_directory)
+      redirect_to root_path
+    end
+  end
+end

--- a/app/controllers/staff/confirmations_controller.rb
+++ b/app/controllers/staff/confirmations_controller.rb
@@ -2,8 +2,9 @@
 
 class Staff::ConfirmationsController < Devise::ConfirmationsController
   include AssessorCurrentNamespace
+  include EnforceEntraIdSignIn
 
-  before_action :redirect_to_home
+  before_action :enforce_entra_id_sign_in
 
   layout "two_thirds"
 
@@ -33,12 +34,4 @@ class Staff::ConfirmationsController < Devise::ConfirmationsController
   # def after_confirmation_path_for(resource_name, resource)
   #   super(resource_name, resource)
   # end
-
-  private
-
-  def redirect_to_home
-    if FeatureFlags::FeatureFlag.active?(:sign_in_with_active_directory)
-      redirect_to root_path
-    end
-  end
 end

--- a/app/controllers/staff/confirmations_controller.rb
+++ b/app/controllers/staff/confirmations_controller.rb
@@ -3,6 +3,8 @@
 class Staff::ConfirmationsController < Devise::ConfirmationsController
   include AssessorCurrentNamespace
 
+  before_action :redirect_to_home
+
   layout "two_thirds"
 
   # GET /resource/confirmation/new
@@ -31,4 +33,12 @@ class Staff::ConfirmationsController < Devise::ConfirmationsController
   # def after_confirmation_path_for(resource_name, resource)
   #   super(resource_name, resource)
   # end
+
+  private
+
+  def redirect_to_home
+    if FeatureFlags::FeatureFlag.active?(:sign_in_with_active_directory)
+      redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/staff/passwords_controller.rb
+++ b/app/controllers/staff/passwords_controller.rb
@@ -3,6 +3,8 @@
 class Staff::PasswordsController < Devise::PasswordsController
   include AssessorCurrentNamespace
 
+  before_action :redirect_to_home
+
   layout "two_thirds"
 
   # GET /resource/password/new
@@ -35,4 +37,12 @@ class Staff::PasswordsController < Devise::PasswordsController
   # def after_sending_reset_password_instructions_path_for(resource_name)
   #   super(resource_name)
   # end
+
+  private
+
+  def redirect_to_home
+    if FeatureFlags::FeatureFlag.active?(:sign_in_with_active_directory)
+      redirect_to root_path
+    end
+  end
 end

--- a/app/controllers/staff/passwords_controller.rb
+++ b/app/controllers/staff/passwords_controller.rb
@@ -2,8 +2,9 @@
 
 class Staff::PasswordsController < Devise::PasswordsController
   include AssessorCurrentNamespace
+  include EnforceEntraIdSignIn
 
-  before_action :redirect_to_home
+  before_action :enforce_entra_id_sign_in
 
   layout "two_thirds"
 
@@ -37,12 +38,4 @@ class Staff::PasswordsController < Devise::PasswordsController
   # def after_sending_reset_password_instructions_path_for(resource_name)
   #   super(resource_name)
   # end
-
-  private
-
-  def redirect_to_home
-    if FeatureFlags::FeatureFlag.active?(:sign_in_with_active_directory)
-      redirect_to root_path
-    end
-  end
 end

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -3,12 +3,24 @@
 class Staff::SessionsController < Devise::SessionsController
   include AssessorCurrentNamespace
 
+  before_action :redirect_to_home, except: %i[signed_out destroy]
+
   layout "two_thirds"
 
   def signed_out
   end
 
+  def destroy
+    super
+  end
+
   protected
+
+  def redirect_to_home
+    if FeatureFlags::FeatureFlag.active?(:sign_in_with_active_directory)
+      redirect_to root_path
+    end
+  end
 
   def after_sign_in_path_for(resource)
     stored_location_for(resource) || assessor_interface_root_path

--- a/app/controllers/staff/sessions_controller.rb
+++ b/app/controllers/staff/sessions_controller.rb
@@ -2,8 +2,9 @@
 
 class Staff::SessionsController < Devise::SessionsController
   include AssessorCurrentNamespace
+  include EnforceEntraIdSignIn
 
-  before_action :redirect_to_home, except: %i[signed_out destroy]
+  before_action :enforce_entra_id_sign_in, except: %i[signed_out destroy]
 
   layout "two_thirds"
 
@@ -15,12 +16,6 @@ class Staff::SessionsController < Devise::SessionsController
   end
 
   protected
-
-  def redirect_to_home
-    if FeatureFlags::FeatureFlag.active?(:sign_in_with_active_directory)
-      redirect_to root_path
-    end
-  end
 
   def after_sign_in_path_for(resource)
     stored_location_for(resource) || assessor_interface_root_path

--- a/app/controllers/staff/unlocks_controller.rb
+++ b/app/controllers/staff/unlocks_controller.rb
@@ -2,8 +2,9 @@
 
 class Staff::UnlocksController < Devise::UnlocksController
   include AssessorCurrentNamespace
+  include EnforceEntraIdSignIn
 
-  before_action :redirect_to_home
+  before_action :enforce_entra_id_sign_in
 
   layout "two_thirds"
 
@@ -33,9 +34,4 @@ class Staff::UnlocksController < Devise::UnlocksController
   # def after_unlock_path_for(resource)
   #   super(resource)
   # end
-  def redirect_to_home
-    if FeatureFlags::FeatureFlag.active?(:sign_in_with_active_directory)
-      redirect_to root_path
-    end
-  end
 end

--- a/app/controllers/staff/unlocks_controller.rb
+++ b/app/controllers/staff/unlocks_controller.rb
@@ -3,6 +3,8 @@
 class Staff::UnlocksController < Devise::UnlocksController
   include AssessorCurrentNamespace
 
+  before_action :redirect_to_home
+
   layout "two_thirds"
 
   # GET /resource/unlock/new
@@ -31,4 +33,9 @@ class Staff::UnlocksController < Devise::UnlocksController
   # def after_unlock_path_for(resource)
   #   super(resource)
   # end
+  def redirect_to_home
+    if FeatureFlags::FeatureFlag.active?(:sign_in_with_active_directory)
+      redirect_to root_path
+    end
+  end
 end


### PR DESCRIPTION
We had access to our old sign in page still on the service. This page should not be in use as users use Entra ID as the way to authenticate. This PR removes it to avoid any spam requests.