### PR TITLE
AQTS-1570-update-fi-email-hint-text

### DIFF
--- a/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
@@ -40,7 +40,7 @@
     <%= f.govuk_text_field :contact_job, label: { text: "Contact’s job title" } %>
 
     <% if @further_information_request_item.application_form.requires_private_email_for_referee? %>
-      <%= f.govuk_email_field :contact_email, label: { text: "Contact’s email address" }, hint: { text: "The email address must use the school’s domain, for example, name@school.edu" } %>
+      <%= f.govuk_email_field :contact_email, label: { text: "Contact’s email address" }, hint: { text: "This email address must use the school’s domain, for example name@school.edu. We do not accept public email addresses such as those from Gmail, Yahoo, Hotmail or Proton mail" } %>
     <% else %>
       <%= f.govuk_email_field :contact_email, label: { text: "Contact’s email address" } %>
     <% end %>

--- a/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
+++ b/app/views/teacher_interface/further_information_request_items/_inner_form.html.erb
@@ -40,7 +40,7 @@
     <%= f.govuk_text_field :contact_job, label: { text: "Contact’s job title" } %>
 
     <% if @further_information_request_item.application_form.requires_private_email_for_referee? %>
-      <%= f.govuk_email_field :contact_email, label: { text: "Contact’s email address" }, hint: { text: "This email address must use the school’s domain, for example name@school.edu. We do not accept public email addresses such as those from Gmail, Yahoo, Hotmail or Proton mail" } %>
+      <%= f.govuk_email_field :contact_email, label: { text: "Contact’s email address" }, hint: { text: "The email address must use the school’s domain, for example, name@school.edu. We do not accept public email addresses such as those from Gmail, Yahoo, Hotmail or Protonmail." } %>
     <% else %>
       <%= f.govuk_email_field :contact_email, label: { text: "Contact’s email address" } %>
     <% end %>


### PR DESCRIPTION
**Ticket**: https://dfedigital.atlassian.net/browse/AQTS-1570

### Why

During PR review, it was identified that applicants responding to the FI reason "We could not verify one or more references you provided" are not currently given guidance that referee email addresses must use a school's email domain.

This can lead to applicants providing public email addresses (for example Gmail, Yahoo, Hotmail or Proton Mail), which cannot be accepted for reference verification and may result in delays when responding to the FI request.




<img width="648" height="806" alt="Screenshot 2026-08-04 at 15 31 23" src="https://github.com/user-attachments/assets/f415c270-fe4a-41fc-bc24-abe35fd204cf" />

