### PR TITLE
Update SLA "Country" column name to "Country/Region"

### DIFF
--- a/app/views/assessor_interface/service_level_agreements/index.html.erb
+++ b/app/views/assessor_interface/service_level_agreements/index.html.erb
@@ -69,7 +69,7 @@
           table.with_head do |head|
             head.with_row do |row|
               row.with_cell(header: true, text: "Reference")
-              row.with_cell(header: true, text: "Country")
+              row.with_cell(header: true, text: "Country/Region")
               row.with_cell(header: true, text: "Working days since submission")
               row.with_cell(header: true, text: "Flagged as")
               row.with_cell(header: true, text: "Status")


### PR DESCRIPTION
The column was returning Country name or Region name so as a result we've updated the column name to reflect that.