### PR TITLE
Add permissions to build-nocache gh workflow

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build-no-cache:
+    permissions:
+      packages: write
     outputs:
       docker-image-tag: ${{ steps.build-image.outputs.tag }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Context

Fix failing build-nocache github workflow

## Changes proposed in this pull request

Provide required github token permissions

## Guidance to review

See [here](https://github.com/DFE-Digital/apply-for-qualified-teacher-status/actions/runs/32122884837)