### PR TITLE
[AQTS-1584] Fix edge-case when applicant goes to decision review request when in draft application

### DIFF
--- a/app/controllers/teacher_interface/decision_review_requests_controller.rb
+++ b/app/controllers/teacher_interface/decision_review_requests_controller.rb
@@ -5,6 +5,7 @@ module TeacherInterface
     include HandleApplicationFormSection
     include HistoryTrackable
 
+    before_action :redirect_unless_application_form_has_assessment
     before_action :redirect_unless_can_request_decision_review,
                   except: :confirmation
     before_action :redirect_if_decision_review_already_received,
@@ -151,6 +152,12 @@ module TeacherInterface
     def decision_review_request_for_current_decline
       @decision_review_request_for_current_decline ||=
         application_form.assessment.decision_review_request_for_current_decline
+    end
+
+    def redirect_unless_application_form_has_assessment
+      return if application_form.assessment.present?
+
+      redirect_to teacher_interface_application_form_path
     end
 
     def redirect_unless_can_request_decision_review

--- a/spec/system/teacher_interface/request_decision_review_spec.rb
+++ b/spec/system/teacher_interface/request_decision_review_spec.rb
@@ -155,6 +155,17 @@ RSpec.describe "Teacher decision review request", type: :system do
     then_i_see_the(:teacher_declined_application_page)
   end
 
+  context "when application has not yet been submitted" do
+    let(:application_form) { create(:application_form, teacher:) }
+
+    it "redirects to application page" do
+      application_form
+
+      when_i_visit_the(:teacher_request_decision_review_declaration_page)
+      then_i_see_the(:teacher_application_page)
+    end
+  end
+
   private
 
   def given_a_declined_application_form_exists_within_last_28_days


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1586

We've been seeing some errors related to an applicant who has previously been declined and created a new draft application. After doing so, they attempted to submit a decision review using the link they received in their email. However, once they go to the decision review page, they see a 500 error which we have observed within Sentry. 

This PR addresses the issue and ensures they're taken to their draft application instead. 