### PR TITLE
2923 - Enable Postgres WAL in test

### DIFF
--- a/terraform/application/config/test/variables.tfvars.json
+++ b/terraform/application/config/test/variables.tfvars.json
@@ -6,5 +6,6 @@
   "namespace": "tra-test",
   "uploads_storage_environment_tag": "Test",
   "bigquery_federated_auth": true,
-  "enable_logit": true
+  "enable_logit": true,
+  "pg_airbyte_enabled": true
 }

--- a/terraform/application/databases.tf
+++ b/terraform/application/databases.tf
@@ -15,4 +15,5 @@ module "postgres" {
   azure_extensions         = ["pg_stat_statements", "pgcrypto"]
   azure_maintenance_window = var.azure_maintenance_window
   server_version           = var.postgres_version
+  use_airbyte              = var.pg_airbyte_enabled
 }

--- a/terraform/application/variables.tf
+++ b/terraform/application/variables.tf
@@ -107,3 +107,6 @@ variable "postgres_version" { default = 17 }
 locals {
   environment_variables = yamldecode(file("${path.module}/config/${var.app_environment}/variables.yml"))
 }
+
+# pg_airbyte_enabled used in the postgres module
+variable "pg_airbyte_enabled" { default = false }


### PR DESCRIPTION
### Context

We are enabling Airbyte in test. As a prerequisite, we need to enable write ahead logging in the Postgres server.
This will require downtime as the Postgres server will reboot.

### Changes proposed in this pull request

- pg_airbyte_enabled set to true in test.

### Guidance to review

- Run `make test terraform-plan` will create 5 azurerm_postgresql_flexible_server_configuration changes including setting wal_level to logical.
- Run `make production terraform-plan` will make no changes other than the standard Kubernetes deployments.

### Link to Trello card

https://trello.com/c/bzl4PvuP/2923-enable-airbyte-in-service-afqts

### Checklist

- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally