### PR TITLE
[AQTS-1590] Introducing SolidCache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "sentry-ruby"
 gem "sidekiq", "<7"
 gem "sidekiq-cron"
 gem "sitemap_generator"
+gem "solid_cache"
 gem "stimulus-rails"
 gem "validate_url"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -655,6 +655,10 @@ GEM
     snaky_hash (2.0.6)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
+    solid_cache (1.0.10)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.2.0)
@@ -801,6 +805,7 @@ DEPENDENCIES
   sidekiq-cron
   site_prism
   sitemap_generator
+  solid_cache
   stimulus-rails
   syntax_tree
   syntax_tree-haml
@@ -1036,6 +1041,7 @@ CHECKSUMS
   site_prism-all_there (3.0.9) sha256=3d9e0b722fa62a3553589130dea23fa50c99dc80f108c851d7480d341d83f4f6
   sitemap_generator (7.1.0) sha256=5e493e67e8846b2a2ffc72799ff0f4a71db6c11c1269f7a9ae3433f40ec0af92
   snaky_hash (2.0.6) sha256=3663cae48cdef582b517025cf8a39d8789996eaf0b4ed89e2f0624836505654a
+  solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
   stimulus-rails (1.3.4) sha256=765676ffa1f33af64ce026d26b48e8ffb2e0b94e0f50e9119e11d6107d67cb06
   stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
   swd (2.0.3) sha256=4cdbe2a4246c19f093fce22e967ec3ebdd4657d37673672e621bf0c7eb770655

--- a/config/analytics_blocklist.yml
+++ b/config/analytics_blocklist.yml
@@ -89,6 +89,13 @@
     - invitation_token
     - reset_password_token
     - unlock_token
+  :solid_cache_entries:
+    - id
+    - key
+    - value
+    - created_at
+    - key_hash
+    - byte_size
   :suitability_records:
     - archive_note
     - note

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -1,0 +1,14 @@
+default: &default
+  store_options:
+    max_age: <%= 7.days.to_i %>
+    max_size: <%= 256.megabytes %>
+    namespace: <%= Rails.env %>
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -3,6 +3,7 @@ default: &default
     max_age: <%= 7.days.to_i %>
     max_size: <%= 256.megabytes %>
     namespace: <%= Rails.env %>
+    expiry_method: :job
 
 development:
   <<: *default

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,15 +25,14 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
     config.public_file_server.headers = {
       "Cache-Control" => "public, max-age=#{2.days.to_i}",
     }
   else
     config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
   end
+
+  config.cache_store = :solid_cache_store
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_URL") }
+  config.cache_store = :solid_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :sidekiq

--- a/db/migrate/20260727160656_create_solid_cache_entries.rb
+++ b/db/migrate/20260727160656_create_solid_cache_entries.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateSolidCacheEntries < ActiveRecord::Migration[8.1]
+  def change
+    create_table :solid_cache_entries do |t|
+      t.binary :key, limit: 1024, null: false
+      t.binary :value, limit: 536_870_912, null: false
+      t.datetime :created_at, null: false
+      t.integer :key_hash, limit: 8, null: false
+      t.integer :byte_size, limit: 4, null: false
+      t.index [:byte_size], name: "index_solid_cache_entries_on_byte_size"
+      t.index %i[key_hash byte_size],
+              name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+      t.index [:key_hash],
+              name: "index_solid_cache_entries_on_key_hash",
+              unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_07_140158) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_27_160656) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -547,6 +547,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_07_140158) do
     t.datetime "updated_at", null: false
     t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
     t.index ["updated_at"], name: "index_sessions_on_updated_at"
+  end
+
+  create_table "solid_cache_entries", force: :cascade do |t|
+    t.integer "byte_size", null: false
+    t.datetime "created_at", null: false
+    t.binary "key", null: false
+    t.bigint "key_hash", null: false
+    t.binary "value", null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
   end
 
   create_table "staff", force: :cascade do |t|

--- a/docs/diagram.mmd
+++ b/docs/diagram.mmd
@@ -382,6 +382,12 @@ erDiagram
 		integer selected_failure_reason_id FK
 		integer work_history_id FK
 	}
+	"SolidCache::Entry" {
+		integer byte_size
+		binary key
+		integer key_hash
+		binary value
+	}
 	Staff {
 		boolean archived
 		boolean assess_permission


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1590

## Context

This is our first step of the "remove Redis" work. Redis currently backs two things: the Sidekiq queue and `Rails.cache`. This PR moves `Rails.cache` to Solid Cache used by RackAttack (we have no other custom caching on our service).

## Change

- Adding `solid_cache` gem and the `solid_cache_entries` migration (Excluding `solid_cache_entries` from dfe-analytics streaming).
- Updating `config.cache_store` to `:solid_cache_store` in production.
- We are running the cache on the same primary database (no separate cache DB).
- config/cache.yml: Maximum age of entries will be 7 days, the maximum size of the cache entries will be 256MB and expiry method is set to be triggered as a background job instead of within a puma thread.

## Rollout

- Test in review environment to ensure records are being created, counters incremented and expired for RackAttack entries.
- In the case we need to roll it back, it'll be a one-line revert of `config.cache_store` to `:redis_cache_store`.