### PR TITLE
[AQTS-1569] Remove auto relink to re-registered GOV.UK One Login accounts

### DIFF
--- a/app/controllers/teachers/omniauth_callbacks_controller.rb
+++ b/app/controllers/teachers/omniauth_callbacks_controller.rb
@@ -17,7 +17,7 @@ class Teachers::OmniauthCallbacksController < ApplicationController
       session[:id_token] = auth&.credentials&.id_token
 
       teacher =
-        FindOrCreateTeacherFromGovOne.call(
+        FindOrCreateTeacherFromOneLogin.call(
           email:,
           gov_one_id:,
           eligibility_check:,

--- a/app/controllers/teachers/omniauth_callbacks_controller.rb
+++ b/app/controllers/teachers/omniauth_callbacks_controller.rb
@@ -9,7 +9,7 @@ class Teachers::OmniauthCallbacksController < ApplicationController
     email = auth&.info&.email
     gov_one_id = auth&.uid
 
-    return error_redirect unless email
+    return error_redirect unless email && gov_one_id
 
     if new_user_without_eligibility_check_completed?(gov_one_id, email)
       redirect_to :eligibility_interface_countries

--- a/app/services/find_or_create_teacher_from_one_login.rb
+++ b/app/services/find_or_create_teacher_from_one_login.rb
@@ -12,6 +12,8 @@ class FindOrCreateTeacherFromOneLogin
   end
 
   def call
+    return nil if gov_one_id.blank?
+
     ActiveRecord::Base.transaction do
       find_or_create_teacher!
 

--- a/app/services/find_or_create_teacher_from_one_login.rb
+++ b/app/services/find_or_create_teacher_from_one_login.rb
@@ -25,16 +25,25 @@ class FindOrCreateTeacherFromOneLogin
     nil
   end
 
+  class DifferentOneLoginUidError < StandardError
+  end
+
   private
 
   attr_reader :email, :gov_one_id, :eligibility_check
 
   def find_or_create_teacher!
-    @teacher =
-      Teacher.find_by(gov_one_id:) || Teacher.find_by(email:) ||
-        Teacher.create!(email:)
+    @teacher = Teacher.find_by(gov_one_id:)
 
-    teacher.update!(gov_one_id:, gov_one_email: email)
+    if teacher.nil?
+      @teacher = Teacher.find_by(email:) || Teacher.create!(email:)
+
+      raise DifferentOneLoginUidError if teacher.gov_one_id.present?
+
+      teacher.update!(gov_one_id:)
+    end
+
+    teacher.update!(gov_one_email: email)
   end
 
   def create_application_form!

--- a/app/services/find_or_create_teacher_from_one_login.rb
+++ b/app/services/find_or_create_teacher_from_one_login.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class FindOrCreateTeacherFromGovOne
+class FindOrCreateTeacherFromOneLogin
   include ServicePattern
 
   attr_reader :teacher

--- a/spec/requests/teachers/omniauth_callbacks/gov_one_spec.rb
+++ b/spec/requests/teachers/omniauth_callbacks/gov_one_spec.rb
@@ -203,4 +203,68 @@ RSpec.describe "/teacher/auth/gov_one/callback", type: :request do
       expect(response).to redirect_to(teacher_interface_root_path)
     end
   end
+
+  context "when the email is nil" do
+    let(:omniauth_hash) do
+      OmniAuth::AuthHash.new(
+        "uid" => gov_one_id,
+        "credentials" => {
+          "id_token" => "99999",
+        },
+      )
+    end
+
+    it "does not generate a new teacher record with an application" do
+      expect { gov_one_callback }.not_to change(Teacher, :count)
+    end
+
+    it "does not set the id_token session" do
+      gov_one_callback
+
+      expect(request.session[:id_token]).to be_nil
+    end
+
+    it "redirects the user back to the sign in page and does not sign in" do
+      gov_one_callback
+
+      expect(controller.current_teacher).to be_nil
+      expect(response).to redirect_to(root_path)
+      expect(request.flash[:alert]).to eq(
+        "There was a problem signing in. Please try again.",
+      )
+    end
+  end
+
+  context "when the uid is nil" do
+    let(:omniauth_hash) do
+      OmniAuth::AuthHash.new(
+        "info" => {
+          "email" => email,
+        },
+        "credentials" => {
+          "id_token" => "99999",
+        },
+      )
+    end
+
+    it "does not generate a new teacher record with an application" do
+      expect { gov_one_callback }.not_to change(Teacher, :count)
+    end
+
+    it "does not set the id_token session" do
+      gov_one_callback
+
+      expect(request.session[:id_token]).to be_nil
+    end
+
+    it "redirects the user back to the sign in page and does not sign in" do
+      gov_one_callback
+
+      expect(controller.current_teacher).to be_nil
+      expect(response).to redirect_to(root_path)
+      expect(request.flash[:alert]).to eq(
+        "There was a problem signing in. Please try again.",
+      )
+    end
+  end
 end

--- a/spec/services/find_or_create_teacher_from_one_login_spec.rb
+++ b/spec/services/find_or_create_teacher_from_one_login_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe FindOrCreateTeacherFromGovOne do
+RSpec.describe FindOrCreateTeacherFromOneLogin do
   subject(:call) do
     described_class.call(email:, gov_one_id:, eligibility_check:)
   end

--- a/spec/services/find_or_create_teacher_from_one_login_spec.rb
+++ b/spec/services/find_or_create_teacher_from_one_login_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe FindOrCreateTeacherFromOneLogin do
     end
   end
 
-  context "when a teacher record exists with one gov_one_id and gets updated with a new one" do
+  context "when a teacher record exists with same email but different one gov_one_id" do
     let!(:existing_teacher) do
       create :teacher, email:, gov_one_id: "old-gov-one-id"
     end
@@ -147,9 +147,12 @@ RSpec.describe FindOrCreateTeacherFromOneLogin do
       expect { call }.not_to change(Teacher, :count)
     end
 
-    it "updates the gov_one_id on the existing teacher record" do
-      call
-      expect(existing_teacher.reload.gov_one_id).to eq(gov_one_id)
+    it "returns nil" do
+      expect(call).to be_nil
+    end
+
+    it "does not update the gov_one_id on the existing teacher record" do
+      expect { call }.not_to change(existing_teacher, :gov_one_id)
     end
   end
 end

--- a/spec/services/find_or_create_teacher_from_one_login_spec.rb
+++ b/spec/services/find_or_create_teacher_from_one_login_spec.rb
@@ -155,4 +155,18 @@ RSpec.describe FindOrCreateTeacherFromOneLogin do
       expect { call }.not_to change(existing_teacher, :gov_one_id)
     end
   end
+
+  context "when the gov_one_id is nil" do
+    let(:gov_one_id) { nil }
+
+    before { create :teacher, email:, gov_one_id: nil }
+
+    it "does not generate a new teacher record" do
+      expect { call }.not_to change(Teacher, :count)
+    end
+
+    it "returns nil" do
+      expect(call).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1569

## Why

Applicant GOV.UK One Login callbacks matched on email and would re-link whatever One Login UID everytime. That means a re-registered One Login account with a new, different UID but with the same email, would silently be linked to an existing application. This was originally intentional as this was something GOV.UK One Login allowed and was happening regularly, but we have changed our service's tolerance for re-linking. This change makes the immutable One Login UID the primary identifier and refuses to relink an application that's already bound to a different UID.


## What

Callback logic:

1. Match by UID -> sign in applicant.
2. No UID match:
  a) Match by email with no linked UID -> first-time GOV.UK One Login use, link the UID and sign in
  b) Match by email already linked to a different UID -> refuse sign-in and no UID re-link. Logged in Sentry as error.
  c) No email match -> create a new application, link the UID, and sign in
