### PR TITLE
AQTS 1540 update SLA permissions 

### DIFF
--- a/app/policies/assessor_interface/service_level_agreement_policy.rb
+++ b/app/policies/assessor_interface/service_level_agreement_policy.rb
@@ -2,6 +2,8 @@
 
 class AssessorInterface::ServiceLevelAgreementPolicy < ApplicationPolicy
   def index?
-    user.manage_staff_permission? && !user.archived?
+    return false if user.archived?
+
+    true
   end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -51,6 +51,9 @@
           href: main_app.assessor_interface_staff_index_path,
           active: current_page?(main_app.assessor_interface_staff_index_path)
         ) %>
+      <% end %>
+
+      <% if AssessorInterface::ServiceLevelAgreementPolicy.new(current_staff, :service_level_agreement).index? %>
         <% service_navigation.with_navigation_item(
           text: "SLA Status",
           href: main_app.assessor_interface_service_level_agreements_path,

--- a/spec/policies/assessor_interface/service_level_agreement_policy_spec.rb
+++ b/spec/policies/assessor_interface/service_level_agreement_policy_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe AssessorInterface::ServiceLevelAgreementPolicy do
   describe "#index?" do
     subject(:index?) { described_class.new(user, nil).index? }
 
-    it_behaves_like "a policy method requiring the manage staff permission"
+    it_behaves_like "a policy method with permission"
   end
 end


### PR DESCRIPTION
**Ticket:**
https://dfedigital.atlassian.net/browse/AQTS-1540

### Why is this change being made?
Following the recent redesign and enhancement of the SLA status page, we identified a usability gap: access to the SLA status was restricted to senior managers. This created unnecessary dependency, preventing wider teams from independently monitoring SLA performance and prioritising their work effectively.

### What has changed?

Removed role-based restrictions that limited access to the SLA status page.