### PR TITLE
[AQTS-1550] Ensure personas can never be enabled in production

### DIFF
--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -3,6 +3,7 @@
 class PersonasController < ApplicationController
   include EligibilityCurrentNamespace
 
+  before_action :ensure_not_production
   before_action :ensure_feature_active
 
   before_action :load_staff_personas,
@@ -68,6 +69,12 @@ class PersonasController < ApplicationController
   end
 
   private
+
+  def ensure_not_production
+    if HostingEnvironment.production?
+      render "errors/not_found", status: :not_found
+    end
+  end
 
   def ensure_feature_active
     unless FeatureFlags::FeatureFlag.active?(:personas)

--- a/spec/requests/personas/eligible_spec.rb
+++ b/spec/requests/personas/eligible_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "POST /personas/:region_id/eligible", type: :request do
+  let(:region) { create :region }
+
+  context "when hosting environment is production and feature flag enabled" do
+    before do
+      FeatureFlags::FeatureFlag.activate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(true)
+    end
+
+    it "404s" do
+      post "/personas/#{region.id}/eligible"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Page not found")
+    end
+  end
+
+  context "when hosting environment is production and feature flag disabled" do
+    before do
+      FeatureFlags::FeatureFlag.deactivate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(true)
+    end
+
+    it "404s" do
+      post "/personas/#{region.id}/eligible"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Page not found")
+    end
+  end
+
+  context "when hosting environment not production and feature flag enabled" do
+    before do
+      FeatureFlags::FeatureFlag.activate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(false)
+    end
+
+    it "redirects to result page" do
+      post "/personas/#{region.id}/eligible"
+
+      expect(response).to redirect_to("/eligibility/result")
+    end
+  end
+
+  context "when hosting environment not production and feature flag disabled" do
+    before do
+      FeatureFlags::FeatureFlag.deactivate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(false)
+    end
+
+    it "Redirects to root path with warning message" do
+      post "/personas/#{region.id}/eligible"
+
+      expect(response).to redirect_to("/")
+    end
+  end
+end

--- a/spec/requests/personas/index_spec.rb
+++ b/spec/requests/personas/index_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GET /personas", type: :request do
+  context "when hosting environment is production and feature flag enabled" do
+    before do
+      FeatureFlags::FeatureFlag.activate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(true)
+    end
+
+    it "404s the personas list" do
+      get personas_path
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Page not found")
+    end
+  end
+
+  context "when hosting environment is production and feature flag disabled" do
+    before do
+      FeatureFlags::FeatureFlag.deactivate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(true)
+    end
+
+    it "404s the personas list" do
+      get personas_path
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Page not found")
+    end
+  end
+
+  context "when hosting environment not production and feature flag enabled" do
+    before do
+      FeatureFlags::FeatureFlag.activate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(false)
+    end
+
+    it "renders the personas page" do
+      get personas_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Personas")
+    end
+  end
+
+  context "when hosting environment not production and feature flag disabled" do
+    before do
+      FeatureFlags::FeatureFlag.deactivate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(false)
+    end
+
+    it "Redirects to root path with warning message" do
+      get personas_path
+
+      expect(response).to redirect_to("/")
+    end
+  end
+end

--- a/spec/requests/personas/ineligible_spec.rb
+++ b/spec/requests/personas/ineligible_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "POST /personas/ineligible", type: :request do
+  context "when hosting environment is production and feature flag enabled" do
+    before do
+      FeatureFlags::FeatureFlag.activate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(true)
+    end
+
+    it "404s" do
+      post "/personas/ineligible"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Page not found")
+    end
+  end
+
+  context "when hosting environment is production and feature flag disabled" do
+    before do
+      FeatureFlags::FeatureFlag.deactivate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(true)
+    end
+
+    it "404s" do
+      post "/personas/ineligible"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Page not found")
+    end
+  end
+
+  context "when hosting environment not production and feature flag enabled" do
+    before do
+      FeatureFlags::FeatureFlag.activate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(false)
+    end
+
+    it "redirects to result page" do
+      post "/personas/ineligible"
+
+      expect(response).to redirect_to("/eligibility/result")
+    end
+  end
+
+  context "when hosting environment not production and feature flag disabled" do
+    before do
+      FeatureFlags::FeatureFlag.deactivate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(false)
+    end
+
+    it "Redirects to root path with warning message" do
+      post "/personas/ineligible"
+
+      expect(response).to redirect_to("/")
+    end
+  end
+end

--- a/spec/requests/personas/staff_spec.rb
+++ b/spec/requests/personas/staff_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "POST /personas/:staff_id/staff", type: :request do
+  let(:staff) { create :staff }
+
+  context "when hosting environment is production and feature flag enabled" do
+    before do
+      FeatureFlags::FeatureFlag.activate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(true)
+    end
+
+    it "404s" do
+      post "/personas/#{staff.id}/staff"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Page not found")
+      expect(controller.current_staff).to be_nil
+    end
+  end
+
+  context "when hosting environment is production and feature flag disabled" do
+    before do
+      FeatureFlags::FeatureFlag.deactivate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(true)
+    end
+
+    it "404s" do
+      post "/personas/#{staff.id}/staff"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Page not found")
+      expect(controller.current_staff).to be_nil
+    end
+  end
+
+  context "when hosting environment not production and feature flag enabled" do
+    before do
+      FeatureFlags::FeatureFlag.activate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(false)
+    end
+
+    it "redirects to assessor interface and signs user in" do
+      post "/personas/#{staff.id}/staff"
+
+      expect(response).to redirect_to("/assessor")
+      expect(controller.current_staff).to eq(staff)
+    end
+  end
+
+  context "when hosting environment not production and feature flag disabled" do
+    before do
+      FeatureFlags::FeatureFlag.deactivate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(false)
+    end
+
+    it "Redirects to root path with warning message" do
+      post "/personas/#{staff.id}/staff"
+
+      expect(response).to redirect_to("/")
+      expect(controller.current_staff).to be_nil
+    end
+  end
+end

--- a/spec/requests/personas/teacher_spec.rb
+++ b/spec/requests/personas/teacher_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "POST /personas/:teacher_id/teacher", type: :request do
+  let(:teacher) { create :teacher }
+
+  context "when hosting environment is production and feature flag enabled" do
+    before do
+      FeatureFlags::FeatureFlag.activate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(true)
+    end
+
+    it "404s" do
+      post "/personas/#{teacher.id}/teacher"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Page not found")
+      expect(controller.current_teacher).to be_nil
+    end
+  end
+
+  context "when hosting environment is production and feature flag disabled" do
+    before do
+      FeatureFlags::FeatureFlag.deactivate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(true)
+    end
+
+    it "404s" do
+      post "/personas/#{teacher.id}/teacher"
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).to include("Page not found")
+      expect(controller.current_teacher).to be_nil
+    end
+  end
+
+  context "when hosting environment not production and feature flag enabled" do
+    before do
+      FeatureFlags::FeatureFlag.activate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(false)
+    end
+
+    it "redirects to teacher interface and signs user in" do
+      post "/personas/#{teacher.id}/teacher"
+
+      expect(response).to redirect_to("/teacher")
+      expect(controller.current_teacher).to eq(teacher)
+    end
+  end
+
+  context "when hosting environment not production and feature flag disabled" do
+    before do
+      FeatureFlags::FeatureFlag.deactivate(:personas)
+      allow(HostingEnvironment).to receive(:production?).and_return(false)
+    end
+
+    it "Redirects to root path with warning message" do
+      post "/personas/#{teacher.id}/teacher"
+
+      expect(response).to redirect_to("/")
+      expect(controller.current_teacher).to be_nil
+    end
+  end
+end

--- a/spec/system/personas_spec.rb
+++ b/spec/system/personas_spec.rb
@@ -3,44 +3,72 @@
 require "rails_helper"
 
 RSpec.describe "Personas", type: :system do
-  it "active" do
-    given_personas_are_activated
-    given_personas_exist
+  context "when personas feature is active" do
+    before do
+      given_personas_are_activated
+      given_personas_exist
+    end
 
-    when_i_visit_the(:personas_page)
-    then_i_see_the(:personas_page)
+    it "returns personas page" do
+      when_i_visit_the(:personas_page)
+      then_i_see_the(:personas_page)
 
-    when_i_click_on_the_staff_tab_item
-    and_i_sign_in_as_a_persona
-    then_i_see_the(:assessor_applications_page)
+      when_i_click_on_the_staff_tab_item
+      and_i_sign_in_as_a_persona
+      then_i_see_the(:assessor_applications_page)
 
-    when_i_visit_the(:personas_page)
+      when_i_visit_the(:personas_page)
 
-    when_i_click_on_the_eligible_checks_tab_item
-    and_i_sign_in_as_a_persona
-    then_i_see_the(:eligibility_eligible_page)
+      when_i_click_on_the_eligible_checks_tab_item
+      and_i_sign_in_as_a_persona
+      then_i_see_the(:eligibility_eligible_page)
 
-    when_i_visit_the(:personas_page)
+      when_i_visit_the(:personas_page)
 
-    when_i_click_on_the_ineligible_checks_tab_item
-    and_i_sign_in_as_a_persona
-    then_i_see_the(:eligibility_ineligible_page)
+      when_i_click_on_the_ineligible_checks_tab_item
+      and_i_sign_in_as_a_persona
+      then_i_see_the(:eligibility_ineligible_page)
 
-    when_i_visit_the(:personas_page)
+      when_i_visit_the(:personas_page)
 
-    when_i_click_on_the_teachers_tab_item
-    and_i_sign_in_as_a_persona
-    then_i_see_the(:teacher_application_page)
+      when_i_click_on_the_teachers_tab_item
+      and_i_sign_in_as_a_persona
+      then_i_see_the(:teacher_application_page)
 
-    when_i_visit_the(:personas_page)
+      when_i_visit_the(:personas_page)
+    end
+
+    context "with hosting environment being production" do
+      before do
+        allow(HostingEnvironment).to receive(:production?).and_return(true)
+      end
+
+      it "returns 404" do
+        when_i_visit_the(:personas_page)
+        then_i_see_page_not_found_error
+      end
+    end
   end
 
-  it "inactive" do
-    given_personas_are_deactivated
+  context "when personas feature is inactive" do
+    before { given_personas_are_deactivated }
 
-    when_i_visit_the(:personas_page)
-    then_i_see_the(:eligibility_start_page)
-    and_i_see_the_feature_disabled_message
+    it "returns feature inactive" do
+      when_i_visit_the(:personas_page)
+      then_i_see_the(:eligibility_start_page)
+      and_i_see_the_feature_disabled_message
+    end
+
+    context "with hosting environment production" do
+      before do
+        allow(HostingEnvironment).to receive(:production?).and_return(true)
+      end
+
+      it "returns 404" do
+        when_i_visit_the(:personas_page)
+        then_i_see_page_not_found_error
+      end
+    end
   end
 
   private
@@ -84,5 +112,9 @@ RSpec.describe "Personas", type: :system do
 
   def and_i_see_the_feature_disabled_message
     expect(personas_page).to have_content("Personas feature not active.")
+  end
+
+  def then_i_see_page_not_found_error
+    expect(page).to have_content("Page not found")
   end
 end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1550

This is an additional layer so that we never allow the `/personas` feature to become active due to human error within production.