### PR TITLE
[AQTS-1544] Remove differentiation of redirect on sign in for magic link flow

### DIFF
--- a/app/controllers/teachers/sessions_controller.rb
+++ b/app/controllers/teachers/sessions_controller.rb
@@ -115,12 +115,9 @@ class Teachers::SessionsController < Devise::SessionsController
 
       self.resource = resource_class.find_by_email(@new_session_form.email)
 
-      if resource
-        resource.send_magic_link
-        redirect_to teacher_check_email_path(email: resource.email)
-      else
-        redirect_to :eligibility_interface_countries
-      end
+      resource.send_magic_link if resource
+
+      redirect_to teacher_check_email_path(email: @new_session_form.email)
     elsif @new_session_form.sign_in_or_sign_up.blank?
       render :new_or_create, status: :unprocessable_entity
     else

--- a/app/views/teachers/sessions/check_email.html.erb
+++ b/app/views/teachers/sessions/check_email.html.erb
@@ -4,12 +4,22 @@
 
 <p class="govuk-body-m">
   <% if @email.present? %>
-    You asked us to send a link to <%= @email %>. Follow the link to confirm your email address.
+    You asked us to send a sign in link to <%= @email %>.
   <% else %>
-    You should have received a link by email. Follow the link to confirm your email address.
+    You asked us to send a sign in link to your email.
   <% end %>
 </p>
 
 <p class="govuk-body">
+  Follow the link in the email to confirm your email address and sign in.
+</p>
+
+<p class="govuk-body">
   If it does not arrive in 5 minutes, check your junk folder or <%= govuk_link_to 'try again', new_teacher_session_path %>.
+</p>
+
+<h2 class="govuk-heading-m">Didn’t receive an email?</h2>
+
+<p class="govuk-body">
+  If you’ve not <%= govuk_link_to 'checked whether you’re eligible to apply', eligibility_interface_countries_path %> yet, you’ll need to do that before you sign in for the first time.
 </p>

--- a/spec/requests/teachers/sessions/create_spec.rb
+++ b/spec/requests/teachers/sessions/create_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe "POST /teacher/sign_in", type: :request do
     it "does not send the email a magic sign in link" do
       expect { sign_in }.not_to have_enqueued_mail(DeviseMailer, :magic_link)
     end
+
+    it "redirects to check your email page" do
+      sign_in
+
+      expect(response).to redirect_to(teacher_check_email_path(email:))
+    end
   end
 
   context "when the sign_in_or_sign_up is not specified" do


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1544

This PR addresses ensures there's no differentiation between whether an application exists or not for the user with the magic link authentication flow.