### PR TITLE
AQTS-1511-holdingpage-for-removed-countries

### DIFF
--- a/app/views/teacher_interface/application_forms/show/_from_ineligible_country.html.erb
+++ b/app/views/teacher_interface/application_forms/show/_from_ineligible_country.html.erb
@@ -1,21 +1,19 @@
 <h2 class="govuk-heading-l">Your QTS application has been closed</h2>
 
 <p class="govuk-body">
-  Thank you for beginning your application for qualified teacher status (QTS) in England. Unfortunately, your application has been closed.
+  Thank you for beginning your application for qualified teacher status (QTS) in England.
 </p>
 
 <p class="govuk-body">
-  As we are unable to verify professional standing documents with the <%= region_teaching_authority_name(view_object.region) %> in <%= CountryName.from_country(view_object.country) %>, we have removed <%= CountryName.from_country(view_object.country) %> from the list of eligible countries.
+  There has been a change to the service which means we can no longer accept applications from teachers trained in <%= CountryName.from_country(view_object.country) %>. This is because this country no longer meets our <%= govuk_link_to "eligibility requirements", "https://www.gov.uk/government/publications/overseas-trained-teachers-apply-for-qualified-teacher-status-in-england/overseas-trained-teachers-apply-for-qualified-teacher-status-in-england#who-can-apply" %>.
 </p>
 
 <p class="govuk-body">
-  This means you will not be able to complete and submit your application.
+  This means your draft application has been closed and cannot be submitted.
 </p>
 
-<h3 class="govuk-heading-m">Why we need to verify documents</h3>
+<h3 class="govuk-heading-m">What you can do next</h3>
 
 <p class="govuk-body">
-  We need to be able to verify all documents submitted by applicants with the relevant authorities. This is to ensure QTS requirements are applied fairly and consistently to every teacher, regardless of the country they trained to teach in.
+  You can explore <%= govuk_link_to "other routes into teaching", "https://getintoteaching.education.gov.uk/routes-into-teaching" %>.
 </p>
-
-<%= render "teacher_interface/application_forms/show/what_can_you_do_next", view_object: %>


### PR DESCRIPTION
**Ticket**: https://dfedigital.atlassian.net/browse/AQTS-1511

### Why is this change being made?

Countries eligible for QTS recognition can be removed from the service as policy changes occur. Applicants who started, but did not submit, an application before a country is closed currently retain a draft application, which can create confusion when they are no longer eligible to apply through the service.

This change ensures that applicants from newly closed countries are clearly informed that their application has been closed due to changes in the service and are signposted to alternative guidance and routes into teaching. At the same time, applicants from countries that remain eligible are able to continue accessing their draft applications without interruption.
<img width="670" height="769" alt="Screenshot 2026-08-04 at 12 32 47" src="https://github.com/user-attachments/assets/341dac74-6883-4f7e-8246-27cc2ca999e0" />
