### PR TITLE
[AQTS-1539] Exclude job arguments in logs and remove info level logs for SolidQueue

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,6 +67,9 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :sidekiq
 
+  # Avoids exposure of personally identifiable information (PII) in logs.
+  config.active_job.log_arguments = false
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/initializers/solid_queue.rb
+++ b/config/initializers/solid_queue.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+SolidQueue.on_start { Rails.logger.level = Logger::WARN }


### PR DESCRIPTION
Setting `active_job.log_arguments = false` to keep job arguments (which can in the future carry PII once we migrate all of our jobs to Solid Queue) out of logs.
Also setting log level for Solid Queue worker to `:warn` to avoid any unnecessary noise in work logs consistent with how Sidekiq used to be configured.
