### PR TITLE
AQTS-1530-verified-by-feature

### DIFF
--- a/app/components/application_form_overview/component.rb
+++ b/app/components/application_form_overview/component.rb
@@ -18,6 +18,7 @@ module ApplicationFormOverview
         application_form,
         current_staff:,
         include_name: true,
+        include_verifier: application_form.verifier.present?,
         highlight_email:,
       ) +
         [

--- a/app/components/timeline_entry/component.rb
+++ b/app/components/timeline_entry/component.rb
@@ -55,6 +55,10 @@ module TimelineEntry
 
     private
 
+    def verification_decision_made_vars
+      { creator_name: creator }
+    end
+
     def status_changed_vars
       {
         old_status:

--- a/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
+++ b/app/controllers/assessor_interface/assessment_recommendation_award_controller.rb
@@ -109,10 +109,7 @@ module AssessorInterface
 
       if @form.valid?
         if @form.confirmation
-          ActiveRecord::Base.transaction do
-            assessment.award!
-            CreateTRSTRNRequest.call(application_form:, user: current_staff)
-          end
+          SendApplicationForQTSAward.call(assessment:, user: current_staff)
 
           redirect_to [:status, :assessor_interface, application_form]
         else

--- a/app/helpers/application_form_helper.rb
+++ b/app/helpers/application_form_helper.rb
@@ -15,6 +15,7 @@ module ApplicationFormHelper
     current_staff:,
     include_name:,
     include_reviewer: true,
+    include_verifier: false,
     highlight_email: false,
     class_context: nil
   )
@@ -142,6 +143,18 @@ module ApplicationFormHelper
                 href: [:assessor_interface, application_form, :assign_reviewer],
               },
             ],
+          }
+        end
+      ),
+      (
+        if include_verifier
+          {
+            key: {
+              text: I18n.t("application_form.summary.verifier"),
+            },
+            value: {
+              text: application_form.verifier.name,
+            },
           }
         end
       ),

--- a/app/models/application_form.rb
+++ b/app/models/application_form.rb
@@ -71,6 +71,7 @@
 #  region_id                                     :bigint           not null
 #  reviewer_id                                   :bigint
 #  teacher_id                                    :bigint           not null
+#  verifier_id                                   :bigint
 #
 # Indexes
 #
@@ -85,6 +86,7 @@
 #  index_application_forms_on_reviewer_id                   (reviewer_id)
 #  index_application_forms_on_stage                         (stage)
 #  index_application_forms_on_teacher_id                    (teacher_id)
+#  index_application_forms_on_verifier_id                   (verifier_id)
 #
 # Foreign Keys
 #
@@ -94,6 +96,7 @@
 #  fk_rails_...  (region_id => regions.id)
 #  fk_rails_...  (reviewer_id => staff.id)
 #  fk_rails_...  (teacher_id => teachers.id)
+#  fk_rails_...  (verifier_id => staff.id)
 #
 class ApplicationForm < ApplicationRecord
   ATTACHABLE_DOCUMENT_TYPES = %w[
@@ -131,6 +134,7 @@ class ApplicationForm < ApplicationRecord
 
   belongs_to :assessor, class_name: "Staff", optional: true
   belongs_to :reviewer, class_name: "Staff", optional: true
+  belongs_to :verifier, class_name: "Staff", optional: true
 
   validates :awarded_at, absence: true, if: :declined_at?
   validates :awarded_at, absence: true, if: :withdrawn_at?

--- a/app/models/timeline_event.rb
+++ b/app/models/timeline_event.rb
@@ -103,6 +103,7 @@ class TimelineEvent < ApplicationRecord
          reviewer_assigned: "reviewer_assigned",
          stage_changed: "stage_changed",
          status_changed: "status_changed",
+         verification_decision_made: "verification_decision_made",
        }
 
   validates :creator, presence: true, unless: -> { creator_name.present? }

--- a/app/services/assign_application_form_verifier.rb
+++ b/app/services/assign_application_form_verifier.rb
@@ -3,9 +3,8 @@
 class AssignApplicationFormVerifier
   include ServicePattern
 
-  def initialize(application_form:, user:, verifier:)
+  def initialize(application_form:, verifier:)
     @application_form = application_form
-    @user = user
     @verifier = verifier
   end
 
@@ -17,5 +16,5 @@ class AssignApplicationFormVerifier
 
   private
 
-  attr_reader :application_form, :user, :verifier
+  attr_reader :application_form, :verifier
 end

--- a/app/services/assign_application_form_verifier.rb
+++ b/app/services/assign_application_form_verifier.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AssignApplicationFormVerifier
+  include ServicePattern
+
+  def initialize(application_form:, user:, verifier:)
+    @application_form = application_form
+    @user = user
+    @verifier = verifier
+  end
+
+  def call
+    return if application_form.verifier == verifier
+
+    application_form.update!(verifier:)
+  end
+
+  private
+
+  attr_reader :application_form, :user, :verifier
+end

--- a/app/services/assign_application_form_verifier.rb
+++ b/app/services/assign_application_form_verifier.rb
@@ -11,7 +11,15 @@ class AssignApplicationFormVerifier
   def call
     return if application_form.verifier == verifier
 
-    application_form.update!(verifier:)
+    ActiveRecord::Base.transaction do
+      application_form.update!(verifier:)
+
+      CreateTimelineEvent.call(
+        "verification_decision_made",
+        application_form:,
+        user: verifier,
+      )
+    end
   end
 
   private

--- a/app/services/review_assessment.rb
+++ b/app/services/review_assessment.rb
@@ -14,6 +14,7 @@ class ReviewAssessment
     ActiveRecord::Base.transaction do
       assessment.review!
 
+      AssignApplicationFormVerifier.call(application_form:, verifier: user)
       ApplicationFormStatusUpdater.call(application_form:, user:)
     end
   end

--- a/app/services/send_application_for_qts_award.rb
+++ b/app/services/send_application_for_qts_award.rb
@@ -9,11 +9,9 @@ class SendApplicationForQTSAward
   end
 
   def call
-    in_verify_stage = assessment.verify?
-
     ActiveRecord::Base.transaction do
       assessment.award!
-      if in_verify_stage
+      if application_form_in_verification_stage?
         AssignApplicationFormVerifier.call(application_form:, verifier: user)
       end
       CreateTRSTRNRequest.call(application_form:, user:)
@@ -25,4 +23,8 @@ class SendApplicationForQTSAward
   attr_reader :assessment, :user
 
   delegate :application_form, to: :assessment
+
+  def application_form_in_verification_stage?
+    application_form.verification_stage?
+  end
 end

--- a/app/services/send_application_for_qts_award.rb
+++ b/app/services/send_application_for_qts_award.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class SendApplicationForQTSAward
+  include ServicePattern
+
+  def initialize(assessment:, user:)
+    @assessment = assessment
+    @user = user
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      assessment.award!
+      AssignApplicationFormVerifier.call(application_form:, verifier: user)
+      CreateTRSTRNRequest.call(application_form:, user:)
+    end
+  end
+
+  private
+
+  attr_reader :assessment, :user
+
+  delegate :application_form, to: :assessment
+end

--- a/app/services/send_application_for_qts_award.rb
+++ b/app/services/send_application_for_qts_award.rb
@@ -9,9 +9,13 @@ class SendApplicationForQTSAward
   end
 
   def call
+    in_verify_stage = assessment.verify?
+
     ActiveRecord::Base.transaction do
       assessment.award!
-      AssignApplicationFormVerifier.call(application_form:, verifier: user)
+      if in_verify_stage
+        AssignApplicationFormVerifier.call(application_form:, verifier: user)
+      end
       CreateTRSTRNRequest.call(application_form:, user:)
     end
   end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -48,6 +48,7 @@
     - requires_preliminary_check
     - requires_private_email_for_referee
     - reviewer_id
+    - verifier_id
     - stage
     - started_with_private_email_for_referee
     - statuses

--- a/config/locales/components.en.yml
+++ b/config/locales/components.en.yml
@@ -123,12 +123,14 @@ en:
           ReferenceRequest: Reference verified
         stage_changed: Stage changed
         status_changed: Status changed
+        verification_decision_made: Verification decision made
       description:
         action_required_by_changed: Application requires %{action} action.
         assessor_assigned: "%{assignee_name} is assigned as the assessor."
         email_sent: "%{subject}"
         note_created: "%{text}"
         reviewer_assigned: "%{assignee_name} is assigned as the reviewer."
+        verification_decision_made: "Verification decision made by %{creator_name}"
         requestable_requested:
           ConsentRequest: Consent has been requested.
           FurtherInformationRequest: Further information has been requested.

--- a/config/locales/teacher_interface.en.yml
+++ b/config/locales/teacher_interface.en.yml
@@ -267,6 +267,7 @@ en:
       days_since_submission: Working days since submission
       assessor: Assigned to
       reviewer: Reviewer
+      verifier: Verified by
       reference: Reference
       unassigned: Not assigned
       status: Status

--- a/db/migrate/20260715042707_add_verifier_to_application_forms.rb
+++ b/db/migrate/20260715042707_add_verifier_to_application_forms.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddVerifierToApplicationForms < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :application_forms,
+                  :verifier,
+                  foreign_key: {
+                    to_table: :staff,
+                  }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -103,6 +103,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_160656) do
     t.boolean "teaching_qualification_part_of_degree"
     t.jsonb "trs_match", default: {}
     t.datetime "updated_at", null: false
+    t.bigint "verifier_id"
     t.datetime "withdrawn_at"
     t.string "work_history_status", default: "not_started", null: false
     t.integer "working_days_between_submitted_and_completed"
@@ -121,6 +122,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_160656) do
     t.index ["reviewer_id"], name: "index_application_forms_on_reviewer_id"
     t.index ["stage"], name: "index_application_forms_on_stage"
     t.index ["teacher_id"], name: "index_application_forms_on_teacher_id"
+    t.index ["verifier_id"], name: "index_application_forms_on_verifier_id"
   end
 
   create_table "application_forms_suitability_records", id: false, force: :cascade do |t|
@@ -777,6 +779,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_27_160656) do
   add_foreign_key "application_forms", "regions"
   add_foreign_key "application_forms", "staff", column: "assessor_id"
   add_foreign_key "application_forms", "staff", column: "reviewer_id"
+  add_foreign_key "application_forms", "staff", column: "verifier_id"
   add_foreign_key "application_forms", "teachers"
   add_foreign_key "application_holds", "application_forms"
   add_foreign_key "assessment_sections", "assessments"

--- a/spec/components/application_form_overview_component_spec.rb
+++ b/spec/components/application_form_overview_component_spec.rb
@@ -31,8 +31,19 @@ RSpec.describe ApplicationFormOverview::Component, type: :component do
       it { is_expected.to include("Working days since submission") }
       it { is_expected.to include("Assigned to") }
       it { is_expected.to include("Reviewer") }
+      it { is_expected.not_to include("Verified by") }
       it { is_expected.to include("Reference") }
       it { is_expected.to include("Status") }
+    end
+
+    context "when a verifier is assigned" do
+      let(:application_form) do
+        create(:application_form, :submitted, verifier: create(:staff))
+      end
+
+      it "includes the verifier row" do
+        expect(dl.text.strip).to include("Verified by")
+      end
     end
   end
 end

--- a/spec/components/timeline_entry_spec.rb
+++ b/spec/components/timeline_entry_spec.rb
@@ -47,6 +47,20 @@ RSpec.describe TimelineEntry::Component, type: :component do
     end
   end
 
+  context "verification decision made" do
+    let(:timeline_event) do
+      create(:timeline_event, :verification_decision_made)
+    end
+
+    it "describes the event" do
+      expect(component.text).to include("Verification decision made")
+    end
+
+    it "attributes to the creator" do
+      expect(component.text).to include(creator.name)
+    end
+  end
+
   context "status changed" do
     let(:timeline_event) do
       create(

--- a/spec/factories/application_forms.rb
+++ b/spec/factories/application_forms.rb
@@ -71,6 +71,7 @@
 #  region_id                                     :bigint           not null
 #  reviewer_id                                   :bigint
 #  teacher_id                                    :bigint           not null
+#  verifier_id                                   :bigint
 #
 # Indexes
 #
@@ -85,6 +86,7 @@
 #  index_application_forms_on_reviewer_id                   (reviewer_id)
 #  index_application_forms_on_stage                         (stage)
 #  index_application_forms_on_teacher_id                    (teacher_id)
+#  index_application_forms_on_verifier_id                   (verifier_id)
 #
 # Foreign Keys
 #
@@ -94,6 +96,7 @@
 #  fk_rails_...  (region_id => regions.id)
 #  fk_rails_...  (reviewer_id => staff.id)
 #  fk_rails_...  (teacher_id => teachers.id)
+#  fk_rails_...  (verifier_id => staff.id)
 #
 FactoryBot.define do
   factory :application_form do

--- a/spec/factories/timeline_events.rb
+++ b/spec/factories/timeline_events.rb
@@ -146,5 +146,9 @@ FactoryBot.define do
       old_value { ApplicationForm.statuses.keys.sample }
       new_value { ApplicationForm.statuses.keys.sample }
     end
+
+    trait :verification_decision_made do
+      event_type { "verification_decision_made" }
+    end
   end
 end

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -199,6 +199,25 @@ RSpec.describe ApplicationFormHelper do
       end
     end
 
+    context "include_verifier false" do
+      subject(:summary_rows_without_verifier) do
+        application_form_summary_rows(
+          application_form,
+          current_staff:,
+          include_name: true,
+          include_verifier: false,
+        )
+      end
+
+      it "does not return the verifier element" do
+        expect(
+          summary_rows_without_verifier.find do |row|
+            row[:key][:text] == "Verified by"
+          end,
+        ).to be_nil
+      end
+    end
+
     context "region has an empty name" do
       before { application_form.region.update(name: "") }
 

--- a/spec/helpers/application_form_helper_spec.rb
+++ b/spec/helpers/application_form_helper_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe ApplicationFormHelper do
       submitted_at: Date.new(2020, 1, 1),
       given_names: "Given",
       family_name: "Family",
+      verifier: create(:staff),
     )
   end
 
@@ -199,22 +200,22 @@ RSpec.describe ApplicationFormHelper do
       end
     end
 
-    context "include_verifier false" do
-      subject(:summary_rows_without_verifier) do
+    context "include_verifier true" do
+      subject(:summary_rows_with_verifier) do
         application_form_summary_rows(
           application_form,
           current_staff:,
           include_name: true,
-          include_verifier: false,
+          include_verifier: true,
         )
       end
 
-      it "does not return the verifier element" do
+      it "returns the verifier element" do
         expect(
-          summary_rows_without_verifier.find do |row|
+          summary_rows_with_verifier.find do |row|
             row[:key][:text] == "Verified by"
           end,
-        ).to be_nil
+        ).not_to be_nil
       end
     end
 

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -270,6 +270,7 @@ RSpec.describe ApplicationForm, type: :model do
     it { is_expected.to belong_to(:teacher) }
     it { is_expected.to have_many(:notes) }
     it { is_expected.to belong_to(:english_language_provider).optional }
+    it { is_expected.to belong_to(:verifier).class_name("Staff").optional }
   end
 
   describe "validations" do

--- a/spec/models/application_form_spec.rb
+++ b/spec/models/application_form_spec.rb
@@ -71,6 +71,7 @@
 #  region_id                                     :bigint           not null
 #  reviewer_id                                   :bigint
 #  teacher_id                                    :bigint           not null
+#  verifier_id                                   :bigint
 #
 # Indexes
 #
@@ -85,6 +86,7 @@
 #  index_application_forms_on_reviewer_id                   (reviewer_id)
 #  index_application_forms_on_stage                         (stage)
 #  index_application_forms_on_teacher_id                    (teacher_id)
+#  index_application_forms_on_verifier_id                   (verifier_id)
 #
 # Foreign Keys
 #
@@ -94,6 +96,7 @@
 #  fk_rails_...  (region_id => regions.id)
 #  fk_rails_...  (reviewer_id => staff.id)
 #  fk_rails_...  (teacher_id => teachers.id)
+#  fk_rails_...  (verifier_id => staff.id)
 #
 require "rails_helper"
 

--- a/spec/models/timeline_event_spec.rb
+++ b/spec/models/timeline_event_spec.rb
@@ -116,6 +116,7 @@ RSpec.describe TimelineEvent do
         reviewer_assigned: "reviewer_assigned",
         stage_changed: "stage_changed",
         status_changed: "status_changed",
+        verification_decision_made: "verification_decision_made",
       ).backed_by_column_of_type(:string)
     end
 

--- a/spec/services/assign_application_form_verifier_spec.rb
+++ b/spec/services/assign_application_form_verifier_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AssignApplicationFormVerifier do
+  subject(:call) { described_class.call(application_form:, user:, verifier:) }
+
+  let!(:application_form) { create(:application_form, :submitted) }
+  let(:user) { create(:staff) }
+  let(:verifier) { create(:staff) }
+
+  describe "application form verifier" do
+    subject(:verifier_on_form) { application_form.verifier }
+
+    it { is_expected.to be_nil }
+
+    context "after calling the service" do
+      before { call }
+
+      it { is_expected.to be(verifier) }
+    end
+  end
+end

--- a/spec/services/assign_application_form_verifier_spec.rb
+++ b/spec/services/assign_application_form_verifier_spec.rb
@@ -3,10 +3,9 @@
 require "rails_helper"
 
 RSpec.describe AssignApplicationFormVerifier do
-  subject(:call) { described_class.call(application_form:, user:, verifier:) }
+  subject(:call) { described_class.call(application_form:, verifier:) }
 
   let!(:application_form) { create(:application_form, :submitted) }
-  let(:user) { create(:staff) }
   let(:verifier) { create(:staff) }
 
   describe "application form verifier" do

--- a/spec/services/assign_application_form_verifier_spec.rb
+++ b/spec/services/assign_application_form_verifier_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe AssignApplicationFormVerifier do
   let!(:application_form) { create(:application_form, :submitted) }
   let(:verifier) { create(:staff) }
 
+  it "creates a timeline event" do
+    expect { call }.to change {
+      application_form.timeline_events.verification_decision_made.count
+    }.by(1)
+  end
+
   describe "application form verifier" do
     subject(:verifier_on_form) { application_form.verifier }
 

--- a/spec/services/review_assessment_spec.rb
+++ b/spec/services/review_assessment_spec.rb
@@ -24,4 +24,9 @@ RSpec.describe ReviewAssessment do
   it "changes the application form stage" do
     expect { call }.to change(application_form, :stage).to("review")
   end
+
+  it "assigns the verifier" do
+    call
+    expect(application_form.verifier).to eq(user)
+  end
 end

--- a/spec/services/review_assessment_spec.rb
+++ b/spec/services/review_assessment_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe ReviewAssessment do
   end
 
   it "assigns the verifier" do
-    call
-    expect(application_form.verifier).to eq(user)
+    expect { call }.to change(application_form, :verifier).to(user)
   end
 end

--- a/spec/services/send_application_for_qts_award_spec.rb
+++ b/spec/services/send_application_for_qts_award_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SendApplicationForQTSAward do
+  subject(:call) { described_class.call(assessment:, user:) }
+
+  let(:application_form) { create(:application_form, :submitted) }
+  let(:assessment) { create(:assessment, application_form:) }
+  let(:user) { create(:staff) }
+
+  it "awards the assessment" do
+    expect { call }.to change { assessment.reload.recommendation }.to("award")
+  end
+
+  it "assigns the verifier" do
+    expect { call }.to change { application_form.reload.verifier }.to(user)
+  end
+
+  it "creates a TRSTRNRequest" do
+    expect { call }.to change(TRSTRNRequest, :count).by(1)
+  end
+
+  context "when a later step fails" do
+    before do
+      allow(CreateTRSTRNRequest).to receive(:call).and_raise(StandardError)
+    end
+
+    it "rolls back the award" do
+      initial_recommendation = assessment.recommendation
+      expect { call }.to raise_error(StandardError)
+      expect(assessment.reload.recommendation).to eq(initial_recommendation)
+    end
+  end
+end

--- a/spec/services/send_application_for_qts_award_spec.rb
+++ b/spec/services/send_application_for_qts_award_spec.rb
@@ -13,8 +13,24 @@ RSpec.describe SendApplicationForQTSAward do
     expect { call }.to change { assessment.reload.recommendation }.to("award")
   end
 
-  it "assigns the verifier" do
-    expect { call }.to change { application_form.reload.verifier }.to(user)
+  context "when the assessment is in the verify stage" do
+    let(:assessment) do
+      create(:assessment, recommendation: "verify", application_form:)
+    end
+
+    it "assigns the verifier" do
+      expect { call }.to change { application_form.reload.verifier }.to(user)
+    end
+  end
+
+  context "when the assessment is in the review stage" do
+    let(:assessment) do
+      create(:assessment, recommendation: "review", application_form:)
+    end
+
+    it "does not assign the verifier" do
+      expect { call }.not_to(change { application_form.reload.verifier })
+    end
   end
 
   it "creates a TRSTRNRequest" do

--- a/spec/services/send_application_for_qts_award_spec.rb
+++ b/spec/services/send_application_for_qts_award_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe SendApplicationForQTSAward do
     expect { call }.to change { assessment.reload.recommendation }.to("award")
   end
 
-  context "when the assessment is in the verify stage" do
-    let(:assessment) do
-      create(:assessment, recommendation: "verify", application_form:)
+  context "when the application form is in the verification stage" do
+    let(:application_form) do
+      create(:application_form, :submitted, stage: "verification")
     end
 
     it "assigns the verifier" do
@@ -23,9 +23,9 @@ RSpec.describe SendApplicationForQTSAward do
     end
   end
 
-  context "when the assessment is in the review stage" do
-    let(:assessment) do
-      create(:assessment, recommendation: "review", application_form:)
+  context "when the application form is in the review stage" do
+    let(:application_form) do
+      create(:application_form, :submitted, stage: "review")
     end
 
     it "does not assign the verifier" do

--- a/spec/support/autoload/page_objects/assessor_interface/application.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/application.rb
@@ -24,6 +24,10 @@ module PageObjects
         summary_list.find_row(key: "Reviewer")
       end
 
+      def verified_by_summary
+        summary_list.find_row(key: "Verified by")
+      end
+
       def status_summary
         summary_list.find_row(key: "Status")
       end

--- a/spec/system/assessor_interface/assigning_verifier_spec.rb
+++ b/spec/system/assessor_interface/assigning_verifier_spec.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Assigning a verifier", type: :system do
+  let(:assessor_user) do
+    create(:staff, :with_assess_permission, name: "Assessor User")
+  end
+  let(:manager_user) do
+    create(
+      :staff,
+      :with_reverse_decision_permission,
+      :with_assess_permission,
+      name: "Manager User",
+    )
+  end
+  let(:original_verifier) { create(:staff, name: "Original Verifier") }
+
+  it "assigns the verifier when awarded at the verify stage" do
+    given_i_am_authorized_as_a_user(assessor_user)
+    given_there_is_an_awardable_application_form_in_verify_stage
+    given_i_can_request_trs_api
+
+    when_i_visit_the(
+      :assessor_complete_assessment_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_complete_the_award_flow
+
+    when_i_click_on_overview_button
+    then_the_verified_by_summary_shows(assessor_user.name)
+  end
+
+  it "does not change the verifier when awarded at the review stage" do
+    given_i_am_authorized_as_a_user(assessor_user)
+    given_there_is_an_awardable_application_form_in_review_stage(
+      verifier: original_verifier,
+    )
+    given_i_can_request_trs_api
+
+    when_i_visit_the(
+      :assessor_complete_assessment_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_complete_the_award_flow
+
+    when_i_click_on_overview_button
+    then_the_verified_by_summary_shows(original_verifier.name)
+  end
+
+  it "resets the verifier when a decision is reversed and then awarded" do
+    given_i_am_authorized_as_a_user(manager_user)
+    given_there_is_an_awarded_application_form(verifier: original_verifier)
+    given_i_can_request_trs_api
+
+    when_i_visit_the(:assessor_application_page, reference:)
+    when_i_click_on_reverse_decision
+    when_i_visit_the(
+      :assessor_reverse_decision_page,
+      reference:,
+      assessment_id:,
+    )
+    when_i_confirm_the_reversal
+
+    when_i_visit_the(
+      :assessor_complete_assessment_page,
+      reference:,
+      assessment_id:,
+    )
+    and_i_complete_the_award_flow
+
+    when_i_click_on_overview_button
+    then_the_verified_by_summary_shows(manager_user.name)
+  end
+
+  private
+
+  def given_there_is_a_base_application_form
+    @application_form =
+      create(
+        :application_form,
+        :with_personal_information,
+        :with_teaching_qualification,
+        :submitted,
+      )
+
+    @assessment = create(:assessment, application_form: @application_form)
+  end
+
+  def given_there_is_an_awardable_application_form_in_verify_stage
+    given_there_is_a_base_application_form
+    @assessment.verify!
+    @assessment.update!(induction_required: false)
+    @application_form.update!(stage: "verification")
+  end
+
+  def given_there_is_an_awardable_application_form_in_review_stage(verifier:)
+    given_there_is_a_base_application_form
+    @assessment.review!
+    @assessment.update!(induction_required: false)
+    @application_form.update!(verifier:)
+  end
+
+  def given_there_is_an_awarded_application_form(verifier:)
+    given_there_is_a_base_application_form
+    work_history =
+      create(:work_history, :completed, application_form: @application_form)
+    create(
+      :received_reference_request,
+      assessment: @assessment,
+      work_history: work_history,
+      verify_passed: true,
+    )
+    @assessment.award!
+    @assessment.update!(induction_required: false)
+    @application_form.update!(verifier:)
+  end
+
+  def given_i_can_request_trs_api
+    stub_request(
+      :post,
+      "https://test-teacher-qualifications-api.education.gov.uk/v3/trn-requests",
+    ).to_return(
+      body: '{"trn": "abcdef", "potential_duplicate": false}',
+      headers: {
+        "Content-Type" => "application/json",
+      },
+    )
+
+    stub_request(
+      :put,
+      "https://test-teacher-qualifications-api.education.gov.uk/v3/persons/abcdef/routes-to-professional-statuses/#{reference}",
+    ).to_return(
+      status: 200,
+      body: "",
+      headers: {
+        "Content-Type" => "application/json",
+      },
+    )
+  end
+
+  def and_i_complete_the_award_flow
+    assessor_complete_assessment_page.award_qts.input.choose
+    assessor_complete_assessment_page.continue_button.click
+
+    assessor_declare_assessment_recommendation_page
+      .form
+      .declaration_checkbox
+      .click
+    assessor_declare_assessment_recommendation_page.form.submit_button.click
+
+    assessor_age_range_subjects_assessment_recommendation_award_page.continue_button.click
+
+    assessor_confirm_assessment_recommendation_page
+      .form
+      .true_radio_item
+      .input
+      .click
+    assessor_confirm_assessment_recommendation_page.form.continue_button.click
+  end
+
+  def when_i_click_on_reverse_decision
+    assessor_application_page.task_lists.last.click_on("Reverse decision")
+  end
+
+  def when_i_confirm_the_reversal
+    assessor_reverse_decision_page.form.submit_button.click
+  end
+
+  def when_i_click_on_overview_button
+    assessor_application_status_page.button_group.overview_button.click
+  end
+
+  def then_the_verified_by_summary_shows(name)
+    expect(assessor_application_page.verified_by_summary.value).to have_text(
+      name,
+    )
+  end
+
+  def reference
+    @application_form.reference
+  end
+
+  def assessment_id
+    @assessment.id
+  end
+end

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     when_i_click_on_overview_button
     then_the_application_form_is_awarded
+    and_the_verified_by_summary_is_shown
   end
 
   it "verify" do
@@ -450,6 +451,12 @@ RSpec.describe "Assessor completing assessment", type: :system do
       end
 
     expect(declined_timeline_event).not_to be_nil
+  end
+
+  def and_the_verified_by_summary_is_shown
+    expect(assessor_application_page.verified_by_summary.value).to have_text(
+      "Authorized User",
+    )
   end
 
   delegate :reference, to: :application_form

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -231,6 +231,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     application_form.assessment.verify!
     application_form.assessment.update!(induction_required: false)
+    ApplicationFormStatusUpdater.call(application_form:, user: assessor_user)
   end
 
   def given_there_is_a_verifiable_application_form_with_work_history

--- a/spec/system/assessor_interface/completing_assessment_spec.rb
+++ b/spec/system/assessor_interface/completing_assessment_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe "Assessor completing assessment", type: :system do
 
     application_form.assessment.verify!
     application_form.assessment.update!(induction_required: false)
-    ApplicationFormStatusUpdater.call(application_form:, user: assessor_user)
+    application_form.update!(stage: "verification")
   end
 
   def given_there_is_a_verifiable_application_form_with_work_history


### PR DESCRIPTION
**Ticket**: https://dfedigital.atlassian.net/browse/AQTS-1530

### Why is this change being made?
Currently, there is no visibility of which admin makes the final verification decision on an application. This makes it difficult for senior managers to understand verification workloads, track decision ownership, and audit outcomes when applications progress through review or award stages.
This change introduces a new Verified by field to capture and display the admin responsible for the most recent verification decision, providing greater transparency and auditability across the verification process.

### What has changed?
Added verification decision ownership

Added a new Verified by field beneath the existing Reviewer field.
The field is automatically populated with the name of the admin who completes the Verification decision task.
Added timeline entries to record when a verification decision is made and by whom.
<img width="687" height="805" alt="Screenshot 2026-07-30 at 22 07 13" src="https://github.com/user-attachments/assets/97ddbab9-893e-4255-a423-3f6f08d26c76" />

