### PR TITLE
Update how email delivery record is created

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -38,5 +38,7 @@ class ApplicationMailer < Mail::Notify::Mailer
         email_delivery,
       )
     end
+  rescue StandardError => e
+    Sentry.capture_exception(e)
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -3,7 +3,7 @@
 class ApplicationMailer < Mail::Notify::Mailer
   default from: I18n.t("service.email.enquiries")
 
-  after_deliver :enqueue_email_delivery_audit
+  after_deliver :create_email_delivery_audit
 
   GOVUK_NOTIFY_TEMPLATE_ID =
     ENV.fetch(
@@ -13,19 +13,30 @@ class ApplicationMailer < Mail::Notify::Mailer
 
   private
 
-  def enqueue_email_delivery_audit
+  def create_email_delivery_audit
     notify_id =
       if message.delivery_method.respond_to?(:response)
         message.delivery_method.response&.id
       end
 
-    EmailDeliveryAuditJob.perform_later(
-      headers["To"].value,
-      headers["Subject"].value,
-      notify_id,
-      mailer_name,
-      action_name,
-      params,
-    )
+    email_delivery =
+      EmailDelivery.create!(
+        to: headers["To"].value,
+        subject: headers["Subject"].value,
+        notify_id:,
+        mailer_class_name: mailer_name,
+        mailer_action_name: action_name,
+        application_form: params[:application_form],
+        further_information_request: params[:further_information_request],
+        reference_request: params[:reference_request],
+        prioritisation_reference_request:
+          params[:prioritisation_reference_request],
+      )
+
+    if notify_id
+      EmailDeliveryNotifyStatusUpdateJob.set(wait: 1.minute).perform_later(
+        email_delivery,
+      )
+    end
   end
 end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationMailer do
+  describe "after_deliver audit" do
+    subject(:deliver_now) { mailer.deliver_now }
+
+    let(:application_form) { create(:application_form, :awarded) }
+
+    let(:mailer) { TeacherMailer.with(application_form:).application_awarded }
+
+    it "creates an EmailDelivery record when an email is delivered" do
+      expect { deliver_now }.to change(EmailDelivery, :count).by(1)
+    end
+
+    it "records the recipient, subject and mailer details" do
+      deliver_now
+
+      delivery = EmailDelivery.last
+
+      expect(delivery).to have_attributes(
+        mailer_class_name: "teacher_mailer",
+        mailer_action_name: "application_awarded",
+        application_form:,
+        to: application_form.teacher.email,
+        subject: "Your QTS application was successful",
+      )
+    end
+
+    it "does not enqueue the status update job without notify_id in response" do
+      expect { deliver_now }.not_to have_enqueued_job(
+        EmailDeliveryNotifyStatusUpdateJob,
+      )
+    end
+
+    context "when Notify returns a notify_id" do
+      let(:notify_response) do
+        instance_double(Notifications::Client::Notification, id: "notify-123")
+      end
+
+      let(:delivery_method) do
+        instance_double(
+          Mail::Notify::DeliveryMethod,
+          response: notify_response,
+          deliver!: true,
+        )
+      end
+
+      before do
+        allow_any_instance_of(Mail::Message).to receive(
+          :delivery_method,
+        ).and_return(delivery_method)
+      end
+
+      it "enqueues the status update job with the record" do
+        expect { deliver_now }.to have_enqueued_job(
+          EmailDeliveryNotifyStatusUpdateJob,
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

This PR changes how the `EmailDelivery` audit record is created. Instead of enqueuing `EmailDeliveryAuditJob` with the email details as arguments, the record is now created directly in an `after_deliver` callback, which then enqueues the `EmailDeliveryNotifyStatusUpdateJob`.

## Why

`EmailDeliveryAuditJob` previously took the recipient address, subject, and notify details as arguments. This may lead to arguments surfacing in logs and sentry events in event of a failure where we may not want them to. Our job arguments should always only include records.

The only thing enqueued now is `EmailDeliveryNotifyStatusUpdateJob`, which carries the EmailDelivery id and not the details.

## Post deploy

Remove `EmailDeliveryAuditJob` job. Reason I'm not doing it as part of this PR is to ensure if there's a job in progress, no errors are raised.