### PR TITLE
[AQTS-1512] Email trigger update for countries removed

### DIFF
--- a/app/views/teacher_mailer/application_from_ineligible_country.text.erb
+++ b/app/views/teacher_mailer/application_from_ineligible_country.text.erb
@@ -1,15 +1,13 @@
 Dear <%= application_form_full_name(@application_form) %>,
 
-Thank you for beginning your application for qualified teacher status (QTS) in England. Unfortunately, we have had to close your application.
+Thank you for beginning your application for qualified teacher status (QTS) in England.
 
-As we are unable to verify professional standing documents with the <%= region_teaching_authority_name(@application_form.region) %> in <%= CountryName.from_country(@application_form.country) %>, we have removed <%= CountryName.from_country(@application_form.country) %> from the list of eligible countries.
+There has been a change to the service which means we can no longer accept applications from teachers trained in <%= CountryName.from_country(@application_form.country) %>. This is because this country no longer meets our [eligibility requirements](https://www.gov.uk/government/publications/overseas-trained-teachers-apply-for-qualified-teacher-status-in-england/overseas-trained-teachers-apply-for-qualified-teacher-status-in-england#who-can-apply).
 
-This means you will not be able to complete and submit your application.
+This means your draft application has been closed and cannot be submitted.
 
-## Why we need to verify documents
+## What you can do next
 
-We need to be able to verify all documents submitted by applicants with the relevant authorities. This is to ensure QTS requirements are applied fairly and consistently to every teacher, regardless of the country they trained to teach in.
-
-[Sign in](<%= new_teacher_session_url %>) for more information about QTS in England.
+You can explore [other routes into teaching](https://getintoteaching.education.gov.uk/routes-into-teaching).
 
 <%= render "shared/teacher_mailer/footer" %>

--- a/config/locales/mailer.en.yml
+++ b/config/locales/mailer.en.yml
@@ -19,7 +19,7 @@ en:
       application_declined:
         subject: Your QTS application was unsuccessful
       application_from_ineligible_country:
-        subject: "Update: Your qualified teacher status (QTS) application"
+        subject: "Your QTS application has been closed"
       application_not_submitted:
         subject:
           0: Your draft QTS application has not been submitted

--- a/lib/tasks/application_forms.rake
+++ b/lib/tasks/application_forms.rake
@@ -24,7 +24,7 @@ namespace :application_forms do
     puts "Sending emails for #{application_forms.count} applications! Are you sure you want to continue?"
     $stdin.gets.chomp
 
-    application_forms.each do |application_form|
+    application_forms.find_each do |application_form|
       puts application_form.reference
 
       teacher = application_form.teacher

--- a/spec/mailers/teacher_mailer_spec.rb
+++ b/spec/mailers/teacher_mailer_spec.rb
@@ -94,11 +94,7 @@ RSpec.describe TeacherMailer, type: :mailer do
     describe "#subject" do
       subject { mail.subject }
 
-      it do
-        expect(subject).to eq(
-          "Update: Your qualified teacher status (QTS) application",
-        )
-      end
+      it { expect(subject).to eq("Your QTS application has been closed") }
     end
 
     describe "#to" do
@@ -114,8 +110,8 @@ RSpec.describe TeacherMailer, type: :mailer do
 
       it do
         expect(subject).to include(
-          "As we are unable to verify professional standing documents with the teaching authority in France, we " \
-            "have removed France from the list of eligible countries.",
+          "There has been a change to the service which means we can no longer accept applications " \
+            "from teachers trained in France. This is because this country no longer meets our [eligibility requirements]",
         )
       end
     end


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1512

Updating content for the `application_from_ineligible_country` email which will get manually triggered by the `application_forms:send_draft_emails_from_ineligible_country` rake task when we switch off the countries.