### PR TITLE
[AQTS-1548] Harden staff Entra ID sign-in identity matching

### DIFF
--- a/app/controllers/staff/omniauth_callbacks_controller.rb
+++ b/app/controllers/staff/omniauth_callbacks_controller.rb
@@ -8,17 +8,32 @@ class Staff::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     email = auth["info"]["email"]
     azure_ad_uid = auth["uid"]
 
-    @staff = Staff.find_by_email(email)
+    return fail_sign_in if azure_ad_uid.blank?
 
-    if @staff&.update(azure_ad_uid:)
-      @staff.confirm unless @staff.confirmed?
-      sign_in_and_redirect @staff, event: :authentication
+    staff = Staff.find_by(azure_ad_uid:)
+
+    if staff.nil?
+      staff = Staff.find_by_email(email)
+
+      if staff.present? && staff.azure_ad_uid.nil?
+        staff.update!(azure_ad_uid:)
+        staff.confirm unless staff.confirmed?
+
+        sign_in_and_redirect staff, event: :authentication
+      else
+        fail_sign_in
+      end
     else
-      redirect_to new_staff_session_url, alert: t(".failure")
+      staff.confirm unless staff.confirmed?
+      sign_in_and_redirect staff, event: :authentication
     end
   end
 
   protected
+
+  def fail_sign_in
+    redirect_to new_staff_session_url, alert: t(".failure")
+  end
 
   def after_sign_in_path_for(resource)
     stored_location_for(resource) || assessor_interface_root_path

--- a/spec/requests/staff/omniauth_callbacks/entra_id_spec.rb
+++ b/spec/requests/staff/omniauth_callbacks/entra_id_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Staff Entra ID sign-in", type: :request do
+  let(:callback_path) { staff_entra_id_omniauth_callback_path }
+  let(:signed_in_redirect_path) { "/assessor" }
+
+  let(:email) { "member@staff.com" }
+  let(:azure_ad_uid) { "uid-123456789" }
+
+  let(:omniauth_hash) do
+    OmniAuth::AuthHash.new(
+      "uid" => azure_ad_uid,
+      "info" => {
+        "email" => email,
+      },
+    )
+  end
+
+  before { OmniAuth.config.mock_auth[:default] = omniauth_hash }
+
+  context "when a staff record already matches the Azure uid" do
+    let!(:staff) { create :staff, email:, azure_ad_uid: }
+
+    it "signs in without relinking and confirms staff" do
+      get callback_path
+
+      expect(response).to redirect_to(signed_in_redirect_path)
+      expect(staff.reload.azure_ad_uid).to eq(azure_ad_uid)
+      expect(staff).to be_confirmed
+      expect(controller.current_staff).to eq(staff)
+    end
+  end
+
+  context "when no uid matches but the email matches an unlinked account" do
+    let!(:staff) { create :staff, email:, azure_ad_uid: nil }
+
+    it "signs in, links the uid and confirms staff" do
+      get callback_path
+
+      expect(response).to redirect_to(signed_in_redirect_path)
+      expect(staff.reload.azure_ad_uid).to eq(azure_ad_uid)
+      expect(staff).to be_confirmed
+      expect(controller.current_staff).to eq(staff)
+    end
+  end
+
+  context "when the email matches an account already linked to a different uid" do
+    let!(:staff) { create :staff, email:, azure_ad_uid: "other-entra-uid" }
+
+    it "refuses to relink, fails sign in and redirects" do
+      get callback_path
+
+      expect(flash[:alert]).to eq(
+        "There was a problem signing you in. Please try again.",
+      )
+      expect(response).to redirect_to(new_staff_session_url)
+
+      expect(staff.reload.azure_ad_uid).to eq("other-entra-uid")
+      expect(controller.current_staff).to be_nil
+    end
+  end
+
+  context "when no staff matches by uid or email" do
+    it "fails sign in and redirects" do
+      get callback_path
+
+      expect(flash[:alert]).to eq(
+        "There was a problem signing you in. Please try again.",
+      )
+      expect(response).to redirect_to(new_staff_session_url)
+
+      expect(controller.current_staff).to be_nil
+    end
+  end
+
+  context "when no auth uid is provided" do
+    let!(:staff) { create :staff, email: }
+    let(:azure_ad_uid) { nil }
+
+    it "fails sign-in without updating accounts with nil uid" do
+      get callback_path
+
+      expect(flash[:alert]).to eq(
+        "There was a problem signing you in. Please try again.",
+      )
+      expect(response).to redirect_to(new_staff_session_url)
+      expect(controller.current_staff).to be_nil
+
+      expect(staff.reload.azure_ad_uid).to be_nil
+    end
+  end
+
+  context "when authentication on Microsoft has failed" do
+    let!(:staff) { create :staff, email: }
+    let(:omniauth_hash) { :access_denied }
+
+    it "fails sign-in" do
+      get callback_path
+
+      expect(response).to redirect_to(root_path)
+      expect(flash[:alert]).to eq(
+        "There was a problem signing in. Please try again.",
+      )
+
+      expect(controller.current_staff).to be_nil
+
+      expect(staff.reload.azure_ad_uid).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1548

Staff sign in already relies on our own single DfE tenant being used in the OmniAuth strategy, so cross-tenant sign-in was never possible. This change enhances the callback on top of that existing control to make identity matching extra bullet-proof.

## Change

* Match staff by the immutable Entra identifier (tid + oid) first, rather than by email. Email is now only used for first-time linking of an account that is invited.
* Refuse to relink once an account is already bound to a uid, so an email that later points at a different Entra identity can't attach to an existing record.