### PR TITLE
AQTS-1519-Add-translation-title

### DIFF
--- a/app/views/assessor_interface/further_information_requests/edit.html.erb
+++ b/app/views/assessor_interface/further_information_requests/edit.html.erb
@@ -40,9 +40,15 @@
 
         <% if item[:applicant_upload_response] %>
           <% applicant_upload_response = item.fetch(:applicant_upload_response) %>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Applicant's document</h3>
           <%= document_link_to(applicant_upload_response) %>
-          <%= document_link_to(applicant_upload_response, translated: true) %>
+          <% if applicant_upload_response.translated_uploads.any? %>
+            <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Document translation</h3>
+            <%= document_link_to(applicant_upload_response, translated: true) %>
+          <% end %>
         <% end %>
+
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" />
 
         <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Further information request</h3>
         <p class="govuk-hint govuk-!-margin-bottom-2"><%= item.fetch(:requested_date) %></p>


### PR DESCRIPTION

**Ticket**
[AQTS-1546](https://dfedigital.atlassian.net/browse/AQTS-1546)

### Why is this change being made?
Currently, when applicants upload translation documents alongside their Further Information (FI) responses, there is no clear distinction in CMS between the original applicant documents and their translations.

This lack of differentiation creates confusion for assessors, making it harder to quickly identify and review the correct files, particularly when multiple documents are submitted.


### What has changed?

Updates have been made to the “Review further information received” page to display documents in a clearer and more structured way:

**Applicant’s document**

Displays all uploaded non-translation (original) documents.


**Document translation**

Displays all uploaded translation documents.
Only appears when translation documents have been provided.


<img width="586" height="763" alt="Screenshot 2026-07-09 at 13 11 55" src="https://github.com/user-attachments/assets/013fd579-7ea5-4afa-8901-4bb2f9b64e19" />
<img width="570" height="845" alt="Screenshot 2026-07-09 at 13 12 13" src="https://github.com/user-attachments/assets/e778d344-998c-4ae5-8ed3-bd04ef2c7173" />
<img width="582" height="796" alt="Screenshot 2026-07-09 at 13 14 14" src="https://github.com/user-attachments/assets/cade150a-6907-49e6-9b80-7f9bd198677f" />
