### PR TITLE
[AQTS-1608] Improve performance of update working days job

### DIFF
--- a/app/jobs/update_working_days_job.rb
+++ b/app/jobs/update_working_days_job.rb
@@ -2,171 +2,32 @@
 
 class UpdateWorkingDaysJob < ApplicationJob
   def perform
-    update_application_forms_since_submission
-    update_application_forms_submitted_to_completed
+    WorkingDays::UpdateApplicationsSinceSubmissionJob.perform_later
+    WorkingDays::UpdateApplicationsSubmittedToCompletedJob.set(
+      wait: 15.minutes,
+    ).perform_later
 
-    update_assessments_since_started
-    update_assessments_started_to_completed
-    update_assessments_submission_to_started
-    update_assessment_started_to_verification
-    update_assessment_submission_to_verification
-    update_assessment_submission_to_prioritisation_decision
+    WorkingDays::UpdateAssessmentsSinceStartedJob.set(
+      wait: 30.minutes,
+    ).perform_later
+    WorkingDays::UpdateAssessmentsStartedToCompletedJob.set(
+      wait: 45.minutes,
+    ).perform_later
+    WorkingDays::UpdateAssessmentsSubmissionToStartedJob.set(
+      wait: 60.minutes,
+    ).perform_later
+    WorkingDays::UpdateAssessmentsStartedToVerificationJob.set(
+      wait: 75.minutes,
+    ).perform_later
+    WorkingDays::UpdateAssessmentsSubmissionToVerificationJob.set(
+      wait: 90.minutes,
+    ).perform_later
+    WorkingDays::UpdateAssessmentsSubmissionToPrioritisationDecisionJob.set(
+      wait: 105.minutes,
+    ).perform_later
 
-    update_further_information_requests_assessment_started_to_requested
-  end
-
-  private
-
-  def calendar
-    @calendar ||=
-      Business::Calendar.new(
-        holidays:
-          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
-      )
-  end
-
-  def today
-    @today ||= Time.zone.now
-  end
-
-  def update_application_forms_since_submission
-    ApplicationForm
-      .where.not(submitted_at: nil)
-      .find_each do |application_form|
-        application_form.update!(
-          working_days_between_submitted_and_today:
-            calendar.business_days_between(
-              application_form.submitted_at,
-              today,
-            ),
-        )
-      end
-  end
-
-  def update_application_forms_submitted_to_completed
-    ApplicationForm.completed_stage.find_each do |application_form|
-      application_form.update!(
-        working_days_between_submitted_and_completed:
-          calendar.business_days_between(
-            application_form.submitted_at,
-            application_form.awarded_at || application_form.declined_at ||
-              application_form.withdrawn_at,
-          ),
-      )
-    end
-  end
-
-  def update_assessments_since_started
-    Assessment
-      .where.not(started_at: nil)
-      .find_each do |assessment|
-        assessment.update!(
-          working_days_between_started_and_today:
-            calendar.business_days_between(assessment.started_at, today),
-        )
-      end
-  end
-
-  def update_assessments_started_to_completed
-    Assessment
-      .joins(:application_form)
-      .includes(:application_form)
-      .where(application_form: { stage: "completed" })
-      .where.not(started_at: nil)
-      .find_each do |assessment|
-        application_form = assessment.application_form
-
-        assessment.update!(
-          working_days_between_started_and_completed:
-            calendar.business_days_between(
-              assessment.started_at,
-              application_form.awarded_at || application_form.declined_at ||
-                application_form.withdrawn_at,
-            ),
-        )
-      end
-  end
-
-  def update_assessments_submission_to_started
-    Assessment
-      .joins(:application_form)
-      .includes(:application_form)
-      .where.not(application_form: { submitted_at: nil })
-      .where.not(started_at: nil)
-      .find_each do |assessment|
-        assessment.update!(
-          working_days_between_submitted_and_started:
-            calendar.business_days_between(
-              assessment.application_form.submitted_at,
-              assessment.started_at,
-            ),
-        )
-      end
-  end
-
-  def update_assessment_started_to_verification
-    Assessment
-      .where.not(started_at: nil)
-      .where.not(verification_started_at: nil)
-      .find_each do |assessment|
-        assessment.update!(
-          working_days_between_started_and_verification_started:
-            calendar.business_days_between(
-              assessment.started_at,
-              assessment.verification_started_at,
-            ),
-        )
-      end
-  end
-
-  def update_assessment_submission_to_verification
-    Assessment
-      .joins(:application_form)
-      .includes(:application_form)
-      .where.not(application_form: { submitted_at: nil })
-      .where.not(verification_started_at: nil)
-      .find_each do |assessment|
-        assessment.update!(
-          working_days_between_submitted_and_verification_started:
-            calendar.business_days_between(
-              assessment.application_form.submitted_at,
-              assessment.verification_started_at,
-            ),
-        )
-      end
-  end
-
-  def update_assessment_submission_to_prioritisation_decision
-    Assessment
-      .joins(:application_form)
-      .includes(:application_form)
-      .where.not(application_form: { submitted_at: nil })
-      .where.not(prioritisation_decision_at: nil)
-      .find_each do |assessment|
-        assessment.update!(
-          working_days_between_submitted_and_prioritisation_decision:
-            calendar.business_days_between(
-              assessment.application_form.submitted_at,
-              assessment.prioritisation_decision_at,
-            ),
-        )
-      end
-  end
-
-  def update_further_information_requests_assessment_started_to_requested
-    FurtherInformationRequest
-      .joins(:assessment)
-      .includes(:assessment)
-      .where.not(assessment: { started_at: nil })
-      .where.not(requested_at: nil)
-      .find_each do |further_information_request|
-        further_information_request.update!(
-          working_days_between_assessment_started_to_requested:
-            calendar.business_days_between(
-              further_information_request.assessment.started_at,
-              further_information_request.requested_at,
-            ),
-        )
-      end
+    WorkingDays::UpdateFurtherInformationRequestsAssessmentStartedToRequestedJob.set(
+      wait: 120.minutes,
+    ).perform_later
   end
 end

--- a/app/jobs/working_days/base_job.rb
+++ b/app/jobs/working_days/base_job.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class WorkingDays::BaseJob < ApplicationJob
+  private
+
+  def calendar
+    @calendar ||=
+      Business::Calendar.new(
+        holidays:
+          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
+      )
+  end
+
+  def today
+    @today ||= Time.zone.now
+  end
+end

--- a/app/jobs/working_days/update_applications_since_submission_job.rb
+++ b/app/jobs/working_days/update_applications_since_submission_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WorkingDays::UpdateApplicationsSinceSubmissionJob < ApplicationJob
+class WorkingDays::UpdateApplicationsSinceSubmissionJob < WorkingDays::BaseJob
   def perform
     ApplicationForm
       .where.not(submitted_at: nil)
@@ -13,19 +13,5 @@ class WorkingDays::UpdateApplicationsSinceSubmissionJob < ApplicationJob
             ),
         )
       end
-  end
-
-  private
-
-  def calendar
-    @calendar ||=
-      Business::Calendar.new(
-        holidays:
-          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
-      )
-  end
-
-  def today
-    @today ||= Time.zone.now
   end
 end

--- a/app/jobs/working_days/update_applications_since_submission_job.rb
+++ b/app/jobs/working_days/update_applications_since_submission_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class WorkingDays::UpdateApplicationsSinceSubmissionJob < ApplicationJob
+  def perform
+    ApplicationForm
+      .where.not(submitted_at: nil)
+      .find_each do |application_form|
+        application_form.update!(
+          working_days_between_submitted_and_today:
+            calendar.business_days_between(
+              application_form.submitted_at,
+              today,
+            ),
+        )
+      end
+  end
+
+  private
+
+  def calendar
+    @calendar ||=
+      Business::Calendar.new(
+        holidays:
+          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
+      )
+  end
+
+  def today
+    @today ||= Time.zone.now
+  end
+end

--- a/app/jobs/working_days/update_applications_submitted_to_completed_job.rb
+++ b/app/jobs/working_days/update_applications_submitted_to_completed_job.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class WorkingDays::UpdateApplicationsSubmittedToCompletedJob < ApplicationJob
+  def perform
+    ApplicationForm.completed_stage.find_each do |application_form|
+      application_form.update!(
+        working_days_between_submitted_and_completed:
+          calendar.business_days_between(
+            application_form.submitted_at,
+            application_form.awarded_at || application_form.declined_at ||
+              application_form.withdrawn_at,
+          ),
+      )
+    end
+  end
+
+  private
+
+  def calendar
+    @calendar ||=
+      Business::Calendar.new(
+        holidays:
+          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
+      )
+  end
+end

--- a/app/jobs/working_days/update_applications_submitted_to_completed_job.rb
+++ b/app/jobs/working_days/update_applications_submitted_to_completed_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WorkingDays::UpdateApplicationsSubmittedToCompletedJob < ApplicationJob
+class WorkingDays::UpdateApplicationsSubmittedToCompletedJob < WorkingDays::BaseJob
   def perform
     ApplicationForm
       .completed_stage
@@ -15,15 +15,5 @@ class WorkingDays::UpdateApplicationsSubmittedToCompletedJob < ApplicationJob
             ),
         )
       end
-  end
-
-  private
-
-  def calendar
-    @calendar ||=
-      Business::Calendar.new(
-        holidays:
-          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
-      )
   end
 end

--- a/app/jobs/working_days/update_applications_submitted_to_completed_job.rb
+++ b/app/jobs/working_days/update_applications_submitted_to_completed_job.rb
@@ -2,16 +2,19 @@
 
 class WorkingDays::UpdateApplicationsSubmittedToCompletedJob < ApplicationJob
   def perform
-    ApplicationForm.completed_stage.find_each do |application_form|
-      application_form.update!(
-        working_days_between_submitted_and_completed:
-          calendar.business_days_between(
-            application_form.submitted_at,
-            application_form.awarded_at || application_form.declined_at ||
-              application_form.withdrawn_at,
-          ),
-      )
-    end
+    ApplicationForm
+      .completed_stage
+      .where(working_days_between_submitted_and_completed: nil)
+      .find_each do |application_form|
+        application_form.update!(
+          working_days_between_submitted_and_completed:
+            calendar.business_days_between(
+              application_form.submitted_at,
+              application_form.awarded_at || application_form.declined_at ||
+                application_form.withdrawn_at,
+            ),
+        )
+      end
   end
 
   private

--- a/app/jobs/working_days/update_assessments_since_started_job.rb
+++ b/app/jobs/working_days/update_assessments_since_started_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WorkingDays::UpdateAssessmentsSinceStartedJob < ApplicationJob
+class WorkingDays::UpdateAssessmentsSinceStartedJob < WorkingDays::BaseJob
   def perform
     Assessment
       .where.not(started_at: nil)
@@ -10,19 +10,5 @@ class WorkingDays::UpdateAssessmentsSinceStartedJob < ApplicationJob
             calendar.business_days_between(assessment.started_at, today),
         )
       end
-  end
-
-  private
-
-  def calendar
-    @calendar ||=
-      Business::Calendar.new(
-        holidays:
-          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
-      )
-  end
-
-  def today
-    @today ||= Time.zone.now
   end
 end

--- a/app/jobs/working_days/update_assessments_since_started_job.rb
+++ b/app/jobs/working_days/update_assessments_since_started_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class WorkingDays::UpdateAssessmentsSinceStartedJob < ApplicationJob
+  def perform
+    Assessment
+      .where.not(started_at: nil)
+      .find_each do |assessment|
+        assessment.update!(
+          working_days_between_started_and_today:
+            calendar.business_days_between(assessment.started_at, today),
+        )
+      end
+  end
+
+  private
+
+  def calendar
+    @calendar ||=
+      Business::Calendar.new(
+        holidays:
+          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
+      )
+  end
+
+  def today
+    @today ||= Time.zone.now
+  end
+end

--- a/app/jobs/working_days/update_assessments_started_to_completed_job.rb
+++ b/app/jobs/working_days/update_assessments_started_to_completed_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WorkingDays::UpdateAssessmentsStartedToCompletedJob < ApplicationJob
+class WorkingDays::UpdateAssessmentsStartedToCompletedJob < WorkingDays::BaseJob
   def perform
     Assessment
       .joins(:application_form)
@@ -24,15 +24,5 @@ class WorkingDays::UpdateAssessmentsStartedToCompletedJob < ApplicationJob
             ),
         )
       end
-  end
-
-  private
-
-  def calendar
-    @calendar ||=
-      Business::Calendar.new(
-        holidays:
-          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
-      )
   end
 end

--- a/app/jobs/working_days/update_assessments_started_to_completed_job.rb
+++ b/app/jobs/working_days/update_assessments_started_to_completed_job.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class WorkingDays::UpdateAssessmentsStartedToCompletedJob < ApplicationJob
+  def perform
+    Assessment
+      .joins(:application_form)
+      .includes(:application_form)
+      .where(application_form: { stage: "completed" })
+      .where.not(started_at: nil)
+      .find_each do |assessment|
+        application_form = assessment.application_form
+
+        assessment.update!(
+          working_days_between_started_and_completed:
+            calendar.business_days_between(
+              assessment.started_at,
+              application_form.awarded_at || application_form.declined_at ||
+                application_form.withdrawn_at,
+            ),
+        )
+      end
+  end
+
+  private
+
+  def calendar
+    @calendar ||=
+      Business::Calendar.new(
+        holidays:
+          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
+      )
+  end
+end

--- a/app/jobs/working_days/update_assessments_started_to_completed_job.rb
+++ b/app/jobs/working_days/update_assessments_started_to_completed_job.rb
@@ -5,7 +5,12 @@ class WorkingDays::UpdateAssessmentsStartedToCompletedJob < ApplicationJob
     Assessment
       .joins(:application_form)
       .includes(:application_form)
-      .where(application_form: { stage: "completed" })
+      .where(
+        application_form: {
+          stage: "completed",
+        },
+        working_days_between_started_and_completed: nil,
+      )
       .where.not(started_at: nil)
       .find_each do |assessment|
         application_form = assessment.application_form

--- a/app/jobs/working_days/update_assessments_started_to_verification_job.rb
+++ b/app/jobs/working_days/update_assessments_started_to_verification_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WorkingDays::UpdateAssessmentsStartedToVerificationJob < ApplicationJob
+class WorkingDays::UpdateAssessmentsStartedToVerificationJob < WorkingDays::BaseJob
   def perform
     Assessment
       .where.not(started_at: nil)
@@ -15,15 +15,5 @@ class WorkingDays::UpdateAssessmentsStartedToVerificationJob < ApplicationJob
             ),
         )
       end
-  end
-
-  private
-
-  def calendar
-    @calendar ||=
-      Business::Calendar.new(
-        holidays:
-          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
-      )
   end
 end

--- a/app/jobs/working_days/update_assessments_started_to_verification_job.rb
+++ b/app/jobs/working_days/update_assessments_started_to_verification_job.rb
@@ -5,6 +5,7 @@ class WorkingDays::UpdateAssessmentsStartedToVerificationJob < ApplicationJob
     Assessment
       .where.not(started_at: nil)
       .where.not(verification_started_at: nil)
+      .where(working_days_between_started_and_verification_started: nil)
       .find_each do |assessment|
         assessment.update!(
           working_days_between_started_and_verification_started:

--- a/app/jobs/working_days/update_assessments_started_to_verification_job.rb
+++ b/app/jobs/working_days/update_assessments_started_to_verification_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class WorkingDays::UpdateAssessmentsStartedToVerificationJob < ApplicationJob
+  def perform
+    Assessment
+      .where.not(started_at: nil)
+      .where.not(verification_started_at: nil)
+      .find_each do |assessment|
+        assessment.update!(
+          working_days_between_started_and_verification_started:
+            calendar.business_days_between(
+              assessment.started_at,
+              assessment.verification_started_at,
+            ),
+        )
+      end
+  end
+
+  private
+
+  def calendar
+    @calendar ||=
+      Business::Calendar.new(
+        holidays:
+          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
+      )
+  end
+end

--- a/app/jobs/working_days/update_assessments_submission_to_prioritisation_decision_job.rb
+++ b/app/jobs/working_days/update_assessments_submission_to_prioritisation_decision_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class WorkingDays::UpdateAssessmentsSubmissionToPrioritisationDecisionJob < ApplicationJob
+  def perform
+    Assessment
+      .joins(:application_form)
+      .includes(:application_form)
+      .where.not(application_form: { submitted_at: nil })
+      .where.not(prioritisation_decision_at: nil)
+      .find_each do |assessment|
+        assessment.update!(
+          working_days_between_submitted_and_prioritisation_decision:
+            calendar.business_days_between(
+              assessment.application_form.submitted_at,
+              assessment.prioritisation_decision_at,
+            ),
+        )
+      end
+  end
+
+  private
+
+  def calendar
+    @calendar ||=
+      Business::Calendar.new(
+        holidays:
+          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
+      )
+  end
+end

--- a/app/jobs/working_days/update_assessments_submission_to_prioritisation_decision_job.rb
+++ b/app/jobs/working_days/update_assessments_submission_to_prioritisation_decision_job.rb
@@ -7,6 +7,7 @@ class WorkingDays::UpdateAssessmentsSubmissionToPrioritisationDecisionJob < Appl
       .includes(:application_form)
       .where.not(application_form: { submitted_at: nil })
       .where.not(prioritisation_decision_at: nil)
+      .where(working_days_between_submitted_and_prioritisation_decision: nil)
       .find_each do |assessment|
         assessment.update!(
           working_days_between_submitted_and_prioritisation_decision:

--- a/app/jobs/working_days/update_assessments_submission_to_prioritisation_decision_job.rb
+++ b/app/jobs/working_days/update_assessments_submission_to_prioritisation_decision_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WorkingDays::UpdateAssessmentsSubmissionToPrioritisationDecisionJob < ApplicationJob
+class WorkingDays::UpdateAssessmentsSubmissionToPrioritisationDecisionJob < WorkingDays::BaseJob
   def perform
     Assessment
       .joins(:application_form)
@@ -17,15 +17,5 @@ class WorkingDays::UpdateAssessmentsSubmissionToPrioritisationDecisionJob < Appl
             ),
         )
       end
-  end
-
-  private
-
-  def calendar
-    @calendar ||=
-      Business::Calendar.new(
-        holidays:
-          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
-      )
   end
 end

--- a/app/jobs/working_days/update_assessments_submission_to_started_job.rb
+++ b/app/jobs/working_days/update_assessments_submission_to_started_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WorkingDays::UpdateAssessmentsSubmissionToStartedJob < ApplicationJob
+class WorkingDays::UpdateAssessmentsSubmissionToStartedJob < WorkingDays::BaseJob
   def perform
     Assessment
       .joins(:application_form)
@@ -17,15 +17,5 @@ class WorkingDays::UpdateAssessmentsSubmissionToStartedJob < ApplicationJob
             ),
         )
       end
-  end
-
-  private
-
-  def calendar
-    @calendar ||=
-      Business::Calendar.new(
-        holidays:
-          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
-      )
   end
 end

--- a/app/jobs/working_days/update_assessments_submission_to_started_job.rb
+++ b/app/jobs/working_days/update_assessments_submission_to_started_job.rb
@@ -7,6 +7,7 @@ class WorkingDays::UpdateAssessmentsSubmissionToStartedJob < ApplicationJob
       .includes(:application_form)
       .where.not(application_form: { submitted_at: nil })
       .where.not(started_at: nil)
+      .where(working_days_between_submitted_and_started: nil)
       .find_each do |assessment|
         assessment.update!(
           working_days_between_submitted_and_started:

--- a/app/jobs/working_days/update_assessments_submission_to_started_job.rb
+++ b/app/jobs/working_days/update_assessments_submission_to_started_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class WorkingDays::UpdateAssessmentsSubmissionToStartedJob < ApplicationJob
+  def perform
+    Assessment
+      .joins(:application_form)
+      .includes(:application_form)
+      .where.not(application_form: { submitted_at: nil })
+      .where.not(started_at: nil)
+      .find_each do |assessment|
+        assessment.update!(
+          working_days_between_submitted_and_started:
+            calendar.business_days_between(
+              assessment.application_form.submitted_at,
+              assessment.started_at,
+            ),
+        )
+      end
+  end
+
+  private
+
+  def calendar
+    @calendar ||=
+      Business::Calendar.new(
+        holidays:
+          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
+      )
+  end
+end

--- a/app/jobs/working_days/update_assessments_submission_to_verification_job.rb
+++ b/app/jobs/working_days/update_assessments_submission_to_verification_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class WorkingDays::UpdateAssessmentsSubmissionToVerificationJob < ApplicationJob
+  def perform
+    Assessment
+      .joins(:application_form)
+      .includes(:application_form)
+      .where.not(application_form: { submitted_at: nil })
+      .where.not(verification_started_at: nil)
+      .find_each do |assessment|
+        assessment.update!(
+          working_days_between_submitted_and_verification_started:
+            calendar.business_days_between(
+              assessment.application_form.submitted_at,
+              assessment.verification_started_at,
+            ),
+        )
+      end
+  end
+
+  private
+
+  def calendar
+    @calendar ||=
+      Business::Calendar.new(
+        holidays:
+          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
+      )
+  end
+end

--- a/app/jobs/working_days/update_assessments_submission_to_verification_job.rb
+++ b/app/jobs/working_days/update_assessments_submission_to_verification_job.rb
@@ -7,6 +7,7 @@ class WorkingDays::UpdateAssessmentsSubmissionToVerificationJob < ApplicationJob
       .includes(:application_form)
       .where.not(application_form: { submitted_at: nil })
       .where.not(verification_started_at: nil)
+      .where(working_days_between_submitted_and_verification_started: nil)
       .find_each do |assessment|
         assessment.update!(
           working_days_between_submitted_and_verification_started:

--- a/app/jobs/working_days/update_assessments_submission_to_verification_job.rb
+++ b/app/jobs/working_days/update_assessments_submission_to_verification_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WorkingDays::UpdateAssessmentsSubmissionToVerificationJob < ApplicationJob
+class WorkingDays::UpdateAssessmentsSubmissionToVerificationJob < WorkingDays::BaseJob
   def perform
     Assessment
       .joins(:application_form)
@@ -17,15 +17,5 @@ class WorkingDays::UpdateAssessmentsSubmissionToVerificationJob < ApplicationJob
             ),
         )
       end
-  end
-
-  private
-
-  def calendar
-    @calendar ||=
-      Business::Calendar.new(
-        holidays:
-          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
-      )
   end
 end

--- a/app/jobs/working_days/update_further_information_requests_assessment_started_to_requested_job.rb
+++ b/app/jobs/working_days/update_further_information_requests_assessment_started_to_requested_job.rb
@@ -7,6 +7,7 @@ class WorkingDays::UpdateFurtherInformationRequestsAssessmentStartedToRequestedJ
       .includes(:assessment)
       .where.not(assessment: { started_at: nil })
       .where.not(requested_at: nil)
+      .where(working_days_between_assessment_started_to_requested: nil)
       .find_each do |further_information_request|
         further_information_request.update!(
           working_days_between_assessment_started_to_requested:

--- a/app/jobs/working_days/update_further_information_requests_assessment_started_to_requested_job.rb
+++ b/app/jobs/working_days/update_further_information_requests_assessment_started_to_requested_job.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class WorkingDays::UpdateFurtherInformationRequestsAssessmentStartedToRequestedJob < ApplicationJob
+  def perform
+    FurtherInformationRequest
+      .joins(:assessment)
+      .includes(:assessment)
+      .where.not(assessment: { started_at: nil })
+      .where.not(requested_at: nil)
+      .find_each do |further_information_request|
+        further_information_request.update!(
+          working_days_between_assessment_started_to_requested:
+            calendar.business_days_between(
+              further_information_request.assessment.started_at,
+              further_information_request.requested_at,
+            ),
+        )
+      end
+  end
+
+  private
+
+  def calendar
+    @calendar ||=
+      Business::Calendar.new(
+        holidays:
+          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
+      )
+  end
+end

--- a/app/jobs/working_days/update_further_information_requests_assessment_started_to_requested_job.rb
+++ b/app/jobs/working_days/update_further_information_requests_assessment_started_to_requested_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class WorkingDays::UpdateFurtherInformationRequestsAssessmentStartedToRequestedJob < ApplicationJob
+class WorkingDays::UpdateFurtherInformationRequestsAssessmentStartedToRequestedJob < WorkingDays::BaseJob
   def perform
     FurtherInformationRequest
       .joins(:assessment)
@@ -17,15 +17,5 @@ class WorkingDays::UpdateFurtherInformationRequestsAssessmentStartedToRequestedJ
             ),
         )
       end
-  end
-
-  private
-
-  def calendar
-    @calendar ||=
-      Business::Calendar.new(
-        holidays:
-          DfE::ReferenceData::BankHolidays::BANK_HOLIDAYS.all.map(&:date),
-      )
   end
 end

--- a/app/services/rollback_assessment.rb
+++ b/app/services/rollback_assessment.rb
@@ -81,6 +81,11 @@ class RollbackAssessment
       application_form.update!(declined_at: nil)
     end
 
+    application_form.update!(working_days_between_submitted_and_completed: nil)
+    application_form.assessment.update!(
+      working_days_between_started_and_completed: nil,
+    )
+
     ApplicationFormStatusUpdater.call(application_form:, user:)
   end
 

--- a/spec/jobs/update_working_days_job_spec.rb
+++ b/spec/jobs/update_working_days_job_spec.rb
@@ -2,403 +2,66 @@
 
 require "rails_helper"
 
-RSpec.describe UpdateWorkingDaysJob, type: :job do
-  describe "#perform" do
-    subject(:perform) do
-      travel_to(wednesday_today) { described_class.new.perform }
-    end
+RSpec.describe UpdateWorkingDaysJob do
+  subject(:perform) { described_class.perform_now }
 
-    # Friday prior to a Monday bank holiday (2023-05-01) weekend
-    let(:friday_previous) { Date.new(2023, 4, 28) }
+  around { |example| freeze_time { example.run } }
 
-    # Wednesday after a Monday bank holiday (2023-05-01) weekend
-    let(:wednesday_today) { Date.new(2023, 5, 3) }
-    let(:friday_application_form) do
-      create(:application_form, :submitted, submitted_at: friday_previous)
-    end
+  it "enqueues the applications-since-submission job immediately" do
+    expect { perform }.to have_enqueued_job(
+      WorkingDays::UpdateApplicationsSinceSubmissionJob,
+    )
+  end
 
-    describe "application form working days since submission" do
-      let(:draft_application_form) { create(:application_form) }
-      let(:tuesday_application_form) do
-        create(
-          :application_form,
-          :submitted,
-          submitted_at: Date.new(2023, 5, 2),
-        )
-      end
+  it "enqueues the applications submitted-to-completed job after 15 minutes" do
+    expect { perform }.to have_enqueued_job(
+      WorkingDays::UpdateApplicationsSubmittedToCompletedJob,
+    ).at(15.minutes.from_now)
+  end
 
-      it "ignores draft application forms" do
-        expect { perform }.not_to(
-          change do
-            draft_application_form.reload.working_days_between_submitted_and_today
-          end,
-        )
-      end
+  it "enqueues the assessments-since-started job after 30 minutes" do
+    expect { perform }.to have_enqueued_job(
+      WorkingDays::UpdateAssessmentsSinceStartedJob,
+    ).at(30.minutes.from_now)
+  end
 
-      it "sets the working days for monday" do
-        expect { perform }.to change {
-          tuesday_application_form.reload.working_days_between_submitted_and_today
-        }.to(1)
-      end
+  it "enqueues the assessments started-to-completed job after 45 minutes" do
+    expect { perform }.to have_enqueued_job(
+      WorkingDays::UpdateAssessmentsStartedToCompletedJob,
+    ).at(45.minutes.from_now)
+  end
 
-      it "sets the working days for friday" do
-        expect { perform }.to change {
-          friday_application_form.reload.working_days_between_submitted_and_today
-        }.to(2)
-      end
-    end
+  it "enqueues the assessments submission-to-started job after 60 minutes" do
+    expect { perform }.to have_enqueued_job(
+      WorkingDays::UpdateAssessmentsSubmissionToStartedJob,
+    ).at(60.minutes.from_now)
+  end
 
-    describe "application form working days from submitted to completed" do
-      let(:draft_application_form) { create(:application_form) }
-      let(:wednesday_application_form_awarded) do
-        create(
-          :application_form,
-          :awarded,
-          submitted_at: friday_previous,
-          awarded_at: wednesday_today,
-        )
-      end
-      let(:wednesday_application_form_declined) do
-        create(
-          :application_form,
-          :declined,
-          submitted_at: friday_previous,
-          declined_at: wednesday_today,
-        )
-      end
-      let(:wednesday_application_form_withdrawn) do
-        create(
-          :application_form,
-          :withdrawn,
-          submitted_at: friday_previous,
-          withdrawn_at: wednesday_today,
-        )
-      end
+  it "enqueues the assessments started-to-verification job after 75 minutes" do
+    expect { perform }.to have_enqueued_job(
+      WorkingDays::UpdateAssessmentsStartedToVerificationJob,
+    ).at(75.minutes.from_now)
+  end
 
-      it "ignores draft application forms" do
-        expect { perform }.not_to(
-          change do
-            draft_application_form.reload.working_days_between_submitted_and_completed
-          end,
-        )
-      end
+  it "enqueues the assessments submission-to-verification job after 90 minutes" do
+    expect { perform }.to have_enqueued_job(
+      WorkingDays::UpdateAssessmentsSubmissionToVerificationJob,
+    ).at(90.minutes.from_now)
+  end
 
-      it "ignores submitted and not completed application forms" do
-        expect { perform }.not_to(
-          change do
-            friday_application_form.reload.working_days_between_submitted_and_completed
-          end,
-        )
-      end
+  it "enqueues the assessments submission-to-prioritisation-decision job after 105 minutes" do
+    expect { perform }.to have_enqueued_job(
+      WorkingDays::UpdateAssessmentsSubmissionToPrioritisationDecisionJob,
+    ).at(105.minutes.from_now)
+  end
 
-      it "sets the working days for awarded" do
-        expect { perform }.to change {
-          wednesday_application_form_awarded.reload.working_days_between_submitted_and_completed
-        }.to(2)
-      end
+  it "enqueues the further-information-requests job after 120 minutes" do
+    expect { perform }.to have_enqueued_job(
+      WorkingDays::UpdateFurtherInformationRequestsAssessmentStartedToRequestedJob,
+    ).at(120.minutes.from_now)
+  end
 
-      it "sets the working days for declined" do
-        expect { perform }.to change {
-          wednesday_application_form_declined.reload.working_days_between_submitted_and_completed
-        }.to(2)
-      end
-
-      it "sets the working days for withdrawn" do
-        expect { perform }.to change {
-          wednesday_application_form_withdrawn.reload.working_days_between_submitted_and_completed
-        }.to(2)
-      end
-    end
-
-    describe "assessment working days since started" do
-      let(:not_started_assessment) { create(:assessment) }
-      let(:friday_assessment) do
-        create(:assessment, started_at: friday_previous)
-      end
-
-      it "ignores not started assessments" do
-        expect { perform }.not_to(
-          change do
-            not_started_assessment.reload.working_days_between_started_and_today
-          end,
-        )
-      end
-
-      it "sets the working days" do
-        expect { perform }.to change {
-          friday_assessment.reload.working_days_between_started_and_today
-        }.to(2)
-      end
-    end
-
-    describe "assessment working days from assessment started to application form completed" do
-      let(:not_started_assessment) do
-        create(:assessment, application_form: friday_application_form)
-      end
-
-      let(:started_incomplete_assessment) do
-        create(
-          :assessment,
-          started_at: friday_previous,
-          application_form: incomplete_application,
-        )
-      end
-      let(:incomplete_application) do
-        create(:application_form, :submitted, submitted_at: friday_previous)
-      end
-
-      let(:awarded_assessment) do
-        create(
-          :assessment,
-          started_at: friday_previous,
-          application_form: wednesday_application_form_awarded,
-        )
-      end
-      let(:wednesday_application_form_awarded) do
-        create(
-          :application_form,
-          :awarded,
-          submitted_at: friday_previous,
-          awarded_at: wednesday_today,
-        )
-      end
-
-      let(:declined_assessment) do
-        create(
-          :assessment,
-          started_at: friday_previous,
-          application_form: wednesday_application_form_declined,
-        )
-      end
-      let(:wednesday_application_form_declined) do
-        create(
-          :application_form,
-          :declined,
-          submitted_at: friday_previous,
-          declined_at: wednesday_today,
-        )
-      end
-
-      let(:withdrawn_assessment) do
-        create(
-          :assessment,
-          started_at: friday_previous,
-          application_form: wednesday_application_form_withdrawn,
-        )
-      end
-      let(:wednesday_application_form_withdrawn) do
-        create(
-          :application_form,
-          :withdrawn,
-          submitted_at: friday_previous,
-          withdrawn_at: wednesday_today,
-        )
-      end
-
-      it "ignores not started assessment" do
-        expect { perform }.not_to(
-          change do
-            not_started_assessment.reload.working_days_between_started_and_completed
-          end,
-        )
-      end
-
-      it "ignores not completed applications assessment that has started" do
-        expect { perform }.not_to(
-          change do
-            started_incomplete_assessment.reload.working_days_between_started_and_completed
-          end,
-        )
-      end
-
-      it "sets the working days for awarded application" do
-        expect { perform }.to change {
-          awarded_assessment.reload.working_days_between_started_and_completed
-        }.to(2)
-      end
-
-      it "sets the working days for declined application" do
-        expect { perform }.to change {
-          declined_assessment.reload.working_days_between_started_and_completed
-        }.to(2)
-      end
-
-      it "sets the working days for withdrawn" do
-        expect { perform }.to change {
-          withdrawn_assessment.reload.working_days_between_started_and_completed
-        }.to(2)
-      end
-    end
-
-    describe "assessment working days from application submitted to assessment started" do
-      let(:not_started_assessment) do
-        create(:assessment, application_form: friday_application_form)
-      end
-
-      let(:wednesday_started_assessment) do
-        create(
-          :assessment,
-          started_at: wednesday_today,
-          application_form: friday_application_form,
-        )
-      end
-      let(:friday_application_form) do
-        create(:application_form, submitted_at: friday_previous)
-      end
-
-      it "ignores not started assessment" do
-        expect { perform }.not_to(
-          change do
-            not_started_assessment.reload.working_days_between_submitted_and_started
-          end,
-        )
-      end
-
-      it "sets the working days for started assessment" do
-        expect { perform }.to change {
-          wednesday_started_assessment.reload.working_days_between_submitted_and_started
-        }.to(2)
-      end
-    end
-
-    describe "assessment working days from application form submitted to assessment verification" do
-      let(:not_started_assessment) do
-        create(:assessment, application_form: friday_application_form)
-      end
-
-      let(:not_started_verification_assessment) do
-        create(
-          :assessment,
-          application_form: application_form_not_verified,
-          started_at: wednesday_today,
-        )
-      end
-      let(:application_form_not_verified) do
-        create(:application_form, submitted_at: friday_previous)
-      end
-
-      let(:wednesday_verification_started_assessment) do
-        create(
-          :assessment,
-          started_at: wednesday_today,
-          verification_started_at: wednesday_today,
-          application_form: friday_application_form,
-        )
-      end
-      let(:friday_application_form) do
-        create(:application_form, submitted_at: friday_previous)
-      end
-
-      it "ignores not started assessment" do
-        expect { perform }.not_to(
-          change do
-            not_started_assessment.reload.working_days_between_submitted_and_verification_started
-          end,
-        )
-      end
-
-      it "ignores not started verification assessment" do
-        expect { perform }.not_to(
-          change do
-            not_started_verification_assessment.reload.working_days_between_submitted_and_verification_started
-          end,
-        )
-      end
-
-      it "sets the working days for started verification assessment" do
-        expect { perform }.to change {
-          wednesday_verification_started_assessment.reload.working_days_between_submitted_and_verification_started
-        }.to(2)
-      end
-    end
-
-    describe "assessment working days from application form submitted to assessment prioritisation decision" do
-      let(:assessment_without_prioritisation_flow) do
-        create(:assessment, application_form: friday_application_form)
-      end
-
-      let(:wednesday_assessment_prioritised) do
-        create(
-          :assessment,
-          started_at: wednesday_today,
-          prioritisation_decision_at: wednesday_today,
-          application_form: friday_application_form,
-        )
-      end
-      let(:friday_application_form) do
-        create(:application_form, submitted_at: friday_previous)
-      end
-
-      it "ignores assessment without prioritisation flow" do
-        expect { perform }.not_to(
-          change do
-            assessment_without_prioritisation_flow.reload.working_days_between_submitted_and_prioritisation_decision
-          end,
-        )
-      end
-
-      it "sets the working days for assessment that has prioritisation decision" do
-        expect { perform }.to change {
-          wednesday_assessment_prioritised.reload.working_days_between_submitted_and_prioritisation_decision
-        }.to(2)
-      end
-    end
-
-    describe "assessment working days from application form started to verification" do
-      let(:not_started_assessment) do
-        create(:assessment, application_form: friday_application_form)
-      end
-
-      let(:not_started_verification_assessment) do
-        create(:assessment, started_at: friday_previous)
-      end
-
-      let(:wednesday_verification_started_assessment) do
-        create(
-          :assessment,
-          started_at: friday_previous,
-          verification_started_at: wednesday_today,
-        )
-      end
-
-      it "ignores not started assessment" do
-        expect { perform }.not_to(
-          change do
-            not_started_assessment.reload.working_days_between_started_and_verification_started
-          end,
-        )
-      end
-
-      it "ignores not started verification assessment" do
-        expect { perform }.not_to(
-          change do
-            not_started_verification_assessment.reload.working_days_between_started_and_verification_started
-          end,
-        )
-      end
-
-      it "sets the working days for started verification assessment" do
-        expect { perform }.to change {
-          wednesday_verification_started_assessment.reload.working_days_between_started_and_verification_started
-        }.to(2)
-      end
-    end
-
-    describe "further information request assessment started to requested" do
-      let(:assessment) { create(:assessment, started_at: friday_previous) }
-      let(:further_information_request) do
-        create(
-          :received_further_information_request,
-          assessment:,
-          requested_at: wednesday_today,
-        )
-      end
-
-      it "sets the working days" do
-        expect { perform }.to change {
-          further_information_request.reload.working_days_between_assessment_started_to_requested
-        }.to(2)
-      end
-    end
+  it "enqueues all nine working-days jobs" do
+    expect { perform }.to have_enqueued_job.exactly(9).times
   end
 end

--- a/spec/jobs/working_days/update_applications_since_submission_job_spec.rb
+++ b/spec/jobs/working_days/update_applications_since_submission_job_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkingDays::UpdateApplicationsSinceSubmissionJob, type: :job do
+  describe "#perform" do
+    subject(:perform) do
+      travel_to(wednesday_today) { described_class.new.perform }
+    end
+
+    # Friday prior to a Monday bank holiday (2023-05-01) weekend
+    let(:friday_previous) { Date.new(2023, 4, 28) }
+
+    # Wednesday after a Monday bank holiday (2023-05-01) weekend
+    let(:wednesday_today) { Date.new(2023, 5, 3) }
+    let(:friday_application_form) do
+      create(:application_form, :submitted, submitted_at: friday_previous)
+    end
+
+    let(:draft_application_form) { create(:application_form) }
+    let(:tuesday_application_form) do
+      create(:application_form, :submitted, submitted_at: Date.new(2023, 5, 2))
+    end
+
+    it "ignores draft application forms" do
+      expect { perform }.not_to(
+        change do
+          draft_application_form.reload.working_days_between_submitted_and_today
+        end,
+      )
+    end
+
+    it "sets the working days for monday" do
+      expect { perform }.to change {
+        tuesday_application_form.reload.working_days_between_submitted_and_today
+      }.to(1)
+    end
+
+    it "sets the working days for friday" do
+      expect { perform }.to change {
+        friday_application_form.reload.working_days_between_submitted_and_today
+      }.to(2)
+    end
+  end
+end

--- a/spec/jobs/working_days/update_applications_submitted_to_completed_job_spec.rb
+++ b/spec/jobs/working_days/update_applications_submitted_to_completed_job_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkingDays::UpdateApplicationsSubmittedToCompletedJob,
+               type: :job do
+  describe "#perform" do
+    subject(:perform) do
+      travel_to(wednesday_today) { described_class.new.perform }
+    end
+
+    # Friday prior to a Monday bank holiday (2023-05-01) weekend
+    let(:friday_previous) { Date.new(2023, 4, 28) }
+
+    # Wednesday after a Monday bank holiday (2023-05-01) weekend
+    let(:wednesday_today) { Date.new(2023, 5, 3) }
+    let(:friday_application_form) do
+      create(:application_form, :submitted, submitted_at: friday_previous)
+    end
+
+    let(:draft_application_form) { create(:application_form) }
+    let(:wednesday_application_form_awarded) do
+      create(
+        :application_form,
+        :awarded,
+        submitted_at: friday_previous,
+        awarded_at: wednesday_today,
+      )
+    end
+    let(:wednesday_application_form_declined) do
+      create(
+        :application_form,
+        :declined,
+        submitted_at: friday_previous,
+        declined_at: wednesday_today,
+      )
+    end
+    let(:wednesday_application_form_withdrawn) do
+      create(
+        :application_form,
+        :withdrawn,
+        submitted_at: friday_previous,
+        withdrawn_at: wednesday_today,
+      )
+    end
+
+    it "ignores draft application forms" do
+      expect { perform }.not_to(
+        change do
+          draft_application_form.reload.working_days_between_submitted_and_completed
+        end,
+      )
+    end
+
+    it "ignores submitted and not completed application forms" do
+      expect { perform }.not_to(
+        change do
+          friday_application_form.reload.working_days_between_submitted_and_completed
+        end,
+      )
+    end
+
+    it "sets the working days for awarded" do
+      expect { perform }.to change {
+        wednesday_application_form_awarded.reload.working_days_between_submitted_and_completed
+      }.to(2)
+    end
+
+    it "sets the working days for declined" do
+      expect { perform }.to change {
+        wednesday_application_form_declined.reload.working_days_between_submitted_and_completed
+      }.to(2)
+    end
+
+    it "sets the working days for withdrawn" do
+      expect { perform }.to change {
+        wednesday_application_form_withdrawn.reload.working_days_between_submitted_and_completed
+      }.to(2)
+    end
+  end
+end

--- a/spec/jobs/working_days/update_assessments_since_started_job_spec.rb
+++ b/spec/jobs/working_days/update_assessments_since_started_job_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkingDays::UpdateAssessmentsSinceStartedJob, type: :job do
+  describe "#perform" do
+    subject(:perform) do
+      travel_to(wednesday_today) { described_class.new.perform }
+    end
+
+    # Friday prior to a Monday bank holiday (2023-05-01) weekend
+    let(:friday_previous) { Date.new(2023, 4, 28) }
+
+    # Wednesday after a Monday bank holiday (2023-05-01) weekend
+    let(:wednesday_today) { Date.new(2023, 5, 3) }
+    let(:friday_application_form) do
+      create(:application_form, :submitted, submitted_at: friday_previous)
+    end
+
+    let(:not_started_assessment) { create(:assessment) }
+    let(:friday_assessment) { create(:assessment, started_at: friday_previous) }
+
+    it "ignores not started assessments" do
+      expect { perform }.not_to(
+        change do
+          not_started_assessment.reload.working_days_between_started_and_today
+        end,
+      )
+    end
+
+    it "sets the working days" do
+      expect { perform }.to change {
+        friday_assessment.reload.working_days_between_started_and_today
+      }.to(2)
+    end
+  end
+end

--- a/spec/jobs/working_days/update_assessments_started_to_completed_job_spec.rb
+++ b/spec/jobs/working_days/update_assessments_started_to_completed_job_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkingDays::UpdateAssessmentsStartedToCompletedJob,
+               type: :job do
+  describe "#perform" do
+    subject(:perform) do
+      travel_to(wednesday_today) { described_class.new.perform }
+    end
+
+    # Friday prior to a Monday bank holiday (2023-05-01) weekend
+    let(:friday_previous) { Date.new(2023, 4, 28) }
+
+    # Wednesday after a Monday bank holiday (2023-05-01) weekend
+    let(:wednesday_today) { Date.new(2023, 5, 3) }
+    let(:friday_application_form) do
+      create(:application_form, :submitted, submitted_at: friday_previous)
+    end
+
+    let(:not_started_assessment) do
+      create(:assessment, application_form: friday_application_form)
+    end
+
+    let(:started_incomplete_assessment) do
+      create(
+        :assessment,
+        started_at: friday_previous,
+        application_form: incomplete_application,
+      )
+    end
+    let(:incomplete_application) do
+      create(:application_form, :submitted, submitted_at: friday_previous)
+    end
+
+    let(:awarded_assessment) do
+      create(
+        :assessment,
+        started_at: friday_previous,
+        application_form: wednesday_application_form_awarded,
+      )
+    end
+    let(:wednesday_application_form_awarded) do
+      create(
+        :application_form,
+        :awarded,
+        submitted_at: friday_previous,
+        awarded_at: wednesday_today,
+      )
+    end
+
+    let(:declined_assessment) do
+      create(
+        :assessment,
+        started_at: friday_previous,
+        application_form: wednesday_application_form_declined,
+      )
+    end
+    let(:wednesday_application_form_declined) do
+      create(
+        :application_form,
+        :declined,
+        submitted_at: friday_previous,
+        declined_at: wednesday_today,
+      )
+    end
+
+    let(:withdrawn_assessment) do
+      create(
+        :assessment,
+        started_at: friday_previous,
+        application_form: wednesday_application_form_withdrawn,
+      )
+    end
+    let(:wednesday_application_form_withdrawn) do
+      create(
+        :application_form,
+        :withdrawn,
+        submitted_at: friday_previous,
+        withdrawn_at: wednesday_today,
+      )
+    end
+
+    it "ignores not started assessment" do
+      expect { perform }.not_to(
+        change do
+          not_started_assessment.reload.working_days_between_started_and_completed
+        end,
+      )
+    end
+
+    it "ignores not completed applications assessment that has started" do
+      expect { perform }.not_to(
+        change do
+          started_incomplete_assessment.reload.working_days_between_started_and_completed
+        end,
+      )
+    end
+
+    it "sets the working days for awarded application" do
+      expect { perform }.to change {
+        awarded_assessment.reload.working_days_between_started_and_completed
+      }.to(2)
+    end
+
+    it "sets the working days for declined application" do
+      expect { perform }.to change {
+        declined_assessment.reload.working_days_between_started_and_completed
+      }.to(2)
+    end
+
+    it "sets the working days for withdrawn" do
+      expect { perform }.to change {
+        withdrawn_assessment.reload.working_days_between_started_and_completed
+      }.to(2)
+    end
+  end
+end

--- a/spec/jobs/working_days/update_assessments_started_to_verification_job_spec.rb
+++ b/spec/jobs/working_days/update_assessments_started_to_verification_job_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkingDays::UpdateAssessmentsStartedToVerificationJob,
+               type: :job do
+  describe "#perform" do
+    subject(:perform) do
+      travel_to(wednesday_today) { described_class.new.perform }
+    end
+
+    # Friday prior to a Monday bank holiday (2023-05-01) weekend
+    let(:friday_previous) { Date.new(2023, 4, 28) }
+
+    # Wednesday after a Monday bank holiday (2023-05-01) weekend
+    let(:wednesday_today) { Date.new(2023, 5, 3) }
+    let(:friday_application_form) do
+      create(:application_form, :submitted, submitted_at: friday_previous)
+    end
+
+    let(:not_started_assessment) do
+      create(:assessment, application_form: friday_application_form)
+    end
+
+    let(:not_started_verification_assessment) do
+      create(:assessment, started_at: friday_previous)
+    end
+
+    let(:wednesday_verification_started_assessment) do
+      create(
+        :assessment,
+        started_at: friday_previous,
+        verification_started_at: wednesday_today,
+      )
+    end
+
+    it "ignores not started assessment" do
+      expect { perform }.not_to(
+        change do
+          not_started_assessment.reload.working_days_between_started_and_verification_started
+        end,
+      )
+    end
+
+    it "ignores not started verification assessment" do
+      expect { perform }.not_to(
+        change do
+          not_started_verification_assessment.reload.working_days_between_started_and_verification_started
+        end,
+      )
+    end
+
+    it "sets the working days for started verification assessment" do
+      expect { perform }.to change {
+        wednesday_verification_started_assessment.reload.working_days_between_started_and_verification_started
+      }.to(2)
+    end
+  end
+end

--- a/spec/jobs/working_days/update_assessments_submission_to_prioritisation_decision_job_spec.rb
+++ b/spec/jobs/working_days/update_assessments_submission_to_prioritisation_decision_job_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkingDays::UpdateAssessmentsSubmissionToPrioritisationDecisionJob,
+               type: :job do
+  describe "#perform" do
+    subject(:perform) do
+      travel_to(wednesday_today) { described_class.new.perform }
+    end
+
+    # Friday prior to a Monday bank holiday (2023-05-01) weekend
+    let(:friday_previous) { Date.new(2023, 4, 28) }
+
+    # Wednesday after a Monday bank holiday (2023-05-01) weekend
+    let(:wednesday_today) { Date.new(2023, 5, 3) }
+    let(:friday_application_form) do
+      create(:application_form, :submitted, submitted_at: friday_previous)
+    end
+
+    let(:assessment_without_prioritisation_flow) do
+      create(:assessment, application_form: friday_application_form)
+    end
+
+    let(:wednesday_assessment_prioritised) do
+      create(
+        :assessment,
+        started_at: wednesday_today,
+        prioritisation_decision_at: wednesday_today,
+        application_form: friday_application_form,
+      )
+    end
+
+    it "ignores assessment without prioritisation flow" do
+      expect { perform }.not_to(
+        change do
+          assessment_without_prioritisation_flow.reload.working_days_between_submitted_and_prioritisation_decision
+        end,
+      )
+    end
+
+    it "sets the working days for assessment that has prioritisation decision" do
+      expect { perform }.to change {
+        wednesday_assessment_prioritised.reload.working_days_between_submitted_and_prioritisation_decision
+      }.to(2)
+    end
+  end
+end

--- a/spec/jobs/working_days/update_assessments_submission_to_started_job_spec.rb
+++ b/spec/jobs/working_days/update_assessments_submission_to_started_job_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkingDays::UpdateAssessmentsSubmissionToStartedJob,
+               type: :job do
+  describe "#perform" do
+    subject(:perform) do
+      travel_to(wednesday_today) { described_class.new.perform }
+    end
+
+    # Friday prior to a Monday bank holiday (2023-05-01) weekend
+    let(:friday_previous) { Date.new(2023, 4, 28) }
+
+    # Wednesday after a Monday bank holiday (2023-05-01) weekend
+    let(:wednesday_today) { Date.new(2023, 5, 3) }
+    let(:friday_application_form) do
+      create(:application_form, :submitted, submitted_at: friday_previous)
+    end
+
+    let(:not_started_assessment) do
+      create(:assessment, application_form: friday_application_form)
+    end
+
+    let(:wednesday_started_assessment) do
+      create(
+        :assessment,
+        started_at: wednesday_today,
+        application_form: friday_application_form,
+      )
+    end
+
+    it "ignores not started assessment" do
+      expect { perform }.not_to(
+        change do
+          not_started_assessment.reload.working_days_between_submitted_and_started
+        end,
+      )
+    end
+
+    it "sets the working days for started assessment" do
+      expect { perform }.to change {
+        wednesday_started_assessment.reload.working_days_between_submitted_and_started
+      }.to(2)
+    end
+  end
+end

--- a/spec/jobs/working_days/update_assessments_submission_to_verification_job_spec.rb
+++ b/spec/jobs/working_days/update_assessments_submission_to_verification_job_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkingDays::UpdateAssessmentsSubmissionToVerificationJob,
+               type: :job do
+  describe "#perform" do
+    subject(:perform) do
+      travel_to(wednesday_today) { described_class.new.perform }
+    end
+
+    # Friday prior to a Monday bank holiday (2023-05-01) weekend
+    let(:friday_previous) { Date.new(2023, 4, 28) }
+
+    # Wednesday after a Monday bank holiday (2023-05-01) weekend
+    let(:wednesday_today) { Date.new(2023, 5, 3) }
+    let(:friday_application_form) do
+      create(:application_form, :submitted, submitted_at: friday_previous)
+    end
+
+    let(:not_started_assessment) do
+      create(:assessment, application_form: friday_application_form)
+    end
+
+    let(:not_started_verification_assessment) do
+      create(
+        :assessment,
+        application_form: application_form_not_verified,
+        started_at: wednesday_today,
+      )
+    end
+    let(:application_form_not_verified) do
+      create(:application_form, submitted_at: friday_previous)
+    end
+
+    let(:wednesday_verification_started_assessment) do
+      create(
+        :assessment,
+        started_at: wednesday_today,
+        verification_started_at: wednesday_today,
+        application_form: friday_application_form,
+      )
+    end
+
+    it "ignores not started assessment" do
+      expect { perform }.not_to(
+        change do
+          not_started_assessment.reload.working_days_between_submitted_and_verification_started
+        end,
+      )
+    end
+
+    it "ignores not started verification assessment" do
+      expect { perform }.not_to(
+        change do
+          not_started_verification_assessment.reload.working_days_between_submitted_and_verification_started
+        end,
+      )
+    end
+
+    it "sets the working days for started verification assessment" do
+      expect { perform }.to change {
+        wednesday_verification_started_assessment.reload.working_days_between_submitted_and_verification_started
+      }.to(2)
+    end
+  end
+end

--- a/spec/jobs/working_days/update_further_information_requests_assessment_started_to_requested_job_spec.rb
+++ b/spec/jobs/working_days/update_further_information_requests_assessment_started_to_requested_job_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkingDays::UpdateFurtherInformationRequestsAssessmentStartedToRequestedJob,
+               type: :job do
+  describe "#perform" do
+    subject(:perform) do
+      travel_to(wednesday_today) { described_class.new.perform }
+    end
+
+    # Friday prior to a Monday bank holiday (2023-05-01) weekend
+    let(:friday_previous) { Date.new(2023, 4, 28) }
+
+    # Wednesday after a Monday bank holiday (2023-05-01) weekend
+    let(:wednesday_today) { Date.new(2023, 5, 3) }
+    let(:friday_application_form) do
+      create(:application_form, :submitted, submitted_at: friday_previous)
+    end
+
+    let(:assessment) { create(:assessment, started_at: friday_previous) }
+    let(:further_information_request) do
+      create(
+        :received_further_information_request,
+        assessment:,
+        requested_at: wednesday_today,
+      )
+    end
+
+    it "sets the working days" do
+      expect { perform }.to change {
+        further_information_request.reload.working_days_between_assessment_started_to_requested
+      }.to(2)
+    end
+  end
+end

--- a/spec/services/rollback_assessment_spec.rb
+++ b/spec/services/rollback_assessment_spec.rb
@@ -8,8 +8,33 @@ RSpec.describe RollbackAssessment do
   let(:user) { create(:staff) }
 
   context "with an award assessment" do
-    let(:application_form) { create(:application_form, :awarded) }
-    let(:assessment) { create(:assessment, :award, application_form:) }
+    let(:application_form) do
+      create(
+        :application_form,
+        :awarded,
+        working_days_between_submitted_and_completed: 50,
+      )
+    end
+    let(:assessment) do
+      create(
+        :assessment,
+        :award,
+        application_form:,
+        working_days_between_started_and_completed: 45,
+      )
+    end
+
+    it "resets awarded_at and completed working days timestamps" do
+      expect { call }.to change(application_form, :awarded_at).to(
+        nil,
+      ).and change(
+              application_form,
+              :working_days_between_submitted_and_completed,
+            ).to(nil).and change(
+                    assessment,
+                    :working_days_between_started_and_completed,
+                  ).to(nil)
+    end
 
     context "having requested verification" do
       before { create(:requested_reference_request, assessment:) }
@@ -70,8 +95,33 @@ RSpec.describe RollbackAssessment do
   end
 
   context "with a decline assessment" do
-    let(:application_form) { create(:application_form, :declined) }
-    let(:assessment) { create(:assessment, :decline, application_form:) }
+    let(:application_form) do
+      create(
+        :application_form,
+        :declined,
+        working_days_between_submitted_and_completed: 50,
+      )
+    end
+    let(:assessment) do
+      create(
+        :assessment,
+        :decline,
+        application_form:,
+        working_days_between_started_and_completed: 45,
+      )
+    end
+
+    it "resets declined_at and completed working days timestamps" do
+      expect { call }.to change(application_form, :declined_at).to(
+        nil,
+      ).and change(
+              application_form,
+              :working_days_between_submitted_and_completed,
+            ).to(nil).and change(
+                    assessment,
+                    :working_days_between_started_and_completed,
+                  ).to(nil)
+    end
 
     context "having requested verification" do
       before { create(:requested_reference_request, assessment:) }
@@ -247,8 +297,33 @@ RSpec.describe RollbackAssessment do
   end
 
   context "with an unknown assessment but declined application" do
-    let(:application_form) { create(:application_form, :declined) }
-    let(:assessment) { create(:assessment, :unknown, application_form:) }
+    let(:application_form) do
+      create(
+        :application_form,
+        :declined,
+        working_days_between_submitted_and_completed: 50,
+      )
+    end
+    let(:assessment) do
+      create(
+        :assessment,
+        :unknown,
+        application_form:,
+        working_days_between_started_and_completed: 45,
+      )
+    end
+
+    it "resets declined_at and completed working days timestamps" do
+      expect { call }.to change(application_form, :declined_at).to(
+        nil,
+      ).and change(
+              application_form,
+              :working_days_between_submitted_and_completed,
+            ).to(nil).and change(
+                    assessment,
+                    :working_days_between_started_and_completed,
+                  ).to(nil)
+    end
 
     it "doesn't change the assessment state" do
       expect { call }.not_to change(assessment, :unknown?)


### PR DESCRIPTION
Ticket: https://dfedigital.atlassian.net/browse/AQTS-1608

## What

Improves the performance of `UpdateWorkingDaysJob` which was causing a CPU spike on the worker pod when its nine calculation passes ran together nightly at the same time.

Two key changes:

1. Split into separate jobs - The single job that ran nine passes back-to-back is now a coordinator that enqueues nine independent `WorkingDays::*` jobs on a staggered schedule (15-minute steps). This spreads the CPU load across 2 hours instead of it all at the same time.
2. Scope to fewer rows - The jobs that calculate values linked to a complete state (e.g. submitted to completed) now only update rows where the value hasn't been set yet. This is because most of values are fixed once already set, so there's no need to re-write the entire scope every night. For the completed ones where there is a possibility for reverse decision, I've added a reset of the working days integer in the `rollback_assessment` service to ensure we don't end up with invalid working day values. The two "since today" updates (applications since submission and assessments since started) are not scoped, as their values change daily and must be recalculated for all records.

## Potential future improvements

1. Updates remain using `update!` (not batched `update_all`) because the dfe-analytics callback must fire on each change to stream to BigQuery. Batching would skip that callback. Once dfe-analytics moves to Airbyte (a DB replica) rather than model callbacks, the need for callback triggers disappear. At that point we can drop per row `update!` in favour of batched `update_all` / `upsert_all`, reducing individual writes into a handful of statements.
2. Review with stakeholders whether the two "since today" updates need to happen when the application has moved to completed. If not, this will allow us to remove completed applications from the scope of updates. This removes the risk of this becoming a growing issue as the number of applications grow. 

## Testing

- [x] Each `WorkingDays::*` job sets its column correctly.
- [x] The coordinator enqueues all nine jobs with the expected delays.