### PR TITLE
[AQTS-1579] Uploading LoPS received into service by assessor/admin

### DIFF
--- a/app/controllers/assessor_interface/professional_standing_requests_controller.rb
+++ b/app/controllers/assessor_interface/professional_standing_requests_controller.rb
@@ -177,7 +177,7 @@ module AssessorInterface
     def location_form_params
       params.require(
         :assessor_interface_professional_standing_request_location_form,
-      ).permit(:received, :location_note)
+      ).permit(:received, :location_note, :attachment)
     end
 
     def review_form_params

--- a/app/forms/assessor_interface/professional_standing_request_location_form.rb
+++ b/app/forms/assessor_interface/professional_standing_request_location_form.rb
@@ -13,10 +13,8 @@ class AssessorInterface::ProfessionalStandingRequestLocationForm
   attribute :location_note, :string
 
   attribute :attachment
-  validates :attachment,
-            file_upload: true,
-            presence: true,
-            unless: -> { document.completed? }
+  validates :attachment, file_upload: true
+  validates :attachment, presence: true, unless: -> { document.completed? }
 
   def save
     return false if invalid?

--- a/app/forms/assessor_interface/professional_standing_request_location_form.rb
+++ b/app/forms/assessor_interface/professional_standing_request_location_form.rb
@@ -8,7 +8,7 @@ class AssessorInterface::ProfessionalStandingRequestLocationForm
   validates :requestable, :user, presence: true
 
   attribute :received, :boolean
-  validates :received, inclusion: [true, false]
+  validates :received, inclusion: [true]
 
   attribute :location_note, :string
 
@@ -26,8 +26,6 @@ class AssessorInterface::ProfessionalStandingRequestLocationForm
 
       if received && !requestable.received?
         ReceiveRequestable.call(requestable:, user:)
-      elsif !received && requestable.received?
-        UnreceiveRequestable.call(requestable:, user:)
       end
 
       if requestable.requested? && requestable.reviewed?

--- a/app/forms/assessor_interface/professional_standing_request_location_form.rb
+++ b/app/forms/assessor_interface/professional_standing_request_location_form.rb
@@ -7,14 +7,14 @@ class AssessorInterface::ProfessionalStandingRequestLocationForm
   attr_accessor :requestable, :user
   validates :requestable, :user, presence: true
 
-  attribute :received, :boolean
-  validates :received, inclusion: [true]
-
   attribute :location_note, :string
 
   attribute :attachment
   validates :attachment, file_upload: true
   validates :attachment, presence: true, unless: -> { document.completed? }
+
+  attribute :received, :boolean
+  validates :received, inclusion: [true]
 
   def save
     return false if invalid?

--- a/app/forms/assessor_interface/professional_standing_request_location_form.rb
+++ b/app/forms/assessor_interface/professional_standing_request_location_form.rb
@@ -12,10 +12,18 @@ class AssessorInterface::ProfessionalStandingRequestLocationForm
 
   attribute :location_note, :string
 
+  attribute :attachment
+  validates :attachment,
+            file_upload: true,
+            presence: true,
+            unless: -> { document.completed? }
+
   def save
     return false if invalid?
 
     ActiveRecord::Base.transaction do
+      create_upload! if attachment.present?
+
       if received && !requestable.received?
         ReceiveRequestable.call(requestable:, user:)
       elsif !received && requestable.received?
@@ -34,4 +42,40 @@ class AssessorInterface::ProfessionalStandingRequestLocationForm
   end
 
   delegate :application_form, to: :requestable
+
+  private
+
+  def create_upload!
+    document.uploads.each(&:destroy!)
+
+    upload =
+      document.uploads.create!(
+        attachment: attachment,
+        filename: attachment.original_filename,
+        malware_scan_result: malware_scan_result(attachment),
+        translation: false,
+      )
+
+    fetch_and_update_malware_scan_results(upload)
+  end
+
+  def document
+    application_form&.written_statement_document
+  end
+
+  def fetch_and_update_malware_scan_results(upload)
+    if FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
+      UpdateMalwareScanResultJob.set(wait: 2.seconds).perform_later(upload)
+    end
+  end
+
+  def malware_scan_result(attachment)
+    if FeatureFlags::FeatureFlag.active?(:fetch_malware_scan_result)
+      "pending"
+    elsif attachment.original_filename == "virus.pdf"
+      "suspect"
+    else
+      "clean"
+    end
+  end
 end

--- a/app/views/assessor_interface/assessment_sections/_professional_standing_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_professional_standing_summary.html.erb
@@ -17,7 +17,7 @@
       },
       note: {
         title: "Additional information",
-        value: "<p class=\"govuk-body\">The competent authority has sent the letter of professional standing directly to the DfE. Follow the instructions below to locate it.</p>#{simple_format(professional_standing_request.location_note)}".html_safe,
+        value: "<p class=\"govuk-body\">The competent authority has sent the letter of professional standing directly to the DfE.</p>#{simple_format(professional_standing_request.location_note)}".html_safe,
       },
     },
   )) %>

--- a/app/views/assessor_interface/assessment_sections/_professional_standing_summary.html.erb
+++ b/app/views/assessor_interface/assessment_sections/_professional_standing_summary.html.erb
@@ -9,11 +9,14 @@
 <% if (professional_standing_request = assessment.professional_standing_request).present? && application_form.teaching_authority_provides_written_statement %>
   <%= render(CheckYourAnswersSummary::Component.new(
     id: "professional-standing-request",
-    model: professional_standing_request,
+    model: application_form,
     title: "Third-party professional standing",
     fields: {
+      written_statement_document: {
+        title: "Applicant's letter of professional standing",
+      },
       note: {
-        title: "Written statement",
+        title: "Additional information",
         value: "<p class=\"govuk-body\">The competent authority has sent the letter of professional standing directly to the DfE. Follow the instructions below to locate it.</p>#{simple_format(professional_standing_request.location_note)}".html_safe,
       },
     },

--- a/app/views/assessor_interface/professional_standing_requests/edit_locate.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_locate.html.erb
@@ -16,12 +16,14 @@
     You can confirm whether you are satisfied with the letter of professional standing during the assessment stage.
   </p>
 
-  <%= f.govuk_check_boxes_fieldset :received, multiple: false, legend: nil do %>
-    <%= f.govuk_check_box :received, true, false, multiple: false, link_errors: true, disabled: @application_form.on_hold?,
-                          label: { text: "The letter of professional standing has been received.", size: "s" } %>
-  <% end %>
+  <%= f.govuk_file_field :attachment, label: { text: "Select a file to upload" }, hint: { text: "You can upload your files in PDF, JPG, PNG or DOCX format. Each file must be no larger than 50MB." }, disabled: @application_form.on_hold? %>
 
   <%= f.govuk_text_area :location_note, label: { text: "Additional information (optional)", size: "m" }, hint: { text: "For example, ticket information or the password needed to open the file." }, disabled: @application_form.on_hold? %>
+
+  <%= f.govuk_check_boxes_fieldset :received, multiple: false, legend: nil do %>
+    <%= f.govuk_check_box :received, true, false, multiple: false, link_errors: true, disabled: @application_form.on_hold?,
+                          label: { text: "I confirm the letter of professional standing has been received.", size: "s" } %>
+  <% end %>
 
   <%= f.govuk_submit disabled: @application_form.on_hold? do %>
     <%= render "shared/assessor_interface/cancel_link" %>

--- a/app/views/assessor_interface/professional_standing_requests/edit_locate.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_locate.html.erb
@@ -9,11 +9,11 @@
   <h1 class="govuk-heading-xl"><%= title %></h1>
 
   <p class="govuk-body">
-    Only use this screen when the response from <%= region_teaching_authority_name_phrase(@application_form.region) %> is received.
+    Upload the letter of professional standing from <%= region_teaching_authority_name_phrase(@application_form.region) %> and confirm you have received it.
   </p>
 
   <p class="govuk-body">
-    This screen is not an assessment of the letter of professional standing, it just confirms that a response has been received.
+    You can confirm whether you are satisfied with the letter of professional standing during the assessment stage.
   </p>
 
   <%= f.govuk_check_boxes_fieldset :received, multiple: false, legend: nil do %>
@@ -21,7 +21,7 @@
                           label: { text: "The letter of professional standing has been received.", size: "s" } %>
   <% end %>
 
-  <%= f.govuk_text_area :location_note, label: { text: "Where to find the response", size: "m" }, hint: nil, disabled: @application_form.on_hold? %>
+  <%= f.govuk_text_area :location_note, label: { text: "Additional information (optional)", size: "m" }, hint: { text: "For example, ticket information or the password needed to open the file." }, disabled: @application_form.on_hold? %>
 
   <%= f.govuk_submit disabled: @application_form.on_hold? do %>
     <%= render "shared/assessor_interface/cancel_link" %>

--- a/app/views/assessor_interface/professional_standing_requests/edit_locate.html.erb
+++ b/app/views/assessor_interface/professional_standing_requests/edit_locate.html.erb
@@ -16,6 +16,22 @@
     You can confirm whether you are satisfied with the letter of professional standing during the assessment stage.
   </p>
 
+  <% if @application_form.written_statement_document.completed? %>
+    <% upload = @application_form.written_statement_document.uploads.first %>
+    <%= govuk_summary_list do |summary_list|
+      summary_list.with_row do |row|
+        row.with_key(text: "Uploaded file")
+        row.with_value { upload_link_to(upload) }
+      end
+    end %>
+
+    <h2 class="govuk-heading-m">Replace the uploaded file</h2>
+
+    <p class="govuk-body">
+      Upload a new file to replace the one you have already uploaded.
+    </p>
+  <% end %>
+
   <%= f.govuk_file_field :attachment, label: { text: "Select a file to upload" }, hint: { text: "You can upload your files in PDF, JPG, PNG or DOCX format. Each file must be no larger than 50MB." }, disabled: @application_form.on_hold? %>
 
   <%= f.govuk_text_area :location_note, label: { text: "Additional information (optional)", size: "m" }, hint: { text: "For example, ticket information or the password needed to open the file." }, disabled: @application_form.on_hold? %>

--- a/config/locales/assessor_interface.en.yml
+++ b/config/locales/assessor_interface.en.yml
@@ -625,8 +625,13 @@ en:
               inclusion: Select whether the teacher requires induction
         assessor_interface/professional_standing_request_location_form:
           attributes:
+            attachment:
+              blank: Select a file to upload
+              encrypted_pdf: The selected file is security protected
+              invalid_content_type: Files must be in PDF, JPG, PNG or DOCX format
+              mismatch_content_type: Files must have matching file type and file name. For example, if the upload is called example.doc, it must be a DOC file.
             received:
-              inclusion: Select whether you received a response about this letter of professional standing
+              inclusion: Select if the letter of professional standing has been received
             expired:
               inclusion: Select whether you want to mark this for review
         assessor_interface/prioritisation_work_history_check_form:

--- a/spec/forms/assessor_interface/professional_standing_request_location_form_spec.rb
+++ b/spec/forms/assessor_interface/professional_standing_request_location_form_spec.rb
@@ -40,6 +40,14 @@ RSpec.describe AssessorInterface::ProfessionalStandingRequestLocationForm,
         end
 
         it { is_expected.to be_valid }
+
+        context "with a new invalid upload" do
+          let(:attachment) do
+            fixture_file_upload("upload.txt", "application/text")
+          end
+
+          it { is_expected.not_to be_valid }
+        end
       end
     end
 

--- a/spec/forms/assessor_interface/professional_standing_request_location_form_spec.rb
+++ b/spec/forms/assessor_interface/professional_standing_request_location_form_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AssessorInterface::ProfessionalStandingRequestLocationForm,
 
   describe "validations" do
     it { is_expected.to validate_presence_of(:user) }
-    it { is_expected.to allow_values(true, false).for(:received) }
+    it { is_expected.to allow_values(true).for(:received) }
 
     context "with nil attachment" do
       let(:attachment) { nil }
@@ -53,116 +53,108 @@ RSpec.describe AssessorInterface::ProfessionalStandingRequestLocationForm,
   describe "#save" do
     subject(:save) { form.save }
 
-    context "when received" do
-      let(:received) { "true" }
-      let(:location_note) { "Note." }
+    let(:received) { "true" }
+    let(:location_note) { "Note." }
+
+    it { is_expected.to be true }
+
+    it "sets the received at date" do
+      expect { save }.to change(requestable, :received_at).from(nil)
+    end
+
+    it "sets the location note" do
+      expect { save }.to change(requestable, :location_note).to("Note.")
+    end
+
+    it "creates an upload on the written statement document" do
+      save
+
+      expect(
+        application_form.written_statement_document.uploads.last,
+      ).to have_attributes(filename: "upload.pdf", translation: false)
+    end
+
+    it "records a received timeline event" do
+      expect { save }.to have_recorded_timeline_event(
+        :requestable_received,
+        creator: user,
+        requestable:,
+      )
+    end
+
+    context "when a written statement has already been uploaded" do
+      let(:application_form) do
+        create :application_form, :submitted, :with_written_statement
+      end
+
+      let!(:existing_upload) do
+        application_form.written_statement_document.uploads.last
+      end
 
       it { is_expected.to be true }
 
-      it "sets the received at date" do
-        expect { save }.to change(requestable, :received_at).from(nil)
-      end
-
-      it "sets the location note" do
-        expect { save }.to change(requestable, :location_note).to("Note.")
-      end
-
-      it "creates an upload on the written statement document" do
-        save
+      it "replaces it with the new upload" do
+        expect { save }.not_to change(
+          application_form.written_statement_document.uploads,
+          :count,
+        )
 
         expect(
           application_form.written_statement_document.uploads.last,
         ).to have_attributes(filename: "upload.pdf", translation: false)
       end
 
-      it "records a received timeline event" do
-        expect { save }.to have_recorded_timeline_event(
-          :requestable_received,
-          creator: user,
-          requestable:,
-        )
-      end
+      context "when no new file is submitted" do
+        let(:attachment) { nil }
 
-      context "when a written statement has already been uploaded" do
-        let(:application_form) do
-          create :application_form, :submitted, :with_written_statement
-        end
-
-        let!(:existing_upload) do
-          application_form.written_statement_document.uploads.last
-        end
-
-        it { is_expected.to be true }
-
-        it "replaces it with the new upload" do
-          expect { save }.not_to change(
-            application_form.written_statement_document.uploads,
-            :count,
-          )
-
-          expect(
-            application_form.written_statement_document.uploads.last,
-          ).to have_attributes(filename: "upload.pdf", translation: false)
-        end
-
-        context "when no new file is submitted" do
-          let(:attachment) { nil }
-
-          it "does not delete the existing written statement document" do
-            save
-
-            expect(existing_upload.reload).to be_present
-          end
-        end
-      end
-
-      context "with fetch_malware_scan_result flag active" do
-        around do |example|
-          FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result)
-          example.run
-          FeatureFlags::FeatureFlag.deactivate(:fetch_malware_scan_result)
-        end
-
-        it "marks the upload as pending" do
+        it "does not delete the existing written statement document" do
           save
-          expect(
-            application_form
-              .written_statement_document
-              .uploads
-              .last
-              .malware_scan_result,
-          ).to eq("pending")
-        end
 
-        it "enqueues a malware scan job" do
-          expect { save }.to have_enqueued_job(UpdateMalwareScanResultJob).with(
-            application_form.written_statement_document.uploads.last,
-          )
-        end
-      end
-
-      context "when the fetch_malware_scan_result flag is inactive" do
-        it "marks the upload as clean" do
-          save
-          expect(
-            application_form
-              .written_statement_document
-              .uploads
-              .last
-              .malware_scan_result,
-          ).to eq("clean")
-        end
-
-        it "does not enqueue a malware scan job" do
-          expect { save }.not_to have_enqueued_job(UpdateMalwareScanResultJob)
+          expect(existing_upload.reload).to be_present
         end
       end
     end
 
-    context "when not received" do
-      let(:received) { "false" }
+    context "with fetch_malware_scan_result flag active" do
+      around do |example|
+        FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result)
+        example.run
+        FeatureFlags::FeatureFlag.deactivate(:fetch_malware_scan_result)
+      end
 
-      it { is_expected.to be true }
+      it "marks the upload as pending" do
+        save
+        expect(
+          application_form
+            .written_statement_document
+            .uploads
+            .last
+            .malware_scan_result,
+        ).to eq("pending")
+      end
+
+      it "enqueues a malware scan job" do
+        expect { save }.to have_enqueued_job(UpdateMalwareScanResultJob).with(
+          application_form.written_statement_document.uploads.last,
+        )
+      end
+    end
+
+    context "when the fetch_malware_scan_result flag is inactive" do
+      it "marks the upload as clean" do
+        save
+        expect(
+          application_form
+            .written_statement_document
+            .uploads
+            .last
+            .malware_scan_result,
+        ).to eq("clean")
+      end
+
+      it "does not enqueue a malware scan job" do
+        expect { save }.not_to have_enqueued_job(UpdateMalwareScanResultJob)
+      end
     end
   end
 end

--- a/spec/forms/assessor_interface/professional_standing_request_location_form_spec.rb
+++ b/spec/forms/assessor_interface/professional_standing_request_location_form_spec.rb
@@ -5,19 +5,49 @@ require "rails_helper"
 RSpec.describe AssessorInterface::ProfessionalStandingRequestLocationForm,
                type: :model do
   subject(:form) do
-    described_class.new(requestable:, user:, received:, location_note:)
+    described_class.new(
+      requestable:,
+      user:,
+      received:,
+      location_note:,
+      attachment:,
+    )
   end
 
-  let(:requestable) { create(:professional_standing_request) }
+  let(:application_form) { create :application_form, :submitted }
+  let(:requestable) do
+    create(:professional_standing_request, application_form:)
+  end
   let(:user) { create(:staff) }
 
   let(:received) { "" }
   let(:location_note) { "" }
+  let(:attachment) { fixture_file_upload("upload.pdf", "application/pdf") }
 
   describe "validations" do
-    it { is_expected.to validate_presence_of(:requestable) }
     it { is_expected.to validate_presence_of(:user) }
     it { is_expected.to allow_values(true, false).for(:received) }
+
+    context "with nil attachment" do
+      let(:attachment) { nil }
+      let(:received) { "true" }
+
+      it { is_expected.not_to be_valid }
+
+      context "when written statement document already completed" do
+        let(:application_form) do
+          create :application_form, :submitted, :with_written_statement
+        end
+
+        it { is_expected.to be_valid }
+      end
+    end
+
+    context "with an attachment" do
+      let(:received) { "true" }
+
+      it { is_expected.to be_valid }
+    end
   end
 
   describe "#save" do
@@ -37,12 +67,95 @@ RSpec.describe AssessorInterface::ProfessionalStandingRequestLocationForm,
         expect { save }.to change(requestable, :location_note).to("Note.")
       end
 
+      it "creates an upload on the written statement document" do
+        save
+
+        expect(
+          application_form.written_statement_document.uploads.last,
+        ).to have_attributes(filename: "upload.pdf", translation: false)
+      end
+
       it "records a received timeline event" do
         expect { save }.to have_recorded_timeline_event(
           :requestable_received,
           creator: user,
           requestable:,
         )
+      end
+
+      context "when a written statement has already been uploaded" do
+        let(:application_form) do
+          create :application_form, :submitted, :with_written_statement
+        end
+
+        let!(:existing_upload) do
+          application_form.written_statement_document.uploads.last
+        end
+
+        it { is_expected.to be true }
+
+        it "replaces it with the new upload" do
+          expect { save }.not_to change(
+            application_form.written_statement_document.uploads,
+            :count,
+          )
+
+          expect(
+            application_form.written_statement_document.uploads.last,
+          ).to have_attributes(filename: "upload.pdf", translation: false)
+        end
+
+        context "when no new file is submitted" do
+          let(:attachment) { nil }
+
+          it "does not delete the existing written statement document" do
+            save
+
+            expect(existing_upload.reload).to be_present
+          end
+        end
+      end
+
+      context "with fetch_malware_scan_result flag active" do
+        around do |example|
+          FeatureFlags::FeatureFlag.activate(:fetch_malware_scan_result)
+          example.run
+          FeatureFlags::FeatureFlag.deactivate(:fetch_malware_scan_result)
+        end
+
+        it "marks the upload as pending" do
+          save
+          expect(
+            application_form
+              .written_statement_document
+              .uploads
+              .last
+              .malware_scan_result,
+          ).to eq("pending")
+        end
+
+        it "enqueues a malware scan job" do
+          expect { save }.to have_enqueued_job(UpdateMalwareScanResultJob).with(
+            application_form.written_statement_document.uploads.last,
+          )
+        end
+      end
+
+      context "when the fetch_malware_scan_result flag is inactive" do
+        it "marks the upload as clean" do
+          save
+          expect(
+            application_form
+              .written_statement_document
+              .uploads
+              .last
+              .malware_scan_result,
+          ).to eq("clean")
+        end
+
+        it "does not enqueue a malware scan job" do
+          expect { save }.not_to have_enqueued_job(UpdateMalwareScanResultJob)
+        end
       end
     end
 

--- a/spec/support/autoload/page_objects/assessor_interface/locate_professional_standing_request.rb
+++ b/spec/support/autoload/page_objects/assessor_interface/locate_professional_standing_request.rb
@@ -7,6 +7,8 @@ module PageObjects
                 "/professional-standing-request/locate"
 
       section :form, "form" do
+        element :attachment,
+                "#assessor-interface-professional-standing-request-location-form-attachment-field"
         element :received_checkbox, ".govuk-checkboxes__input", visible: false
         element :received_true_radio_item,
                 "#assessor-interface-professional-standing-request-location-form-received-true-field",

--- a/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
+++ b/spec/system/assessor_interface/pre_assessment_tasks_spec.rb
@@ -160,6 +160,7 @@ RSpec.describe "Assessor pre-assessment tasks", type: :system do
   def when_i_fill_in_the_locate_form
     form = assessor_locate_professional_standing_request_page.form
 
+    form.attachment.attach_file Rails.root.join(file_fixture("upload.pdf"))
     form.received_checkbox.click
     form.note_textarea.fill_in with: "Note."
     form.submit_button.click


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1579

## What

This PR introduces a new upload functionality by assessors/admins for Letter of Professional Standing (LoPS) that have been received by teaching authorities. 

In this PR, I've added a new "attachment" attribute to `ProfessionalStandingRequestLocationForm` instead of including the `UploadableForm` which is mostly designed for the teacher interface and created some unnecessary blockers to achieving this feature. As a result, I've brought in only the relevant parts of that module into this form directly to keep things simple. 

----

### Screenshot for blank form 
<img width="769" height="875" alt="Screenshot 2026-08-07 at 13 01 29" src="https://github.com/user-attachments/assets/b9f6a2b8-e0c2-4cc4-9d9d-f3dac856df73" />

---- 

### Screenshot for when file already uploaded
<img width="750" height="1053" alt="Screenshot 2026-08-07 at 12 57 53" src="https://github.com/user-attachments/assets/b05df7b5-e050-4f60-abc6-264dce87d44b" />
