### PR TITLE
AQTS 1515 FI submit bug

### DIFF
--- a/app/controllers/assessor_interface/further_information_requests_controller.rb
+++ b/app/controllers/assessor_interface/further_information_requests_controller.rb
@@ -30,7 +30,7 @@ module AssessorInterface
       redirect_to [:status, :assessor_interface, application_form]
     rescue FurtherInformationRequests::CreateFromAssessmentSections::AlreadyExists
       flash[:warning] = "Further information has already been requested."
-      render :new, status: :unprocessable_entity
+      redirect_to [:assessor_interface, application_form]
     end
 
     def edit

--- a/spec/requests/assessor_interface/further_information_requests_spec.rb
+++ b/spec/requests/assessor_interface/further_information_requests_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assessor Interface - Further Information Requests",
+               type: :request do
+  let(:signed_in_staff) { create(:staff, :with_assess_permission) }
+
+  let(:application_form) do
+    create(
+      :application_form,
+      :with_personal_information,
+      :assessment_in_progress,
+      :with_assessment,
+    ).tap do |application_form|
+      application_form.assessment.sections << create(
+        :assessment_section,
+        :qualifications,
+        :failed,
+        selected_failure_reasons: [
+          build(
+            :selected_failure_reason,
+            key: "qualifications_dont_match_subjects",
+            assessor_feedback: "A note.",
+          ),
+        ],
+      )
+    end
+  end
+
+  let(:assessment) { application_form.assessment }
+
+  before { sign_in(signed_in_staff) }
+
+  describe "POST /assessor/applications/:reference/assessments/:assessment_id/further-information-requests" do
+    subject(:create_request) do
+      post(
+        "/assessor/applications/#{application_form.reference}" \
+          "/assessments/#{assessment.id}/further-information-requests",
+      )
+    end
+
+    context "when no request exists yet" do
+      it "creates a further information request" do
+        expect { create_request }.to change(
+          assessment.further_information_requests,
+          :count,
+        ).by(1)
+      end
+
+      it "redirects to the application status page" do
+        create_request
+        expect(response).to redirect_to(
+          "/assessor/applications/#{application_form.reference}/status",
+        )
+      end
+    end
+
+    context "when a request already exists (e.g. resubmitted via the back button)" do
+      before { create(:further_information_request, assessment:) }
+
+      it "does not create a second request" do
+        expect { create_request }.not_to change(
+          assessment.further_information_requests,
+          :count,
+        )
+      end
+
+      it "redirects to the application overview page rather than erroring" do
+        create_request
+        expect(response).to redirect_to(
+          "/assessor/applications/#{application_form.reference}",
+        )
+      end
+
+      it "sets a warning flash message" do
+        create_request
+        expect(flash[:warning]).to eq(
+          "Further information has already been requested.",
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/teacher_interface/consent_requests_spec.rb
+++ b/spec/requests/teacher_interface/consent_requests_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Teacher Interface - Consent Requests", type: :request do
   end
 
   describe "POST /teacher/application/consent-requests/submit" do
-    subject(:perform) do
+    subject(:create_request) do
       post submit_teacher_interface_application_form_consent_requests_path(
              application_form,
            )
@@ -26,18 +26,18 @@ RSpec.describe "Teacher Interface - Consent Requests", type: :request do
       end
 
       it "redirects safely to the application form" do
-        perform
+        create_request
         expect(response).to redirect_to(%i[teacher_interface application_form])
       end
 
       it "does not deliver a submission email" do
         expect(DeliverEmail).not_to receive(:call)
-        perform
+        create_request
       end
 
       it "does not attempt to receive the requestables again" do
         expect(ReceiveRequestable).not_to receive(:call)
-        perform
+        create_request
       end
     end
 
@@ -48,18 +48,18 @@ RSpec.describe "Teacher Interface - Consent Requests", type: :request do
       end
 
       it "redirects safely to the application form" do
-        perform
+        create_request
         expect(response).to redirect_to(%i[teacher_interface application_form])
       end
 
       it "delivers a submission email" do
         expect(DeliverEmail).to receive(:call)
-        perform
+        create_request
       end
 
       it "calls ReceiveRequestable twice" do
         expect(ReceiveRequestable).to receive(:call).twice
-        perform
+        create_request
       end
     end
   end


### PR DESCRIPTION
**Ticket:**
https://dfedigital.atlassian.net/browse/AQTS-1515

### What

Updated the Further Information (FI) submission flow to handle duplicate submissions gracefully.
If an assessor submits the FI request twice it is only processed once and the user is redirected to the Application Overview page.

### Why

Previously, a double submission resulted in a 500 "Something went wrong" error page.
Redirecting users to the Application Overview page after a successful submission provides a smoother user experience and prevents unnecessary errors.